### PR TITLE
[SC-63] [HUM-126] Fix triggering a pipeline item from the TUI

### DIFF
--- a/cmd/cmdtui/tui.go
+++ b/cmd/cmdtui/tui.go
@@ -542,13 +542,17 @@ func (m model) handleDispatch() (tea.Model, tea.Cmd) {
 
 func dispatchIssueCmd(name, projectDir, tmuxTarget, prompt, issueKey string) tea.Cmd {
 	return func() tea.Msg {
-		err := spawnAgentInTmux(name, projectDir, tmuxTarget, "--prompt", prompt, "--skip-permissions")
+		err := spawnAgentInTmux(name, projectDir, tmuxTarget, false, "--prompt", prompt, "--skip-permissions")
 		return dispatchResultMsg{issueKey: issueKey, agentName: name, err: err}
 	}
 }
 
 // spawnAgentInTmux splits a new tmux pane and starts a human agent there.
-func spawnAgentInTmux(name, projectDir, tmuxTarget string, extraFlags ...string) error {
+// stopOnExit governs cleanup: interactive sessions block in the pane until
+// Claude exits and then want the container torn down, whereas dispatched
+// (--prompt) agents launch detached and must keep running after the spawning
+// command returns.
+func spawnAgentInTmux(name, projectDir, tmuxTarget string, stopOnExit bool, extraFlags ...string) error {
 	humanExe, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("cannot find executable: %w", err)
@@ -560,8 +564,7 @@ func spawnAgentInTmux(name, projectDir, tmuxTarget string, extraFlags ...string)
 		parts = append(parts, "--workspace", projectDir)
 		paneDir = projectDir
 	}
-	agentCmd := strings.Join(parts, " ")
-	cmd := fmt.Sprintf("%s; EC=$?; %s agent stop --async %s 2>/dev/null; [ $EC -ne 0 ] && { echo; echo 'Press enter to close'; read; }", agentCmd, humanExe, name)
+	cmd := buildPaneCmd(strings.Join(parts, " "), humanExe, name, stopOnExit)
 	tmuxArgs := []string{"split-window", "-h", "-c", paneDir}
 	if tmuxTarget != "" {
 		tmuxArgs = append(tmuxArgs, "-t", tmuxTarget)
@@ -579,6 +582,19 @@ func spawnAgentInTmux(name, projectDir, tmuxTarget string, extraFlags ...string)
 	}
 	_, _ = runner.Run(context.Background(), "tmux", "select-layout", "-t", layoutTarget, "even-horizontal")
 	return nil
+}
+
+// buildPaneCmd assembles the shell line run inside the spawned tmux pane.
+// When stopOnExit is set, an `agent stop` follows the agent command so the
+// container is torn down once an interactive Claude session ends. Dispatched
+// agents run detached, so stopping would kill them the instant they start —
+// there the pane only lingers on failure to surface the error.
+func buildPaneCmd(agentCmd, humanExe, name string, stopOnExit bool) string {
+	const holdOnError = `[ $EC -ne 0 ] && { echo; echo 'Press enter to close'; read; }`
+	if stopOnExit {
+		return fmt.Sprintf("%s; EC=$?; %s agent stop --async %s 2>/dev/null; %s", agentCmd, humanExe, name, holdOnError)
+	}
+	return fmt.Sprintf("%s; EC=$?; %s", agentCmd, holdOnError)
 }
 
 // --- open in browser ---
@@ -688,7 +704,7 @@ func (m model) handleSpawnAgentResult(msg spawnAgentMsg) (tea.Model, tea.Cmd) {
 
 func spawnAgentCmd(name, projectDir, tmuxTarget string) tea.Cmd {
 	return func() tea.Msg {
-		err := spawnAgentInTmux(name, projectDir, tmuxTarget, "--interactive", "--skip-permissions")
+		err := spawnAgentInTmux(name, projectDir, tmuxTarget, true, "--interactive", "--skip-permissions")
 		return spawnAgentMsg{name: name, err: err}
 	}
 }

--- a/cmd/cmdtui/tui.go
+++ b/cmd/cmdtui/tui.go
@@ -35,14 +35,14 @@ const defaultWidth = 80
 
 // trackerIssues groups issues from one tracker instance and project.
 type trackerIssues struct {
-	TrackerName    string
-	TrackerKind    string
-	TrackerRole    string // "pm", "engineering", or empty
-	Project        string
-	Issues         []tracker.Issue
-	ReadyForReview map[string]bool // issue keys currently flagged ready for review (see CLAUDE.md Review handoff)
+	TrackerName       string
+	TrackerKind       string
+	TrackerRole       string // "pm", "engineering", or empty
+	Project           string
+	Issues            []tracker.Issue
+	ReadyForReview    map[string]bool   // issue keys currently flagged ready for review (see CLAUDE.md Review handoff)
 	ReadyForReviewPRs map[string]string // issue key -> pull-request URL from the handoff's pr: line, when present
-	Err            error
+	Err               error
 }
 
 // flatIssue is a single issue with its tracker context, used for cursor indexing.
@@ -564,7 +564,11 @@ func spawnAgentInTmux(name, projectDir, tmuxTarget string, stopOnExit bool, extr
 		parts = append(parts, "--workspace", projectDir)
 		paneDir = projectDir
 	}
-	cmd := buildPaneCmd(strings.Join(parts, " "), humanExe, name, stopOnExit)
+	// The pane command is interpreted by a shell, so every token must be quoted.
+	// The dispatch prompt (e.g. "/human-execute HUM-42") contains a space; left
+	// unquoted the shell splits it and `agent start` sees an extra positional
+	// argument, failing with "accepts 1 arg(s), received 2".
+	cmd := buildPaneCmd(shellJoin(parts), shellQuote(humanExe), name, stopOnExit)
 	tmuxArgs := []string{"split-window", "-h", "-c", paneDir}
 	if tmuxTarget != "" {
 		tmuxArgs = append(tmuxArgs, "-t", tmuxTarget)
@@ -595,6 +599,23 @@ func buildPaneCmd(agentCmd, humanExe, name string, stopOnExit bool) string {
 		return fmt.Sprintf("%s; EC=$?; %s agent stop --async %s 2>/dev/null; %s", agentCmd, humanExe, name, holdOnError)
 	}
 	return fmt.Sprintf("%s; EC=$?; %s", agentCmd, holdOnError)
+}
+
+// shellQuote wraps a token in single quotes so a POSIX shell treats it as one
+// literal argument, preserving spaces and metacharacters. Embedded single
+// quotes are closed, escaped, and reopened ('\'').
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// shellJoin shell-quotes each token and joins them with spaces into a single
+// command line safe to hand to a shell.
+func shellJoin(parts []string) string {
+	quoted := make([]string, len(parts))
+	for i, p := range parts {
+		quoted[i] = shellQuote(p)
+	}
+	return strings.Join(quoted, " ")
 }
 
 // --- open in browser ---

--- a/cmd/cmdtui/tui_test.go
+++ b/cmd/cmdtui/tui_test.go
@@ -1486,3 +1486,18 @@ func TestReviewMarker(t *testing.T) {
 	assert.Contains(t, linked, "(R)")
 	assert.Contains(t, linked, "\x1b]8;;https://github.com/o/r/pull/7\x1b\\")
 }
+
+func TestBuildPaneCmd(t *testing.T) {
+	const agentCmd = "human agent start agent-1 --prompt /human-execute HUM-42"
+
+	// Interactive sessions block in the pane, then tear the container down.
+	interactive := buildPaneCmd(agentCmd, "human", "agent-1", true)
+	assert.Contains(t, interactive, "human agent stop --async agent-1")
+
+	// Dispatched (--prompt) agents run detached: stopping would kill the agent
+	// the instant it is triggered, so no stop must be issued.
+	dispatched := buildPaneCmd(agentCmd, "human", "agent-1", false)
+	assert.NotContains(t, dispatched, "agent stop")
+	// Both modes still hold the pane open on failure to surface the error.
+	assert.Contains(t, dispatched, "Press enter to close")
+}

--- a/cmd/cmdtui/tui_test.go
+++ b/cmd/cmdtui/tui_test.go
@@ -1501,3 +1501,16 @@ func TestBuildPaneCmd(t *testing.T) {
 	// Both modes still hold the pane open on failure to surface the error.
 	assert.Contains(t, dispatched, "Press enter to close")
 }
+
+func TestShellJoin_quotesSpacedPrompt(t *testing.T) {
+	// A slash-command prompt contains a space; without quoting the shell would
+	// split it and `agent start` would see two positional args.
+	parts := []string{"/usr/bin/human", "agent", "start", "agent-2", "--prompt", "/human-execute HUM-126"}
+	got := shellJoin(parts)
+	assert.Contains(t, got, "'/human-execute HUM-126'", "spaced prompt must stay one quoted token")
+	assert.Equal(t, "'/usr/bin/human' 'agent' 'start' 'agent-2' '--prompt' '/human-execute HUM-126'", got)
+}
+
+func TestShellQuote_escapesEmbeddedQuote(t *testing.T) {
+	assert.Equal(t, `'it'\''s'`, shellQuote("it's"))
+}


### PR DESCRIPTION
## Problem

Triggering (dispatching) a pipeline item from the TUI with **Enter** failed: the agent never ran. Spawning an interactive agent with `a` worked, which masked the issue.

Traces to PM [Shortcut #63](https://app.shortcut.com/) (Agent orchestration: spawn and manage background Claude Code agents via tmux) and engineering ticket HUM-126.

## Root causes (two bugs in `spawnAgentInTmux`)

1. **Unquoted prompt** — the pane command is run by a shell, but tokens were joined with bare spaces. A dispatch prompt like `/human-execute HUM-42` contains a space, so the shell split it and `agent start` received an extra positional argument, failing with `accepts 1 arg(s), received 2`. The agent never started.
2. **Premature `agent stop`** — the trailing `agent stop --async` (added in HUM-84 for interactive cleanup-on-exit) also ran on the `--prompt` path. Dispatched agents launch **detached** and `agent start` returns immediately, so the stop tore the container down the instant it was triggered.

## Fix

- Shell-quote every token via `shellQuote`/`shellJoin` so multi-word prompts stay a single argument.
- Gate the stop-on-exit cleanup behind a `stopOnExit bool`: only interactive sessions (which block in the pane until Claude exits) want it; dispatched agents stay running and the pane only lingers on failure.
- Extract pane-command assembly into testable `buildPaneCmd`.

## Tests

New unit coverage: `TestBuildPaneCmd`, `TestShellJoin_quotesSpacedPrompt`, `TestShellQuote_escapesEmbeddedQuote`. `make check` passes (tests, lint, sec, secrets). Manually verified end-to-end: triggering a pipeline item now builds the devcontainer and runs the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)