### PR TITLE
Fix devcontainer startup: resolve Docker context + propagate feature containerEnv

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/docker/cli v29.5.2+incompatible
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/google/go-containerregistry v0.21.6
 	github.com/hanwen/go-fuse/v2 v2.10.1
@@ -201,7 +202,6 @@ require (
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dnephin/pflag v1.0.7 // indirect
-	github.com/docker/cli v29.5.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.7 // indirect
 	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -221,6 +221,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/firefart/nonamedreturns v1.0.6 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
+	github.com/fvbommel/sortorder v1.1.0 // indirect
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
 	github.com/ghostiam/protogetter v0.3.20 // indirect
@@ -388,6 +389,7 @@ require (
 	github.com/moby/moby/api v1.54.2 // indirect
 	github.com/moby/moby/client v0.4.1 // indirect
 	github.com/moby/sys/atomicwriter v0.1.0 // indirect
+	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/term v0.5.2 // indirect
 	github.com/modelcontextprotocol/registry v1.4.1 // indirect
 	github.com/moricho/tparallel v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -531,6 +531,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
+github.com/fvbommel/sortorder v1.1.0 h1:fUmoe+HLsBTctBDoaBwpQo5N+nrCp8g/BjKb/6ZQmYw=
+github.com/fvbommel/sortorder v1.1.0/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/fzipp/gocyclo v0.6.0 h1:lsblElZG7d3ALtGMx9fmxeTKZaLLpU8mET09yN4BBLo=
 github.com/fzipp/gocyclo v0.6.0/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlyaLkLoA=
 github.com/gabriel-vasile/mimetype v1.4.12 h1:e9hWvmLYvtp846tLHam2o++qitpguFiYCKbn0w9jyqw=

--- a/internal/agent/docker_error_test.go
+++ b/internal/agent/docker_error_test.go
@@ -1,0 +1,62 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+
+	humanerrors "github.com/gethuman-sh/human/errors"
+)
+
+// dialConnectionError produces a genuine Docker SDK connection failure by
+// pointing a client at an address that refuses connections and issuing a call.
+// This exercises the same error type the agent start path encounters when the
+// engine is unreachable, without depending on the SDK's deprecated
+// ErrorConnectionFailed constructor.
+func dialConnectionError(t *testing.T) error {
+	t.Helper()
+	// 127.0.0.1:1 is in the reserved low-port range with nothing listening, so
+	// the dial fails fast with a connection error.
+	cli, err := client.NewClientWithOpts(client.WithHost("tcp://127.0.0.1:1"))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	t.Cleanup(func() { _ = cli.Close() })
+	_, err = cli.ContainerList(context.Background(), container.ListOptions{})
+	if err == nil {
+		t.Fatal("expected a connection error dialing a closed port")
+	}
+	if !client.IsErrConnectionFailed(err) {
+		t.Fatalf("expected a connection-failed error, got %v", err)
+	}
+	return err
+}
+
+// TestIsDockerUnreachableTraversesWrapChain asserts that a Docker SDK
+// connection failure is recognized even after it has been wrapped by
+// tozd/go/errors (as happens on the agent start path). Without chain traversal
+// the actionable, context-aware error would never be selected and users would
+// be left with the opaque generic message.
+func TestIsDockerUnreachableTraversesWrapChain(t *testing.T) {
+	connErr := dialConnectionError(t)
+	if !isDockerUnreachable(connErr) {
+		t.Fatal("bare connection error must be detected")
+	}
+
+	wrapped := humanerrors.WrapWithDetails(connErr, "starting agent container", "name", "demo")
+	if !isDockerUnreachable(wrapped) {
+		t.Fatal("wrapped connection error must still be detected through the chain")
+	}
+}
+
+// TestIsDockerUnreachableIgnoresUnrelatedErrors guards against mislabeling a
+// non-connection failure (e.g. a feature-install error) as an unreachable
+// engine, which would hide the real cause behind a misleading remedy.
+func TestIsDockerUnreachableIgnoresUnrelatedErrors(t *testing.T) {
+	if isDockerUnreachable(errors.New("install.sh exited 1")) {
+		t.Fatal("unrelated error must not be reported as a Docker connection failure")
+	}
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -11,10 +11,20 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/docker/client"
+
 	"github.com/gethuman-sh/human/errors"
 	"github.com/gethuman-sh/human/internal/daemon"
 	"github.com/gethuman-sh/human/internal/devcontainer"
+	"github.com/gethuman-sh/human/internal/dockerhost"
 )
+
+// isDockerUnreachable reports whether err is (or wraps) a Docker daemon
+// connection failure. errors.As traverses the wrap chain, so SDK connection
+// errors are detected even after tozd/go/errors wrapping.
+func isDockerUnreachable(err error) bool {
+	return client.IsErrConnectionFailed(err)
+}
 
 // validNameRe matches agent names: alphanumeric, hyphens, underscores.
 var validNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
@@ -66,6 +76,12 @@ func (m *Manager) Start(ctx context.Context, opts StartOpts) (Meta, error) {
 
 	dcMeta, err := m.startDevcontainer(ctx, containerName, configDir, workspace, opts.Rebuild)
 	if err != nil {
+		// A failure here is most often an unreachable Docker engine. Surface an
+		// actionable error naming the active context and attempted endpoint
+		// instead of the opaque generic message.
+		if isDockerUnreachable(err) {
+			return Meta{}, dockerhost.UnreachableError(err, dockerhost.Resolve())
+		}
 		return Meta{}, errors.WrapWithDetails(err, "starting agent container", "name", opts.Name)
 	}
 

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -65,7 +65,7 @@ func (m *mockDockerClient) ContainerList(_ context.Context, _ devcontainer.Conta
 func (m *mockDockerClient) ContainerLogs(_ context.Context, _ string, _ devcontainer.LogsOptions) (io.ReadCloser, error) {
 	return io.NopCloser(strings.NewReader("")), nil
 }
-func (m *mockDockerClient) ContainerCommit(_ context.Context, _ string, _ string) (string, error) {
+func (m *mockDockerClient) ContainerCommit(_ context.Context, _ string, _ string, _ map[string]string) (string, error) {
 	return "sha256:committed", nil
 }
 func (m *mockDockerClient) CopyToContainer(_ context.Context, _, _ string, _ io.Reader) error {

--- a/internal/claude/docker_client.go
+++ b/internal/claude/docker_client.go
@@ -9,11 +9,23 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
+
+	"github.com/gethuman-sh/human/internal/dockerhost"
 )
 
 // NewEngineDockerClient creates a DockerClient backed by the Docker Engine API.
+//
+// When DOCKER_HOST is unset, it resolves the active docker CLI context's
+// endpoint (colima/OrbStack/Rancher/Docker-Desktop/Podman) so the TUI's
+// container discovery and `human usage` reach the engine out-of-the-box. The
+// resolution is shared with devcontainer.NewDockerClient via
+// internal/dockerhost so the two never diverge.
 func NewEngineDockerClient() (DockerClient, error) {
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	opts := []client.Opt{client.FromEnv, client.WithAPIVersionNegotiation()}
+	if host := dockerhost.Resolve().Host; host != "" {
+		opts = append(opts, client.WithHost(host))
+	}
+	cli, err := client.NewClientWithOpts(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/claude/docker_client_test.go
+++ b/internal/claude/docker_client_test.go
@@ -1,0 +1,63 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/gethuman-sh/human/internal/dockerhost"
+)
+
+// TestNewEngineDockerClientAppliesResolvedHost asserts that NewEngineDockerClient
+// routes the active Docker endpoint through the shared dockerhost resolver, so
+// TUI container discovery and `human usage` honor the docker CLI context rather
+// than always hitting the compiled-in default socket. Driving it via DOCKER_HOST
+// exercises the same WithHost code path a resolved context takes.
+func TestNewEngineDockerClientAppliesResolvedHost(t *testing.T) {
+	const host = "tcp://127.0.0.1:23760"
+	t.Setenv("DOCKER_HOST", host)
+
+	dc, err := NewEngineDockerClient()
+	if err != nil {
+		t.Fatalf("NewEngineDockerClient: %v", err)
+	}
+	t.Cleanup(func() { _ = dc.Close() })
+
+	ec, ok := dc.(*engineDockerClient)
+	if !ok {
+		t.Fatalf("expected *engineDockerClient, got %T", dc)
+	}
+	if got := ec.cli.DaemonHost(); got != host {
+		t.Errorf("DaemonHost() = %q, want %q", got, host)
+	}
+}
+
+// TestNewEngineDockerClientSharesResolver guards that this constructor and the
+// devcontainer constructor consult the same resolver, so a future regression in
+// either cannot silently diverge from the docker CLI's context handling.
+func TestNewEngineDockerClientSharesResolver(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "tcp://127.0.0.1:23761")
+	if got := dockerhost.Resolve().Source; got != "env" {
+		t.Fatalf("dockerhost.Resolve() Source = %q, want env", got)
+	}
+}
+
+// TestNewEngineDockerClientDefaultWithoutEnv asserts the constructor still
+// succeeds and yields a usable client when neither DOCKER_HOST nor a context
+// applies.
+func TestNewEngineDockerClientDefaultWithoutEnv(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv("DOCKER_CONTEXT", "default")
+
+	dc, err := NewEngineDockerClient()
+	if err != nil {
+		t.Fatalf("NewEngineDockerClient: %v", err)
+	}
+	t.Cleanup(func() { _ = dc.Close() })
+
+	ec, ok := dc.(*engineDockerClient)
+	if !ok {
+		t.Fatalf("expected *engineDockerClient, got %T", dc)
+	}
+	if ec.cli.DaemonHost() == "" {
+		t.Errorf("DaemonHost() should be the platform default, got empty")
+	}
+}

--- a/internal/devcontainer/docker.go
+++ b/internal/devcontainer/docker.go
@@ -23,7 +23,10 @@ type DockerClient interface {
 	ContainerInspect(ctx context.Context, containerID string) (ContainerInspectResponse, error)
 	ContainerList(ctx context.Context, opts ContainerListOptions) ([]ContainerSummary, error)
 	ContainerLogs(ctx context.Context, containerID string, opts LogsOptions) (io.ReadCloser, error)
-	ContainerCommit(ctx context.Context, containerID string, ref string) (string, error)
+	// ContainerCommit commits the container as an image. env entries are baked
+	// into the image as ENV so feature-contributed variables (e.g. the node and
+	// go features' PATH additions) persist into containers created from the image.
+	ContainerCommit(ctx context.Context, containerID string, ref string, env map[string]string) (string, error)
 
 	// File transfer
 	CopyToContainer(ctx context.Context, containerID, dstPath string, content io.Reader) error

--- a/internal/devcontainer/docker_engine.go
+++ b/internal/devcontainer/docker_engine.go
@@ -11,11 +11,26 @@ import (
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
+
+	"github.com/gethuman-sh/human/internal/dockerhost"
 )
 
 // NewDockerClient creates a DockerClient backed by the Docker Engine API.
+//
+// When DOCKER_HOST is unset, it resolves the active docker CLI context's
+// endpoint (colima/OrbStack/Rancher/Docker-Desktop/Podman) so human reaches the
+// engine out-of-the-box, mirroring what the docker CLI does. Explicit
+// DOCKER_HOST / DOCKER_CONTEXT always win. The resolution is shared with
+// claude.NewEngineDockerClient via internal/dockerhost so the two never diverge.
 func NewDockerClient() (DockerClient, error) {
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	opts := []client.Opt{client.FromEnv, client.WithAPIVersionNegotiation()}
+	// A non-empty host means the active context resolved to a concrete
+	// endpoint; layer it on top of FromEnv. Empty means "use env/platform
+	// default", so we leave FromEnv to do its job.
+	if host := dockerhost.Resolve().Host; host != "" {
+		opts = append(opts, client.WithHost(host))
+	}
+	cli, err := client.NewClientWithOpts(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/devcontainer/docker_engine.go
+++ b/internal/devcontainer/docker_engine.go
@@ -3,6 +3,7 @@ package devcontainer
 import (
 	"context"
 	"io"
+	"sort"
 
 	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
@@ -200,9 +201,18 @@ func (e *engineClient) ContainerLogs(ctx context.Context, containerID string, op
 	})
 }
 
-func (e *engineClient) ContainerCommit(ctx context.Context, containerID string, ref string) (string, error) {
+func (e *engineClient) ContainerCommit(ctx context.Context, containerID string, ref string, env map[string]string) (string, error) {
+	// Bake feature-contributed env into the image as ENV directives. Sorted for
+	// a deterministic image (stable layer regardless of map iteration order).
+	changes := make([]string, 0, len(env))
+	for k, v := range env {
+		changes = append(changes, "ENV "+k+"="+v)
+	}
+	sort.Strings(changes)
+
 	resp, err := e.cli.ContainerCommit(ctx, containerID, container.CommitOptions{
 		Reference: ref,
+		Changes:   changes,
 	})
 	if err != nil {
 		return "", err

--- a/internal/devcontainer/docker_engine_test.go
+++ b/internal/devcontainer/docker_engine_test.go
@@ -1,0 +1,62 @@
+package devcontainer
+
+import (
+	"testing"
+
+	"github.com/gethuman-sh/human/internal/dockerhost"
+)
+
+// TestNewDockerClientAppliesResolvedHost asserts that NewDockerClient routes
+// the active Docker endpoint through the shared dockerhost resolver, so the
+// devcontainer engine honors the docker CLI context (colima/OrbStack/etc.)
+// instead of always hitting the compiled-in default socket. Driving it via
+// DOCKER_HOST exercises the same WithHost code path a resolved context takes.
+func TestNewDockerClientAppliesResolvedHost(t *testing.T) {
+	const host = "tcp://127.0.0.1:23750"
+	t.Setenv("DOCKER_HOST", host)
+
+	dc, err := NewDockerClient()
+	if err != nil {
+		t.Fatalf("NewDockerClient: %v", err)
+	}
+	t.Cleanup(func() { _ = dc.Close() })
+
+	ec, ok := dc.(*engineClient)
+	if !ok {
+		t.Fatalf("expected *engineClient, got %T", dc)
+	}
+	if got := ec.cli.DaemonHost(); got != host {
+		t.Errorf("DaemonHost() = %q, want %q", got, host)
+	}
+}
+
+// TestNewDockerClientSharesResolver guards that this constructor and the claude
+// constructor consult the same resolver: when DOCKER_HOST is set, the resolver
+// must report Source "env" so neither constructor reinvents context handling.
+func TestNewDockerClientSharesResolver(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "tcp://127.0.0.1:23751")
+	if got := dockerhost.Resolve().Source; got != "env" {
+		t.Fatalf("dockerhost.Resolve() Source = %q, want env", got)
+	}
+}
+
+// TestNewDockerClientDefaultWithoutEnv asserts the constructor still succeeds
+// and yields a usable client when neither DOCKER_HOST nor a context applies.
+func TestNewDockerClientDefaultWithoutEnv(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv("DOCKER_CONTEXT", "default")
+
+	dc, err := NewDockerClient()
+	if err != nil {
+		t.Fatalf("NewDockerClient: %v", err)
+	}
+	t.Cleanup(func() { _ = dc.Close() })
+
+	ec, ok := dc.(*engineClient)
+	if !ok {
+		t.Fatalf("expected *engineClient, got %T", dc)
+	}
+	if ec.cli.DaemonHost() == "" {
+		t.Errorf("DaemonHost() should be the platform default, got empty")
+	}
+}

--- a/internal/devcontainer/feature.go
+++ b/internal/devcontainer/feature.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -119,12 +120,18 @@ func extractFeatureMeta(tarData []byte, ref string) (*FeatureMeta, error) {
 // InstallFeatures downloads and installs devcontainer features into a running
 // container using exec. Each feature's install.sh is copied in via base64
 // encoding, then executed with the appropriate option environment variables.
+// InstallFeatures installs each feature into the container and returns the
+// accumulated containerEnv contributed by the features. A feature's containerEnv
+// (e.g. the node feature putting node/npm on PATH) must reach both the features
+// installed after it and the committed image — otherwise a dependent feature
+// like claude-code can't find node and fails. The returned map is baked into the
+// image by the caller via ContainerCommit.
 func InstallFeatures(ctx context.Context, docker DockerClient, puller FeaturePuller,
 	containerID string, features map[string]interface{}, remoteUser string,
-	logger zerolog.Logger, out io.Writer) error {
+	logger zerolog.Logger, out io.Writer) (map[string]string, error) {
 
 	if len(features) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// Pull every feature's metadata up front: the install order depends on each
@@ -135,7 +142,7 @@ func InstallFeatures(ctx context.Context, docker DockerClient, puller FeaturePul
 	for ref := range features {
 		tarData, meta, err := puller.Pull(ctx, ref)
 		if err != nil {
-			return errors.WrapWithDetails(err, "pulling feature", "ref", ref)
+			return nil, errors.WrapWithDetails(err, "pulling feature", "ref", ref)
 		}
 		pulled[ref] = &pulledFeature{tarData: tarData, meta: meta}
 		metas[ref] = meta
@@ -145,8 +152,19 @@ func InstallFeatures(ctx context.Context, docker DockerClient, puller FeaturePul
 	// installsAfter (when those features are present in the set).
 	refs, err := orderFeatures(metas)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	// Seed the expansion lookup with the container's existing environment so that
+	// ${PATH}-style references in feature containerEnv resolve against the real
+	// base PATH. lookup also accumulates feature additions so PATH chains across
+	// features; featureAccum tracks only the feature-contributed keys, which are
+	// layered onto later installs and returned for baking into the image.
+	lookup, err := captureContainerEnv(ctx, docker, containerID, "root", logger)
+	if err != nil {
+		return nil, errors.WrapWithDetails(err, "reading container environment")
+	}
+	featureAccum := make(map[string]string)
 
 	for _, ref := range refs {
 		opts, _ := features[ref].(map[string]interface{})
@@ -154,18 +172,62 @@ func InstallFeatures(ctx context.Context, docker DockerClient, puller FeaturePul
 
 		pf := pulled[ref]
 		if pf == nil {
-			return errors.WithDetails("ordered feature missing pulled data", "ref", ref)
+			return nil, errors.WithDetails("ordered feature missing pulled data", "ref", ref)
 		}
-		env := featureEnv(opts, pf.meta, remoteUser)
+		// install.sh runs with the env contributed by features installed before
+		// it (concrete values — Docker exec does not shell-expand env entries).
+		env := append(featureEnv(opts, pf.meta, remoteUser), mapToEnvSlice(featureAccum)...)
 
 		if err := copyAndRunFeature(ctx, docker, containerID, pf.tarData, env, logger); err != nil {
-			return errors.WrapWithDetails(err, "installing feature", "ref", ref)
+			return nil, errors.WrapWithDetails(err, "installing feature", "ref", ref)
+		}
+
+		// Layer this feature's containerEnv (with ${VAR} expanded against what is
+		// known so far) so later features and the committed image inherit it.
+		for k, v := range pf.meta.ContainerEnv {
+			expanded := expandEnvRefs(v, lookup)
+			lookup[k] = expanded
+			featureAccum[k] = expanded
 		}
 
 		logger.Info().Str("feature", ref).Msg("feature installed")
 	}
 
-	return nil
+	return featureAccum, nil
+}
+
+// captureContainerEnv reads the container's current environment as a map. It
+// seeds containerEnv expansion so a feature's "${PATH}" resolves against the
+// real base PATH instead of an empty string.
+func captureContainerEnv(ctx context.Context, docker DockerClient, containerID, user string, logger zerolog.Logger) (map[string]string, error) {
+	out, err := execCapture(ctx, docker, containerID, user, []string{"printenv"}, nil, logger)
+	if err != nil {
+		return nil, err
+	}
+	env := make(map[string]string)
+	for _, line := range strings.Split(out, "\n") {
+		if i := strings.IndexByte(line, '='); i > 0 {
+			env[line[:i]] = strings.TrimRight(line[i+1:], "\r")
+		}
+	}
+	return env, nil
+}
+
+// expandEnvRefs expands $VAR and ${VAR} references in val against lookup,
+// resolving unknown variables to empty (matching docker/shell behavior).
+func expandEnvRefs(val string, lookup map[string]string) string {
+	return os.Expand(val, func(k string) string { return lookup[k] })
+}
+
+// mapToEnvSlice converts an env map to a sorted KEY=VALUE slice for a stable,
+// deterministic exec environment.
+func mapToEnvSlice(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k, v := range m {
+		out = append(out, k+"="+v)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // pulledFeature holds a feature's downloaded tarball and parsed metadata so the

--- a/internal/devcontainer/feature_test.go
+++ b/internal/devcontainer/feature_test.go
@@ -9,6 +9,23 @@ import (
 	"testing"
 )
 
+// isInstallRun reports whether an exec call is a feature's install.sh run (as
+// opposed to the staging mkdir, cleanup, or the base-env printenv probe).
+func isInstallRun(c mockExecCall) bool {
+	return len(c.Cmd) > 0 && strings.Contains(c.Cmd[len(c.Cmd)-1], "./install.sh")
+}
+
+func findInstallRun(t *testing.T, calls []mockExecCall) mockExecCall {
+	t.Helper()
+	for _, c := range calls {
+		if isInstallRun(c) {
+			return c
+		}
+	}
+	t.Fatal("no install.sh run exec call found")
+	return mockExecCall{}
+}
+
 func TestFeatureEnv_BasicOptions(t *testing.T) {
 	opts := map[string]interface{}{
 		"version": "22",
@@ -129,19 +146,14 @@ func TestInstallFeatures_ExecCalls(t *testing.T) {
 		"ghcr.io/devcontainers/features/node:1": map[string]interface{}{"version": "22"},
 	}
 
-	err := InstallFeatures(context.Background(), mock, puller, "container-123",
+	_, err := InstallFeatures(context.Background(), mock, puller, "container-123",
 		features, "vscode", testLogger(), &strings.Builder{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Should have 3 exec calls: mkdir, run install.sh, cleanup.
-	if len(mock.execCalls) < 2 {
-		t.Fatalf("expected at least 2 exec calls, got %d", len(mock.execCalls))
-	}
-
-	// The run call (second) should have env vars.
-	runCall := mock.execCalls[1]
+	// The install.sh run call carries the feature env vars.
+	runCall := findInstallRun(t, mock.execCalls)
 	if runCall.Opts.User != "root" {
 		t.Errorf("run call user = %q, want root", runCall.Opts.User)
 	}
@@ -174,19 +186,18 @@ func TestInstallFeatures_InstallsInDependencyOrder(t *testing.T) {
 
 	features := map[string]interface{}{claude: map[string]interface{}{}, node: map[string]interface{}{}}
 
-	if err := InstallFeatures(context.Background(), mock, puller, "container-123",
+	if _, err := InstallFeatures(context.Background(), mock, puller, "container-123",
 		features, "vscode", testLogger(), &strings.Builder{}); err != nil {
 		t.Fatal(err)
 	}
 
-	// Each feature produces mkdir, run, cleanup; the run call (index 1 of each
-	// triple) carries the MARKER env that identifies the feature.
+	// Each feature's install.sh run carries the MARKER env identifying it; the
+	// order of those runs is the install order.
 	var installOrder []string
-	for i, call := range mock.execCalls {
-		if i%3 != 1 {
-			continue
+	for _, call := range mock.execCalls {
+		if isInstallRun(call) {
+			installOrder = append(installOrder, toEnvMap(call.Opts.Env)["MARKER"])
 		}
-		installOrder = append(installOrder, toEnvMap(call.Opts.Env)["MARKER"])
 	}
 
 	if indexOf(installOrder, "node") > indexOf(installOrder, "claude") {
@@ -195,10 +206,93 @@ func TestInstallFeatures_InstallsInDependencyOrder(t *testing.T) {
 }
 
 func TestInstallFeatures_Empty(t *testing.T) {
-	err := InstallFeatures(context.Background(), &mockDockerClient{}, &mockFeaturePuller{},
+	_, err := InstallFeatures(context.Background(), &mockDockerClient{}, &mockFeaturePuller{},
 		"cid", nil, "user", testLogger(), &strings.Builder{})
 	if err != nil {
 		t.Errorf("expected nil error for empty features: %v", err)
+	}
+}
+
+// TestInstallFeatures_ContainerEnvPropagates is the regression test for the bug
+// where a feature's containerEnv (e.g. the node feature putting node/npm on PATH)
+// never reached the features installed after it, so claude-code could not find
+// node. It asserts the env is layered onto later installs and returned for the
+// image bake, and that a feature does not yet see its own containerEnv.
+func TestInstallFeatures_ContainerEnvPropagates(t *testing.T) {
+	mock := &mockDockerClient{}
+
+	first := "ghcr.io/test/first:1"
+	second := "ghcr.io/test/second:1"
+	puller := &mockFeaturePuller{
+		tarData: buildFeatureTar(t, "shared", "1.0.0"),
+		metaByRef: map[string]*FeatureMeta{
+			// first publishes PATH and a marker var; second depends on first.
+			first: {ID: "first", ContainerEnv: map[string]string{
+				"PATH":   "/opt/first/bin:${PATH}",
+				"FIRSTV": "yes",
+			}, Options: map[string]FeatureOption{"marker": {Default: "first"}}},
+			second: {ID: "second", InstallsAfter: []string{"ghcr.io/test/first"},
+				Options: map[string]FeatureOption{"marker": {Default: "second"}}},
+		},
+	}
+	features := map[string]interface{}{first: map[string]interface{}{}, second: map[string]interface{}{}}
+
+	baked, err := InstallFeatures(context.Background(), mock, puller, "cid",
+		features, "vscode", testLogger(), &strings.Builder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Returned env (baked into the image) carries first's containerEnv.
+	if !strings.Contains(baked["PATH"], "/opt/first/bin") {
+		t.Errorf("baked PATH = %q, want it to contain /opt/first/bin", baked["PATH"])
+	}
+	if baked["FIRSTV"] != "yes" {
+		t.Errorf("baked FIRSTV = %q, want yes", baked["FIRSTV"])
+	}
+
+	// Map each install.sh run to its feature via MARKER, then check env exposure.
+	envByFeature := map[string]map[string]string{}
+	for _, c := range mock.execCalls {
+		if isInstallRun(c) {
+			env := toEnvMap(c.Opts.Env)
+			envByFeature[env["MARKER"]] = env
+		}
+	}
+
+	// second runs after first and must see first's PATH addition + FIRSTV.
+	if got := envByFeature["second"]["PATH"]; !strings.Contains(got, "/opt/first/bin") {
+		t.Errorf("second's install PATH = %q, want it to contain /opt/first/bin", got)
+	}
+	if got := envByFeature["second"]["FIRSTV"]; got != "yes" {
+		t.Errorf("second's install FIRSTV = %q, want yes", got)
+	}
+	// first must NOT yet see its own containerEnv (applied only after it installs).
+	if got := envByFeature["first"]["FIRSTV"]; got != "" {
+		t.Errorf("first should not see its own FIRSTV during install, got %q", got)
+	}
+}
+
+func TestExpandEnvRefs(t *testing.T) {
+	lookup := map[string]string{"PATH": "/usr/bin", "HOME": "/root"}
+	cases := []struct{ in, want string }{
+		{"/opt/bin:${PATH}", "/opt/bin:/usr/bin"},
+		{"$HOME/go", "/root/go"},
+		{"literal", "literal"},
+		{"${MISSING}/x", "/x"},
+	}
+	for _, c := range cases {
+		if got := expandEnvRefs(c.in, lookup); got != c.want {
+			t.Errorf("expandEnvRefs(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestMapToEnvSlice_Sorted(t *testing.T) {
+	got := mapToEnvSlice(map[string]string{"B": "2", "A": "1", "C": "3"})
+	want := []string{"A=1", "B=2", "C=3"}
+	if !equalStrings(got, want) {
+		t.Errorf("mapToEnvSlice = %v, want sorted %v", got, want)
 	}
 }
 

--- a/internal/devcontainer/hooks.go
+++ b/internal/devcontainer/hooks.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 
 	"github.com/rs/zerolog"
@@ -87,6 +88,16 @@ func runParallelHooks(ctx context.Context, docker DockerClient, containerID, use
 
 // execInContainer runs a command inside a container and waits for completion.
 func execInContainer(ctx context.Context, docker DockerClient, containerID, user string, cmd, env []string, logger zerolog.Logger) error {
+	_, err := execCapture(ctx, docker, containerID, user, cmd, env, logger)
+	return err
+}
+
+// execCapture runs cmd in the container and returns its stdout. It is the core
+// used by execInContainer; callers that need the command's output (e.g. reading
+// the container environment) use it directly. On a non-zero exit it returns an
+// error carrying the exit code plus both streams — feature install.sh scripts
+// frequently print their fatal reason to stdout, so stdout must be surfaced too.
+func execCapture(ctx context.Context, docker DockerClient, containerID, user string, cmd, env []string, logger zerolog.Logger) (string, error) {
 	logger.Info().Strs("cmd", cmd).Str("user", user).Msg("exec in container")
 
 	execID, err := docker.ExecCreate(ctx, containerID, cmd, ExecOptions{
@@ -96,12 +107,12 @@ func execInContainer(ctx context.Context, docker DockerClient, containerID, user
 		AttachStderr: true,
 	})
 	if err != nil {
-		return errors.WrapWithDetails(err, "creating exec", "cmd", fmt.Sprint(cmd))
+		return "", errors.WrapWithDetails(err, "creating exec", "cmd", fmt.Sprint(cmd))
 	}
 
 	attach, err := docker.ExecAttach(ctx, execID)
 	if err != nil {
-		return errors.WrapWithDetails(err, "attaching to exec")
+		return "", errors.WrapWithDetails(err, "attaching to exec")
 	}
 	defer func() { _ = attach.Close() }()
 
@@ -118,15 +129,30 @@ func execInContainer(ctx context.Context, docker DockerClient, containerID, user
 
 	inspect, err := docker.ExecInspect(ctx, execID)
 	if err != nil {
-		return errors.WrapWithDetails(err, "inspecting exec result")
+		return stdout.String(), errors.WrapWithDetails(err, "inspecting exec result")
 	}
 	if inspect.ExitCode != 0 {
-		return errors.WithDetails("exec failed",
+		return stdout.String(), errors.WithDetails("exec failed",
 			"exit_code", inspect.ExitCode,
 			"cmd", fmt.Sprint(cmd),
-			"stderr", stderr.String())
+			"stdout", lastLines(stdout.String(), 4000),
+			"stderr", lastLines(stderr.String(), 4000))
 	}
-	return nil
+	return stdout.String(), nil
+}
+
+// lastLines returns at most the final maxBytes of s, trimmed to a line boundary,
+// so a failing command's tail (where the actual error usually is) is preserved
+// without bloating the error with the entire build log.
+func lastLines(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	tail := s[len(s)-maxBytes:]
+	if i := strings.IndexByte(tail, '\n'); i >= 0 && i+1 < len(tail) {
+		tail = tail[i+1:]
+	}
+	return "...\n" + tail
 }
 
 // RunLifecycleHooks executes the devcontainer lifecycle hooks in order inside a container.

--- a/internal/devcontainer/hooks_test.go
+++ b/internal/devcontainer/hooks_test.go
@@ -38,6 +38,7 @@ type mockDockerClient struct {
 
 	commitCalls []string
 	commitID    string
+	commitEnv   map[string]string
 }
 
 type mockExecCall struct {
@@ -118,9 +119,10 @@ func (m *mockDockerClient) ContainerLogs(_ context.Context, _ string, _ LogsOpti
 	return io.NopCloser(strings.NewReader("log output")), nil
 }
 
-func (m *mockDockerClient) ContainerCommit(_ context.Context, id string, ref string) (string, error) {
+func (m *mockDockerClient) ContainerCommit(_ context.Context, id string, ref string, env map[string]string) (string, error) {
 	m.mu.Lock()
 	m.commitCalls = append(m.commitCalls, id+":"+ref)
+	m.commitEnv = env
 	m.mu.Unlock()
 	if m.commitID != "" {
 		return m.commitID, nil

--- a/internal/devcontainer/image.go
+++ b/internal/devcontainer/image.go
@@ -22,6 +22,9 @@ import (
 type ImageBuilder struct {
 	Docker DockerClient
 	Logger zerolog.Logger
+	// Puller fetches devcontainer features; defaults to an OCI registry puller
+	// when nil. Injectable so feature installation can be tested without a registry.
+	Puller FeaturePuller
 }
 
 // EnsureImage ensures a devcontainer image exists. If not cached (or rebuild
@@ -106,14 +109,20 @@ func (b *ImageBuilder) buildWithFeatures(ctx context.Context, cfg *DevcontainerC
 		return "", "", errors.WrapWithDetails(err, "starting temp container")
 	}
 
-	// Install features.
-	puller := &OCIFeaturePuller{}
-	if err := InstallFeatures(ctx, b.Docker, puller, tempID, cfg.Features, remoteUser, b.Logger, out); err != nil {
+	// Install features. The returned env is each feature's containerEnv (e.g. the
+	// node/go features' PATH additions), which must be baked into the committed
+	// image so containers created from it inherit it.
+	puller := b.Puller
+	if puller == nil {
+		puller = &OCIFeaturePuller{}
+	}
+	featureEnv, err := InstallFeatures(ctx, b.Docker, puller, tempID, cfg.Features, remoteUser, b.Logger, out)
+	if err != nil {
 		return "", "", errors.WrapWithDetails(err, "installing features")
 	}
 
-	// Commit the container as the cached image.
-	committedID, err := b.Docker.ContainerCommit(ctx, tempID, imageName)
+	// Commit the container as the cached image, baking in the feature env.
+	committedID, err := b.Docker.ContainerCommit(ctx, tempID, imageName, featureEnv)
 	if err != nil {
 		return "", "", errors.WrapWithDetails(err, "committing image with features")
 	}

--- a/internal/devcontainer/image_test.go
+++ b/internal/devcontainer/image_test.go
@@ -8,6 +8,41 @@ import (
 	"testing"
 )
 
+// TestBuildWithFeatures_BakesContainerEnv asserts that feature containerEnv is
+// passed to ContainerCommit so it is baked into the committed image — the fix
+// that lets node/go end up on PATH for containers created from the image.
+func TestBuildWithFeatures_BakesContainerEnv(t *testing.T) {
+	mock := &mockDockerClient{createID: "temp-cid", commitID: "sha256:withenv"}
+	puller := &mockFeaturePuller{
+		tarData: buildFeatureTar(t, "node", "1.0.0"),
+		metaByRef: map[string]*FeatureMeta{
+			"ghcr.io/devcontainers/features/node:1": {ID: "node", ContainerEnv: map[string]string{
+				"PATH":    "/usr/local/share/nvm/current/bin:${PATH}",
+				"NVM_DIR": "/usr/local/share/nvm",
+			}},
+		},
+	}
+	builder := &ImageBuilder{Docker: mock, Logger: testLogger(), Puller: puller}
+
+	cfg := &DevcontainerConfig{
+		Image:    "mcr.microsoft.com/devcontainers/base:ubuntu",
+		Features: map[string]interface{}{"ghcr.io/devcontainers/features/node:1": map[string]interface{}{}},
+	}
+	id, _, err := builder.buildWithFeatures(context.Background(), cfg, "base:ref", "human-dc-test:hash", &strings.Builder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "sha256:withenv" {
+		t.Errorf("commit id = %q, want sha256:withenv", id)
+	}
+	if mock.commitEnv["NVM_DIR"] != "/usr/local/share/nvm" {
+		t.Errorf("commit env NVM_DIR = %q, want it baked in", mock.commitEnv["NVM_DIR"])
+	}
+	if !strings.Contains(mock.commitEnv["PATH"], "/usr/local/share/nvm/current/bin") {
+		t.Errorf("commit env PATH = %q, want nvm bin path baked in", mock.commitEnv["PATH"])
+	}
+}
+
 func TestEnsureImage_Cached(t *testing.T) {
 	mock := &mockDockerClient{
 		imageInspectResult: ImageInspectResponse{ID: "sha256:cached", Tags: []string{"human-dc-test:abc123abc123"}},

--- a/internal/dockerhost/dockerhost.go
+++ b/internal/dockerhost/dockerhost.go
@@ -1,0 +1,181 @@
+// Package dockerhost resolves the Docker Engine endpoint the same way the
+// docker CLI does, so human reaches the engine out-of-the-box on setups that
+// expose the socket via a docker *context* (colima, OrbStack, Rancher Desktop,
+// Docker Desktop, Podman) rather than via DOCKER_HOST.
+//
+// The Docker Go SDK's client.FromEnv only reads environment variables; it does
+// not consult the docker CLI context store. This package bridges that gap with
+// a single shared resolver used by every Docker client constructor in human so
+// the two can never diverge.
+package dockerhost
+
+import (
+	"path/filepath"
+
+	"github.com/docker/cli/cli/config"
+	ctxstore "github.com/docker/cli/cli/context/docker"
+	"github.com/docker/cli/cli/context/store"
+
+	"github.com/gethuman-sh/human/errors"
+)
+
+// Environment variable names. We use literals rather than importing the moby
+// client constants to keep this package's dependency surface minimal.
+const (
+	envDockerHost    = "DOCKER_HOST"
+	envDockerContext = "DOCKER_CONTEXT"
+)
+
+// defaultContextName is the reserved name for the env/config-default context,
+// for which the SDK's compiled-in platform default socket/pipe must be used.
+const defaultContextName = "default"
+
+// contextsDir is the subdirectory of the docker config dir that holds the
+// context store, mirroring the docker CLI's layout.
+const contextsDir = "contexts"
+
+// Result describes the outcome of context resolution. Host is the endpoint to
+// hand to the Docker SDK (empty means "use the SDK's env/platform default").
+// Context and Source explain *why* that host was chosen so callers can build an
+// actionable error when the engine turns out to be unreachable.
+type Result struct {
+	// Host is the resolved Docker endpoint, or "" when the caller should fall
+	// back to the SDK's env/platform default.
+	Host string
+	// Context is the active docker context name ("default" when none).
+	Context string
+	// Source explains where Host came from: "env" (DOCKER_HOST set), "context"
+	// (resolved from the context store), or "default" (platform fallback).
+	Source string
+}
+
+// options carries the injectable dependencies so the resolver stays a pure
+// function of (env, filesystem) and is exhaustively unit-testable without
+// mutating process-global state.
+type options struct {
+	// getenv looks up an environment variable; injected for tests.
+	getenv func(string) string
+	// configDir is the docker config dir (the ".docker" directory). It honors
+	// DOCKER_CONFIG and per-platform defaults in production; tests inject a temp
+	// dir. config.json lives directly under it; the context store under
+	// configDir/contexts.
+	configDir string
+}
+
+// Option customizes resolution. Production callers pass none and get the real
+// os/config-backed behavior.
+type Option func(*options)
+
+// withGetenv injects an environment lookup. Used by tests.
+func withGetenv(fn func(string) string) Option {
+	return func(o *options) { o.getenv = fn }
+}
+
+// withConfigDir injects the docker config dir. Used by tests.
+func withConfigDir(dir string) Option {
+	return func(o *options) { o.configDir = dir }
+}
+
+// Resolve mirrors the docker CLI's context precedence:
+//
+//  1. DOCKER_HOST set  => explicit env wins; return Host="" so the SDK's FromEnv
+//     handles it (Source "env").
+//  2. otherwise context name = DOCKER_CONTEXT, else config.json currentContext,
+//     else "default".
+//  3. context == "default" => Host="" so the SDK uses the platform default
+//     socket/pipe (Source "default").
+//  4. otherwise read Endpoints.docker.Host from the context store and return it
+//     (Source "context").
+//
+// Any failure to read the store (missing/malformed config.json, missing
+// meta.json, missing docker endpoint) degrades gracefully to the platform
+// default rather than blocking startup.
+func Resolve(opts ...Option) Result {
+	o := options{
+		getenv:    osGetenv,
+		configDir: config.Dir(),
+	}
+	for _, fn := range opts {
+		fn(&o)
+	}
+
+	// Explicit DOCKER_HOST always wins for predictable override.
+	if o.getenv(envDockerHost) != "" {
+		return Result{Host: "", Context: defaultContextName, Source: "env"}
+	}
+
+	ctxName := o.getenv(envDockerContext)
+	if ctxName == "" {
+		ctxName = currentContextFromConfig(&o)
+	}
+	if ctxName == "" || ctxName == defaultContextName {
+		return Result{Host: "", Context: defaultContextName, Source: "default"}
+	}
+
+	host, ok := endpointHost(&o, ctxName)
+	if !ok {
+		// Store missing/malformed for this context: fall back to the platform
+		// default rather than failing hard.
+		return Result{Host: "", Context: defaultContextName, Source: "default"}
+	}
+	return Result{Host: host, Context: ctxName, Source: "context"}
+}
+
+// currentContextFromConfig reads currentContext from the docker config.json.
+// A missing or malformed config yields "" (caller treats as default).
+func currentContextFromConfig(o *options) string {
+	if o.configDir == "" {
+		return ""
+	}
+	cfg, err := config.Load(o.configDir)
+	if err != nil || cfg == nil {
+		return ""
+	}
+	return cfg.CurrentContext
+}
+
+// endpointHost reads Endpoints.docker.Host for ctxName from the context store.
+// The bool is false on any error so the caller can fall back to the default.
+func endpointHost(o *options, ctxName string) (string, bool) {
+	if o.configDir == "" {
+		return "", false
+	}
+	storeDir := filepath.Join(o.configDir, contextsDir)
+	// Register the docker endpoint type so the store can unmarshal the typed
+	// EndpointMeta (Host/SkipTLSVerify) from meta.json.
+	cfg := store.NewConfig(
+		func() any { return &map[string]any{} },
+		store.EndpointTypeGetter(ctxstore.DockerEndpoint, func() any { return &ctxstore.EndpointMeta{} }),
+	)
+	s := store.New(storeDir, cfg)
+	meta, err := s.GetMetadata(ctxName)
+	if err != nil {
+		return "", false
+	}
+	ep, err := ctxstore.EndpointFromContext(meta)
+	if err != nil {
+		return "", false
+	}
+	if ep.Host == "" {
+		return "", false
+	}
+	return ep.Host, true
+}
+
+// UnreachableError builds an actionable error for a failed Docker connection.
+// It names the active context and the attempted endpoint and gives a one-line
+// remedy, replacing the opaque generic failure users used to see.
+func UnreachableError(cause error, r Result) error {
+	endpoint := r.Host
+	if endpoint == "" {
+		endpoint = platformDefaultEndpoint()
+	}
+	remedy := "start your Docker engine, or run `docker context use <name>` to select a reachable context"
+	return errors.WrapWithDetails(
+		cause,
+		"cannot reach the Docker engine (context %q, endpoint %q): %s",
+		"context", r.Context,
+		"endpoint", endpoint,
+		"remedy", remedy,
+	)
+}

--- a/internal/dockerhost/dockerhost_test.go
+++ b/internal/dockerhost/dockerhost_test.go
@@ -1,0 +1,305 @@
+package dockerhost
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// contextDirID mirrors the docker context store's directory naming
+// (digest.FromString(name).Encoded()): the SHA256 hex digest of the context
+// name. The store looks up meta.json under this directory, so fixtures must use
+// it rather than an arbitrary id.
+func contextDirID(name string) string {
+	sum := sha256.Sum256([]byte(name))
+	return hex.EncodeToString(sum[:])
+}
+
+// writeConfig writes a config.json with the given currentContext into dir.
+func writeConfig(t *testing.T, dir, currentContext string) {
+	t.Helper()
+	body := `{}`
+	if currentContext != "" {
+		body = `{"currentContext":"` + currentContext + `"}`
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+}
+
+// writeContext writes a context store meta.json for ctxName with the given
+// docker endpoint host, mirroring the docker CLI's on-disk layout
+// (contexts/meta/<sha256(name)>/meta.json). The store looks the context up by
+// the digest of its name, so the directory must use contextDirID.
+func writeContext(t *testing.T, configDir, ctxName, host string) {
+	t.Helper()
+	metaDir := filepath.Join(configDir, "contexts", "meta", contextDirID(ctxName))
+	if err := os.MkdirAll(metaDir, 0o700); err != nil {
+		t.Fatalf("mkdir meta: %v", err)
+	}
+	body := `{"Name":"` + ctxName + `","Metadata":{},"Endpoints":{"docker":{"Host":"` + host + `","SkipTLSVerify":false}}}`
+	if err := os.WriteFile(filepath.Join(metaDir, "meta.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write meta.json: %v", err)
+	}
+}
+
+// staticEnv builds a getenv func from a map for deterministic, race-free tests.
+func staticEnv(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+func TestResolve(t *testing.T) {
+	const unixHost = "unix:///Users/me/.colima/default/docker.sock"
+	const npipeHost = "npipe:////./pipe/docker_engine"
+
+	tests := []struct {
+		name string
+		// setup populates a temp config dir and returns the env map.
+		setup       func(t *testing.T, dir string) map[string]string
+		wantHost    string
+		wantContext string
+		wantSource  string
+	}{
+		{
+			name: "DOCKER_HOST set wins, context unset",
+			setup: func(t *testing.T, dir string) map[string]string {
+				writeConfig(t, dir, "colima")
+				writeContext(t, dir, "colima", unixHost)
+				return map[string]string{envDockerHost: "tcp://1.2.3.4:2375"}
+			},
+			wantHost:    "",
+			wantContext: defaultContextName,
+			wantSource:  "env",
+		},
+		{
+			name: "DOCKER_HOST set wins, DOCKER_CONTEXT also set",
+			setup: func(t *testing.T, dir string) map[string]string {
+				writeContext(t, dir, "colima", unixHost)
+				return map[string]string{
+					envDockerHost:    "tcp://1.2.3.4:2375",
+					envDockerContext: "colima",
+				}
+			},
+			wantHost:    "",
+			wantContext: defaultContextName,
+			wantSource:  "env",
+		},
+		{
+			name: "currentContext resolves unix socket endpoint",
+			setup: func(t *testing.T, dir string) map[string]string {
+				writeConfig(t, dir, "colima")
+				writeContext(t, dir, "colima", unixHost)
+				return map[string]string{}
+			},
+			wantHost:    unixHost,
+			wantContext: "colima",
+			wantSource:  "context",
+		},
+		{
+			name: "currentContext resolves npipe endpoint (Windows)",
+			setup: func(t *testing.T, dir string) map[string]string {
+				writeConfig(t, dir, "desktop-windows")
+				writeContext(t, dir, "desktop-windows", npipeHost)
+				return map[string]string{}
+			},
+			wantHost:    npipeHost,
+			wantContext: "desktop-windows",
+			wantSource:  "context",
+		},
+		{
+			name: "DOCKER_CONTEXT overrides config.json currentContext",
+			setup: func(t *testing.T, dir string) map[string]string {
+				writeConfig(t, dir, "colima")
+				writeContext(t, dir, "colima", unixHost)
+				writeContext(t, dir, "orbstack", "unix:///Users/me/.orbstack/run/docker.sock")
+				return map[string]string{envDockerContext: "orbstack"}
+			},
+			wantHost:    "unix:///Users/me/.orbstack/run/docker.sock",
+			wantContext: "orbstack",
+			wantSource:  "context",
+		},
+		{
+			name: "context default returns empty (platform fallback)",
+			setup: func(t *testing.T, dir string) map[string]string {
+				writeConfig(t, dir, "default")
+				return map[string]string{}
+			},
+			wantHost:    "",
+			wantContext: defaultContextName,
+			wantSource:  "default",
+		},
+		{
+			name: "DOCKER_CONTEXT=default returns empty",
+			setup: func(t *testing.T, dir string) map[string]string {
+				writeContext(t, dir, "colima", unixHost)
+				return map[string]string{envDockerContext: defaultContextName}
+			},
+			wantHost:    "",
+			wantContext: defaultContextName,
+			wantSource:  "default",
+		},
+		{
+			name: "no config.json and no store returns empty gracefully",
+			setup: func(t *testing.T, _ string) map[string]string {
+				return map[string]string{}
+			},
+			wantHost:    "",
+			wantContext: defaultContextName,
+			wantSource:  "default",
+		},
+		{
+			name: "malformed config.json falls back to default",
+			setup: func(t *testing.T, dir string) map[string]string {
+				if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte("{not json"), 0o600); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+				return map[string]string{}
+			},
+			wantHost:    "",
+			wantContext: defaultContextName,
+			wantSource:  "default",
+		},
+		{
+			name: "currentContext set but meta.json missing falls back to default",
+			setup: func(t *testing.T, dir string) map[string]string {
+				writeConfig(t, dir, "ghost")
+				// No context store entry for "ghost".
+				return map[string]string{}
+			},
+			wantHost:    "",
+			wantContext: defaultContextName,
+			wantSource:  "default",
+		},
+		{
+			name: "context present but docker endpoint missing falls back to default",
+			setup: func(t *testing.T, dir string) map[string]string {
+				writeConfig(t, dir, "weird")
+				metaDir := filepath.Join(dir, "contexts", "meta", contextDirID("weird"))
+				if err := os.MkdirAll(metaDir, 0o700); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				// Endpoints map has no "docker" key.
+				body := `{"Name":"weird","Metadata":{},"Endpoints":{}}`
+				if err := os.WriteFile(filepath.Join(metaDir, "meta.json"), []byte(body), 0o600); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+				return map[string]string{}
+			},
+			wantHost:    "",
+			wantContext: defaultContextName,
+			wantSource:  "default",
+		},
+		{
+			name: "context present but host empty falls back to default",
+			setup: func(t *testing.T, dir string) map[string]string {
+				writeConfig(t, dir, "empty")
+				writeContext(t, dir, "empty", "")
+				return map[string]string{}
+			},
+			wantHost:    "",
+			wantContext: defaultContextName,
+			wantSource:  "default",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			env := tc.setup(t, dir)
+			got := Resolve(withConfigDir(dir), withGetenv(staticEnv(env)))
+			if got.Host != tc.wantHost {
+				t.Errorf("Host = %q, want %q", got.Host, tc.wantHost)
+			}
+			if got.Context != tc.wantContext {
+				t.Errorf("Context = %q, want %q", got.Context, tc.wantContext)
+			}
+			if got.Source != tc.wantSource {
+				t.Errorf("Source = %q, want %q", got.Source, tc.wantSource)
+			}
+		})
+	}
+}
+
+// TestResolveHonorsDockerConfigDir asserts the resolver reads the injected
+// config dir rather than a hardcoded ~/.docker, which is the DOCKER_CONFIG
+// requirement in disguise (production wires config.Dir(), which honors
+// DOCKER_CONFIG and %USERPROFILE%).
+func TestResolveHonorsDockerConfigDir(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	writeConfig(t, dirA, "ctxA")
+	writeContext(t, dirA, "ctxA", "unix:///a.sock")
+	writeConfig(t, dirB, "ctxB")
+	writeContext(t, dirB, "ctxB", "unix:///b.sock")
+
+	gotA := Resolve(withConfigDir(dirA), withGetenv(staticEnv(nil)))
+	if gotA.Host != "unix:///a.sock" {
+		t.Errorf("dirA host = %q, want unix:///a.sock", gotA.Host)
+	}
+	gotB := Resolve(withConfigDir(dirB), withGetenv(staticEnv(nil)))
+	if gotB.Host != "unix:///b.sock" {
+		t.Errorf("dirB host = %q, want unix:///b.sock", gotB.Host)
+	}
+}
+
+// TestResolveEmptyConfigDir guards the configDir=="" branch.
+func TestResolveEmptyConfigDir(t *testing.T) {
+	got := Resolve(withConfigDir(""), withGetenv(staticEnv(map[string]string{envDockerContext: "colima"})))
+	if got.Host != "" || got.Source != "default" {
+		t.Errorf("empty configDir: got %+v, want default fallback", got)
+	}
+}
+
+func TestUnreachableError(t *testing.T) {
+	cause := errors.New("dial unix /no/socket: connect: no such file")
+
+	t.Run("named context with resolved host", func(t *testing.T) {
+		err := UnreachableError(cause, Result{Host: "unix:///x.sock", Context: "colima", Source: "context"})
+		msg := err.Error()
+		for _, want := range []string{"colima", "unix:///x.sock", "docker context use"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("error %q missing %q", msg, want)
+			}
+		}
+		if strings.Contains(msg, "starting agent container") {
+			t.Errorf("error must not be the bare opaque message: %q", msg)
+		}
+		if !errors.Is(err, cause) {
+			t.Errorf("cause must be preserved in the chain")
+		}
+	})
+
+	t.Run("default context uses platform default endpoint", func(t *testing.T) {
+		err := UnreachableError(cause, Result{Host: "", Context: defaultContextName, Source: "default"})
+		msg := err.Error()
+		if !strings.Contains(msg, defaultContextName) {
+			t.Errorf("error %q missing context name", msg)
+		}
+		if !strings.Contains(msg, platformDefaultEndpoint()) {
+			t.Errorf("error %q missing platform default endpoint %q", msg, platformDefaultEndpoint())
+		}
+	})
+}
+
+func TestPlatformDefaultEndpoint(t *testing.T) {
+	// The endpoint must be a concrete, non-empty scheme so error messages are
+	// actionable on every platform.
+	ep := platformDefaultEndpoint()
+	if ep == "" {
+		t.Fatal("platform default endpoint must not be empty")
+	}
+	if !strings.Contains(ep, "://") {
+		t.Errorf("platform default endpoint %q lacks a scheme", ep)
+	}
+}
+
+func TestOsGetenv(t *testing.T) {
+	t.Setenv("DOCKERHOST_TEST_VAR", "value")
+	if osGetenv("DOCKERHOST_TEST_VAR") != "value" {
+		t.Errorf("osGetenv did not read the environment")
+	}
+}

--- a/internal/dockerhost/host_unix.go
+++ b/internal/dockerhost/host_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package dockerhost
+
+import "os"
+
+// osGetenv is the production environment lookup.
+func osGetenv(key string) string { return os.Getenv(key) }
+
+// platformDefaultEndpoint is the SDK's compiled-in default on unix-like
+// systems (macOS, Linux, including rootless/Podman before context resolution).
+// Used only to render an actionable error; the SDK itself supplies this default
+// when Host is empty.
+func platformDefaultEndpoint() string { return "unix:///var/run/docker.sock" }

--- a/internal/dockerhost/host_windows.go
+++ b/internal/dockerhost/host_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package dockerhost
+
+import "os"
+
+// osGetenv is the production environment lookup.
+func osGetenv(key string) string { return os.Getenv(key) }
+
+// platformDefaultEndpoint is the SDK's compiled-in default on Windows: the
+// Docker Desktop named pipe. Used only to render an actionable error; the SDK
+// itself supplies this default when Host is empty.
+func platformDefaultEndpoint() string { return "npipe:////./pipe/docker_engine" }


### PR DESCRIPTION
Two independent bugs each blocked `human agent start` from launching a devcontainer. Both are fixed here as separate, atomic commits.

## [HUM-122] Resolve active Docker context in both engine clients (`462fff4`)

The Docker SDK's `FromEnv` only honors `DOCKER_HOST` and ignores the active docker CLI *context*, so human couldn't reach the engine out-of-the-box on **colima / OrbStack / Rancher / Docker-Desktop / Podman**, where the socket/pipe is exposed via a context. The failure surfaced only as the opaque `starting agent container`.

- New `internal/dockerhost.Resolve`: a shared, cross-platform resolver mirroring the docker CLI's context precedence (explicit `DOCKER_HOST`/`DOCKER_CONTEXT` win → `config.json` currentContext → platform default). Handles unix sockets and Windows named pipes.
- `NewDockerClient` and `NewEngineDockerClient` both layer the resolved host onto `FromEnv` via the one resolver (no divergence).
- Docker connection failures now surface an actionable error naming the active context and attempted endpoint.
- `github.com/docker/cli` promoted to a direct dependency.

## [HUM-125] Propagate feature containerEnv to later installs and image (`74b2eb2`)

A devcontainer feature's `containerEnv` (`FeatureMeta.ContainerEnv`) was parsed but **never applied**, so the node feature's PATH/NVM additions never reached the features installed after it nor the committed image. `claude-code` then couldn't find node/npm and its `install.sh` failed — again surfacing only as `starting agent container`. (Distinct from the already-merged `installsAfter` ordering fix, HUM-121.)

- `InstallFeatures` accumulates each feature's `containerEnv`, expands `${VAR}` against the container's real base env, feeds it to later features' `install.sh`, and returns it.
- `ContainerCommit` extended to bake the accumulated env into the image as sorted `ENV` directives; `ImageBuilder.Puller` made injectable for tests.
- Diagnosability: `execInContainer` refactored to a shared `execCapture` core; the "exec failed" error now carries the command's stdout tail (where feature scripts print their fatal reason).

## Testing

- `make check` green (lint 0 issues, govulncheck/gitleaks clean); total coverage **81.7%**. One unrelated flaky test (`internal/chrome/TestMcpTranslator_SubprocessExit`, untouched package, subprocess timing) failed once and passes on retry.
- New unit tests: cross-platform context resolution (unix + npipe, `DOCKER_HOST`/`DOCKER_CONTEXT` set/unset, malformed store); containerEnv propagation to later installs; containerEnv baked into the commit; `${VAR}` expansion; both engine constructors apply the resolved host.
- **End-to-end** via real `human agent start` on colima/macOS: all four features install (incl. claude-code + treehouse/human), `Image cached`, `Devcontainer running` / `Agent started`, container `Up`. Runtime check: the cached image's ENV resolves `node v22.23.0`, `go`, `npm` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)