### PR TITLE
[SC-86] Autonomous bug-fix: forge PR capability + /human-autofix

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ This writes skill and agent files to `.claude/` in the current directory. Re-run
 | `/human-brainstorm` | Explores the codebase and generates 2-3 implementation approaches |
 | `/human-plan` | Fetches a ticket and produces a structured implementation plan |
 | `/human-bug-plan` | Analyzes a bug ticket for root cause and writes a fix plan |
+| `/human-autofix` | Autonomously verifies, reproduces, fixes, and opens a PR for a bug end to end — the whole trail recorded on the tracker |
 | `/human-execute` | Loads a plan, executes step by step, runs a review checkpoint |
 | `/human-review` | Diffs the current branch against acceptance criteria |
 | `/human-findbugs` | Multi-agent pipeline to find logic errors, race conditions, and security issues |

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ human jira issue start KAN-1           # transition + assign
 human jira issue edit KAN-1 --title "New title"
 human jira issue comment add KAN-1 "Shipped"
 
+human github pr create --repo owner/repo --head fix-login --base main --title "Fix login" --body "Closes #42"  # open a PR (forge backends only)
+
 human search "retry logic"             # cross-tracker search
 human notion search "quarterly report" # Notion
 human figma file get <file-key>        # Figma

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ human jira issue start KAN-1           # transition + assign
 human jira issue edit KAN-1 --title "New title"
 human jira issue comment add KAN-1 "Shipped"
 
-human github pr create --repo owner/repo --head fix-login --base main --title "Fix login" --body "Closes #42"  # open a PR (forge backends only)
+human pr create --head fix-login --title "Fix login" --body "Closes #42"  # open a PR; forge + repo derived from the git origin remote
 
 human search "retry logic"             # cross-tracker search
 human notion search "quarterly report" # Notion

--- a/cmd/cmdauto/auto.go
+++ b/cmd/cmdauto/auto.go
@@ -116,6 +116,45 @@ func BuildAutoStatusCmd(deps cmdutil.Deps) *cobra.Command {
 	}
 }
 
+// BuildAutoPRCreateCmd creates the top-level "pr create" command that derives
+// the code forge and repository from the local git "origin" remote, so a PR
+// can be opened from inside the repo without naming the forge kind or --repo.
+func BuildAutoPRCreateCmd(deps cmdutil.Deps) *cobra.Command {
+	var repo, base, head, title, body string
+
+	prCmd := &cobra.Command{
+		Use:   "pr",
+		Short: "Pull request operations (auto-detect forge from git origin)",
+	}
+
+	createCmd := &cobra.Command{
+		Use:     "create",
+		Short:   "Open a pull request on the forge derived from the git origin remote",
+		Example: `  human pr create --head fix-login --title "Fix login" --body "Closes #42"`,
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			f, originRepo, err := cmdutil.OriginForge(cmd, deps)
+			if err != nil {
+				return err
+			}
+			if repo == "" {
+				repo = originRepo
+			}
+			return cmdprovider.RunCreatePullRequest(cmd.Context(), f, cmd.OutOrStdout(), repo, base, head, title, body)
+		},
+	}
+	createCmd.Flags().StringVar(&repo, "repo", "", "Repository owner/repo (defaults to the git origin remote)")
+	createCmd.Flags().StringVar(&head, "head", "", "Head branch holding the changes")
+	_ = createCmd.MarkFlagRequired("head")
+	createCmd.Flags().StringVar(&base, "base", "main", "Base branch to merge into")
+	createCmd.Flags().StringVar(&title, "title", "", "Pull request title")
+	_ = createCmd.MarkFlagRequired("title")
+	createCmd.Flags().StringVar(&body, "body", "", "Pull request description in markdown")
+
+	prCmd.AddCommand(createCmd)
+	return prCmd
+}
+
 // PrintAutoHints prints contextual guidance to stderr after auto-detected commands.
 func PrintAutoHints(w io.Writer, kind, key, project, afterCmd string) {
 	_, _ = fmt.Fprintf(w, "\nDetected tracker: %s\n", kind)

--- a/cmd/cmdauto/auto_test.go
+++ b/cmd/cmdauto/auto_test.go
@@ -1,0 +1,71 @@
+package cmdauto
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/cmd/cmdutil"
+	"github.com/gethuman-sh/human/internal/github"
+	"github.com/gethuman-sh/human/internal/gitrepo"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+func TestBuildAutoPRCreateCmd_structure(t *testing.T) {
+	prCmd := BuildAutoPRCreateCmd(cmdutil.Deps{})
+	assert.Equal(t, "pr", prCmd.Name())
+
+	create := prCmd.Commands()
+	require.Len(t, create, 1)
+	assert.Equal(t, "create", create[0].Name())
+
+	flags := create[0].Flags()
+	for _, name := range []string{"repo", "head", "base", "title", "body"} {
+		assert.NotNil(t, flags.Lookup(name), "expected --%s flag", name)
+	}
+}
+
+func TestBuildAutoPRCreateCmd_run(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/gethuman-sh/human/pulls", r.URL.Path)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"number":7,"title":"Fix","html_url":"https://github.com/gethuman-sh/human/pull/7"}`))
+	}))
+	defer srv.Close()
+
+	// Derive the forge from a github origin remote without touching a real repo.
+	prev := gitrepo.OriginURL
+	gitrepo.OriginURL = func(_ context.Context, _ string) (string, error) {
+		return "git@github.com:gethuman-sh/human.git", nil
+	}
+	defer func() { gitrepo.OriginURL = prev }()
+
+	deps := cmdutil.Deps{
+		LoadInstances: func(_ string) ([]tracker.Instance, error) {
+			return []tracker.Instance{{
+				Name:     "gh",
+				Kind:     "github",
+				URL:      srv.URL,
+				Provider: github.New(srv.URL, "t"),
+			}}, nil
+		},
+		InstanceFromFlags: func(_ *cobra.Command) *tracker.Instance { return nil },
+		AuditLogPath:      func() string { return "" },
+	}
+
+	root := &cobra.Command{Use: "human"}
+	root.AddCommand(BuildAutoPRCreateCmd(deps))
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"pr", "create", "--head", "fix-login", "--title", "Fix"})
+
+	require.NoError(t, root.Execute())
+	assert.Contains(t, out.String(), "https://github.com/gethuman-sh/human/pull/7")
+}

--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -965,7 +965,7 @@ func fetchTrackerIssuesFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolve
 		// Scan PM-tracker comments for [human:ready-for-review] handoffs and
 		// propagate the flagged engineering keys to engineering-tracker
 		// results. See cli/CLAUDE.md "Review handoff".
-		readyKeys := scanReadyForReview(jobs, results)
+		readyKeys, readyPRs := scanReadyForReview(jobs, results)
 		for i := range results {
 			if results[i].TrackerRole != "engineering" {
 				continue
@@ -973,6 +973,12 @@ func fetchTrackerIssuesFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolve
 			for _, iss := range results[i].Issues {
 				if readyKeys[iss.Key] {
 					results[i].ReadyForReview = append(results[i].ReadyForReview, iss.Key)
+					if pr := readyPRs[iss.Key]; pr != "" {
+						if results[i].ReadyForReviewPRs == nil {
+							results[i].ReadyForReviewPRs = make(map[string]string)
+						}
+						results[i].ReadyForReviewPRs[iss.Key] = pr
+					}
 				}
 			}
 		}
@@ -988,8 +994,9 @@ func fetchTrackerIssuesFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolve
 //
 // jobs and results are aligned 1:1 so we can recover the tracker.Provider for
 // a given result without re-loading instances from disk.
-func scanReadyForReview(jobs []fetchJob, results []daemon.TrackerIssuesResult) map[string]bool {
+func scanReadyForReview(jobs []fetchJob, results []daemon.TrackerIssuesResult) (map[string]bool, map[string]string) {
 	ready := make(map[string]bool)
+	prs := make(map[string]string)
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 	for i := range results {
@@ -1010,26 +1017,30 @@ func scanReadyForReview(jobs []fetchJob, results []daemon.TrackerIssuesResult) m
 				if err != nil {
 					return
 				}
-				keys := latestReadyKeys(comments)
+				keys, pr := latestReadyKeys(comments)
 				if len(keys) == 0 {
 					return
 				}
 				mu.Lock()
 				for _, k := range keys {
 					ready[k] = true
+					if pr != "" {
+						prs[k] = pr
+					}
 				}
 				mu.Unlock()
 			}(commenter, issue.Key)
 		}
 	}
 	wg.Wait()
-	return ready
+	return ready, prs
 }
 
 // latestReadyKeys walks a comment thread and returns the engineering keys
-// from the most recent [human:ready-for-review] comment, unless a later
+// from the most recent [human:ready-for-review] comment (and the pull-request
+// URL on its optional pr: line, if any), unless a later
 // [human:review-complete] comment has already superseded it.
-func latestReadyKeys(comments []tracker.Comment) []string {
+func latestReadyKeys(comments []tracker.Comment) ([]string, string) {
 	// Find the most recent handoff and the most recent review-complete.
 	var latestHandoff tracker.Comment
 	var latestComplete tracker.Comment
@@ -1049,15 +1060,15 @@ func latestReadyKeys(comments []tracker.Comment) []string {
 		}
 	}
 	if !haveHandoff {
-		return nil
+		return nil, ""
 	}
 	// Inclusive boundary: tracker timestamps are second-granular, so a
 	// review-complete posted in the same second as the handoff must still
 	// clear it (otherwise the (R) annotation lingers after review is done).
 	if haveComplete && !latestComplete.Created.Before(latestHandoff.Created) {
-		return nil
+		return nil, ""
 	}
-	return daemon.ParseEngineeringKeysFromHandoff(latestHandoff.Body)
+	return daemon.ParseEngineeringKeysFromHandoff(latestHandoff.Body), daemon.ParsePRFromHandoff(latestHandoff.Body)
 }
 
 // dockerAgentCleaner implements daemon.AgentCleaner using a real Docker client.

--- a/cmd/cmddaemon/review_handoff_test.go
+++ b/cmd/cmddaemon/review_handoff_test.go
@@ -16,6 +16,7 @@ func TestLatestReadyKeys(t *testing.T) {
 		name     string
 		comments []tracker.Comment
 		want     []string
+		wantPR   string
 	}{
 		{
 			name: "single handoff returns its keys",
@@ -24,6 +25,14 @@ func TestLatestReadyKeys(t *testing.T) {
 				{Body: "[human:ready-for-review]\nengineering: HUM-89", Created: t0.Add(time.Minute)},
 			},
 			want: []string{"HUM-89"},
+		},
+		{
+			name: "handoff with pr line returns the URL",
+			comments: []tracker.Comment{
+				{Body: "[human:ready-for-review]\nengineering: HUM-89\npr: https://github.com/o/r/pull/7", Created: t0},
+			},
+			want:   []string{"HUM-89"},
+			wantPR: "https://github.com/o/r/pull/7",
 		},
 		{
 			name: "later review-complete clears the flag",
@@ -69,8 +78,9 @@ func TestLatestReadyKeys(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := latestReadyKeys(tt.comments)
+			got, gotPR := latestReadyKeys(tt.comments)
 			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantPR, gotPR)
 		})
 	}
 }

--- a/cmd/cmdprovider/provider.go
+++ b/cmd/cmdprovider/provider.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gethuman-sh/human/cmd/cmdutil"
 	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/forge"
 	"github.com/gethuman-sh/human/internal/tracker"
 )
 
