### PR TITLE
Fix init: ca.crt mount included when MITM intercept is disabled

### DIFF
--- a/internal/init/step_devcontainer.go
+++ b/internal/init/step_devcontainer.go
@@ -205,7 +205,6 @@ func buildDevcontainerConfig(proxy, intercept bool, stacks []StackType) devconta
 		Image:        "mcr.microsoft.com/devcontainers/base:ubuntu",
 		RemoteUser:   "vscode",
 		Features:     features,
-		Mounts:       []string{"source=${localEnv:HOME}/.human/ca.crt,target=/home/vscode/.human/ca.crt,type=bind,readonly"},
 		RunArgs:      []string{"--add-host=host.docker.internal:host-gateway"},
 		ForwardPorts: []int{19285, 19286},
 		RemoteEnv: map[string]string{ // #nosec G101 -- not a credential, just env var name referencing localEnv
@@ -219,6 +218,7 @@ func buildDevcontainerConfig(proxy, intercept bool, stacks []StackType) devconta
 
 	switch {
 	case proxy && intercept:
+		cfg.Mounts = []string{"source=${localEnv:HOME}/.human/ca.crt,target=/home/vscode/.human/ca.crt,type=bind,readonly"}
 		cfg.CapAdd = []string{"NET_ADMIN"}
 		cfg.RemoteEnv["NODE_EXTRA_CA_CERTS"] = "/home/vscode/.human/ca.crt"
 		cfg.PostStartCommand = "export HUMAN_PROXY_ADDR=$(getent hosts host.docker.internal | awk '{print $1}'):19287 && sudo -E human-proxy-setup && sudo cp /home/vscode/.human/ca.crt /usr/local/share/ca-certificates/human-proxy.crt && sudo update-ca-certificates && human install --agent claude && human chrome-bridge"

--- a/internal/init/wizard_test.go
+++ b/internal/init/wizard_test.go
@@ -649,7 +649,7 @@ func TestDevcontainerStep_BasicConfig(t *testing.T) {
 	assert.Contains(t, data, "ghcr.io/devcontainers/features/node:1")
 	assert.Contains(t, data, "ghcr.io/stephanschmidt/treehouse/human:1")
 	assert.Contains(t, data, `"BROWSER": "human-browser"`)
-	assert.Contains(t, data, ".human/ca.crt,target=/home/vscode/.human/ca.crt,type=bind,readonly")
+	assert.NotContains(t, data, "ca.crt")
 	assert.Contains(t, data, `"HUMAN_DAEMON_ADDR": "host.docker.internal:19285"`)
 	assert.Contains(t, data, `"HUMAN_DAEMON_TOKEN": "${localEnv:HUMAN_DAEMON_TOKEN}"`)
 	assert.Contains(t, data, `"HUMAN_CHROME_ADDR": "host.docker.internal:19286"`)
@@ -717,6 +717,7 @@ func TestDevcontainerStep_WithProxyAndIntercept(t *testing.T) {
 	assert.Contains(t, data, "sudo -E human-proxy-setup")
 	assert.Contains(t, data, "NODE_EXTRA_CA_CERTS")
 	assert.Contains(t, data, "update-ca-certificates")
+	assert.Contains(t, data, ".human/ca.crt,target=/home/vscode/.human/ca.crt,type=bind,readonly")
 	assert.Contains(t, data, "human install --agent claude")
 }
 


### PR DESCRIPTION
The mount was placed in the struct literal before the switch statement that checks the intercept flag, so it leaked into all configurations including the default (no proxy) case. Moved the assignment into the proxy && intercept branch only.

Closes StephanSchmidt/human#20