### PR TITLE
[HUM-120] Surface the full error cause chain in LogError

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,13 +1,50 @@
 package errors
 
 import (
+	stderrors "errors"
+	"strings"
+
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	goerrors "gitlab.com/tozd/go/errors"
 )
 
 func LogError(err error) *zerolog.Event {
-	return log.Error().Err(err).Fields(goerrors.AllDetails(err)).Err(err)
+	// tozd's Error() and %+v only expose the outermost wrap message, so the root
+	// cause (e.g. a Docker connection failure) is invisible to users unless we
+	// render the full chain ourselves.
+	return log.Error().Str("error", CauseChain(err)).Fields(goerrors.AllDetails(err))
+}
+
+// CauseChain renders the full unwrapped error chain as "outer: inner: root".
+// Wrappers like WrapWithDetails report the same message at multiple chain
+// levels; those consecutive duplicates are collapsed so the output stays
+// readable. Returns "" for a nil error.
+func CauseChain(err error) string {
+	if err == nil {
+		return ""
+	}
+	var b strings.Builder
+	var last string
+	for e := err; e != nil; e = stderrors.Unwrap(e) {
+		msg := e.Error()
+		if msg == "" || msg == last {
+			continue
+		}
+		last = msg
+		if b.Len() == 0 {
+			b.WriteString(msg)
+			continue
+		}
+		// A leaf error built with fmt.Errorf("%w") already embeds its cause as a
+		// suffix; don't append it twice.
+		if strings.HasSuffix(b.String(), msg) {
+			continue
+		}
+		b.WriteString(": ")
+		b.WriteString(msg)
+	}
+	return b.String()
 }
 
 func WithDetails(message string, details ...interface{}) error {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,11 +1,62 @@
 package errors
 
 import (
+	"bytes"
+	stderrors "errors"
+	"fmt"
 	"testing"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLogError_EmitsCauseChainAndDetails(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Logger
+	log.Logger = zerolog.New(&buf)
+	defer func() { log.Logger = orig }()
+
+	root := stderrors.New("dial unix /var/run/docker.sock: no such file or directory")
+	err := WrapWithDetails(root, "starting agent container", "name", "fix-bug")
+
+	LogError(err).Msg("command failed")
+
+	out := buf.String()
+	// The root cause must be surfaced, not just the outermost wrap message.
+	assert.Contains(t, out, "starting agent container: dial unix /var/run/docker.sock")
+	// Structured details still ride along.
+	assert.Contains(t, out, "fix-bug")
+}
+
+func TestCauseChain(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		assert.Empty(t, CauseChain(nil))
+	})
+
+	t.Run("collapses duplicate wrap messages and surfaces root cause", func(t *testing.T) {
+		root := stderrors.New("dial unix /var/run/docker.sock: no such file or directory")
+		wrapped := WrapWithDetails(root, "starting agent container", "name", "fix-bug")
+
+		// tozd reports the wrap message twice in the unwrap chain; the duplicate
+		// is collapsed and the root cause is appended.
+		assert.Equal(t,
+			"starting agent container: dial unix /var/run/docker.sock: no such file or directory",
+			CauseChain(wrapped))
+	})
+
+	t.Run("single error returns its message", func(t *testing.T) {
+		assert.Equal(t, "boom", CauseChain(stderrors.New("boom")))
+	})
+
+	t.Run("does not duplicate a suffix already embedded by fmt.Errorf", func(t *testing.T) {
+		root := stderrors.New("inner")
+		// fmt.Errorf-style wrapping embeds the cause as a suffix.
+		fmtWrapped := fmt.Errorf("outer: %w", root)
+		assert.Equal(t, "outer: inner", CauseChain(fmtWrapped))
+	})
+}
 
 func Test_isFormatVerb(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## What

`LogError` previously logged only the outermost wrap message (tozd's `Error()`/`%+v` expose just the top wrap), so the actual root cause — e.g. a Docker connection failure — was invisible in logs. This renders the full unwrapped chain via a new `CauseChain(err)` helper (`"outer: inner: root"`), collapsing consecutive duplicate messages that `WrapWithDetails` produces so the output stays readable.

It also drops the old implementation's redundant double `.Err(err)` call.

## Provenance

Salvaged from an unmerged commit (`200e6db`, authored 2026-06-17) that was stranded on a local-only branch and never pushed. Cherry-picked clean onto `main`. The companion HUM-120 docker-context commit was **not** revived — that feature already landed on `main` via `462fff4 [HUM-122] Resolve active Docker context in both engine clients`.

## Verification

- `make test` — 2836 tests pass
- `go vet` + `staticcheck` clean on `errors/`
- `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)