@@ -39,7 +40,20 @@ func BuildProviderCommands(kind string, deps cmdutil.Deps) []*cobra.Command {
 	issueCmd.AddCommand(buildIssueStatusesCmd(kind, deps))
 	issueCmd.AddCommand(buildIssueStatusSetCmd(kind, deps))
 
-	return []*cobra.Command{issuesCmd, issueCmd}
+	cmds := []*cobra.Command{issuesCmd, issueCmd}
+
+	// Only code forges (GitHub, …) expose pull-request operations; pure issue
+	// trackers must not advertise a `pr` command they can't fulfil.
+	if forge.IsForgeKind(kind) {
+		prCmd := &cobra.Command{
+			Use:   "pr",
+			Short: "Pull request operations",
+		}
+		prCmd.AddCommand(buildPRCreateCmd(kind, deps))
+		cmds = append(cmds, prCmd)
+	}
+
+	return cmds
 }
 
 func buildIssuesListCmd(kind string, deps cmdutil.Deps) *cobra.Command {
@@ -102,6 +116,33 @@ func buildIssueCreateCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 	cmd.Flags().StringVar(&typ, "type", "Task", "Issue type (Jira only, e.g. Task, Bug, Story)")
 	cmd.Flags().StringVar(&description, "description", "", "Issue description in markdown (separate from title)")
 	cmd.Flags().StringVar(&parent, "parent", "", "Parent issue key to create this as a subtask (Linear, Jira, Shortcut, Azure DevOps, GitHub, ClickUp; not supported on GitLab)")
+	return cmd
+}
+
+func buildPRCreateCmd(kind string, deps cmdutil.Deps) *cobra.Command {
+	var repo, base, head, title, body string
+
+	cmd := &cobra.Command{
+		Use:     "create",
+		Short:   "Open a pull request",
+		Example: `  human github pr create --repo=octocat/hello-world --head=fix-login --base=main --title "Fix login" --body "Closes #42"`,
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			f, err := cmdutil.ResolveForge(cmd, kind, deps)
+			if err != nil {
+				return err
+			}
+			return RunCreatePullRequest(cmd.Context(), f, cmd.OutOrStdout(), repo, base, head, title, body)
+		},
+	}
+	cmd.Flags().StringVar(&repo, "repo", "", "Repository (GitHub: owner/repo)")
+	_ = cmd.MarkFlagRequired("repo")
+	cmd.Flags().StringVar(&head, "head", "", "Head branch holding the changes")
+	_ = cmd.MarkFlagRequired("head")
+	cmd.Flags().StringVar(&base, "base", "main", "Base branch to merge into")
+	cmd.Flags().StringVar(&title, "title", "", "Pull request title")
+	_ = cmd.MarkFlagRequired("title")
+	cmd.Flags().StringVar(&body, "body", "", "Pull request description in markdown")
 	return cmd
 }
 
@@ -325,6 +366,25 @@ func RunCreateIssue(ctx context.Context, p tracker.Provider, out io.Writer, proj
 		return errors.WithDetails("create returned no issue", "project", project)
 	}
 	_, _ = fmt.Fprintf(out, "%s\t%s\n", issue.Key, issue.Title)
+	return nil
+}
+
+// RunCreatePullRequest opens a pull request on a code forge and prints the URL.
+func RunCreatePullRequest(ctx context.Context, f forge.Creator, out io.Writer, repo, base, head, title, body string) error {
+	pr, err := f.CreatePullRequest(ctx, &forge.PullRequest{
+		Repo:  repo,
+		Base:  base,
+		Head:  head,
+		Title: title,
+		Body:  body,
+	})
+	if err != nil {
+		return err
+	}
+	if pr == nil {
+		return errors.WithDetails("create returned no pull request", "repo", repo)
+	}
+	_, _ = fmt.Fprintf(out, "%s\t%s\n", pr.URL, pr.Title)
 	return nil
 }
 

--- a/cmd/cmdprovider/provider.go
+++ b/cmd/cmdprovider/provider.go
@@ -132,11 +132,17 @@ func buildPRCreateCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if repo == "" {
+				// Default to the repository of the local git origin remote.
+				repo, err = cmdutil.OriginRepo(cmd)
+				if err != nil {
+					return err
+				}
+			}
 			return RunCreatePullRequest(cmd.Context(), f, cmd.OutOrStdout(), repo, base, head, title, body)
 		},
 	}
-	cmd.Flags().StringVar(&repo, "repo", "", "Repository (GitHub: owner/repo)")
-	_ = cmd.MarkFlagRequired("repo")
+	cmd.Flags().StringVar(&repo, "repo", "", "Repository (GitHub: owner/repo); defaults to the git origin remote")
 	cmd.Flags().StringVar(&head, "head", "", "Head branch holding the changes")
 	_ = cmd.MarkFlagRequired("head")
 	cmd.Flags().StringVar(&base, "base", "main", "Base branch to merge into")

--- a/cmd/cmdprovider/provider.go
+++ b/cmd/cmdprovider/provider.go
@@ -101,7 +101,7 @@ func buildIssueCreateCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 	_ = cmd.MarkFlagRequired("project")
 	cmd.Flags().StringVar(&typ, "type", "Task", "Issue type (Jira only, e.g. Task, Bug, Story)")
 	cmd.Flags().StringVar(&description, "description", "", "Issue description in markdown (separate from title)")
-	cmd.Flags().StringVar(&parent, "parent", "", "Parent task ID for creating subtasks (ClickUp)")
+	cmd.Flags().StringVar(&parent, "parent", "", "Parent issue key to create this as a subtask (Linear, Jira, Shortcut, Azure DevOps, GitHub, ClickUp; not supported on GitLab)")
 	return cmd
 }
 
