### PR TITLE
[HUM-147] Suppress 3 unfixed docker cp/archive CVEs in govulncheck allow-list

### DIFF
--- a/scripts/govulncheck.sh
+++ b/scripts/govulncheck.sh
@@ -3,15 +3,20 @@
 # govulncheck wrapper that filters known false positives.
 #
 # Why this exists:
-#   govulncheck reports server-side Moby/dockerd vulnerabilities whenever the
-#   `github.com/docker/docker` module is imported, regardless of whether the
-#   importer acts as a Docker daemon or just as a client. We use the module
-#   purely as a client library to talk to a remote Docker Engine API
-#   (see internal/claude/docker_client.go) — we never run dockerd, never run
-#   AuthZ plugins, and never accept inbound Docker API requests. The flagged
-#   code paths are not reachable in our threat model.
+#   govulncheck reports Moby/dockerd vulnerabilities whenever the
+#   `github.com/docker/docker` module is imported, and it cannot do symbol-level
+#   reachability for that `+incompatible` module — so it flags on import alone,
+#   not on the specific API we call. We use the module as a client library to
+#   talk to a remote Docker Engine API (see internal/devcontainer/docker_engine.go);
+#   we never run dockerd, never run AuthZ plugins, and never accept inbound
+#   Docker API requests. Each suppressed finding below is either unreachable in
+#   our threat model, or reachable only behind a trust boundary we already
+#   assume (a hostile container image — which, given the daemon holds host
+#   Docker access by design, is already outside our boundary). The rationale is
+#   documented per-ID; the archive-PUT one (GO-2026-5746) is an explicit
+#   residual-risk acceptance, NOT a "not reachable" claim.
 #
-#   Both findings are unfixed upstream (Fixed in: N/A) so there is no version
+#   All findings are unfixed upstream (Fixed in: N/A) so there is no version
 #   bump that resolves them. We suppress them here with explicit IDs and a
 #   review date so they don't quietly persist forever.
 #
@@ -23,6 +28,31 @@
 #   GO-2026-4887 (CVE-2026-34040, GHSA-x744-4wpc-v9h2)
 #     "AuthZ plugin bypass when provided oversized request bodies"
 #     Server-side: dockerd AuthZ plugin enforcement. We don't run AuthZ plugins.
+#
+#   GO-2026-5668 ("Race condition in docker cp allows creation of arbitrary
+#                 empty files on the host via symlink swap")
+#     Host-side `docker cp` copy-OUT path that writes extracted entries to a
+#     host directory. human never copies container content out to a host path:
+#     it only streams an in-memory tar INTO containers via CopyToContainer (the
+#     archive PUT API) — never CopyFromContainer and never the `docker cp` CLI.
+#     The vulnerable host-write path is unreachable.
+#
+#   GO-2026-5617 ("Race condition in docker cp allows bind mount redirection to
+#                 host path")
+#     Same host-side copy-OUT path as GO-2026-5668; human performs no
+#     container->host copy, so it is unreachable.
+#
+#   GO-2026-5746 ("PUT /containers/{id}/archive executes container binary on the
+#                 host")
+#     REACHABLE — unlike the entries above, human does exercise this API:
+#     internal/devcontainer/feature.go copies a devcontainer-feature tar into a
+#     freshly created container via CopyToContainer. The exploit requires a
+#     malicious container IMAGE (it manipulates archive-extraction paths). human
+#     only copies into containers it just created from images the operator
+#     declares in devcontainer.json, and the daemon already holds full host
+#     Docker access by design — a hostile base image is already outside this
+#     trust boundary. Accepted as RESIDUAL RISK pending an upstream fix;
+#     re-evaluate if human ever copies into images from untrusted sources.
 #
 # Review reminder:
 #   Re-evaluate this allow-list every time `make upgrade-deps` is run, or at
@@ -43,6 +73,11 @@ set -uo pipefail
 SUPPRESSED=(
   "GO-2026-4883"
   "GO-2026-4887"
+  # docker cp / archive-PUT findings — see per-ID rationale in the header.
+  # 5668/5617: unreachable (no container->host copy). 5746: accepted residual risk.
+  "GO-2026-5668"
+  "GO-2026-5617"
+  "GO-2026-5746"
 )
 
 # Build a jq array literal like ["GO-2026-4883","GO-2026-4887"]


### PR DESCRIPTION
## What

Adds three unfixed `github.com/docker/docker` CVEs to the `SUPPRESSED` allow-list in `scripts/govulncheck.sh`, so the `make sec` govulncheck gate passes again. Each carries a per-ID justification.

## Why

These are freshly-disclosed, **unfixed upstream** (`Fixed in: N/A`) — `make upgrade-deps` is a no-op (deps already current; `docker/docker v28.5.2` is latest), so there is no version to move to. govulncheck can't do symbol-level reachability for the `+incompatible` docker module, so it flags on import alone.

## Per-CVE rationale (honest, differentiated)

| CVE | Disposition |
|-----|-------------|
| **GO-2026-5668** — `docker cp` symlink-swap race → arbitrary empty host file | **Unreachable** — `human` only streams a tar *into* containers via `CopyToContainer`; never copies *out* to a host path, never uses the `docker cp` CLI |
| **GO-2026-5617** — `docker cp` race → bind-mount redirection to host path | **Unreachable** — same copy-OUT path; `human` does no container→host copy |
| **GO-2026-5746** — `PUT /containers/{id}/archive` executes container binary on host | **Reachable, accepted residual risk** — `human` uses `CopyToContainer` (`internal/devcontainer/feature.go`) to install devcontainer features. Exploit needs a malicious base **image**; operator-declared `devcontainer.json` images + the daemon's existing host-Docker access already place a hostile image outside the trust boundary. Documented as residual risk, **not** a false "unreachable" claim. |

## Reviewer note

The only judgment call is suppressing **GO-2026-5746** (residual-risk acceptance vs. leaving the gate red until an upstream fix, or hardening the feature-install path). The other two are genuinely unreachable. Re-evaluate the whole allow-list when Moby ships a fix (review date already in the script).

## Verification

- `make sec` → "OK: no vulnerabilities outside the suppression list"
- `bash -n scripts/govulncheck.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)