### PR TITLE
[HUM-134] human agent-context command + SessionStart hook

### DIFF
--- a/cmd/cmdagentcontext/agent-context.md
+++ b/cmd/cmdagentcontext/agent-context.md
@@ -1,0 +1,28 @@
+# Working with `human` in this repository
+
+The `human` CLI is available here. Prefer its tools over ad-hoc approaches.
+
+## Navigate code — use this instead of grep or reading whole files
+Run `human codenav index .` once per repo, then:
+- `human codenav def <name>` — go-to-definition (`--outline` for signature + location only)
+- `human codenav refs <name>` — find references (with enclosing symbol + line)
+- `human codenav callers <qname>` / `callees <qname>` — call graph
+- `human codenav callpath --from A --to B` — concrete call paths
+- `human codenav impact <qname>` (or `--diff`) — blast radius of a change
+- `human codenav search <query>` — full-text search (`--symbols` for names)
+- `human codenav overview` / `outline <file>` — cold-start a codebase
+
+If a codenav command errors, run `human codenav <sub> --help` and retry — do not fall back to grep.
+
+## Read and track work
+- `human get <KEY>` — fetch an issue (auto-detects the tracker from the key)
+- `human list` / `human search "<query>"` — list or search issues across trackers
+- `human <tracker> issue create|edit|status|comment …` — create and update engineering tickets
+
+## Pull product context
+- `human notion search "<query>"` — docs, specs, notes
+- `human figma file get <key>` — designs, components, comments
+- `human amplitude events list` — product analytics
+
+## Ship
+- `human pr create --head <branch> --title "…" --body "…"` — open a PR (forge and repo derived from the git origin remote)

--- a/cmd/cmdagentcontext/agentcontext.go
+++ b/cmd/cmdagentcontext/agentcontext.go
@@ -1,0 +1,56 @@
+// Package cmdagentcontext provides the "agent-context" command: a static,
+// local, instant block of guidance that primes a coding agent (Claude Code) to
+// prefer human's in-session tools (codenav, trackers, knowledge, PRs) over
+// ad-hoc approaches. It is wired as a Claude Code SessionStart hook by
+// `human install`, and is deliberately free of any config/daemon/vault access
+// so it never slows session startup.
+package cmdagentcontext
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+//go:embed agent-context.md
+var agentContext string
+
+// BuildAgentContextCmd creates the "agent-context" command.
+func BuildAgentContextCmd() *cobra.Command {
+	var asHook bool
+	cmd := &cobra.Command{
+		Use:   "agent-context",
+		Short: "Print guidance that primes a coding agent to use human's tools",
+		Long: "Prints a static, curated block describing the human capabilities a " +
+			"coding agent should use in-session (code navigation, issue tracking, " +
+			"context retrieval, PRs). Installed as a Claude Code SessionStart hook by " +
+			"`human install`. Local and instant — it loads no config and never " +
+			"contacts the daemon.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			body := strings.TrimRight(agentContext, "\n")
+			if asHook {
+				// Emit the Claude Code SessionStart hook output that injects the
+				// block as additional session context.
+				out := map[string]any{
+					"hookSpecificOutput": map[string]any{
+						"hookEventName":     "SessionStart",
+						"additionalContext": body,
+					},
+				}
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				return enc.Encode(out)
+			}
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), body)
+			return nil
+		},
+	}
+	// --hook emits the SessionStart hook JSON (additionalContext) instead of
+	// plain text; the SessionStart hook registered by `human install` uses it.
+	cmd.Flags().BoolVar(&asHook, "hook", false, "emit Claude Code SessionStart hook JSON")
+	_ = cmd.Flags().MarkHidden("hook")
+	return cmd
+}

--- a/cmd/cmdagentcontext/agentcontext_test.go
+++ b/cmd/cmdagentcontext/agentcontext_test.go
@@ -1,0 +1,51 @@
+package cmdagentcontext
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAgentContext_PlainOutput(t *testing.T) {
+	cmd := BuildAgentContextCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{"human codenav", "human get <KEY>", "human pr create"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("plain output is missing %q", want)
+		}
+	}
+}
+
+// TestAgentContext_HookJSON locks the shape the SessionStart hook relies on:
+// hookSpecificOutput.{hookEventName,additionalContext}.
+func TestAgentContext_HookJSON(t *testing.T) {
+	cmd := BuildAgentContextCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--hook"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var out struct {
+		HookSpecificOutput struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("--hook output is not valid JSON: %v", err)
+	}
+	if out.HookSpecificOutput.HookEventName != "SessionStart" {
+		t.Errorf("hookEventName = %q, want SessionStart", out.HookSpecificOutput.HookEventName)
+	}
+	if !strings.Contains(out.HookSpecificOutput.AdditionalContext, "human codenav") {
+		t.Error("additionalContext is missing the codenav guidance")
+	}
+}