@@ -296,6 +296,9 @@ func RunGetIssue(ctx context.Context, p tracker.Provider, out io.Writer, key str
 	_, _ = fmt.Fprintf(out, "| Priority | %s |\n", displayOrNone(issue.Priority))
 	_, _ = fmt.Fprintf(out, "| Assignee | %s |\n", displayOrNone(issue.Assignee))
 	_, _ = fmt.Fprintf(out, "| Reporter | %s |\n", displayOrNone(issue.Reporter))
+	if issue.ParentKey != "" {
+		_, _ = fmt.Fprintf(out, "| Parent   | %s |\n", issue.ParentKey)
+	}
 
 	if issue.Description != "" {
 		_, _ = fmt.Fprintf(out, "\n## Description\n\n%s", issue.Description)
@@ -305,7 +308,8 @@ func RunGetIssue(ctx context.Context, p tracker.Provider, out io.Writer, key str
 }
 
 // RunCreateIssue creates a new issue. When parent is non-empty, the issue is
-// created as a subtask of the given parent key (ClickUp).
+// created as a subtask of the given parent key. Subtask support is
+// provider-specific (see the --parent flag help); GitLab rejects it.
 func RunCreateIssue(ctx context.Context, p tracker.Provider, out io.Writer, project, typ, title, description, parent string) error {
 	issue, err := p.CreateIssue(ctx, &tracker.Issue{
 		Project:     project,

--- a/cmd/cmdprovider/provider_test.go
+++ b/cmd/cmdprovider/provider_test.go
@@ -13,8 +13,19 @@ import (
 
 	"github.com/gethuman-sh/human/cmd/cmdutil"
 	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/forge"
 	"github.com/gethuman-sh/human/internal/tracker"
 )
+
+// --- fake forge.Creator ---
+
+type fakeForge struct {
+	createFn func(ctx context.Context, pr *forge.PullRequest) (*forge.PullRequest, error)
+}
+
+func (f *fakeForge) CreatePullRequest(ctx context.Context, pr *forge.PullRequest) (*forge.PullRequest, error) {
+	return f.createFn(ctx, pr)
+}
 
 // --- mock tracker.Provider ---
 
@@ -263,6 +274,41 @@ func TestRunCreateIssue_Error(t *testing.T) {
 	err := RunCreateIssue(context.Background(), p, &buf, "KAN", "Task", "Title", "", "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "create failed")
+}
+
+func TestRunCreatePullRequest_Success(t *testing.T) {
+	f := &fakeForge{
+		createFn: func(_ context.Context, pr *forge.PullRequest) (*forge.PullRequest, error) {
+			assert.Equal(t, "octocat/hello-world", pr.Repo)
+			assert.Equal(t, "main", pr.Base)
+			assert.Equal(t, "fix-login", pr.Head)
+			assert.Equal(t, "Fix login", pr.Title)
+			return &forge.PullRequest{
+				Number: 7,
+				Title:  "Fix login",
+				URL:    "https://github.com/octocat/hello-world/pull/7",
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	err := RunCreatePullRequest(context.Background(), f, &buf, "octocat/hello-world", "main", "fix-login", "Fix login", "body")
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "https://github.com/octocat/hello-world/pull/7")
+	assert.Contains(t, buf.String(), "Fix login")
+}
+
+func TestRunCreatePullRequest_Error(t *testing.T) {
+	f := &fakeForge{
+		createFn: func(_ context.Context, _ *forge.PullRequest) (*forge.PullRequest, error) {
+			return nil, errors.WithDetails("pr failed")
+		},
+	}
+
+	var buf bytes.Buffer
+	err := RunCreatePullRequest(context.Background(), f, &buf, "octocat/hello-world", "main", "fix-login", "Fix login", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "pr failed")
 }
 
 // --- RunEditIssue tests ---
@@ -770,6 +816,31 @@ func TestBuildProviderCommands_ReturnsExpectedCommands(t *testing.T) {
 	assert.True(t, subNames["start"], "expected 'start' subcommand")
 	assert.True(t, subNames["statuses"], "expected 'statuses' subcommand")
 	assert.True(t, subNames["status"], "expected 'status' subcommand")
+}
+
+func TestBuildProviderCommands_ForgeKindHasPRCommand(t *testing.T) {
+	cmds := BuildProviderCommands("github", cmdutil.Deps{})
+
+	var prCmd *cobra.Command
+	for _, c := range cmds {
+		if c.Name() == "pr" {
+			prCmd = c
+		}
+	}
+	require.NotNil(t, prCmd, "github should expose a 'pr' command")
+
+	subNames := make(map[string]bool)
+	for _, sub := range prCmd.Commands() {
+		subNames[sub.Name()] = true
+	}
+	assert.True(t, subNames["create"], "expected 'create' subcommand under pr")
+}
+
+func TestBuildProviderCommands_NonForgeKindHasNoPRCommand(t *testing.T) {
+	cmds := BuildProviderCommands("jira", cmdutil.Deps{})
+	for _, c := range cmds {
+		assert.NotEqual(t, "pr", c.Name(), "non-forge kind must not expose a 'pr' command")
+	}
 }
 
 func TestBuildProviderCommands_IssuesHasListSubcommand(t *testing.T) {

--- a/cmd/cmdprovider/provider_test.go
+++ b/cmd/cmdprovider/provider_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -14,6 +16,8 @@ import (
 	"github.com/gethuman-sh/human/cmd/cmdutil"
 	"github.com/gethuman-sh/human/errors"
 	"github.com/gethuman-sh/human/internal/forge"
+	"github.com/gethuman-sh/human/internal/github"
+	"github.com/gethuman-sh/human/internal/gitrepo"
 	"github.com/gethuman-sh/human/internal/tracker"
 )
 
@@ -841,6 +845,44 @@ func TestBuildProviderCommands_NonForgeKindHasNoPRCommand(t *testing.T) {
 	for _, c := range cmds {
 		assert.NotEqual(t, "pr", c.Name(), "non-forge kind must not expose a 'pr' command")
 	}
+}
+
+func TestPRCreate_DefaultsRepoFromOrigin(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/gethuman-sh/human/pulls", r.URL.Path)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"number":9,"title":"Fix","html_url":"https://github.com/gethuman-sh/human/pull/9"}`))
+	}))
+	defer srv.Close()
+
+	prev := gitrepo.OriginURL
+	gitrepo.OriginURL = func(_ context.Context, _ string) (string, error) {
+		return "https://github.com/gethuman-sh/human.git", nil
+	}
+	defer func() { gitrepo.OriginURL = prev }()
+
+	deps := cmdutil.Deps{
+		LoadInstances: func(_ string) ([]tracker.Instance, error) {
+			return []tracker.Instance{{
+				Name: "gh", Kind: "github", URL: srv.URL, Provider: github.New(srv.URL, "t"),
+			}}, nil
+		},
+		InstanceFromFlags: func(_ *cobra.Command) *tracker.Instance { return nil },
+		AuditLogPath:      func() string { return "" },
+	}
+
+	root := &cobra.Command{Use: "human"}
+	for _, c := range BuildProviderCommands("github", deps) {
+		root.AddCommand(c)
+	}
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	// --repo omitted on purpose: it must be filled from the git origin remote.
+	root.SetArgs([]string{"pr", "create", "--head", "fix-login", "--title", "Fix"})
+
+	require.NoError(t, root.Execute())
+	assert.Contains(t, out.String(), "https://github.com/gethuman-sh/human/pull/9")
 }
 
 func TestBuildProviderCommands_IssuesHasListSubcommand(t *testing.T) {

--- a/cmd/cmdprovider/provider_test.go
+++ b/cmd/cmdprovider/provider_test.go
@@ -197,6 +197,26 @@ func TestRunGetIssue_EmptyFields(t *testing.T) {
 	assert.Contains(t, out, "| Assignee | None |")
 	assert.Contains(t, out, "| Reporter | None |")
 	assert.NotContains(t, out, "## Description")
+	// No parent row when the issue is not a subtask.
+	assert.NotContains(t, out, "| Parent")
+}
+
+func TestRunGetIssue_WithParent(t *testing.T) {
+	p := &mockProvider{
+		getIssueFn: func(_ context.Context, _ string) (*tracker.Issue, error) {
+			return &tracker.Issue{
+				Key:       "KAN-50",
+				Title:     "Child task",
+				Status:    "To Do",
+				ParentKey: "KAN-1",
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	err := RunGetIssue(context.Background(), p, &buf, "KAN-50")
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "| Parent   | KAN-1 |")
 }
 
 func TestRunGetIssue_Error(t *testing.T) {

--- a/cmd/cmdtui/tui.go
+++ b/cmd/cmdtui/tui.go
@@ -41,6 +41,7 @@ type trackerIssues struct {
 	Project        string
 	Issues         []tracker.Issue
 	ReadyForReview map[string]bool // issue keys currently flagged ready for review (see CLAUDE.md Review handoff)
+	ReadyForReviewPRs map[string]string // issue key -> pull-request URL from the handoff's pr: line, when present
 	Err            error
 }
 
@@ -1913,6 +1914,9 @@ func fromDaemonResults(results []daemon.TrackerIssuesResult) []trackerIssues {
 			}
 			out[i].ReadyForReview = set
 		}
+		if len(r.ReadyForReviewPRs) > 0 {
+			out[i].ReadyForReviewPRs = r.ReadyForReviewPRs
+		}
 		if r.Err != "" {
 			out[i].Err = fmt.Errorf("%s", r.Err)
 		}
@@ -2066,15 +2070,11 @@ func renderIssuesPanel(groups []trackerIssues, fetchedAt time.Time, w, cursor in
 			if issue.IsBug() {
 				bugMarker = errorStyle.Render("(B)")
 			}
-			reviewMarker := "   "
-			if g.ReadyForReview[issue.Key] {
-				reviewMarker = specialStyle.Render("(R)")
-			}
 			_, _ = fmt.Fprintf(&b, "%s%-12s %s %s %-14s %s\n",
 				prefix,
 				keyStyle.Render(issue.Key),
 				bugMarker,
-				reviewMarker,
+				reviewMarker(g.ReadyForReview[issue.Key], g.ReadyForReviewPRs[issue.Key]),
 				stageStyled,
 				title)
 			flatIdx++
@@ -2089,6 +2089,22 @@ func renderIssuesPanel(groups []trackerIssues, fetchedAt time.Time, w, cursor in
 // with consecutive-host dedup counts and a small source tag.
 //
 // available is the vertical budget in rows. When available <= 1 the
+// reviewMarker renders the (R) ready-for-review annotation. When a pull-request
+// URL is known (from the handoff's pr: line), the marker is wrapped in an OSC 8
+// hyperlink so it opens the PR in terminals that support clickable links;
+// terminals that don't simply show "(R)". Returns blank spacing when the issue
+// is not flagged for review.
+func reviewMarker(ready bool, prURL string) string {
+	if !ready {
+		return "   "
+	}
+	marker := specialStyle.Render("(R)")
+	if prURL == "" {
+		return marker
+	}
+	return "\x1b]8;;" + prURL + "\x1b\\" + marker + "\x1b]8;;\x1b\\"
+}
+
 // panel renders nothing so the footer cannot be clipped on very short
 // terminals. Zero events also collapses to nothing rather than leaving
 // a visible empty frame.

--- a/cmd/cmdtui/tui_test.go
+++ b/cmd/cmdtui/tui_test.go
@@ -1471,3 +1471,18 @@ func TestRenderToolStatsPanel_singleTool(t *testing.T) {
 	assert.Contains(t, out, "(100%)")
 	assert.Contains(t, out, "0.0% error rate")
 }
+
+func TestReviewMarker(t *testing.T) {
+	// Not flagged: blank spacing, no (R).
+	assert.NotContains(t, reviewMarker(false, ""), "(R)")
+
+	// Ready, no PR: shows (R), no hyperlink escape.
+	plain := reviewMarker(true, "")
+	assert.Contains(t, plain, "(R)")
+	assert.NotContains(t, plain, "\x1b]8;;")
+
+	// Ready with PR: (R) wrapped in an OSC 8 hyperlink to the PR.
+	linked := reviewMarker(true, "https://github.com/o/r/pull/7")
+	assert.Contains(t, linked, "(R)")
+	assert.Contains(t, linked, "\x1b]8;;https://github.com/o/r/pull/7\x1b\\")
+}

--- a/cmd/cmdutil/origin_test.go
+++ b/cmd/cmdutil/origin_test.go
@@ -1,0 +1,76 @@
+package cmdutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/github"
+	"github.com/gethuman-sh/human/internal/gitrepo"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+func stubOrigin(t *testing.T, url string, err error) {
+	t.Helper()
+	prev := gitrepo.OriginURL
+	gitrepo.OriginURL = func(_ context.Context, _ string) (string, error) { return url, err }
+	t.Cleanup(func() { gitrepo.OriginURL = prev })
+}
+
+func githubDeps() Deps {
+	return Deps{
+		LoadInstances: func(_ string) ([]tracker.Instance, error) {
+			return []tracker.Instance{{
+				Name:     "gh",
+				Kind:     "github",
+				URL:      "https://api.github.com",
+				Provider: github.New("https://api.github.com", "t"),
+			}}, nil
+		},
+		InstanceFromFlags: func(_ *cobra.Command) *tracker.Instance { return nil },
+		AuditLogPath:      func() string { return "" },
+	}
+}
+
+func TestOriginForge_success(t *testing.T) {
+	stubOrigin(t, "git@github.com:gethuman-sh/human.git", nil)
+
+	f, repo, err := OriginForge(&cobra.Command{}, githubDeps())
+	require.NoError(t, err)
+	assert.Equal(t, "gethuman-sh/human", repo)
+	assert.NotNil(t, f)
+}
+
+func TestOriginForge_unsupportedHost(t *testing.T) {
+	stubOrigin(t, "git@bitbucket.org:foo/bar.git", nil)
+
+	_, _, err := OriginForge(&cobra.Command{}, githubDeps())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forge")
+}
+
+func TestOriginForge_gitError(t *testing.T) {
+	stubOrigin(t, "", errors.New("no origin"))
+
+	_, _, err := OriginForge(&cobra.Command{}, githubDeps())
+	require.Error(t, err)
+}
+
+func TestOriginRepo_success(t *testing.T) {
+	stubOrigin(t, "https://github.com/gethuman-sh/human.git", nil)
+
+	repo, err := OriginRepo(&cobra.Command{})
+	require.NoError(t, err)
+	assert.Equal(t, "gethuman-sh/human", repo)
+}
+
+func TestOriginRepo_gitError(t *testing.T) {
+	stubOrigin(t, "", errors.New("no origin"))
+
+	_, err := OriginRepo(&cobra.Command{})
+	require.Error(t, err)
+}

--- a/cmd/cmdutil/resolve.go
+++ b/cmd/cmdutil/resolve.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gethuman-sh/human/internal/config"
 	"github.com/gethuman-sh/human/internal/dispatch"
 	"github.com/gethuman-sh/human/internal/env"
+	"github.com/gethuman-sh/human/internal/forge"
 	"github.com/gethuman-sh/human/internal/slack"
 	"github.com/gethuman-sh/human/internal/telegram"
 	"github.com/gethuman-sh/human/internal/tracker"
@@ -99,6 +100,36 @@ func ResolveProvider(cmd *cobra.Command, kind string, deps Deps) (tracker.Provid
 
 	p, dpCleanup := applyDestructiveWrapper(ctx, p, instance.Name, instance.Kind, deps, os.Stderr)
 	return p, func() { dpCleanup(); auditCleanup() }, nil
+}
+
+// ResolveForge resolves the configured instance for the given kind and returns
+// it as a forge.Forge (code-host) capability. Forge operations (opening a PR)
+// are intentionally not wrapped by the tracker decorator chain: they do not
+// mutate tracker data and have no audit/policy semantics. A clear error is
+// returned when the resolved backend is not a forge (e.g. a pure issue tracker).
+func ResolveForge(cmd *cobra.Command, kind string, deps Deps) (forge.Forge, error) {
+	ctx := cmdContext(cmd)
+	instances, err := loadInstancesCtx(ctx, deps)
+	if err != nil {
+		return nil, err
+	}
+
+	if inst := deps.InstanceFromFlags(cmd); inst != nil {
+		instances = append(instances, *inst)
+	}
+
+	trackerName, _ := cmd.Root().PersistentFlags().GetString("tracker")
+
+	instance, err := tracker.ResolveByKind(kind, instances, trackerName)
+	if err != nil {
+		return nil, err
+	}
+
+	f, ok := instance.Provider.(forge.Forge)
+	if !ok {
+		return nil, errors.WithDetails("pull requests not supported by this tracker", "kind", kind)
+	}
+	return f, nil
 }
 
 // ResolveAutoProvider loads all instances, applies flag overrides, and resolves

--- a/cmd/cmdutil/resolve.go
+++ b/cmd/cmdutil/resolve.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gethuman-sh/human/internal/dispatch"
 	"github.com/gethuman-sh/human/internal/env"
 	"github.com/gethuman-sh/human/internal/forge"
+	"github.com/gethuman-sh/human/internal/gitrepo"
 	"github.com/gethuman-sh/human/internal/slack"
 	"github.com/gethuman-sh/human/internal/telegram"
 	"github.com/gethuman-sh/human/internal/tracker"
@@ -130,6 +131,49 @@ func ResolveForge(cmd *cobra.Command, kind string, deps Deps) (forge.Forge, erro
 		return nil, errors.WithDetails("pull requests not supported by this tracker", "kind", kind)
 	}
 	return f, nil
+}
+
+// OriginForge derives the code forge from the local git "origin" remote and
+// returns it together with the "owner/repo" parsed from that remote. The forge
+// kind comes from the remote host (e.g. github.com → github); the configured
+// instance is then resolved by kind via ResolveForge. Use it for commands that
+// should default to "the repository I'm standing in".
+func OriginForge(cmd *cobra.Command, deps Deps) (forge.Forge, string, error) {
+	ctx := cmdContext(cmd)
+	dir := config.ResolveDirCtx(ctx, config.DirProject)
+	raw, err := gitrepo.OriginURL(ctx, dir)
+	if err != nil {
+		return nil, "", err
+	}
+	host, repo, ok := forge.ParseRemoteURL(raw)
+	if !ok {
+		return nil, "", errors.WithDetails("could not parse git origin remote", "remote", raw)
+	}
+	kind := forge.KindForHost(host)
+	if kind == "" {
+		return nil, "", errors.WithDetails("git origin host is not a supported forge", "host", host)
+	}
+	f, err := ResolveForge(cmd, kind, deps)
+	if err != nil {
+		return nil, "", err
+	}
+	return f, repo, nil
+}
+
+// OriginRepo returns the "owner/repo" parsed from the local git "origin"
+// remote. Used by the per-kind `pr create` command to default --repo.
+func OriginRepo(cmd *cobra.Command) (string, error) {
+	ctx := cmdContext(cmd)
+	dir := config.ResolveDirCtx(ctx, config.DirProject)
+	raw, err := gitrepo.OriginURL(ctx, dir)
+	if err != nil {
+		return "", err
+	}
+	_, repo, ok := forge.ParseRemoteURL(raw)
+	if !ok {
+		return "", errors.WithDetails("could not parse git origin remote", "remote", raw)
+	}
+	return repo, nil
 }
 
 // ResolveAutoProvider loads all instances, applies flag overrides, and resolves

--- a/internal/azuredevops/client.go
+++ b/internal/azuredevops/client.go
@@ -21,8 +21,9 @@ var _ tracker.Provider = (*Client)(nil)
 
 // Client is an Azure DevOps REST API client that implements tracker.Provider.
 type Client struct {
-	api *apiclient.Client
-	org string
+	api     *apiclient.Client
+	org     string
+	baseURL string
 }
 
 // New creates an Azure DevOps client with the given base URL, organization, and PAT.
@@ -33,7 +34,8 @@ func New(baseURL, org, token string) *Client {
 			apiclient.WithHeader("Accept", "application/json"),
 			apiclient.WithProviderName("azuredevops"),
 		),
-		org: org,
+		org:     org,
+		baseURL: baseURL,
 	}
 }
 
@@ -119,7 +121,10 @@ func (c *Client) GetIssue(ctx context.Context, key string) (*tracker.Issue, erro
 	}
 
 	path := fmt.Sprintf("/%s/%s/_apis/wit/workitems/%d", url.PathEscape(c.org), url.PathEscape(project), id)
-	resp, err := c.doRequest(ctx, http.MethodGet, path, "api-version=7.1", nil, "")
+	// $expand=relations surfaces the parent hierarchy link so subtasks can
+	// report their parent. The batch list endpoint omits relations, so this
+	// only applies to single-issue reads.
+	resp, err := c.doRequest(ctx, http.MethodGet, path, "$expand=relations&api-version=7.1", nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -145,6 +150,22 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 	if issue.Description != "" {
 		ops = append(ops, patchOp{Op: "add", Path: "/fields/System.Description", Value: issue.Description})
 	}
+	// Azure models a subtask as a hierarchy link to the parent work item
+	// (Hierarchy-Reverse points from child to parent), added at create time.
+	if issue.ParentKey != "" {
+		_, parentID, err := parseIssueKey(issue.ParentKey)
+		if err != nil {
+			return nil, errors.WrapWithDetails(err, "invalid parent key", "parentKey", issue.ParentKey)
+		}
+		ops = append(ops, patchOp{
+			Op:   "add",
+			Path: "/relations/-",
+			Value: adoRelation{
+				Rel: hierarchyReverseRel,
+				URL: c.workItemURL(parentID),
+			},
+		})
+	}
 
 	body, err := json.Marshal(ops)
 	if err != nil {
@@ -167,6 +188,7 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 		Title:       wi.Fields.Title,
 		Description: wi.Fields.Description,
 		URL:         fmt.Sprintf("https://dev.azure.com/%s/%s/_workitems/edit/%d", c.org, project, wi.ID),
+		ParentKey:   issue.ParentKey,
 	}, nil
 }
 
@@ -481,8 +503,36 @@ func (c *Client) toTrackerIssue(wi adoWorkItem, project string) tracker.Issue {
 	if wi.Fields.CreatedBy != nil {
 		issue.Reporter = wi.Fields.CreatedBy.DisplayName
 	}
+	// Work item URLs are org-scoped (no project segment), so the parent is
+	// assumed to live in the same project as the child for key reconstruction.
+	if parentID := parentIDFromRelations(wi.Relations); parentID != "" {
+		issue.ParentKey = project + "/" + parentID
+	}
 
 	return issue
+}
+
+// hierarchyReverseRel is the Azure DevOps link type pointing from a child work
+// item to its parent.
+const hierarchyReverseRel = "System.LinkTypes.Hierarchy-Reverse"
+
+// workItemURL builds the org-scoped REST URL Azure expects when linking to a
+// work item by ID.
+func (c *Client) workItemURL(id int) string {
+	return fmt.Sprintf("%s/%s/_apis/wit/workItems/%d", strings.TrimRight(c.baseURL, "/"), url.PathEscape(c.org), id)
+}
+
+// parentIDFromRelations returns the numeric ID of the parent work item from a
+// hierarchy-reverse relation, or "" when the item has no parent.
+func parentIDFromRelations(relations []adoRelation) string {
+	for _, rel := range relations {
+		if rel.Rel == hierarchyReverseRel {
+			if idx := strings.LastIndex(rel.URL, "/"); idx >= 0 && idx < len(rel.URL)-1 {
+				return rel.URL[idx+1:]
+			}
+		}
+	}
+	return ""
 }
 
 // apisPath builds an Azure DevOps API path, scoped to a project when provided

--- a/internal/azuredevops/client_test.go
+++ b/internal/azuredevops/client_test.go
@@ -796,3 +796,59 @@ func TestAdoCategoryToType(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateIssue_withParent(t *testing.T) {
+	var gotOps []patchOp
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotOps))
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"id":99,"fields":{"System.Title":"Child","System.State":"New","System.WorkItemType":"Task","System.TeamProject":"Human"}}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "myorg", "pat-test")
+	issue, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Project:   "Human",
+		Title:     "Child",
+		ParentKey: "Human/42",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Human/99", issue.Key)
+	assert.Equal(t, "Human/42", issue.ParentKey)
+
+	require.Len(t, gotOps, 2)
+	relOp := gotOps[1]
+	assert.Equal(t, "/relations/-", relOp.Path)
+	val, ok := relOp.Value.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "System.LinkTypes.Hierarchy-Reverse", val["rel"])
+	assert.Contains(t, val["url"].(string), "/42")
+}
+
+func TestCreateIssue_invalidParent(t *testing.T) {
+	client := New("http://localhost", "myorg", "pat-test")
+	_, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Project:   "Human",
+		Title:     "Child",
+		ParentKey: "noslash",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid parent key")
+}
+
+func TestGetIssue_withParent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "relations", r.URL.Query().Get("$expand"))
+		_, _ = fmt.Fprint(w, `{"id":99,"fields":{"System.Title":"Child","System.State":"Active","System.WorkItemType":"Task","System.TeamProject":"Human"},"relations":[
+			{"rel":"System.LinkTypes.Hierarchy-Reverse","url":"https://dev.azure.com/myorg/_apis/wit/workItems/42"}
+		]}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "myorg", "pat-test")
+	issue, err := client.GetIssue(context.Background(), "Human/99")
+	require.NoError(t, err)
+	assert.Equal(t, "Human/42", issue.ParentKey)
+}

--- a/internal/azuredevops/types.go
+++ b/internal/azuredevops/types.go
@@ -2,10 +2,17 @@ package azuredevops
 
 // adoWorkItem is the Azure DevOps API representation of a work item.
 type adoWorkItem struct {
-	ID     int       `json:"id"`
-	Rev    int       `json:"rev"`
-	Fields adoFields `json:"fields"`
-	URL    string    `json:"url"`
+	ID        int           `json:"id"`
+	Rev       int           `json:"rev"`
+	Fields    adoFields     `json:"fields"`
+	URL       string        `json:"url"`
+	Relations []adoRelation `json:"relations"` // present only with $expand=relations
+}
+
+// adoRelation is a link between work items (e.g. parent/child hierarchy).
+type adoRelation struct {
+	Rel string `json:"rel"`
+	URL string `json:"url"`
 }
 
 // adoFields contains the System.* and Microsoft.* fields of a work item.

--- a/internal/claude/embed/human-autofix-skill.md
+++ b/internal/claude/embed/human-autofix-skill.md
@@ -1,0 +1,131 @@
+---
+name: human-autofix
+description: Autonomously verify, reproduce, fix, and open a PR for a reported bug end to end
+argument-hint: <bug-ticket-key>
+---
+
+# Overview
+
+Point this skill at a bug ticket and it runs the full bug-fix pipeline autonomously: **triage & reproduce → verdict → (if a real bug) plan → test-first fix on a branch → verify → open a pull request and hand off for review**. The whole trail is recorded on the tracker (comments + the engineering ticket + the PR); **no `.human/` working files** are produced.
+
+This skill runs **without user interaction**. Do NOT use `AskUserQuestion` at any step — reach a verdict and act on it (SC-86: "no further input"). Every run ends in exactly one verdict: **confirmed**, **not-a-bug**, or **undetermined**.
+
+Follow these steps in order.
+
+## Step 1 — Parse argument
+
+`$ARGUMENTS` is the bug ticket key — the PM ticket. Call it `<BUG_KEY>`. Resolve its tracker with `human tracker list` (or just use `human get <BUG_KEY>` when only one tracker type is configured). Call the tracker `<tracker>`.
+
+## Step 2 — Phase 1: Triage & reproduce (verdict)
+
+Delegate to the **human-bug-triage** agent:
+
+```
+Task(subagent_type="human-bug-triage", prompt="Triage bug ticket <BUG_KEY>: reproduce it, find the root cause, and reach a verdict.")
+```
+
+It posts a `[human:bug-verdict] <verdict>` comment on the bug ticket and returns the verdict (`confirmed` | `not-a-bug` | `undetermined`) plus, for a confirmed bug, the root cause and a fix outline.
+
+## Step 3 — Verdict gate
+
+- **not-a-bug** — the agent has already posted its reasoning. Reclassify or close the ticket: discover statuses with `human <tracker> issue statuses <BUG_KEY>`, then move it with `human <tracker> issue status <BUG_KEY> "<closed-or-wontdo-status>"`. Make **no code changes**. Report and STOP.
+- **undetermined** — the agent has posted an honest status (e.g. could not reproduce). Make **no code changes**. Leave the ticket open for a human. Report and STOP.
+- **confirmed** — continue.
+
+## Step 4 — Phase 2: Plan + engineering ticket
+
+1. Pick the engineering tracker: from `human tracker list`, choose the tracker whose role is `engineering` and note its first project (e.g. Linear project `HUM`). Call them `<ENG_TRACKER>` and `<ENG_PROJECT>`.
+2. Delegate to the **human-planner** agent, seeding it with the triage root cause:
+
+```
+Task(subagent_type="human-planner", prompt="Create an implementation plan to fix bug <BUG_KEY>. The root-cause analysis from triage:\n<paste the triage root cause + fix outline>\nThe plan's Changes section MUST begin with adding a regression test that fails because of the bug, then fixing the root cause. Return the plan as output; do not write files or create tickets.")
+```
+
+Capture the output as `<PLAN_CONTENT>`. Ensure its header has a `**PM ticket**: <BUG_KEY>` line and an `**Engineering ticket**: TBD` line.
+
+3. Create the engineering ticket:
+
+```bash
+human <ENG_TRACKER> issue create --project=<ENG_PROJECT> "Fix: <short bug summary>" --description "$(cat <<'PLAN_EOF'
+<PLAN_CONTENT>
+PLAN_EOF
+)"
+```
+
+Capture `<ENG_KEY>`, then update its description so the `**Engineering ticket**:` line reads `<ENG_KEY>` (replacing `TBD`). The fixer and verify agents read the plan from this ticket.
+
+## Step 5 — Phase 3: Test-first fix
+
+Delegate to the **human-bug-fixer** agent:
+
+```
+Task(subagent_type="human-bug-fixer", prompt="Fix engineering ticket <ENG_KEY> (PM bug <BUG_KEY>) test-first on a feature branch and push it.")
+```
+
+It creates branch `autofix/<eng-key>`, writes a regression test that **fails** because of the bug, implements the root-cause fix, confirms the suite is green, commits referencing **both** keys, pushes the branch, and returns the branch name. If it reports it could not reach a green build/test, STOP and report — do not open a PR.
+
+## Step 6 — Phase 4: Verify (done gate)
+
+Delegate to the **human-bug-verify** agent:
+
+```
+Task(subagent_type="human-bug-verify", prompt="Verify engineering ticket <ENG_KEY> (PM bug <BUG_KEY>): confirm the regression test fails before / passes after the fix, the full suite is green, and the fix addresses the root cause. Post the verdict as a comment on <BUG_KEY>.")
+```
+
+If the verdict is NOT DONE, re-run Step 5 once to address the gaps; if it still fails, STOP and report honestly without opening a PR.
+
+## Step 7 — Phase 5: Open PR + hand off
+
+Only after a DONE verdict:
+
+1. Open the pull request (forge + repo are derived from the git origin remote, so no `--repo` is needed):
+
+```bash
+human pr create --head autofix/<eng-key> --base main --title "[<BUG_KEY>] [<ENG_KEY>] <short summary>" --body "$(cat <<'PR_EOF'
+## Summary
+Fixes <BUG_KEY>. <one-line root cause>.
+
+## Verdict
+Confirmed bug, reproduced.
+
+## Tests
+Regression test added — fails before the fix, passes after. Full suite green.
+
+Engineering ticket: <ENG_KEY>
+PR_EOF
+)"
+```
+
+Capture the printed PR URL as `<PR_URL>`. If the bug ticket is itself a GitHub issue, add a `Closes <owner/repo>#<n>` line to the body so the merge auto-closes it.
+
+2. Post the review handoff comment on the bug (PM) ticket. The format is fixed so it can be parsed across trackers; `<short-shas>` come from `git log --grep=<ENG_KEY> --format='%h' HEAD` (comma-separated):
+
+```bash
+human <tracker> issue comment add <BUG_KEY> "$(cat <<'HANDOFF_EOF'
+[human:ready-for-review]
+engineering: <ENG_KEY>
+branch: autofix/<eng-key>
+commits: <short-shas>
+pr: <PR_URL>
+HANDOFF_EOF
+)"
+```
+
+3. Move the bug ticket to a review status if one exists (`human <tracker> issue statuses <BUG_KEY>`, then `human <tracker> issue status <BUG_KEY> "<status>"`).
+
+If `human pr create` fails (no recognised git origin, or no forge token configured), STOP with an honest status comment on the bug ticket and skip the handoff — **do not report success**.
+
+## Step 8 — Summary
+
+Report the verdict. For a confirmed fix, present the traceability chain:
+
+```
+Autofix complete for <BUG_KEY>
+
+Verdict: confirmed
+- PM bug:     <tracker> <BUG_KEY>
+- Eng ticket: <ENG_TRACKER> <ENG_KEY>
+- Branch:     autofix/<eng-key>
+- PR:         <PR_URL>
+- Handoff:    [human:ready-for-review] comment posted on <BUG_KEY>
+```

--- a/internal/claude/embed/human-bug-fixer-agent.md
+++ b/internal/claude/embed/human-bug-fixer-agent.md
@@ -1,0 +1,44 @@
+---
+name: human-bug-fixer
+description: Fixes a confirmed bug test-first on a feature branch — failing regression test, root-cause fix, green suite, commit referencing both keys, push
+tools: Bash, Read, Grep, Glob, Write, Edit
+model: inherit
+---
+
+# Human Bug Fixer Agent
+
+You implement the fix for a confirmed bug from the plan in its engineering ticket. You work **test-first on a feature branch**, fix the root cause, keep the suite green, commit referencing both ticket keys, and push the branch. You write no `.human/` files.
+
+## Available commands
+
+```bash
+# Fetch the engineering ticket whose description holds the fix plan
+human get <ENG_KEY>
+human <TRACKER> issue get <ENG_KEY>
+```
+
+Use `human tracker list` first when multiple trackers are configured.
+
+## Fix process
+
+1. **Read the plan** — fetch the engineering ticket (`human get <ENG_KEY>`). Its description is the implementation plan. Parse the header for `**PM ticket**: <BUG_KEY>` and `**Engineering ticket**: <ENG_KEY>` — every commit must reference **both**.
+2. **Create the feature branch** off the current default branch:
+   ```bash
+   git switch -c autofix/<eng-key>   # <eng-key> lowercased, e.g. autofix/hum-105
+   ```
+3. **Write the regression test first** — add a test that captures the bug. Run it and **confirm it FAILS** for the documented reason (capture the red output). If it passes, your test does not reproduce the bug — fix the test before touching product code.
+4. **Fix the root cause** — implement the change from the plan. Do not paper over the symptom. Read each file before editing it.
+5. **Go green** — the new test now passes; run the full suite (e.g. `make check`, `make test`, `go test ./...`, `npm test`) and confirm no regressions. If you cannot reach green, stop and report what failed — do not push a broken branch.
+6. **Commit** — one or more commits, each referencing **both** keys, e.g. `[<BUG_KEY>] [<ENG_KEY>] Fix <summary>`.
+7. **Push** the branch: `git push -u origin autofix/<eng-key>`.
+8. **Report** the branch name, the commit SHAs, and a short red→green summary (the failing-then-passing test output).
+
+## Principles
+
+- Test-first is mandatory: a fix without a test that fails before and passes after is not done.
+- Read before you edit. Follow the plan's order.
+- **Boil the Lake**: handle the edge cases and related tests the fix genuinely needs; don't leave known gaps.
+- Keep the change scoped to the bug — no unrelated refactors.
+- Never push a branch whose suite is not green.
+
+Do NOT use `AskUserQuestion` — you cannot interact with the user. Implement autonomously and report the results.

--- a/internal/claude/embed/human-bug-triage-agent.md
+++ b/internal/claude/embed/human-bug-triage-agent.md
@@ -1,0 +1,71 @@
+---
+name: human-bug-triage
+description: Reproduces a reported bug, finds the root cause, and reaches a confirmed / not-a-bug / undetermined verdict, recording everything on the tracker
+tools: Bash, Read, Grep, Glob
+model: inherit
+---
+
+# Human Bug Triage Agent
+
+You are a QA + root-cause triage agent. You use the `human` CLI to fetch a bug ticket, try to reproduce the bug, investigate the codebase for the root cause, and reach **one** explicit verdict. You record the analysis and verdict **on the tracker as a comment** — you do not write any local files.
+
+## Available commands
+
+```bash
+# List configured trackers (always start here when multiple trackers are configured)
+human tracker list
+
+# Quick command (auto-detect tracker — works when only one tracker type is configured)
+human get <TICKET_KEY>
+
+# Provider-specific commands (replace <TRACKER> with jira, github, gitlab, linear, azuredevops, or shortcut)
+human <TRACKER> issue get <TICKET_KEY>
+human <TRACKER> issue comment list <TICKET_KEY>
+human <TRACKER> issue comment add <TICKET_KEY> "comment body"
+```
+
+## Tracker resolution
+
+1. Run `human tracker list` to see all configured trackers.
+2. When only one tracker type is configured, quick commands work: `human get <KEY>`.
+3. When multiple tracker types are configured, use provider-specific commands: `human shortcut issue get <KEY>`.
+4. Use `--tracker=<name>` to select a specific named instance within the same tracker type.
+
+## Triage process
+
+1. **Understand the report** — fetch the ticket (`human <tracker> issue get <key>`) and its discussion (`human <tracker> issue comment list <key>`). Extract error messages, stack traces, failing inputs, and reproduction steps.
+2. **Reproduce** — try to make the bug happen: run the failing command, write or run a quick check, or exercise the affected code path. Note exactly what you ran and what happened.
+3. **Investigate** — use Grep/Glob/Read to trace the code flow to the actual root cause. Cite specific files and line numbers.
+4. **Reach a verdict** — exactly one of:
+   - **confirmed** — the bug is real and you reproduced it (or proved the defect from the code with strong evidence).
+   - **not-a-bug** — works as intended, user error, misconfiguration, an external dependency, or already fixed.
+   - **undetermined** — you could not reproduce it or cannot decide. Do not guess.
+5. **Record on the tracker** — post a single comment whose **first line** is the machine-readable verdict marker, followed by the evidence (see Output format). Post with `human <tracker> issue comment add <key> "<comment-body>"`.
+
+## Principles
+
+- No fix without root cause. **Iron Law**: never bless a fix path without first identifying the actual cause. A change that masks the symptom is not a fix.
+- Evidence-based: cite files and line numbers; quote what you ran to reproduce.
+- Be honest: if you cannot reproduce, say `undetermined` — never inflate it to `confirmed`.
+- For a confirmed bug, preserve traceability: the eventual commits will reference both the PM bug key and the engineering ticket key.
+
+## Output format
+
+Post this comment on the ticket (and return the same content to the caller):
+
+```markdown
+[human:bug-verdict] <confirmed|not-a-bug|undetermined>
+
+## Reproduction
+<exactly what you ran and what happened — or why it could not be reproduced>
+
+## Root Cause
+<for confirmed: why the bug occurs, with file:line references. For not-a-bug: why it is not a defect. For undetermined: what is still unknown.>
+
+## Fix Outline
+<for confirmed only: the ordered approach to fix the root cause, plus the regression test that should fail before the fix>
+```
+
+Return to the caller: the verdict word, and (for confirmed) the Root Cause + Fix Outline so the planner can build on it.
+
+Do NOT use `AskUserQuestion` — you cannot interact with the user. Reach a verdict autonomously.

--- a/internal/claude/embed/human-bug-verify-agent.md
+++ b/internal/claude/embed/human-bug-verify-agent.md
@@ -1,0 +1,64 @@
+---
+name: human-bug-verify
+description: Verifies a bug fix — regression test fails-before/passes-after, full suite green, root cause addressed — and records the verdict on the tracker
+tools: Bash, Read, Grep, Glob
+model: inherit
+---
+
+# Human Bug Verify Agent
+
+You are the done gate for an autonomous bug fix. You confirm the fix is complete and shippable and record a DONE / NOT DONE verdict **as a comment on the bug ticket** — you write no local files.
+
+## Available commands
+
+```bash
+human get <ENG_KEY>
+human <TRACKER> issue get <ENG_KEY>
+human <TRACKER> issue comment add <BUG_KEY> "comment body"
+```
+
+Use `human tracker list` first when multiple trackers are configured.
+
+## Verify process
+
+1. **Read the plan** — fetch the engineering ticket (`human get <ENG_KEY>`) for the intended fix and its test plan.
+2. **Confirm the regression test** — locate the test added for this bug. Verify it genuinely covers the bug: it must **fail without the fix and pass with it**. Prove the "fails before" direction (e.g. temporarily revert the fix hunk, or `git stash` the product change, run the test, see it fail, then restore) rather than assuming it.
+3. **Run the full suite** — `make check` (or the project's `make test` / `go test ./...` / `npm test`). It must be green. If tests fail, the fix is NOT DONE.
+4. **Check the root cause** — confirm the change addresses the documented cause, not just the symptom, and is scoped to the bug (no unrelated changes).
+5. **Record the verdict** — post a comment on the **bug ticket** (`<BUG_KEY>`) in the format below and return the verdict word to the caller.
+
+## Definition of Done
+
+- [ ] A regression test exists that fails before the fix and passes after it
+- [ ] Full test suite passes
+- [ ] The fix addresses the root cause, not the symptom
+- [ ] No unrelated changes (scope check)
+- [ ] Commits reference **both** the PM bug key and the engineering ticket key
+
+## Principles
+
+- Evidence-based verdicts only. Every PASS cites code or test output; every FAIL cites what is missing.
+- Do not hedge — state DONE or NOT DONE.
+- If tests fail, it is NOT DONE. No exceptions.
+
+## Output format
+
+Post this comment on the bug ticket (and return the verdict word):
+
+```markdown
+[human:bug-verify] <DONE|NOT DONE>
+
+## Regression test
+<test name + evidence it fails before / passes after>
+
+## Suite
+<result of the full test run>
+
+## Root cause addressed
+<PASS/FAIL with file:line evidence>
+
+## Remaining work
+<for NOT DONE: the specific gaps>
+```
+
+Do NOT use `AskUserQuestion` — you cannot interact with the user. Return the structured verdict so the calling skill can act on it.

--- a/internal/claude/install.go
+++ b/internal/claude/install.go
@@ -145,6 +145,18 @@ var gardeningHygieneAgentContent []byte
 //go:embed embed/gardening-triage-agent.md
 var gardeningTriageAgentContent []byte
 
+//go:embed embed/human-autofix-skill.md
+var autofixSkillContent []byte
+
+//go:embed embed/human-bug-triage-agent.md
+var bugTriageAgentContent []byte
+
+//go:embed embed/human-bug-fixer-agent.md
+var bugFixerAgentContent []byte
+
+//go:embed embed/human-bug-verify-agent.md
+var bugVerifyAgentContent []byte
+
 var userHomeDir = os.UserHomeDir
 
 // FileWriter abstracts filesystem operations for testability.
@@ -232,6 +244,10 @@ func Install(w io.Writer, fw FileWriter, personal bool) error {
 		{content: gardeningComplexityAgentContent, relPath: filepath.Join("agents", "gardening-complexity.md")},
 		{content: gardeningHygieneAgentContent, relPath: filepath.Join("agents", "gardening-hygiene.md")},
 		{content: gardeningTriageAgentContent, relPath: filepath.Join("agents", "gardening-triage.md")},
+		{content: autofixSkillContent, relPath: filepath.Join("skills", "human-autofix", "SKILL.md")},
+		{content: bugTriageAgentContent, relPath: filepath.Join("agents", "human-bug-triage.md")},
+		{content: bugFixerAgentContent, relPath: filepath.Join("agents", "human-bug-fixer.md")},
+		{content: bugVerifyAgentContent, relPath: filepath.Join("agents", "human-bug-verify.md")},
 	}
 
 	for _, f := range files {

--- a/internal/claude/install_test.go
+++ b/internal/claude/install_test.go
@@ -113,6 +113,10 @@ func TestInstall_CreatesNewFiles(t *testing.T) {
 	gardeningComplexityAgentPath := filepath.Join(".claude", "agents", "gardening-complexity.md")
 	gardeningHygieneAgentPath := filepath.Join(".claude", "agents", "gardening-hygiene.md")
 	gardeningTriageAgentPath := filepath.Join(".claude", "agents", "gardening-triage.md")
+	autofixSkillPath := filepath.Join(".claude", "skills", "human-autofix", "SKILL.md")
+	bugTriageAgentPath := filepath.Join(".claude", "agents", "human-bug-triage.md")
+	bugFixerAgentPath := filepath.Join(".claude", "agents", "human-bug-fixer.md")
+	bugVerifyAgentPath := filepath.Join(".claude", "agents", "human-bug-verify.md")
 
 	assert.Equal(t, string(skillContent), string(fw.files[skillPath]))
 	assert.Equal(t, string(agentContent), string(fw.files[agentPath]))
@@ -159,6 +163,10 @@ func TestInstall_CreatesNewFiles(t *testing.T) {
 	assert.Equal(t, string(gardeningComplexityAgentContent), string(fw.files[gardeningComplexityAgentPath]))
 	assert.Equal(t, string(gardeningHygieneAgentContent), string(fw.files[gardeningHygieneAgentPath]))
 	assert.Equal(t, string(gardeningTriageAgentContent), string(fw.files[gardeningTriageAgentPath]))
+	assert.Equal(t, string(autofixSkillContent), string(fw.files[autofixSkillPath]))
+	assert.Equal(t, string(bugTriageAgentContent), string(fw.files[bugTriageAgentPath]))
+	assert.Equal(t, string(bugFixerAgentContent), string(fw.files[bugFixerAgentPath]))
+	assert.Equal(t, string(bugVerifyAgentContent), string(fw.files[bugVerifyAgentPath]))
 }
 
 func TestInstall_OverwritesIdenticalFiles(t *testing.T) {
@@ -209,6 +217,7 @@ func TestInstall_CreatesParentDirectories(t *testing.T) {
 	ideateSkillDir := filepath.Join(".claude", "skills", "human-ideate")
 	sprintSkillDir := filepath.Join(".claude", "skills", "human-sprint")
 	gardeningSkillDir := filepath.Join(".claude", "skills", "human-gardening")
+	autofixSkillDir := filepath.Join(".claude", "skills", "human-autofix")
 	agentDir := filepath.Join(".claude", "agents")
 	assert.True(t, fw.dirs[skillDir], "expected plan skill parent directory to be created")
 	assert.True(t, fw.dirs[readySkillDir], "expected ready skill parent directory to be created")
@@ -221,6 +230,7 @@ func TestInstall_CreatesParentDirectories(t *testing.T) {
 	assert.True(t, fw.dirs[ideateSkillDir], "expected ideate skill parent directory to be created")
 	assert.True(t, fw.dirs[sprintSkillDir], "expected sprint skill parent directory to be created")
 	assert.True(t, fw.dirs[gardeningSkillDir], "expected gardening skill parent directory to be created")
+	assert.True(t, fw.dirs[autofixSkillDir], "expected autofix skill parent directory to be created")
 	assert.True(t, fw.dirs[agentDir], "expected agent parent directory to be created")
 }
 

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -16,7 +16,10 @@ type TrackerIssuesResult struct {
 	Project        string          `json:"project"`
 	Issues         []tracker.Issue `json:"issues"`
 	ReadyForReview []string        `json:"ready_for_review,omitempty"`
-	Err            string          `json:"error,omitempty"`
+	// ReadyForReviewPRs maps an engineering ticket key to the pull-request URL
+	// carried on its handoff comment's optional `pr:` line, when present.
+	ReadyForReviewPRs map[string]string `json:"ready_for_review_prs,omitempty"`
+	Err               string            `json:"error,omitempty"`
 }
 
 // Request is sent from the client to the daemon (one JSON line per connection).

--- a/internal/daemon/review_handoff.go
+++ b/internal/daemon/review_handoff.go
@@ -42,6 +42,24 @@ func ParseEngineeringKeysFromHandoff(body string) []string {
 	return nil
 }
 
+// ParsePRFromHandoff extracts the pull-request URL from the optional `pr:`
+// line of a [human:ready-for-review] comment body. Returns "" when the body is
+// not a handoff block or carries no pr: line (the line is optional — handoffs
+// from flows that only push a branch omit it).
+func ParsePRFromHandoff(body string) string {
+	trimmed := strings.TrimSpace(body)
+	if !strings.HasPrefix(trimmed, ReadyForReviewHeader) {
+		return ""
+	}
+	for _, line := range strings.Split(trimmed, "\n") {
+		line = strings.TrimSpace(line)
+		if rest, ok := strings.CutPrefix(line, "pr:"); ok {
+			return strings.TrimSpace(rest)
+		}
+	}
+	return ""
+}
+
 // IsReviewComplete reports whether the comment body is a review-complete
 // follow-up, which supersedes any earlier handoff for the same engineering
 // keys.

--- a/internal/daemon/review_handoff_test.go
+++ b/internal/daemon/review_handoff_test.go
@@ -47,6 +47,40 @@ func TestParseEngineeringKeysFromHandoff(t *testing.T) {
 	}
 }
 
+func TestParsePRFromHandoff(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "handoff with pr line",
+			body: "[human:ready-for-review]\nengineering: HUM-89\nbranch: autofix/hum-89\ncommits: 2037e40\npr: https://github.com/o/r/pull/7",
+			want: "https://github.com/o/r/pull/7",
+		},
+		{
+			name: "handoff without pr line",
+			body: "[human:ready-for-review]\nengineering: HUM-89\nbranch: main",
+			want: "",
+		},
+		{
+			name: "not a handoff",
+			body: "pr: https://example.com/pull/1",
+			want: "",
+		},
+		{
+			name: "quoted header does not trigger",
+			body: "> [human:ready-for-review]\n> pr: https://github.com/o/r/pull/7",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ParsePRFromHandoff(tt.body))
+		})
+	}
+}
+
 func TestIsReviewComplete(t *testing.T) {
 	assert.True(t, IsReviewComplete("[human:review-complete]\nverdict: pass"))
 	assert.True(t, IsReviewComplete("  [human:review-complete]\nverdict: pass"))

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -1,0 +1,47 @@
+// Package forge abstracts code-hosting (forge) operations such as opening
+// pull requests. It is deliberately separate from internal/tracker: a pull
+// request is a code-repository concept, not an issue-tracker one. Some
+// backends (GitHub, GitLab) are both a tracker and a forge and implement
+// both interfaces; pure issue trackers (Jira, Linear, Shortcut, …) implement
+// only tracker.Provider.
+package forge
+
+import "context"
+
+// PullRequest carries both the request to open a pull request and the created
+// result. Repo/Base/Head/Title/Body are inputs; Number/URL are populated on
+// return (Title is echoed back from the forge).
+type PullRequest struct {
+	Repo  string // "owner/repo" (GitHub) or "group/project" (GitLab)
+	Base  string // target branch the PR merges into (e.g. "main")
+	Head  string // source branch holding the changes
+	Title string
+	Body  string
+
+	Number int    // populated on return
+	URL    string // populated on return
+}
+
+// Creator opens a pull request on a code-forge host.
+type Creator interface {
+	CreatePullRequest(ctx context.Context, pr *PullRequest) (*PullRequest, error)
+}
+
+// Forge aggregates code-forge operations. Today that is only pull-request
+// creation; future operations (list, merge, status) extend this interface.
+type Forge interface {
+	Creator
+}
+
+// IsForgeKind reports whether a tracker kind also acts as a code forge that
+// can open pull requests. It gates which `human <kind>` command trees expose
+// the `pr` subcommand, so pure issue trackers don't advertise an operation
+// they can't perform.
+func IsForgeKind(kind string) bool {
+	switch kind {
+	case "github":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -6,7 +6,11 @@
 // only tracker.Provider.
 package forge
 
-import "context"
+import (
+	"context"
+	"net/url"
+	"strings"
+)
 
 // PullRequest carries both the request to open a pull request and the created
 // result. Repo/Base/Head/Title/Body are inputs; Number/URL are populated on
@@ -44,4 +48,68 @@ func IsForgeKind(kind string) bool {
 	default:
 		return false
 	}
+}
+
+// KindForHost maps a git remote host to a forge kind, or "" if the host is not
+// a recognised forge. It mirrors the host→kind mapping in tracker/urlparse.go
+// so a repository's origin remote can be matched to a configured forge.
+func KindForHost(host string) string {
+	switch strings.ToLower(host) {
+	case "github.com":
+		return "github"
+	default:
+		return ""
+	}
+}
+
+// ParseRemoteURL extracts the host and "owner/repo" path from a git remote URL,
+// accepting the common forms:
+//
+//	https://github.com/owner/repo.git
+//	ssh://git@github.com/owner/repo.git
+//	git@github.com:owner/repo.git   (scp-style, no scheme)
+//
+// A trailing ".git" and surrounding slashes are stripped. It returns ok=false
+// for input it cannot parse into a non-empty host and repo path.
+func ParseRemoteURL(raw string) (host, repo string, ok bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", false
+	}
+
+	// scp-style syntax has no scheme: [user@]host:path.
+	if !strings.Contains(raw, "://") {
+		rest := raw
+		if at := strings.LastIndex(rest, "@"); at >= 0 {
+			rest = rest[at+1:]
+		}
+		colon := strings.Index(rest, ":")
+		if colon < 0 {
+			return "", "", false
+		}
+		host = rest[:colon]
+		repo = normalizeRepoPath(rest[colon+1:])
+		if host == "" || repo == "" {
+			return "", "", false
+		}
+		return host, repo, true
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil || u.Hostname() == "" {
+		return "", "", false
+	}
+	host = u.Hostname() // drops userinfo and port
+	repo = normalizeRepoPath(u.Path)
+	if host == "" || repo == "" {
+		return "", "", false
+	}
+	return host, repo, true
+}
+
+// normalizeRepoPath trims slashes and a trailing ".git" from a remote path.
+func normalizeRepoPath(p string) string {
+	p = strings.Trim(p, "/")
+	p = strings.TrimSuffix(p, ".git")
+	return strings.Trim(p, "/")
 }

--- a/internal/forge/forge_test.go
+++ b/internal/forge/forge_test.go
@@ -1,0 +1,21 @@
+package forge
+
+import "testing"
+
+func TestIsForgeKind(t *testing.T) {
+	tests := map[string]bool{
+		"github":      true,
+		"gitlab":      false, // not implemented yet (stubbed as a follow-up)
+		"jira":        false,
+		"linear":      false,
+		"shortcut":    false,
+		"clickup":     false,
+		"azuredevops": false,
+		"":            false,
+	}
+	for kind, want := range tests {
+		if got := IsForgeKind(kind); got != want {
+			t.Errorf("IsForgeKind(%q) = %v, want %v", kind, got, want)
+		}
+	}
+}

--- a/internal/forge/forge_test.go
+++ b/internal/forge/forge_test.go
@@ -19,3 +19,49 @@ func TestIsForgeKind(t *testing.T) {
 		}
 	}
 }
+
+func TestKindForHost(t *testing.T) {
+	tests := map[string]string{
+		"github.com": "github",
+		"GitHub.com": "github", // case-insensitive
+		"gitlab.com": "",       // not yet supported
+		"example.com": "",
+		"":            "",
+	}
+	for host, want := range tests {
+		if got := KindForHost(host); got != want {
+			t.Errorf("KindForHost(%q) = %q, want %q", host, got, want)
+		}
+	}
+}
+
+func TestParseRemoteURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		wantHost string
+		wantRepo string
+		wantOK   bool
+	}{
+		{"https with .git", "https://github.com/octocat/hello-world.git", "github.com", "octocat/hello-world", true},
+		{"https without .git", "https://github.com/octocat/hello-world", "github.com", "octocat/hello-world", true},
+		{"https trailing slash", "https://github.com/octocat/hello-world/", "github.com", "octocat/hello-world", true},
+		{"scp-style", "git@github.com:octocat/hello-world.git", "github.com", "octocat/hello-world", true},
+		{"scp-style no .git", "git@github.com:octocat/hello-world", "github.com", "octocat/hello-world", true},
+		{"ssh scheme", "ssh://git@github.com/octocat/hello-world.git", "github.com", "octocat/hello-world", true},
+		{"https with port", "https://github.com:443/octocat/hello-world.git", "github.com", "octocat/hello-world", true},
+		{"surrounding space", "  https://github.com/octocat/hello-world.git\n", "github.com", "octocat/hello-world", true},
+		{"empty", "", "", "", false},
+		{"garbage", "not a url", "", "", false},
+		{"scheme no host", "file:///local/path", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host, repo, ok := ParseRemoteURL(tt.raw)
+			if ok != tt.wantOK || host != tt.wantHost || repo != tt.wantRepo {
+				t.Errorf("ParseRemoteURL(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tt.raw, host, repo, ok, tt.wantHost, tt.wantRepo, tt.wantOK)
+			}
+		})
+	}
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -14,10 +14,15 @@ import (
 
 	"github.com/gethuman-sh/human/errors"
 	"github.com/gethuman-sh/human/internal/apiclient"
+	"github.com/gethuman-sh/human/internal/forge"
 	"github.com/gethuman-sh/human/internal/tracker"
 )
 
-var _ tracker.Provider = (*Client)(nil)
+var (
+	_ tracker.Provider = (*Client)(nil)
+	// GitHub is both an issue tracker and a code forge.
+	_ forge.Forge = (*Client)(nil)
+)
 
 // Client is a GitHub REST API client that implements tracker.Lister,
 // tracker.Getter, and tracker.Creator.
@@ -196,6 +201,47 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 		Description: result.Body,
 		URL:         fmt.Sprintf("https://github.com/%s/%s/issues/%d", owner, repo, result.Number),
 		ParentKey:   issue.ParentKey,
+	}, nil
+}
+
+// CreatePullRequest implements forge.Creator via the GitHub pulls API.
+func (c *Client) CreatePullRequest(ctx context.Context, pr *forge.PullRequest) (*forge.PullRequest, error) {
+	owner, repo, err := splitProject(pr.Repo)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := pullCreateRequest{
+		Title: pr.Title,
+		Head:  pr.Head,
+		Base:  pr.Base,
+		Body:  pr.Body,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, errors.WrapWithDetails(err, "marshalling pull request request",
+			"repo", pr.Repo)
+	}
+
+	path := fmt.Sprintf("/repos/%s/%s/pulls", url.PathEscape(owner), url.PathEscape(repo))
+	resp, err := c.doRequest(ctx, http.MethodPost, path, "", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	var result pullCreateResponse
+	if err := apiclient.DecodeJSON(resp, &result, "repo", pr.Repo); err != nil {
+		return nil, err
+	}
+
+	return &forge.PullRequest{
+		Repo:   pr.Repo,
+		Base:   pr.Base,
+		Head:   pr.Head,
+		Title:  result.Title,
+		Body:   pr.Body,
+		Number: result.Number,
+		URL:    result.HTMLURL,
 	}, nil
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -181,13 +181,45 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 		return nil, err
 	}
 
+	// GitHub has no parent field on create — the sub-issue link is a separate
+	// call keyed by the new issue's internal ID, made only once it exists.
+	if issue.ParentKey != "" {
+		if err := c.addSubIssue(ctx, issue.ParentKey, result.ID); err != nil {
+			return nil, err
+		}
+	}
+
 	return &tracker.Issue{
 		Key:         fmt.Sprintf("%s/%s#%d", owner, repo, result.Number),
 		Project:     issue.Project,
 		Title:       result.Title,
 		Description: result.Body,
 		URL:         fmt.Sprintf("https://github.com/%s/%s/issues/%d", owner, repo, result.Number),
+		ParentKey:   issue.ParentKey,
 	}, nil
+}
+
+// addSubIssue links a freshly created issue under a parent via GitHub's
+// sub-issues API. The parent is addressed by its issue number, while the child
+// is referenced by its internal ID (not its number).
+func (c *Client) addSubIssue(ctx context.Context, parentKey string, childID int) error {
+	owner, repo, number, err := parseIssueKey(parentKey)
+	if err != nil {
+		return errors.WrapWithDetails(err, "invalid parent key", "parentKey", parentKey)
+	}
+
+	payload, err := json.Marshal(map[string]int{"sub_issue_id": childID})
+	if err != nil {
+		return errors.WrapWithDetails(err, "marshalling sub-issue request", "parentKey", parentKey)
+	}
+
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/sub_issues", url.PathEscape(owner), url.PathEscape(repo), number)
+	resp, err := c.doRequest(ctx, http.MethodPost, path, "", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	_ = resp.Body.Close()
+	return nil
 }
 
 // AddComment implements tracker.Commenter.

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gethuman-sh/human/internal/forge"
 	"github.com/gethuman-sh/human/internal/tracker"
 
 	"github.com/stretchr/testify/assert"
@@ -255,6 +256,71 @@ func TestCreateIssue_httpError(t *testing.T) {
 		Title:   "Will fail",
 	})
 
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "returned")
+}
+
+func TestCreatePullRequest_happy(t *testing.T) {
+	var gotBody pullCreateRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/repos/octocat/hello-world/pulls", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"number":42,"title":"Fix login","html_url":"https://github.com/octocat/hello-world/pull/42"}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "ghp_test")
+	pr, err := client.CreatePullRequest(context.Background(), &forge.PullRequest{
+		Repo:  "octocat/hello-world",
+		Base:  "main",
+		Head:  "autofix/hum-105",
+		Title: "Fix login",
+		Body:  "Closes octocat/hello-world#7",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 42, pr.Number)
+	assert.Equal(t, "https://github.com/octocat/hello-world/pull/42", pr.URL)
+	assert.Equal(t, "Fix login", pr.Title)
+
+	assert.Equal(t, "Fix login", gotBody.Title)
+	assert.Equal(t, "autofix/hum-105", gotBody.Head)
+	assert.Equal(t, "main", gotBody.Base)
+	assert.Equal(t, "Closes octocat/hello-world#7", gotBody.Body)
+}
+
+func TestCreatePullRequest_invalidRepo(t *testing.T) {
+	client := New("https://api.github.com", "ghp_test")
+	_, err := client.CreatePullRequest(context.Background(), &forge.PullRequest{
+		Repo:  "no-slash",
+		Base:  "main",
+		Head:  "feature",
+		Title: "x",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "owner/repo")
+}
+
+func TestCreatePullRequest_httpError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "ghp_test")
+	_, err := client.CreatePullRequest(context.Background(), &forge.PullRequest{
+		Repo:  "octocat/hello-world",
+		Base:  "main",
+		Head:  "feature",
+		Title: "Will fail",
+	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "returned")
 }

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -982,3 +982,57 @@ func TestTransitionIssue_caseInsensitive(t *testing.T) {
 	err := client.TransitionIssue(context.Background(), "octocat/hello-world#1", "Open")
 	require.NoError(t, err)
 }
+
+func TestCreateIssue_withParent(t *testing.T) {
+	var subIssueBody map[string]int
+	createCalled, subCalled := false, false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/octocat/hello-world/issues":
+			createCalled = true
+			w.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprint(w, `{"id":555,"number":99,"title":"Child","body":""}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/octocat/hello-world/issues/7/sub_issues":
+			subCalled = true
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &subIssueBody))
+			w.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprint(w, `{}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "ghp_test")
+	issue, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Project:   "octocat/hello-world",
+		Title:     "Child",
+		ParentKey: "octocat/hello-world#7",
+	})
+	require.NoError(t, err)
+	assert.True(t, createCalled, "create endpoint should be called")
+	assert.True(t, subCalled, "sub_issues endpoint should be called")
+	assert.Equal(t, 555, subIssueBody["sub_issue_id"]) // child's internal id, not its number
+	assert.Equal(t, "octocat/hello-world#99", issue.Key)
+	assert.Equal(t, "octocat/hello-world#7", issue.ParentKey)
+}
+
+func TestCreateIssue_invalidParent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"id":555,"number":99,"title":"Child","body":""}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "ghp_test")
+	_, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Project:   "octocat/hello-world",
+		Title:     "Child",
+		ParentKey: "nohash",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid parent key")
+}

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -34,6 +34,19 @@ type createResponse struct {
 	Body   string `json:"body"`
 }
 
