### PR TITLE
[HUM-132] Fix daemon destructive-op confirmation (unknown flag: --yes)

### DIFF
--- a/cmd/cmdprovider/provider.go
+++ b/cmd/cmdprovider/provider.go
@@ -154,7 +154,6 @@ func buildPRCreateCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 
 func buildIssueEditCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 	var title, description string
-	var yes bool
 
 	cmd := &cobra.Command{
 		Use:     "edit KEY",
@@ -179,19 +178,15 @@ func buildIssueEditCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 				opts.Description = &description
 			}
 
-			_ = yes // consumed by daemon interceptor via --yes flag; unused here
 			return RunEditIssue(cmd.Context(), p, cmd.OutOrStdout(), args[0], opts)
 		},
 	}
 	cmd.Flags().StringVar(&title, "title", "", "New issue title")
 	cmd.Flags().StringVar(&description, "description", "", "New issue description (markdown)")
-	cmd.Flags().BoolVar(&yes, "yes", false, "Skip interactive confirmation")
 	return cmd
 }
 
 func buildIssueDeleteCmd(kind string, deps cmdutil.Deps) *cobra.Command {
-	var yes bool
-
 	cmd := &cobra.Command{
 		Use:   "delete KEY",
 		Short: "Delete (or close) an issue by key",
@@ -202,10 +197,12 @@ func buildIssueDeleteCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 				return err
 			}
 			defer cleanup()
+			// --yes is a hidden root persistent flag: the daemon injects it after a
+			// TUI approval, and direct CLI use can pass it to skip the stdin prompt.
+			yes, _ := cmd.Flags().GetBool("yes")
 			return RunDeleteIssue(cmd.Context(), p, os.Stdin, cmd.OutOrStdout(), args[0], yes)
 		},
 	}
-	cmd.Flags().BoolVar(&yes, "yes", false, "Skip interactive confirmation")
 	return cmd
 }
 

--- a/cmd/cmdprovider/provider_test.go
+++ b/cmd/cmdprovider/provider_test.go
@@ -916,6 +916,7 @@ func newTestRoot(mp *mockProvider) (*cobra.Command, cmdutil.Deps) {
 	root := &cobra.Command{Use: "human"}
 	root.PersistentFlags().String("tracker", "", "")
 	root.PersistentFlags().Bool("safe", false, "")
+	root.PersistentFlags().Bool("yes", false, "") // mirrors the real root (main.go); daemon injects --yes on re-exec
 
 	jiraCmd := &cobra.Command{Use: "jira"}
 	cmds := BuildProviderCommands("jira", deps)
@@ -1096,6 +1097,43 @@ func TestCmd_IssueStart_Success(t *testing.T) {
 	assert.Contains(t, buf.String(), "Started KAN-1")
 }
 
+// TestCmd_DestructiveVerbs_AcceptYesFlag is a regression guard for HUM-132: the
+// daemon re-executes an approved destructive op with "--yes" appended, so every
+// destructive verb detectDestructive intercepts (delete/edit/status/start) must
+// accept the root-persistent --yes flag — not just the two that used to register
+// it locally.
+func TestCmd_DestructiveVerbs_AcceptYesFlag(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"status", []string{"jira", "issue", "status", "KAN-1", "Done", "--yes"}},
+		{"start", []string{"jira", "issue", "start", "KAN-1", "--yes"}},
+		{"edit", []string{"jira", "issue", "edit", "KAN-1", "--title", "x", "--yes"}},
+		{"delete", []string{"jira", "issue", "delete", "KAN-1", "--yes"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mp := &mockProvider{
+				transitionFn:     func(_ context.Context, _, _ string) error { return nil },
+				assignFn:         func(_ context.Context, _, _ string) error { return nil },
+				getCurrentUserFn: func(_ context.Context) (string, error) { return "user-1", nil },
+				deleteIssueFn:    func(_ context.Context, _ string) error { return nil },
+				editIssueFn: func(_ context.Context, _ string, _ tracker.EditOptions) (*tracker.Issue, error) {
+					return &tracker.Issue{Key: "KAN-1"}, nil
+				},
+			}
+			root, _ := newTestRoot(mp)
+			var buf bytes.Buffer
+			root.SetOut(&buf)
+			root.SetErr(&buf)
+			root.SetArgs(tc.args)
+			require.NoError(t, root.Execute())
+			assert.NotContains(t, buf.String(), "unknown flag")
+		})
+	}
+}
+
 func TestCmd_IssueStatuses_Success(t *testing.T) {
 	mp := &mockProvider{
 		listStatusesFn: func(_ context.Context, key string) ([]tracker.Status, error) {
@@ -1142,6 +1180,7 @@ func TestCmd_LoadInstancesError(t *testing.T) {
 	root := &cobra.Command{Use: "human"}
 	root.PersistentFlags().String("tracker", "", "")
 	root.PersistentFlags().Bool("safe", false, "")
+	root.PersistentFlags().Bool("yes", false, "") // mirrors the real root (main.go); daemon injects --yes on re-exec
 	jiraCmd := &cobra.Command{Use: "jira"}
 	cmds := BuildProviderCommands("jira", deps)
 	for _, c := range cmds {

--- a/main.go
+++ b/main.go
@@ -143,6 +143,12 @@ Configure trackers and tools in .humanconfig.yaml or pass credentials via flags/
 	pf := rootCmd.PersistentFlags()
 	pf.String("tracker", "", "Named tracker instance from .humanconfig")
 	pf.Bool("safe", os.Getenv("HUMAN_SAFE") == "1", "Block destructive operations (deletes)")
+	// --yes skips the interactive confirmation for a destructive operation. The
+	// daemon injects it after a TUI approval when re-executing the command, so it
+	// must be accepted by every (current and future) destructive subcommand —
+	// hence a single persistent flag here rather than per-command registration.
+	pf.Bool("yes", false, "Skip interactive confirmation for destructive operations")
+	_ = pf.MarkHidden("yes")
 
 	// Credential flags — functional but hidden from help (use env vars or .humanconfig).
 	credFlags := []struct{ name, env, help string }{


### PR DESCRIPTION
Approving a daemon-intercepted destructive op (e.g. `issue status … Done`) failed with `Error: unknown flag: --yes`, so the issue never changed — the user could approve repeatedly with no effect.

**Root cause:** on approval the daemon re-executes the command with `--yes` appended (`internal/daemon/server.go:691`), but `--yes` was registered only on `edit`/`delete` (`cmd/cmdprovider/provider.go`). `detectDestructive` also intercepts `status`/`start`, which lacked the flag.

**Fix:** register `--yes` once as a hidden **persistent flag on the root command** (`main.go`) so every destructive verb accepts it; drop the two per-command registrations; `delete` reads it via `cmd.Flags()`. Regression test added covering `status`/`start`/`edit`/`delete` with `--yes`.

`go build` / `make lint` / gosec(0) / `make check-test`(2385) green.

Closes HUM-132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)