--- a/internal/claude/hooks.go
+++ b/internal/claude/hooks.go
@@ -12,6 +12,11 @@ import (
 
 const hookCommand = "human hook"
 
+// agentContextHookCommand primes each new session with the guidance from
+// `human agent-context` via the SessionStart hook's additionalContext output.
+// It runs in addition to the monitoring `human hook` on SessionStart.
+const agentContextHookCommand = "human agent-context --hook"
+
 // hookEvents lists the Claude Code hook events we register for.
 var hookEvents = []struct {
 	name    string
@@ -70,9 +75,14 @@ func mergeHooksIntoSettings(w io.Writer, fw FileWriter, path string) error {
 
 	changed := false
 	for _, evt := range hookEvents {
-		if addHookMatcher(hooks, evt.name, evt.async, evt.matcher) {
+		if addHookCommand(hooks, evt.name, hookCommand, evt.async, evt.matcher) {
 			changed = true
 		}
+	}
+	// SessionStart also injects the agent-context guidance. It runs synchronously
+	// (not async) so Claude Code reads its additionalContext output as context.
+	if addHookCommand(hooks, "SessionStart", agentContextHookCommand, false, "") {
+		changed = true
 	}
 
 	if !changed {
@@ -96,12 +106,12 @@ func mergeHooksIntoSettings(w io.Writer, fw FileWriter, path string) error {
 	return nil
 }
 
-// addHookMatcher adds our hook matcher to an event if not already present.
-// Returns true if a new matcher was added.
-func addHookMatcher(hooks map[string]interface{}, eventName string, async bool, matcher string) bool {
+// addHookCommand registers a command for an event if that exact command is not
+// already present. Returns true if a new matcher was added.
+func addHookCommand(hooks map[string]interface{}, eventName, command string, async bool, matcher string) bool {
 	matchers, _ := hooks[eventName].([]interface{})
 
-	// Check if our hook already exists.
+	// Check if this command is already registered for the event.
 	for _, m := range matchers {
 		matcherObj, ok := m.(map[string]interface{})
 		if !ok {
@@ -113,7 +123,7 @@ func addHookMatcher(hooks map[string]interface{}, eventName string, async bool, 
 			if !ok {
 				continue
 			}
-			if cmd, _ := hookDef["command"].(string); cmd == hookCommand {
+			if cmd, _ := hookDef["command"].(string); cmd == command {
 				return false // already registered
 			}
 		}
@@ -121,7 +131,7 @@ func addHookMatcher(hooks map[string]interface{}, eventName string, async bool, 
 
 	hookDef := map[string]interface{}{
 		"type":    "command",
-		"command": hookCommand,
+		"command": command,
 	}
 	if async {
 		hookDef["async"] = true

--- a/internal/claude/hooks_test.go
+++ b/internal/claude/hooks_test.go
@@ -43,13 +43,18 @@ func TestInstallHooks_NewSettings(t *testing.T) {
 	hooks, ok := settings["hooks"].(map[string]interface{})
 	require.True(t, ok, "hooks key should exist")
 
-	// All 12 events registered.
+	// All 12 events registered. SessionStart carries two commands: the
+	// monitoring `human hook` and the priming `human agent-context`.
 	for _, evt := range []string{"UserPromptSubmit", "Stop", "SubagentStart", "SubagentStop",
 		"PreToolUse", "PostToolUse", "PostToolUseFailure",
 		"PermissionRequest", "Notification", "StopFailure", "SessionStart", "SessionEnd"} {
 		matchers, ok := hooks[evt].([]interface{})
 		require.True(t, ok, "event %s should have matchers", evt)
-		assert.Len(t, matchers, 1)
+		want := 1
+		if evt == "SessionStart" {
+			want = 2
+		}
+		assert.Len(t, matchers, want, "event %s", evt)
 	}
 
 	// No hook script file should be written — hooks invoke `human hook` directly.
@@ -159,7 +164,11 @@ func TestInstallHooks_Idempotent(t *testing.T) {
 		"PreToolUse", "PostToolUse", "PostToolUseFailure",
 		"PermissionRequest", "Notification", "StopFailure", "SessionStart", "SessionEnd"} {
 		matchers := hooks[evt].([]interface{})
-		assert.Len(t, matchers, 1, "event %s should still have exactly 1 matcher", evt)
+		want := 1
+		if evt == "SessionStart" {
+			want = 2 // human hook + human agent-context, still no duplicates
+		}
+		assert.Len(t, matchers, want, "event %s should not gain duplicate matchers", evt)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/gethuman-sh/human/cmd/cmdagent"
+	"github.com/gethuman-sh/human/cmd/cmdagentcontext"
 	"github.com/gethuman-sh/human/cmd/cmdamplitude"
 	"github.com/gethuman-sh/human/cmd/cmdauto"
 	"github.com/gethuman-sh/human/cmd/cmdbrowser"
@@ -308,6 +309,10 @@ Configure trackers and tools in .humanconfig.yaml or pass credentials via flags/
 	codenavCmd.GroupID = "utility"
 	rootCmd.AddCommand(codenavCmd)
 
+	agentContextCmd := cmdagentcontext.BuildAgentContextCmd()
+	agentContextCmd.GroupID = "utility"
+	rootCmd.AddCommand(agentContextCmd)
+
 	// hook reads Claude Code hook JSON from stdin, extracts event fields,
 	// and forwards them to the daemon as hook-event args. Runs locally
 	// (listed in isLocalSubcommand) so stdin is available.
@@ -417,6 +422,7 @@ var localSubcommands = map[string]bool{
 	"usage":         true,
 	"index":         true,
 	"codenav":       true,
+	"agent-context": true,
 	"tui":           true,
 	"ping":          true,
 	"proxy":         true,


### PR DESCRIPTION
An always-on, code-owned nudge so Claude Code prefers human's in-session tools every session — without drift and without depending on a skill trigger firing.

- **`human agent-context`** — prints curated guidance covering the agent-facing capabilities: codenav (prefer over grep), issue tracking (`get`/`list`/`search`/`issue …`), context retrieval (Notion/Figma/Amplitude), and `pr create`. Infra (proxy, chrome, daemon, devcontainer, …) deliberately excluded. Static + local + instant — no config load, no daemon round-trip, so it can't slow session start. `--hook` emits the SessionStart `additionalContext` JSON.
- **`human install`** registers a synchronous SessionStart hook running `human agent-context --hook` alongside the existing monitoring `human hook`.

Verified: plain + `--hook` output, install registers the hook (tests updated), `go build`/`make lint`/gosec(0)/`make check-test`(2385) green.

Closes HUM-134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)