+type pullCreateRequest struct {
+	Title string `json:"title"`
+	Head  string `json:"head"`
+	Base  string `json:"base"`
+	Body  string `json:"body,omitempty"`
+}
+
+type pullCreateResponse struct {
+	Number  int    `json:"number"`
+	Title   string `json:"title"`
+	HTMLURL string `json:"html_url"`
+}
+
 type commentRequest struct {
 	Body string `json:"body"`
 }

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -28,6 +28,7 @@ type createRequest struct {
 }
 
 type createResponse struct {
+	ID     int    `json:"id"` // internal issue ID, required by the sub-issues endpoint
 	Number int    `json:"number"`
 	Title  string `json:"title"`
 	Body   string `json:"body"`

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -133,6 +133,15 @@ func (c *Client) GetIssue(ctx context.Context, key string) (*tracker.Issue, erro
 
 // CreateIssue implements tracker.Creator.
 func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracker.Issue, error) {
+	// GitLab's REST v4 API has no parent/child relationship for issues — that
+	// lives only in the GraphQL work-items API. Fail loudly rather than
+	// silently dropping the parent the caller asked for.
+	if issue.ParentKey != "" {
+		return nil, errors.WithDetails(
+			"gitlab does not support subtasks via the REST API; issue parent/child links require GitLab's GraphQL work-items API",
+			"parentKey", issue.ParentKey)
+	}
+
 	encodedProject, err := splitProject(issue.Project)
 	if err != nil {
 		return nil, err

--- a/internal/gitlab/client_test.go
+++ b/internal/gitlab/client_test.go
@@ -777,3 +777,14 @@ func TestAssignIssue_invalidKey(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid issue key format")
 }
+
+func TestCreateIssue_parentUnsupported(t *testing.T) {
+	client := New("http://localhost", "glpat-test")
+	_, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Project:   "mygroup/myproject",
+		Title:     "Child",
+		ParentKey: "mygroup/myproject#1",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support subtasks")
+}

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -1,0 +1,37 @@
+// Package gitrepo reads facts about the local git repository by shelling out
+// to git. It is the single place that runs git from Go (elsewhere git is only
+// invoked from agent prompts), so the exec is isolated and testable.
+package gitrepo
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+
+	"github.com/gethuman-sh/human/errors"
+)
+
+// runner executes a command and returns its combined stdout. It is a package
+// variable so tests can stub git invocation without a real repository.
+var runner = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).Output() // #nosec G204 -- only called with the hardcoded "git" command and fixed subcommands
+}
+
+// OriginURL returns the URL of the "origin" remote for the repository at dir
+// (running `git -C <dir> remote get-url origin`). dir may be "." for the
+// current working directory. The returned value is trimmed of surrounding
+// whitespace.
+//
+// It is a package variable so callers in other packages can stub git access
+// in their own tests without a real repository.
+var OriginURL = func(ctx context.Context, dir string) (string, error) {
+	out, err := runner(ctx, "git", "-C", dir, "remote", "get-url", "origin")
+	if err != nil {
+		return "", errors.WrapWithDetails(err, "reading git origin remote", "dir", dir)
+	}
+	url := strings.TrimSpace(string(out))
+	if url == "" {
+		return "", errors.WithDetails("git origin remote is empty", "dir", dir)
+	}
+	return url, nil
+}

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -1,0 +1,57 @@
+package gitrepo
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func withRunner(t *testing.T, fn func(ctx context.Context, name string, args ...string) ([]byte, error)) {
+	t.Helper()
+	prev := runner
+	runner = fn
+	t.Cleanup(func() { runner = prev })
+}
+
+func TestOriginURL_success(t *testing.T) {
+	var gotArgs []string
+	withRunner(t, func(_ context.Context, name string, args ...string) ([]byte, error) {
+		gotArgs = append([]string{name}, args...)
+		return []byte("https://github.com/octocat/hello-world.git\n"), nil
+	})
+
+	url, err := OriginURL(context.Background(), "/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if url != "https://github.com/octocat/hello-world.git" {
+		t.Errorf("url = %q, want trimmed origin", url)
+	}
+	want := []string{"git", "-C", "/repo", "remote", "get-url", "origin"}
+	if len(gotArgs) != len(want) {
+		t.Fatalf("args = %v, want %v", gotArgs, want)
+	}
+	for i := range want {
+		if gotArgs[i] != want[i] {
+			t.Errorf("arg[%d] = %q, want %q", i, gotArgs[i], want[i])
+		}
+	}
+}
+
+func TestOriginURL_commandError(t *testing.T) {
+	withRunner(t, func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return nil, errors.New("exit status 128")
+	})
+	if _, err := OriginURL(context.Background(), "."); err == nil {
+		t.Fatal("expected error when git fails")
+	}
+}
+
+func TestOriginURL_empty(t *testing.T) {
+	withRunner(t, func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return []byte("  \n"), nil
+	})
+	if _, err := OriginURL(context.Background(), "."); err == nil {
+		t.Fatal("expected error when origin is empty")
+	}
+}

