### PR TITLE
[HUM-124] Bump Go toolchain to 1.26.4 to clear stdlib govulncheck findings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gethuman-sh/human
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/1password/onepassword-sdk-go v0.4.0


### PR DESCRIPTION
## What

Bumps the `go` directive in `go.mod` from `1.26.3` to `1.26.4`.

## Why

The CI **security** job's govulncheck gate (`scripts/govulncheck.sh`) was failing on three new Go **standard-library** vulnerabilities, all fixed in go1.26.4:

| ID | Package | Detail |
|----|---------|--------|
| GO-2026-5037 | `crypto/x509` | inefficient candidate hostname parsing |
| GO-2026-5038 | `mime` | `WordDecoder.DecodeHeader` CPU exhaustion (CVE-2026-42504) |
| GO-2026-5039 | `net/textproto` | — |

CI installs Go via `go-version-file: go.mod`, so bumping the directive makes `setup-go` pull the patched toolchain and the findings clear automatically. No code changes.

These are *fixable* stdlib bugs, so they are intentionally **not** added to the govulncheck suppression list — that list is reserved for the unfixable Docker-daemon false positives (GO-2026-4883 / GO-2026-4887).

## Verification

Ran `make check` locally with the go1.26.4 toolchain — exit 0:
- govulncheck gate → `OK: no vulnerabilities outside the suppression list`
- golangci-lint → `0 issues`
- tests pass, gitleaks → no leaks

## Reviewer notes

Failing run before fix: https://github.com/gethuman-sh/human/actions/runs/27721235743

🤖 Generated with [Claude Code](https://claude.com/claude-code)