### PR TITLE
[HUM-91] Add passive version-update notice to human CLI

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -103,7 +103,7 @@ type daemonState struct {
 
 // initDaemon performs the early initialization steps for the daemon: token,
 // PID file, project registry, daemon info, and signal context.
-func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, debug bool, projectDirs []string, cmdFactory func() *cobra.Command) (*daemonState, error) {
+func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, debug bool, projectDirs []string, cmdFactory func() *cobra.Command, version string) (*daemonState, error) {
 	token, err := daemon.LoadOrCreateToken()
 	if err != nil {
 		return nil, errors.WrapWithDetails(err, "failed to load/create token")
@@ -130,6 +130,7 @@ func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, de
 		ProxyAddr:  proxyFullAddr,
 		Token:      token,
 		PID:        os.Getpid(),
+		Version:    version,
 		Projects:   projectInfos,
 	}
 	if err := daemon.WriteInfo(info); err != nil {
@@ -217,9 +218,7 @@ func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, de
 // runDaemonForeground runs the daemon in the current process (blocking).
 // It writes a PID file on start and removes it on shutdown.
 func runDaemonForeground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, interactive, safe, debug bool, projectDirs []string, cmdFactory func() *cobra.Command, version string) error {
-	_ = version // reserved for future use
-
-	ds, err := initDaemon(cmd, addr, chromeAddr, proxyAddr, safe, debug, projectDirs, cmdFactory)
+	ds, err := initDaemon(cmd, addr, chromeAddr, proxyAddr, safe, debug, projectDirs, cmdFactory, version)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.2
 
 require (
 	github.com/1password/onepassword-sdk-go v0.4.0
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v1.0.0
@@ -80,7 +81,6 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/MirrexOne/unqueryvet v1.5.3 // indirect

--- a/internal/browser/open_darwin.go
+++ b/internal/browser/open_darwin.go
@@ -5,5 +5,5 @@ package browser
 import "os/exec"
 
 func startBrowser(url string) error {
-	return exec.Command("open", url).Start()
+	return exec.Command("open", url).Start() // #nosec G204 -- url is passed by the caller; "open" is a macOS system command
 }

--- a/internal/claude/usage_test.go
+++ b/internal/claude/usage_test.go
@@ -90,6 +90,7 @@ func TestCalculateUsage(t *testing.T) {
 	sonnet := summary.Models["sonnet 4.5"]
 	if sonnet == nil {
 		t.Fatal("expected sonnet 4.5 model entry")
+		return
 	}
 	if sonnet.InputTokens != 1_000_000 {
 		t.Errorf("sonnet input = %d, want 1000000", sonnet.InputTokens)
@@ -97,6 +98,7 @@ func TestCalculateUsage(t *testing.T) {
 	opus := summary.Models["opus 4.6"]
 	if opus == nil {
 		t.Fatal("expected opus 4.6 model entry")
+		return
 	}
 	if opus.OutputTokens != 1_000_000 {
 		t.Errorf("opus output = %d, want 1000000", opus.OutputTokens)
@@ -119,6 +121,7 @@ func TestCalculateUsageCacheTokens(t *testing.T) {
 	sonnet := summary.Models["sonnet 4.5"]
 	if sonnet == nil {
 		t.Fatal("expected sonnet 4.5 model entry")
+		return
 	}
 	if sonnet.CacheCreate != 1_000_000 {
 		t.Errorf("sonnet cache_create = %d, want 1000000", sonnet.CacheCreate)
@@ -227,6 +230,7 @@ func TestMergeUsage(t *testing.T) {
 	opus := dst.Models["opus 4.6"]
 	if opus == nil {
 		t.Fatal("expected opus 4.6 in dst after merge")
+		return
 	}
 	if opus.InputTokens != 300 {
 		t.Errorf("opus input = %d, want 300", opus.InputTokens)
@@ -240,6 +244,7 @@ func TestMergeUsage(t *testing.T) {
 	sonnet := dst.Models["sonnet 4.5"]
 	if sonnet == nil {
 		t.Fatal("expected sonnet 4.5 in dst after merge")
+		return
 	}
 	if sonnet.InputTokens != 300 {
 		t.Errorf("sonnet input = %d, want 300", sonnet.InputTokens)
@@ -506,6 +511,7 @@ func TestCollectInstanceUsage(t *testing.T) {
 	opus := results[0].Summary.Models["opus 4.6"]
 	if opus == nil {
 		t.Fatal("expected opus 4.6 model entry")
+		return
 	}
 	if opus.InputTokens != 500 {
 		t.Errorf("opus input = %d, want 500", opus.InputTokens)

--- a/internal/daemon/info.go
+++ b/internal/daemon/info.go
@@ -36,7 +36,12 @@ type DaemonInfo struct {
 	ProxyAddr  string        `json:"proxy_addr,omitempty"`
 	Token      string        `json:"token"`
 	PID        int           `json:"pid"`
-	Projects   []ProjectInfo `json:"projects,omitempty"`
+	// Version carries the daemon binary's build version so clients can warn
+	// about skew between the running daemon and the CLI binary.
+	// omitempty preserves backward-compatibility with daemon.json files
+	// written by older builds that do not emit this field.
+	Version  string        `json:"version,omitempty"`
+	Projects []ProjectInfo `json:"projects,omitempty"`
 }
 
 // InfoPath returns the default path for the daemon info file (~/.human/daemon.json).

--- a/internal/devcontainer/manager_test.go
+++ b/internal/devcontainer/manager_test.go
@@ -58,6 +58,7 @@ func TestManager_Up_NewContainer(t *testing.T) {
 	}
 	if meta == nil {
 		t.Fatal("expected non-nil meta")
+		return
 	}
 	if meta.Status != StatusRunning {
 		t.Errorf("status = %q, want %q", meta.Status, StatusRunning)

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,186 @@
+// Package update provides a passive, best-effort version check that runs on
+// every CLI invocation. It caches the latest known GitHub release so the
+// check adds zero latency on the critical path.
+package update
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/spf13/afero"
+)
+
+const (
+	cacheFileName  = "update-check.json"
+	checkInterval  = 24 * time.Hour
+	cacheMaxAge    = 48 * time.Hour
+	githubReleases = "https://api.github.com/repos/StephanSchmidt/human/releases/latest"
+)
+
+// fs is the filesystem abstraction — replaced with MemMapFs in tests.
+var fs afero.Fs = afero.NewOsFs()
+
+// httpGet is the HTTP client — replaced with a mock in tests.
+var httpGet = func(url string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	return http.DefaultClient.Do(req)
+}
+
+// updateCache is the persisted JSON for the cached release information.
+type updateCache struct {
+	LatestVersion string    `json:"latest_version"`
+	CheckedAt     time.Time `json:"checked_at"`
+}
+
+// CachePath returns the path to the update-check cache file.
+// Falls back to a relative path when the home directory cannot be resolved.
+func CachePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".", ".human", cacheFileName)
+	}
+	return filepath.Join(home, ".human", cacheFileName)
+}
+
+// CheckAndRefresh fetches the latest release from GitHub and writes it to
+// cachePath when the existing cache is older than 24 hours. Errors are
+// silently discarded — the update check is best-effort.
+func CheckAndRefresh(cachePath string) {
+	// Skip the network call when the cache is still fresh.
+	if isCacheFresh(cachePath, checkInterval) {
+		return
+	}
+
+	resp, err := httpGet(githubReleases)
+	if err != nil {
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return
+	}
+
+	var payload struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil || payload.TagName == "" {
+		return
+	}
+
+	cache := updateCache{
+		LatestVersion: payload.TagName,
+		CheckedAt:     time.Now().UTC(),
+	}
+	writeCache(cachePath, cache)
+}
+
+// CachedLatestVersion returns the latest version from the on-disk cache.
+// Returns "" when the cache is absent, corrupt, or older than 48 hours.
+func CachedLatestVersion(cachePath string) string {
+	cache, err := readCache(cachePath)
+	if err != nil {
+		return ""
+	}
+	// Discard stale cache entries so a dormant installation does not forever
+	// show an outdated "latest" version after the cache has gone cold.
+	if time.Since(cache.CheckedAt) > cacheMaxAge {
+		return ""
+	}
+	return cache.LatestVersion
+}
+
+// IsNewer reports whether latestVersion is strictly greater than currentVersion
+// using semver comparison. Returns false for dev builds, empty strings, or
+// inputs that cannot be parsed as valid semver.
+func IsNewer(currentVersion, latestVersion string) bool {
+	if currentVersion == "" || currentVersion == "dev" {
+		return false
+	}
+	if latestVersion == "" {
+		return false
+	}
+	current, err := semver.NewVersion(currentVersion)
+	if err != nil {
+		return false
+	}
+	latest, err := semver.NewVersion(latestVersion)
+	if err != nil {
+		return false
+	}
+	return latest.GreaterThan(current)
+}
+
+// InstallHint returns a human-readable upgrade command appropriate for the
+// installation method inferred from the executable path. Falls back to the
+// GitHub releases URL when detection is inconclusive.
+func InstallHint() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return "https://github.com/StephanSchmidt/human/releases"
+	}
+	lower := strings.ToLower(exe)
+
+	// Homebrew installs go under Cellar; the standard path is
+	// /opt/homebrew/Cellar/... (Apple Silicon) or /usr/local/Cellar/... (Intel).
+	if strings.Contains(lower, "cellar") || strings.Contains(lower, "homebrew") {
+		return "brew upgrade human"
+	}
+
+	// go install places the binary inside $GOPATH/bin or $HOME/go/bin.
+	gopath := os.Getenv("GOPATH")
+	gobin := os.Getenv("GOBIN")
+	homeGoBin := filepath.Join(os.Getenv("HOME"), "go", "bin")
+	if (gopath != "" && strings.HasPrefix(exe, filepath.Join(gopath, "bin"))) ||
+		(gobin != "" && strings.HasPrefix(exe, gobin)) ||
+		strings.HasPrefix(exe, homeGoBin) {
+		return "go install github.com/StephanSchmidt/human@latest"
+	}
+
+	return "https://github.com/StephanSchmidt/human/releases"
+}
+
+// --- internal helpers ---
+
+// isCacheFresh returns true when the cache file exists and was written within
+// the given maxAge window.
+func isCacheFresh(cachePath string, maxAge time.Duration) bool {
+	cache, err := readCache(cachePath)
+	if err != nil {
+		return false
+	}
+	return time.Since(cache.CheckedAt) < maxAge
+}
+
+func readCache(cachePath string) (updateCache, error) {
+	data, err := afero.ReadFile(fs, cachePath)
+	if err != nil {
+		return updateCache{}, err
+	}
+	var cache updateCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return updateCache{}, err
+	}
+	return cache, nil
+}
+
+func writeCache(cachePath string, cache updateCache) {
+	if err := fs.MkdirAll(filepath.Dir(cachePath), 0o700); err != nil {
+		return
+	}
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return
+	}
+	_ = afero.WriteFile(fs, cachePath, data, 0o600)
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,198 @@
+package update
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+)
+
+// useMemFs swaps the package-level filesystem to an in-memory one for the
+// duration of a test, then restores the original on cleanup.
+func useMemFs(t *testing.T) afero.Fs {
+	t.Helper()
+	mem := afero.NewMemMapFs()
+	orig := fs
+	fs = mem
+	t.Cleanup(func() { fs = orig })
+	return mem
+}
+
+// TestIsNewer verifies all semver comparison branches, including dev/empty/bad
+// inputs that must never trigger an update notice.
+func TestIsNewer(t *testing.T) {
+	tests := []struct {
+		current string
+		latest  string
+		want    bool
+	}{
+		{"v0.17.0", "v0.18.0", true},
+		{"0.17.0", "0.18.0", true},
+		{"v0.18.0", "v0.17.0", false},
+		{"v0.18.0", "v0.18.0", false},
+		{"dev", "v0.18.0", false},
+		{"", "v0.18.0", false},
+		{"v0.17.0", "", false},
+		{"not-semver", "v0.18.0", false},
+		{"v0.17.0", "not-semver", false},
+	}
+	for _, tc := range tests {
+		got := IsNewer(tc.current, tc.latest)
+		if got != tc.want {
+			t.Errorf("IsNewer(%q, %q) = %v, want %v", tc.current, tc.latest, got, tc.want)
+		}
+	}
+}
+
+// TestReadWriteCache verifies that a cache round-trip preserves the version
+// and timestamp with sub-second precision.
+func TestReadWriteCache(t *testing.T) {
+	useMemFs(t)
+	path := "/tmp/.human/update-check.json"
+
+	now := time.Now().UTC().Truncate(time.Second)
+	writeCache(path, updateCache{LatestVersion: "v0.18.0", CheckedAt: now})
+
+	got, err := readCache(path)
+	if err != nil {
+		t.Fatalf("readCache: %v", err)
+	}
+	if got.LatestVersion != "v0.18.0" {
+		t.Errorf("version: got %q, want %q", got.LatestVersion, "v0.18.0")
+	}
+	if !got.CheckedAt.Equal(now) {
+		t.Errorf("checked_at: got %v, want %v", got.CheckedAt, now)
+	}
+}
+
+// TestReadCache_Missing expects an error when the cache file does not exist.
+func TestReadCache_Missing(t *testing.T) {
+	useMemFs(t)
+	_, err := readCache("/nonexistent/path.json")
+	if err == nil {
+		t.Fatal("expected error for missing cache, got nil")
+	}
+}
+
+// TestReadCache_Corrupt expects an error when the cache JSON is malformed.
+func TestReadCache_Corrupt(t *testing.T) {
+	mem := useMemFs(t)
+	path := "/tmp/corrupt.json"
+	_ = afero.WriteFile(mem, path, []byte("not json"), 0o600)
+
+	_, err := readCache(path)
+	if err == nil {
+		t.Fatal("expected error for corrupt cache, got nil")
+	}
+}
+
+// TestCachedLatestVersion_Fresh expects the stored version when the cache is
+// younger than 48 hours.
+func TestCachedLatestVersion_Fresh(t *testing.T) {
+	mem := useMemFs(t)
+	path := "/tmp/.human/update-check.json"
+	cache := updateCache{LatestVersion: "v0.18.0", CheckedAt: time.Now().UTC()}
+	data, _ := json.Marshal(cache)
+	_ = mem.MkdirAll(filepath.Dir(path), 0o700)
+	_ = afero.WriteFile(mem, path, data, 0o600)
+
+	got := CachedLatestVersion(path)
+	if got != "v0.18.0" {
+		t.Errorf("got %q, want %q", got, "v0.18.0")
+	}
+}
+
+// TestCachedLatestVersion_Stale expects an empty string for a cache entry
+// older than 48 hours.
+func TestCachedLatestVersion_Stale(t *testing.T) {
+	mem := useMemFs(t)
+	path := "/tmp/.human/update-check.json"
+	cache := updateCache{
+		LatestVersion: "v0.18.0",
+		CheckedAt:     time.Now().UTC().Add(-49 * time.Hour),
+	}
+	data, _ := json.Marshal(cache)
+	_ = mem.MkdirAll(filepath.Dir(path), 0o700)
+	_ = afero.WriteFile(mem, path, data, 0o600)
+
+	got := CachedLatestVersion(path)
+	if got != "" {
+		t.Errorf("stale cache should return empty string, got %q", got)
+	}
+}
+
+// TestCheckAndRefresh_SkipsWhenFresh confirms no HTTP request is made when
+// the cache was written less than 24 hours ago.
+func TestCheckAndRefresh_SkipsWhenFresh(t *testing.T) {
+	mem := useMemFs(t)
+	path := "/tmp/.human/update-check.json"
+	cache := updateCache{LatestVersion: "v0.17.0", CheckedAt: time.Now().UTC()}
+	data, _ := json.Marshal(cache)
+	_ = mem.MkdirAll(filepath.Dir(path), 0o700)
+	_ = afero.WriteFile(mem, path, data, 0o600)
+
+	origGet := httpGet
+	httpGet = func(_ string) (*http.Response, error) {
+		t.Fatal("httpGet must not be called when cache is fresh")
+		return nil, nil
+	}
+	t.Cleanup(func() { httpGet = origGet })
+
+	CheckAndRefresh(path)
+}
+
+// TestCheckAndRefresh_RefreshesWhenStale confirms the cache is updated when
+// older than 24 hours, using an httptest server to avoid real network calls.
+func TestCheckAndRefresh_RefreshesWhenStale(t *testing.T) {
+	mem := useMemFs(t)
+	path := "/tmp/.human/update-check.json"
+
+	// Write a stale cache entry.
+	stale := updateCache{LatestVersion: "v0.17.0", CheckedAt: time.Now().UTC().Add(-25 * time.Hour)}
+	data, _ := json.Marshal(stale)
+	_ = mem.MkdirAll(filepath.Dir(path), 0o700)
+	_ = afero.WriteFile(mem, path, data, 0o600)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"tag_name":"v0.18.0"}`)
+	}))
+	defer srv.Close()
+
+	origGet := httpGet
+	httpGet = func(_ string) (*http.Response, error) {
+		return http.Get(srv.URL) //nolint:noctx
+	}
+	t.Cleanup(func() { httpGet = origGet })
+
+	CheckAndRefresh(path)
+
+	got := CachedLatestVersion(path)
+	if got != "v0.18.0" {
+		t.Errorf("after refresh, got %q, want %q", got, "v0.18.0")
+	}
+}
+
+// TestInstallHint_GoPath checks that a path inside GOPATH/bin yields the
+// go install hint.
+func TestInstallHint_GoPath(t *testing.T) {
+	// The hint logic inspects os.Executable(), which returns the test binary
+	// path — not easily controllable. We validate that the function returns a
+	// non-empty string (it always falls back to the releases URL).
+	hint := InstallHint()
+	if hint == "" {
+		t.Fatal("InstallHint returned empty string")
+	}
+	// Must be one of the three expected forms.
+	if !strings.Contains(hint, "brew") &&
+		!strings.Contains(hint, "go install") &&
+		!strings.Contains(hint, "github.com/StephanSchmidt/human/releases") {
+		t.Errorf("unexpected hint: %q", hint)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/StephanSchmidt/human/cmd/cmdagent"
 	"github.com/StephanSchmidt/human/cmd/cmdamplitude"
@@ -37,6 +38,7 @@ import (
 	"github.com/StephanSchmidt/human/internal/config"
 	"github.com/StephanSchmidt/human/internal/daemon"
 	"github.com/StephanSchmidt/human/internal/tracker"
+	"github.com/StephanSchmidt/human/internal/update"
 )
 
 var (
@@ -456,6 +458,60 @@ func isLocalSubcommand(args []string) bool {
 	return false
 }
 
+// --- update notices ---
+
+// isTTY reports whether stderr is an interactive terminal. Update notices
+// and skew warnings are suppressed in non-interactive contexts (pipes, CI,
+// daemon child processes) to avoid polluting structured output.
+func isTTY() bool {
+	return term.IsTerminal(int(os.Stderr.Fd()))
+}
+
+// printUpdateNotice writes a one-line update hint to stderr when a newer
+// version is available in the GitHub releases cache. The check itself runs
+// in the background so it never blocks the command on the critical path.
+func printUpdateNotice(currentVersion string) {
+	if currentVersion == "" || currentVersion == "dev" {
+		return
+	}
+	// Daemon child processes share the same binary but should not print to
+	// the operator's terminal — messages would appear in the daemon log.
+	if os.Getenv("_HUMAN_DAEMON_CHILD") != "" {
+		return
+	}
+	if !isTTY() {
+		return
+	}
+	cachePath := update.CachePath()
+	// Refresh the cache in the background so the notice appears on the next
+	// invocation after the cache goes stale, never blocking this one.
+	go update.CheckAndRefresh(cachePath)
+	latest := update.CachedLatestVersion(cachePath)
+	if update.IsNewer(currentVersion, latest) {
+		hint := update.InstallHint()
+		fmt.Fprintf(os.Stderr, "\nA new version %s is available — run `%s`\n\n", latest, hint)
+	}
+}
+
+// printDaemonSkewWarning alerts the operator when the CLI binary version
+// differs from the version of the currently running daemon. A skew can mean
+// the daemon still has the old code path and a restart is needed.
+func printDaemonSkewWarning(clientVersion, daemonVersion string) {
+	if clientVersion == "" || clientVersion == "dev" {
+		return
+	}
+	if daemonVersion == "" || daemonVersion == "dev" {
+		return
+	}
+	if clientVersion == daemonVersion {
+		return
+	}
+	if !isTTY() {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "warning: client v%s is talking to daemon v%s — consider restarting the daemon after upgrading\n", clientVersion, daemonVersion)
+}
+
 // --- main ---
 
 // subcmdFromBinary checks whether the binary was invoked via a symlink
@@ -543,6 +599,16 @@ func main() {
 	if addr == "" {
 		addr, token = discoverDaemon(token)
 	}
+
+	// Warn when the CLI binary and the running daemon are on different versions.
+	// Skipped silently when the daemon is unreachable or its info file is absent.
+	if addr != "" {
+		if info, infoErr := daemon.ReadInfo(); infoErr == nil {
+			printDaemonSkewWarning(version, info.Version)
+		}
+	}
+	// Passive update notice — fires a background goroutine then reads the cache.
+	printUpdateNotice(version)
 
 	if addr != "" && !isLocalSubcommand(args) {
 		exitCode, err := daemon.RunRemote(addr, token, args, version)

--- a/main.go
+++ b/main.go
@@ -464,7 +464,7 @@ func isLocalSubcommand(args []string) bool {
 // and skew warnings are suppressed in non-interactive contexts (pipes, CI,
 // daemon child processes) to avoid polluting structured output.
 func isTTY() bool {
-	return term.IsTerminal(int(os.Stderr.Fd()))
+	return term.IsTerminal(int(os.Stderr.Fd())) // #nosec G115 -- fd is from os.Stderr.Fd(), safe range
 }
 
 // printUpdateNotice writes a one-line update hint to stderr when a newer


### PR DESCRIPTION
## Summary

- Adds a passive, once-per-day stderr notice when a newer version is available on GitHub Releases
- Notice is install-path-aware: shows the right upgrade command for Homebrew, `go install`, or binary download
- Adds a warning when the CLI client and daemon are running different versions
- All checks are best-effort: silent on network failure, suppressed in non-TTY, skipped for dev builds

## Tickets

PM ticket: HUM-91
Engineering ticket: HUM-92

## Changes

- `internal/update/` — new package: throttled cache (`~/.human/update-check.json`), GitHub Releases API check, semver comparison via `Masterminds/semver/v3`, install-path detection
- `internal/daemon/info.go` — `Version string` field added to `DaemonInfo` (omitempty, backward-compat)
- `cmd/cmddaemon/daemon.go` — propagates binary version into `daemon.json` at startup
- `main.go` — wires `printUpdateNotice()` and `printDaemonSkewWarning()` after daemon discovery

## Test plan

- [ ] `make test` passes (9 new tests in `internal/update`)
- [ ] `make lint` clean
- [ ] No notice printed when `version=dev` (default local build)
- [ ] Notice appears after manually writing a stale cache: `echo '{"latest_version":"v99.0.0","checked_at":"2020-01-01T00:00:00Z"}' > ~/.human/update-check.json`
- [ ] No notice when piping output (non-TTY)
- [ ] Skew warning appears when client and daemon versions differ

🤖 Generated with [Claude Code](https://claude.com/claude-code)