--- a/internal/jira/client.go
+++ b/internal/jira/client.go
@@ -96,7 +96,7 @@ func (c *Client) ListIssues(ctx context.Context, opts tracker.ListOptions) ([]tr
 func (c *Client) GetIssue(ctx context.Context, key string) (*tracker.Issue, error) {
 	path := fmt.Sprintf("/rest/api/3/issue/%s", url.PathEscape(key))
 	query := url.Values{
-		"fields": {"summary,status,description,assignee,reporter,priority,issuetype"},
+		"fields": {"summary,status,description,assignee,reporter,priority,issuetype,parent"},
 	}
 
 	resp, err := c.doRequest(ctx, http.MethodGet, path, query.Encode(), nil)
@@ -119,6 +119,11 @@ func (c *Client) GetIssue(ctx context.Context, key string) (*tracker.Issue, erro
 		desc = adf.ToMarkdown(doc)
 	}
 
+	parentKey := ""
+	if f.Parent != nil {
+		parentKey = f.Parent.Key
+	}
+
 	return &tracker.Issue{
 		Key:         detail.Key,
 		Title:       f.Summary,
@@ -129,6 +134,7 @@ func (c *Client) GetIssue(ctx context.Context, key string) (*tracker.Issue, erro
 		Reporter:    nameOrEmpty(f.Reporter),
 		Description: desc,
 		URL:         c.baseURL + "/browse/" + detail.Key,
+		ParentKey:   parentKey,
 	}, nil
 }
 
@@ -141,6 +147,11 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 			IssueType:   nameOnly{Name: issue.Type},
 			Description: adf.FromMarkdown(issue.Description),
 		},
+	}
+	// Jira models subtasks as a parent link; the issue type must be a
+	// subtask-type (e.g. "Sub-task") for the server to accept it.
+	if issue.ParentKey != "" {
+		payload.Fields.Parent = &keyField{Key: issue.ParentKey}
 	}
 
 	body, err := json.Marshal(payload)
