### PR TITLE
[HUM-121] Order devcontainer feature install by installsAfter

### DIFF
--- a/internal/devcontainer/feature.go
+++ b/internal/devcontainer/feature.go
@@ -127,21 +127,38 @@ func InstallFeatures(ctx context.Context, docker DockerClient, puller FeaturePul
 		return nil
 	}
 
-	// Sort feature refs for deterministic installation order.
-	refs := sortedFeatureRefs(features)
+	// Pull every feature's metadata up front: the install order depends on each
+	// feature's installsAfter edges, which are only known after Pull. Caching the
+	// tarball and meta here also avoids a second Pull during installation.
+	pulled := make(map[string]*pulledFeature, len(features))
+	metas := make(map[string]*FeatureMeta, len(features))
+	for ref := range features {
+		tarData, meta, err := puller.Pull(ctx, ref)
+		if err != nil {
+			return errors.WrapWithDetails(err, "pulling feature", "ref", ref)
+		}
+		pulled[ref] = &pulledFeature{tarData: tarData, meta: meta}
+		metas[ref] = meta
+	}
+
+	// Order features so each is installed only after the features it lists in
+	// installsAfter (when those features are present in the set).
+	refs, err := orderFeatures(metas)
+	if err != nil {
+		return err
+	}
 
 	for _, ref := range refs {
 		opts, _ := features[ref].(map[string]interface{})
 		_, _ = fmt.Fprintf(out, "  Installing feature: %s\n", ref) // #nosec G705 -- CLI output
 
-		tarData, meta, err := puller.Pull(ctx, ref)
-		if err != nil {
-			return errors.WrapWithDetails(err, "pulling feature", "ref", ref)
+		pf := pulled[ref]
+		if pf == nil {
+			return errors.WithDetails("ordered feature missing pulled data", "ref", ref)
 		}
+		env := featureEnv(opts, pf.meta, remoteUser)
 
-		env := featureEnv(opts, meta, remoteUser)
-
-		if err := copyAndRunFeature(ctx, docker, containerID, tarData, env, logger); err != nil {
+		if err := copyAndRunFeature(ctx, docker, containerID, pf.tarData, env, logger); err != nil {
 			return errors.WrapWithDetails(err, "installing feature", "ref", ref)
 		}
 
@@ -149,6 +166,13 @@ func InstallFeatures(ctx context.Context, docker DockerClient, puller FeaturePul
 	}
 
 	return nil
+}
+
+// pulledFeature holds a feature's downloaded tarball and parsed metadata so the
+// install loop can run without re-pulling after ordering.
+type pulledFeature struct {
+	tarData []byte
+	meta    *FeatureMeta
 }
 
 // copyAndRunFeature copies the entire feature tarball into the container using
@@ -221,13 +245,129 @@ func featureEnv(opts map[string]interface{}, meta *FeatureMeta, remoteUser strin
 	return env
 }
 
-// sortedFeatureRefs returns feature references in deterministic order
-// (lexicographic by ref string).
-func sortedFeatureRefs(features map[string]interface{}) []string {
-	refs := make([]string, 0, len(features))
-	for ref := range features {
+// normalizeRef reduces a feature reference to its registry/repository part,
+// dropping any tag or digest. installsAfter entries are conventionally untagged
+// (ghcr.io/devcontainers/features/node) while config refs are tagged
+// (ghcr.io/devcontainers/features/node:1); edge matching must compare on the
+// repository part so the two resolve to the same node.
+func normalizeRef(ref string) string {
+	parsed, err := name.ParseReference(ref)
+	if err != nil {
+		// Fall back to a tag/digest strip so an unparseable ref still matches
+		// deterministically rather than silently never matching.
+		ref = strings.TrimSuffix(ref, "/")
+		if at := strings.LastIndex(ref, "@"); at != -1 {
+			ref = ref[:at]
+		}
+		if slash := strings.LastIndex(ref, "/"); slash != -1 {
+			if colon := strings.LastIndex(ref[slash:], ":"); colon != -1 {
+				ref = ref[:slash+colon]
+			}
+		}
+		return ref
+	}
+	return parsed.Context().Name()
+}
+
+// orderFeatures returns feature references in installation order, respecting
+// each feature's installsAfter edges (restricted to features present in the
+// set) and using alphabetical order as a deterministic tie-break. Edges to
+// features that are absent from the set are ignored. A cycle in the edges is
+// reported as an error rather than looping.
+func orderFeatures(metas map[string]*FeatureMeta) ([]string, error) {
+	refs := make([]string, 0, len(metas))
+	for ref := range metas {
 		refs = append(refs, ref)
 	}
 	sort.Strings(refs)
-	return refs
+
+	dependents, indegree := buildFeatureGraph(refs, metas)
+
+	order := kahnSort(refs, dependents, indegree)
+
+	if len(order) != len(refs) {
+		remaining := make([]string, 0, len(refs)-len(order))
+		for _, ref := range refs {
+			if indegree[ref] > 0 {
+				remaining = append(remaining, ref)
+			}
+		}
+		sort.Strings(remaining)
+		return nil, errors.WithDetails("feature installsAfter cycle", "features", remaining)
+	}
+
+	return order, nil
+}
+
+// buildFeatureGraph constructs the installsAfter dependency graph over the
+// present features. An edge dep -> ref means dep must install before ref.
+// Edges to absent features and self-edges are ignored; duplicate edges are
+// collapsed so the returned indegree stays accurate.
+func buildFeatureGraph(refs []string, metas map[string]*FeatureMeta) (dependents map[string][]string, indegree map[string]int) {
+	// Map each present feature's normalized repository to its config ref so
+	// untagged installsAfter entries can resolve to tagged config refs.
+	byRepo := make(map[string]string, len(refs))
+	for _, ref := range refs {
+		byRepo[normalizeRef(ref)] = ref
+	}
+
+	dependents = make(map[string][]string, len(refs))
+	indegree = make(map[string]int, len(refs))
+	for _, ref := range refs {
+		indegree[ref] = 0
+	}
+	for _, ref := range refs {
+		meta := metas[ref]
+		if meta == nil {
+			continue
+		}
+		seen := make(map[string]struct{})
+		for _, after := range meta.InstallsAfter {
+			dep, present := byRepo[normalizeRef(after)]
+			if !present || dep == ref {
+				continue
+			}
+			if _, dup := seen[dep]; dup {
+				continue
+			}
+			seen[dep] = struct{}{}
+			dependents[dep] = append(dependents[dep], ref)
+			indegree[ref]++
+		}
+	}
+	return dependents, indegree
+}
+
+// kahnSort topologically sorts refs via Kahn's algorithm, picking the
+// alphabetically smallest install-ready node at each step for determinism.
+// A returned order shorter than refs signals a cycle (nodes with residual
+// indegree were never released).
+func kahnSort(refs []string, dependents map[string][]string, indegree map[string]int) []string {
+	ready := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		if indegree[ref] == 0 {
+			ready = append(ready, ref)
+		}
+	}
+	sort.Strings(ready)
+
+	order := make([]string, 0, len(refs))
+	for len(ready) > 0 {
+		ref := ready[0]
+		ready = ready[1:]
+		order = append(order, ref)
+
+		newlyReady := make([]string, 0)
+		for _, dep := range dependents[ref] {
+			indegree[dep]--
+			if indegree[dep] == 0 {
+				newlyReady = append(newlyReady, dep)
+			}
+		}
+		if len(newlyReady) > 0 {
+			ready = append(ready, newlyReady...)
+			sort.Strings(ready)
+		}
+	}
+	return order
 }

--- a/internal/devcontainer/feature_test.go
+++ b/internal/devcontainer/feature_test.go
@@ -154,6 +154,46 @@ func TestInstallFeatures_ExecCalls(t *testing.T) {
 	}
 }
 
+func TestInstallFeatures_InstallsInDependencyOrder(t *testing.T) {
+	mock := &mockDockerClient{}
+
+	claude := "ghcr.io/anthropics/devcontainer-features/claude-code:1"
+	node := "ghcr.io/devcontainers/features/node:1"
+
+	// Each feature carries a distinct option default so its run exec call can be
+	// attributed back to the feature via its env var.
+	puller := &mockFeaturePuller{
+		tarData: buildFeatureTar(t, "shared", "1.0.0"),
+		metaByRef: map[string]*FeatureMeta{
+			claude: {ID: "claude-code", InstallsAfter: []string{"ghcr.io/devcontainers/features/node"},
+				Options: map[string]FeatureOption{"marker": {Default: "claude"}}},
+			node: {ID: "node",
+				Options: map[string]FeatureOption{"marker": {Default: "node"}}},
+		},
+	}
+
+	features := map[string]interface{}{claude: map[string]interface{}{}, node: map[string]interface{}{}}
+
+	if err := InstallFeatures(context.Background(), mock, puller, "container-123",
+		features, "vscode", testLogger(), &strings.Builder{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Each feature produces mkdir, run, cleanup; the run call (index 1 of each
+	// triple) carries the MARKER env that identifies the feature.
+	var installOrder []string
+	for i, call := range mock.execCalls {
+		if i%3 != 1 {
+			continue
+		}
+		installOrder = append(installOrder, toEnvMap(call.Opts.Env)["MARKER"])
+	}
+
+	if indexOf(installOrder, "node") > indexOf(installOrder, "claude") {
+		t.Errorf("node must install before claude-code; install order = %v", installOrder)
+	}
+}
+
 func TestInstallFeatures_Empty(t *testing.T) {
 	err := InstallFeatures(context.Background(), &mockDockerClient{}, &mockFeaturePuller{},
 		"cid", nil, "user", testLogger(), &strings.Builder{})
@@ -162,30 +202,162 @@ func TestInstallFeatures_Empty(t *testing.T) {
 	}
 }
 
-func TestSortedFeatureRefs(t *testing.T) {
-	features := map[string]interface{}{
-		"ghcr.io/z/feature:1": nil,
-		"ghcr.io/a/feature:1": nil,
-		"ghcr.io/m/feature:1": nil,
+func TestOrderFeatures_Independent(t *testing.T) {
+	metas := map[string]*FeatureMeta{
+		"ghcr.io/z/feature:1": {},
+		"ghcr.io/a/feature:1": {},
+		"ghcr.io/m/feature:1": {},
 	}
-	refs := sortedFeatureRefs(features)
-	if refs[0] != "ghcr.io/a/feature:1" || refs[2] != "ghcr.io/z/feature:1" {
-		t.Errorf("not sorted: %v", refs)
+	order, err := orderFeatures(metas)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"ghcr.io/a/feature:1", "ghcr.io/m/feature:1", "ghcr.io/z/feature:1"}
+	if !equalStrings(order, want) {
+		t.Errorf("order = %v, want alphabetical %v", order, want)
 	}
 }
 
-// mockFeaturePuller returns pre-configured feature content.
+func TestOrderFeatures_ReorderByDependency(t *testing.T) {
+	// claude-code sorts alphabetically before node but must install after it.
+	claude := "ghcr.io/anthropics/devcontainer-features/claude-code:1"
+	node := "ghcr.io/devcontainers/features/node:1"
+	metas := map[string]*FeatureMeta{
+		claude: {InstallsAfter: []string{"ghcr.io/devcontainers/features/node"}},
+		node:   {},
+	}
+	order, err := orderFeatures(metas)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if indexOf(order, node) > indexOf(order, claude) {
+		t.Errorf("expected %s before %s, got %v", node, claude, order)
+	}
+}
+
+func TestOrderFeatures_TagMismatchMatching(t *testing.T) {
+	// Dependency declared untagged (...node) but present tagged (...node:1).
+	dependent := "ghcr.io/x/dependent:2"
+	node := "ghcr.io/devcontainers/features/node:1"
+	metas := map[string]*FeatureMeta{
+		dependent: {InstallsAfter: []string{"ghcr.io/devcontainers/features/node"}},
+		node:      {},
+	}
+	order, err := orderFeatures(metas)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if indexOf(order, node) > indexOf(order, dependent) {
+		t.Errorf("untagged edge should resolve to tagged ref; order = %v", order)
+	}
+}
+
+func TestOrderFeatures_AbsentDependencyIgnored(t *testing.T) {
+	a := "ghcr.io/a/feature:1"
+	b := "ghcr.io/b/feature:1"
+	metas := map[string]*FeatureMeta{
+		a: {InstallsAfter: []string{"ghcr.io/not/present"}},
+		b: {},
+	}
+	order, err := orderFeatures(metas)
+	if err != nil {
+		t.Fatalf("edge to absent feature must be ignored, got error: %v", err)
+	}
+	want := []string{a, b}
+	if !equalStrings(order, want) {
+		t.Errorf("order = %v, want deterministic alphabetical %v", order, want)
+	}
+}
+
+func TestOrderFeatures_Cycle(t *testing.T) {
+	a := "ghcr.io/a/feature:1"
+	b := "ghcr.io/b/feature:1"
+	metas := map[string]*FeatureMeta{
+		a: {InstallsAfter: []string{"ghcr.io/b/feature"}},
+		b: {InstallsAfter: []string{"ghcr.io/a/feature"}},
+	}
+	_, err := orderFeatures(metas)
+	if err == nil {
+		t.Fatal("expected cycle error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("expected cycle error, got %v", err)
+	}
+}
+
+func TestNormalizeRef(t *testing.T) {
+	cases := map[string]string{
+		"ghcr.io/devcontainers/features/node:1": "ghcr.io/devcontainers/features/node",
+		"ghcr.io/devcontainers/features/node":   "ghcr.io/devcontainers/features/node",
+	}
+	for in, want := range cases {
+		if got := normalizeRef(in); got != want {
+			t.Errorf("normalizeRef(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNormalizeRef_UnparseableFallback(t *testing.T) {
+	// An uppercase repository is invalid for name.ParseReference, exercising the
+	// string-strip fallback. The tag must still be dropped so edge matching works.
+	cases := map[string]string{
+		"REG.io/Org/Repo:7":          "REG.io/Org/Repo",
+		"REG.io/Org/Repo@sha256:abc": "REG.io/Org/Repo",
+		"REG.io/Org/Repo/":           "REG.io/Org/Repo",
+	}
+	for in, want := range cases {
+		if got := normalizeRef(in); got != want {
+			t.Errorf("normalizeRef(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// mockFeaturePuller returns pre-configured feature content. When metaByRef is
+// set, it serves per-ref metadata so multi-feature ordering can be exercised;
+// otherwise it falls back to the single fixed tarData/meta.
 type mockFeaturePuller struct {
-	tarData []byte
-	meta    *FeatureMeta
-	err     error
+	tarData   []byte
+	meta      *FeatureMeta
+	metaByRef map[string]*FeatureMeta
+	tarByRef  map[string][]byte
+	err       error
+	pulled    []string
 }
 
-func (m *mockFeaturePuller) Pull(_ context.Context, _ string) ([]byte, *FeatureMeta, error) {
+func (m *mockFeaturePuller) Pull(_ context.Context, ref string) ([]byte, *FeatureMeta, error) {
 	if m.err != nil {
 		return nil, nil, m.err
 	}
+	m.pulled = append(m.pulled, ref)
+	if m.metaByRef != nil {
+		tar := m.tarData
+		if t, ok := m.tarByRef[ref]; ok {
+			tar = t
+		}
+		return tar, m.metaByRef[ref], nil
+	}
 	return m.tarData, m.meta, nil
+}
+
+func indexOf(s []string, v string) int {
+	for i, e := range s {
+		if e == v {
+			return i
+		}
+	}
+	return -1
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func toEnvMap(env []string) map[string]string {


### PR DESCRIPTION
## What

Devcontainer features were installed in plain alphabetical order, ignoring each feature's `installsAfter` dependency. As a result `claude-code` (which declares `installsAfter: [.../node]`) installed *before* `node`, ran on a Node-less base image, and its `install.sh` exited non-zero — surfacing only as the opaque `Error: starting agent container`.

## Why

The `installsAfter` metadata was already parsed into `FeatureMeta` but referenced nowhere — install ordering came solely from `sort.Strings` over the config refs.

## How

- `InstallFeatures` now pulls every feature's tarball + meta up front (cached in a `pulledFeature` map), since ordering depends on `installsAfter` edges only known post-Pull. The install loop reuses the cached data — no second Pull.
- Replaced `sortedFeatureRefs` with `orderFeatures`, a Kahn topological sort over `installsAfter` edges with an alphabetically-sorted ready-set for a deterministic tie-break. Cycles return `errors.WithDetails("feature installsAfter cycle", ...)`.
- Added `normalizeRef` (strips tag/digest) so untagged `installsAfter` entries (`.../node`) match tagged config refs (`.../node:1`).
- Decomposed graph-building (`buildFeatureGraph`) and the sort (`kahnSort`) into helpers.

## Tests

Table tests for reorder / independent / tag-mismatch / absent-dependency / cycle, `normalizeRef` coverage, and an end-to-end `TestInstallFeatures_InstallsInDependencyOrder` verifying node installs before claude-code. Pass deterministically across repeated runs.

- `make test` — all pass
- `make lint` — 0 issues
- Coverage: devcontainer package 67.8% → 69.9%; changed functions 83–100%

## Reviewer notes

- `make check` currently fails on a **pre-existing** `govulncheck` finding (`GO-2026-5037/5038/5039`) in the Docker `client` dependency — confirmed failing identically on a clean tree, unrelated to this change. Worth a separate dep-bump/suppression ticket.
- Secondary diagnosability (the opaque `Error: starting agent container`) is left as-is; the underlying error already carries `stderr`/`exit_code` via `WithDetails`. A follow-up ticket if louder failure logging is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)