### PR TITLE
[HUM-133] codenav navigation skill + CLI recovery hardening

### DIFF
--- a/cmd/cmdcodenav/codenav.go
+++ b/cmd/cmdcodenav/codenav.go
@@ -34,7 +34,12 @@ func BuildCodenavCmd() *cobra.Command {
 		Short: "Index and navigate code structure (local SQLite, for AI agents)",
 		Long: "codenav indexes repositories into a local SQLite database and answers " +
 			"structural questions — go-to-definition, find-references, call graphs, " +
-			"blast radius, and full-text search — fast, offline, and token-frugal.",
+			"blast radius, and full-text search — fast, offline, and token-frugal.\n\n" +
+			"Run `human codenav index .` once per repository before querying.",
+		// Query subcommands need an index. Fail fast with an actionable message
+		// when the repo hasn't been indexed yet, so a caller (human or agent)
+		// runs `index` instead of mistaking an empty result for "not found".
+		PersistentPreRunE: requireIndexForQueries,
 	}
 	// --db and --json are shared by every subcommand. --db defaults to
 	// ~/.human/codenav.db, overridable per invocation.
@@ -62,6 +67,31 @@ func BuildCodenavCmd() *cobra.Command {
 }
 
 // --- shared helpers --------------------------------------------------------
+
+// requireIndexForQueries runs before every codenav subcommand and, for the
+// query verbs, returns an actionable error when no repository has been indexed
+// yet. Index-management verbs (index/projects/status/rm) are exempt because
+// they are expected to work against an empty database.
+func requireIndexForQueries(cmd *cobra.Command, _ []string) error {
+	switch cmd.Name() {
+	case "codenav", "index", "projects", "status", "rm", "help":
+		return nil
+	}
+	st, err := openStore(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = st.Close() }()
+	projs, err := st.ListProjects()
+	if err != nil {
+		return err
+	}
+	if len(projs) == 0 {
+		return errors.WithDetails(
+			"no repository is indexed yet — run: human codenav index <path> (e.g. human codenav index .)")
+	}
+	return nil
+}
 
 func openStore(cmd *cobra.Command) (*store.Store, error) {
 	db, _ := cmd.Flags().GetString("db")
@@ -105,9 +135,10 @@ func buildIndexCmd() *cobra.Command {
 	var name string
 	var full bool
 	cmd := &cobra.Command{
-		Use:   "index <path>",
-		Short: "Index or refresh a repository",
-		Args:  cobra.ExactArgs(1),
+		Use:     "index <path>",
+		Short:   "Index or refresh a repository",
+		Example: "  human codenav index .\n  human codenav index . --name myrepo --full",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			root, err := filepath.Abs(args[0])
 			if err != nil {
@@ -396,9 +427,10 @@ func buildSearchCmd() *cobra.Command {
 	var symbols bool
 	var limit int
 	cmd := &cobra.Command{
-		Use:   "search <query>",
-		Short: "Full-text search (code bodies by default, --symbols for names)",
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "search <query>",
+		Short:   "Full-text search (code bodies by default, --symbols for names)",
+		Example: "  human codenav search \"ListenAndServe\"\n  human codenav search ResolveForge --symbols   # find the qualified name to feed def/refs",
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			q := strings.Join(args, " ")
 			st, err := openStore(cmd)
@@ -443,9 +475,10 @@ func buildSearchCmd() *cobra.Command {
 func buildDefCmd() *cobra.Command {
 	var outline bool
 	cmd := &cobra.Command{
-		Use:   "def <name|qname>",
-		Short: "Go-to-definition (+ source body; --outline for signature only)",
-		Args:  cobra.ExactArgs(1),
+		Use:     "def <name|qname>",
+		Short:   "Go-to-definition (+ source body; --outline for signature only)",
+		Example: "  human codenav def BuildProxyCmd\n  human codenav def BuildProxyCmd --outline   # signature + location only (token-frugal)",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			st, err := openStore(cmd)
 			if err != nil {
@@ -565,9 +598,10 @@ func buildCallPathCmd() *cobra.Command {
 	var from, to string
 	var maxDepth, limit int
 	cmd := &cobra.Command{
-		Use:   "callpath --from A --to B",
-		Short: "Concrete call paths between two symbols (shortest first)",
-		Args:  cobra.NoArgs,
+		Use:     "callpath --from A --to B",
+		Short:   "Concrete call paths between two symbols (shortest first)",
+		Example: "  human codenav callpath --from main --to ResolveForge --max 12 --limit 8",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if from == "" || to == "" {
 				return errors.WithDetails("callpath requires --from and --to")
@@ -654,9 +688,10 @@ func buildImpactCmd() *cobra.Command {
 	var diff bool
 	var depth int
 	cmd := &cobra.Command{
-		Use:   "impact <qname>",
-		Short: "Blast radius: transitive callers of a symbol (or of a git diff with --diff)",
-		Args:  cobra.ArbitraryArgs,
+		Use:     "impact <qname>",
+		Short:   "Blast radius: transitive callers of a symbol (or of a git diff with --diff)",
+		Example: "  human codenav impact ResolveForge\n  human codenav impact --diff   # what your uncommitted changes put at risk",
+		Args:    cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			st, err := openStore(cmd)
 			if err != nil {

--- a/internal/claude/embed/codenav-skill.md
+++ b/internal/claude/embed/codenav-skill.md
@@ -1,0 +1,45 @@
+---
+name: codenav
+description: Navigate code structure fast and token-frugally. Use whenever you need to find where a symbol is defined or used, who calls a function (or what it calls), trace a call path, gauge the blast radius of a change, or search code by symbol/text — i.e. go-to-definition, find-references, callers/callees, call graph, impact analysis. Prefer this over grep and reading whole files for structural questions.
+allowed-tools: Bash(human codenav *)
+---
+
+# Code Navigation (codenav)
+
+`human codenav` indexes a repository into a local SQLite database and answers structural questions about it precisely and cheaply. **Prefer it over `grep`/`rg` and reading whole files** when the question is "where is X defined / used / who calls it / what breaks if I change it".
+
+## First: make sure the repo is indexed
+
+Queries need an index. Run this once per repository (re-run after large changes):
+
+```bash
+human codenav index .
+```
+
+If any query reports the repo is not indexed, run the line above, then retry the query.
+
+## Commands
+
+```bash
+human codenav def <name>            # go-to-definition (+ source). Add --outline for signature + location only (token-frugal)
+human codenav refs <name>           # find references, each with its enclosing symbol and source line
+human codenav callers <qname>       # who transitively calls this (--depth N)
+human codenav callees <qname>       # what this transitively calls (--depth N)
+human codenav callpath --from A --to B   # concrete call paths between two symbols
+human codenav impact <qname>        # blast radius: transitive callers; or `--diff` for impact of uncommitted changes
+human codenav search <query>        # full-text search over code (default) or symbol names (--symbols)
+human codenav outline <file>        # symbols in a file with signatures, no bodies
+human codenav overview              # architecture summary: kinds + most-called hub symbols (good cold-start)
+```
+
+Every command supports `--json` for structured output. Start an unfamiliar codebase with `overview`, then `outline`/`def`.
+
+## If a command errors — try harder, don't fall back to grep
+
+codenav is a normal CLI, so recover the way you would with `git` or `go`:
+
+1. Read the error message — it usually says exactly what to do (e.g. "run: human codenav index .").
+2. If you're unsure of flags or arguments, run `human codenav <subcommand> --help` and retry with corrected arguments.
+3. If a symbol isn't found by `def`/`refs`, try `human codenav search <name> --symbols` to find the right qualified name, then retry.
+
+Only fall back to `grep`/file reads if codenav genuinely cannot answer the question after these steps.

--- a/internal/claude/install.go
+++ b/internal/claude/install.go
@@ -157,6 +157,9 @@ var bugFixerAgentContent []byte
 //go:embed embed/human-bug-verify-agent.md
 var bugVerifyAgentContent []byte
 
+//go:embed embed/codenav-skill.md
+var codenavSkillContent []byte
+
 var userHomeDir = os.UserHomeDir
 
 // FileWriter abstracts filesystem operations for testability.
@@ -248,6 +251,7 @@ func Install(w io.Writer, fw FileWriter, personal bool) error {
 		{content: bugTriageAgentContent, relPath: filepath.Join("agents", "human-bug-triage.md")},
 		{content: bugFixerAgentContent, relPath: filepath.Join("agents", "human-bug-fixer.md")},
 		{content: bugVerifyAgentContent, relPath: filepath.Join("agents", "human-bug-verify.md")},
+		{content: codenavSkillContent, relPath: filepath.Join("skills", "codenav", "SKILL.md")},
 	}
 
 	for _, f := range files {


### PR DESCRIPTION
Make Claude Code prefer `codenav` for structural navigation — via a **CLI skill, not MCP**. (MCP tools get abandoned after one error → Claude falls back to grep; a CLI self-recovers via `--help` and rides the internal-tool bias.)

- **`human install`** writes `.claude/skills/codenav/SKILL.md`: trigger-rich `description` (the always-preloaded nudge), `allowed-tools: Bash(human codenav *)`, and a body encoding the recovery loop (on error → `--help`/retry, not grep; if not indexed → `index` first).
- **`cmd/cmdcodenav` hardening**: a query before indexing now fails fast with an actionable "run: `human codenav index .`" (root `PersistentPreRunE`) instead of an opaque empty result; flag-bearing subcommands carry `--help` examples.

Verified: query-before-index returns the hint, `--help` shows examples, install writes the skill. `go build` / `make lint` / gosec(0) / `make check-test`(2385) green.

Closes HUM-133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)