@@ -165,6 +176,7 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 		Title:       issue.Title,
 		Description: issue.Description,
 		URL:         c.baseURL + "/browse/" + result.Key,
+		ParentKey:   issue.ParentKey,
 	}, nil
 }
 

--- a/internal/jira/client_test.go
+++ b/internal/jira/client_test.go
@@ -660,3 +660,41 @@ func TestListStatuses_httpError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "returned")
 }
+
+func TestCreateIssue_withParent(t *testing.T) {
+	var gotBody createRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"id":"10005","key":"KAN-50"}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "user@example.com", "token")
+	issue, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Project:   "KAN",
+		Type:      "Sub-task",
+		Title:     "Child",
+		ParentKey: "KAN-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "KAN-50", issue.Key)
+	assert.Equal(t, "KAN-1", issue.ParentKey)
+	require.NotNil(t, gotBody.Fields.Parent)
+	assert.Equal(t, "KAN-1", gotBody.Fields.Parent.Key)
+}
+
+func TestGetIssue_withParent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Query().Get("fields"), "parent")
+		_, _ = fmt.Fprint(w, `{"key":"KAN-50","fields":{"summary":"Child","status":{"name":"To Do"},"issuetype":{"name":"Sub-task"},"parent":{"key":"KAN-1"}}}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "user@example.com", "token")
+	issue, err := client.GetIssue(context.Background(), "KAN-50")
+	require.NoError(t, err)
+	assert.Equal(t, "KAN-1", issue.ParentKey)
+}

--- a/internal/jira/types.go
+++ b/internal/jira/types.go
@@ -35,6 +35,7 @@ type issueDetailFields struct {
 	Reporter    *nameField      `json:"reporter"`
 	Description json.RawMessage `json:"description"`
 	IssueType   nameOnly        `json:"issuetype"`
+	Parent      *keyField       `json:"parent"`
 }
 
 type nameField struct {
@@ -51,6 +52,7 @@ type createFields struct {
 	Summary     string         `json:"summary"`
 	IssueType   nameOnly       `json:"issuetype"`
 	Description map[string]any `json:"description,omitempty"`
+	Parent      *keyField      `json:"parent,omitempty"`
 }
 
 type keyField struct {

--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -74,6 +74,7 @@ const getIssueQuery = `query($id: String!) {
 	issue(id: $id) {
 		identifier url title description state { name type } priorityLabel
 		assignee { name } creator { name } labels { nodes { name } }
+		parent { identifier }
 	}
 }`
 
@@ -118,8 +119,8 @@ const deleteIssueMutation = `mutation($id: String!) {
 	issueDelete(id: $id) { success }
 }`
 
-const createIssueMutation = `mutation($teamId: String!, $title: String!, $description: String, $projectId: String) {
-	issueCreate(input: { teamId: $teamId, title: $title, description: $description, projectId: $projectId }) {
+const createIssueMutation = `mutation($teamId: String!, $title: String!, $description: String, $projectId: String, $parentId: String) {
+	issueCreate(input: { teamId: $teamId, title: $title, description: $description, projectId: $projectId, parentId: $parentId }) {
 		success
 		issue { identifier url title description }
 	}
@@ -256,6 +257,15 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 	}
 	if projectID != "" {
 		vars["projectId"] = projectID
+	}
+	// Linear's parentId is the parent's internal UUID, not its human-facing
+	// identifier (e.g. "ENG-12"), so resolve the key the caller passed.
+	if issue.ParentKey != "" {
+		parentID, err := c.resolveIssueID(ctx, issue.ParentKey)
+		if err != nil {
+			return nil, err
+		}
+		vars["parentId"] = parentID
 	}
 
 	data, err := c.doGraphQL(ctx, createIssueMutation, vars)
@@ -656,6 +666,9 @@ func toTrackerIssue(li linearIssue, project string) tracker.Issue {
 		for _, n := range li.Labels.Nodes {
 			issue.Labels = append(issue.Labels, n.Name)
 		}
+	}
+	if li.Parent != nil {
+		issue.ParentKey = li.Parent.Identifier
 	}
 
 	return issue

--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -1593,3 +1593,62 @@ func TestDeleteIssue_resolveIssueIDError(t *testing.T) {
 
 	require.Error(t, err)
 }
+
+func TestCreateIssue_withParent(t *testing.T) {
+	srv := httptest.NewServer(&graphQLHandler{
+		t: t,
+		handlers: map[string]func(vars map[string]any) string{
+			"teams(": func(_ map[string]any) string {
+				return `{"data":{"teams":{"nodes":[{"id":"team-uuid-123"}]}}}`
+			},
+			"projects(": func(_ map[string]any) string {
+				return `{"data":{"projects":{"nodes":[]}}}`
+			},
+			// resolveIssueID looks up the parent's internal UUID by identifier.
+			"issue(": func(vars map[string]any) string {
+				assert.Equal(t, "ENG-1", vars["id"])
+				return `{"data":{"issue":{"id":"parent-uuid-1"}}}`
+			},
+			"issueCreate(": func(vars map[string]any) string {
+				assert.Equal(t, "parent-uuid-1", vars["parentId"])
+				return `{"data":{"issueCreate":{"success":true,"issue":{
+					"identifier":"ENG-2","title":"Child","description":"",
+					"state":{"name":""},"priorityLabel":"","assignee":null,"creator":null,
+					"labels":{"nodes":[]}
+				}}}}`
+			},
+		},
+	})
+	defer srv.Close()
+
+	client := New(srv.URL, "lin_test")
+	issue, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Project:   "ENG",
+		Title:     "Child",
+		ParentKey: "ENG-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ENG-2", issue.Key)
+}
+
+func TestGetIssue_withParent(t *testing.T) {
+	srv := httptest.NewServer(&graphQLHandler{
+		t: t,
+		handlers: map[string]func(vars map[string]any) string{
+			"issue(": func(_ map[string]any) string {
+				return `{"data":{"issue":{
+					"identifier":"ENG-2","title":"Child","description":"",
+					"state":{"name":"Todo","type":"unstarted"},"priorityLabel":"",
+					"assignee":null,"creator":null,"labels":{"nodes":[]},
+					"parent":{"identifier":"ENG-1"}
+				}}}`
+			},
+		},
+	})
+	defer srv.Close()
+
+	client := New(srv.URL, "lin_test")
+	issue, err := client.GetIssue(context.Background(), "ENG-2")
+	require.NoError(t, err)
+	assert.Equal(t, "ENG-1", issue.ParentKey)
+}

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -12,6 +12,12 @@ type linearIssue struct {
 	Creator       *nameNode       `json:"creator"`
 	Labels        labelConnection `json:"labels"`
 	UpdatedAt     string          `json:"updatedAt"`
+	Parent        *identifierNode `json:"parent"`
+}
+
+// identifierNode holds a related issue's human-facing identifier (e.g. "ENG-12").
+type identifierNode struct {
+	Identifier string `json:"identifier"`
 }
 
 type nameNode struct {

--- a/internal/shortcut/client.go
+++ b/internal/shortcut/client.go
@@ -251,6 +251,15 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 	if isValidStoryType(issue.Type) {
 		body["story_type"] = issue.Type
 	}
+	// A subtask in Shortcut is a story that points at a parent story; the
+	// key the caller passes is the numeric parent story ID.
+	if issue.ParentKey != "" {
+		parentID, err := parseStoryID(issue.ParentKey)
+		if err != nil {
+			return nil, errors.WrapWithDetails(err, "invalid parent story ID", "parentKey", issue.ParentKey)
+		}
+		body["parent_story_id"] = parentID
+	}
 
 	stateID, err := c.defaultWorkflowStateID(ctx)
 	if err != nil {
@@ -289,6 +298,7 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 		Description: story.Description,
 		Type:        story.StoryType,
 		URL:         story.AppURL,
+		ParentKey:   parentStoryKey(story.ParentStoryID),
 	}, nil
 }
 
@@ -730,10 +740,20 @@ func (c *Client) toTrackerIssue(ctx context.Context, story scStory, project stri
 		Description: story.Description,
 		URL:         story.AppURL,
 	}
+	issue.ParentKey = parentStoryKey(story.ParentStoryID)
 	if story.UpdatedAt != "" {
 		issue.UpdatedAt, _ = time.Parse(time.RFC3339, story.UpdatedAt)
 	}
 	return issue, nil
+}
+
+// parentStoryKey renders a parent story ID as a tracker issue key, or "" when
+// the story has no parent.
+func parentStoryKey(id *int64) string {
+	if id == nil {
+		return ""
+	}
+	return strconv.FormatInt(*id, 10)
 }
 
 // toTrackerComment converts a Shortcut comment to a tracker.Comment.

--- a/internal/shortcut/client_test.go
+++ b/internal/shortcut/client_test.go
@@ -1091,3 +1091,66 @@ func TestListStatuses_caching(t *testing.T) {
 
 	assert.Equal(t, 1, fetchCount)
 }
+
+func TestCreateIssue_withParent(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v3/workflows":
+			_, _ = fmt.Fprint(w, `[{"id":1,"name":"Default","states":[{"id":500,"name":"To Do","type":"unstarted"}]}]`)
+		case "/api/v3/groups":
+			_, _ = fmt.Fprint(w, `[{"id":"grp-uuid-1","name":"Human"}]`)
+		case "/api/v3/stories":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &gotBody))
+			w.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprint(w, `{"id":99,"name":"Child","parent_story_id":42}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "tok-test")
+	issue, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Project:   "Human",
+		Title:     "Child",
+		ParentKey: "42",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "99", issue.Key)
+	assert.Equal(t, "42", issue.ParentKey)
+	assert.Equal(t, float64(42), gotBody["parent_story_id"])
+}
+
+func TestCreateIssue_invalidParent(t *testing.T) {
+	client := New("http://localhost", "tok-test")
+	_, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Project:   "Human",
+		Title:     "Child",
+		ParentKey: "not-a-number",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid parent story ID")
+}
+
+func TestGetIssue_withParent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v3/stories/99":
+			_, _ = fmt.Fprint(w, `{"id":99,"name":"Child","workflow_state_id":500,"parent_story_id":42}`)
+		case "/api/v3/workflows":
+			_, _ = fmt.Fprint(w, `[{"id":1,"name":"Default","states":[{"id":500,"name":"To Do","type":"unstarted"}]}]`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "tok-test")
+	issue, err := client.GetIssue(context.Background(), "99")
+	require.NoError(t, err)
+	assert.Equal(t, "42", issue.ParentKey)
+}

--- a/internal/shortcut/types.go
+++ b/internal/shortcut/types.go
@@ -12,7 +12,8 @@ type scStory struct {
 	RequestedByID   string   `json:"requested_by_id"`
 	Archived        bool     `json:"archived"`
 	ProjectID       *int64   `json:"project_id"`
-	GroupID         string   `json:"group_id"` // UUID of the group (team)
+	GroupID         string   `json:"group_id"`        // UUID of the group (team)
+	ParentStoryID   *int64   `json:"parent_story_id"` // set when this story is a subtask
 	UpdatedAt       string   `json:"updated_at"`
 }
 

--- a/main.go
+++ b/main.go
@@ -195,6 +195,10 @@ Configure trackers and tools in .humanconfig.yaml or pass credentials via flags/
 	autoStatusCmd.GroupID = "shortcuts"
 	rootCmd.AddCommand(autoStatusCmd)
 
+	autoPRCmd := cmdauto.BuildAutoPRCreateCmd(autoDeps)
+	autoPRCmd.GroupID = "shortcuts"
+	rootCmd.AddCommand(autoPRCmd)
+
 	// --- Provider commands (dynamic registration) ---
 	providers := []string{"jira", "github", "gitlab", "linear", "azuredevops", "shortcut", "clickup"}
 	for _, kind := range providers {


### PR DESCRIPTION
Implements SC-86 (autonomously fix a reported bug end to end) across three engineering tickets.

## What's here
- **HUM-104** — `internal/forge` abstraction (separate from `internal/tracker`, since a PR is a code-host concept) + GitHub `CreatePullRequest` + `human <forge> pr create`.
- **HUM-105** — derive the forge + repo from the git `origin` remote, so `human pr create` works with no `--repo`/kind.
- **HUM-103** — `/human-autofix` orchestrator + triage/fixer/verify agents (three-way verdict, tracker-only artifacts, test-first fix, PR + handoff), and surfacing the handoff `pr:` URL in the daemon/TUI.

## Notes
- Opened as a dogfooding test of the very `human pr create` command this branch introduces.
- `make check` green (build + lint + tests + gosec + govulncheck + gitleaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)