### PR TITLE
[SC-124] [HUM-149] TUI tmux preflight: detect tmux at launch and guide install/relaunch

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ human tui
 
 The TUI shows running Claude Code instances, token usage per 5-hour window, daemon status, and connected containers — all in one view. It auto-starts the daemon if needed.
 
+Agent spawn (`a`) and dispatch (`⏎`) require **tmux** on the host and that the TUI itself runs inside a tmux session. Browsing issues and every other view work without it. If tmux is missing, install it (`brew install tmux` on macOS, `sudo apt-get install tmux` on Debian/Ubuntu, or your distro's package). To run the TUI inside a session, launch it as:
+
+```bash
+tmux new -s human "human tui"
+```
+
+The TUI runs a launch-time preflight and shows a banner with the exact command to run if either check fails.
+
 ## CLI usage
 
 Quick commands auto-detect the tracker from the key format. Use `--table` for human-readable output.

--- a/cmd/cmdtui/tmux.go
+++ b/cmd/cmdtui/tmux.go
@@ -1,0 +1,85 @@
+package cmdtui
+
+import (
+	"os/exec"
+
+	"github.com/gethuman-sh/human/internal/platform"
+)
+
+// pathLooker abstracts exec.LookPath so tmux detection is unit-testable
+// without touching the host PATH. Mirrors internal/init.PathLooker but kept
+// local to avoid importing the heavy init wizard package into the TUI.
+type pathLooker interface {
+	LookPath(file string) (string, error)
+}
+
+// osPathLooker resolves binaries against the real host PATH.
+type osPathLooker struct{}
+
+func (osPathLooker) LookPath(file string) (string, error) { return exec.LookPath(file) }
+
+// tmuxState is the immutable result of the launch-time tmux preflight.
+// Both signals are captured independently so the UI can distinguish
+// "tmux missing" from "tmux present but not in a session".
+type tmuxState struct {
+	installed   bool   // tmux is on $PATH
+	inSession   bool   // process is inside a tmux session ($TMUX set)
+	installCmd  string // platform-appropriate install command, "" when installed
+	relaunchCmd string // copy-pasteable relaunch command
+	goos        string // captured GOOS, retained for hint text
+}
+
+// relaunchCommand is the copy-pasteable command that starts the TUI inside a
+// fresh tmux session. Static across platforms (tmux CLI is uniform).
+const relaunchCommand = `tmux new -s human "human tui"`
+
+// detectTmux runs the two independent preflight checks. looker, the tmux-env
+// value and goos are injected so the whole result is reproducible in tests
+// without real syscalls or a real host.
+func detectTmux(looker pathLooker, tmuxEnv, goos string) tmuxState {
+	_, err := looker.LookPath("tmux")
+	installed := err == nil
+	st := tmuxState{
+		installed:   installed,
+		inSession:   tmuxEnv != "",
+		relaunchCmd: relaunchCommand,
+		goos:        goos,
+	}
+	if !installed {
+		st.installCmd = tmuxInstallCommand(goos)
+	}
+	return st
+}
+
+// tmuxInstallCommand returns the platform-appropriate install command,
+// switching on GOOS exactly like sound.go's notificationCommand.
+func tmuxInstallCommand(goos string) string {
+	switch goos {
+	case "darwin":
+		return "brew install tmux"
+	case "linux":
+		if platform.IsWSL() {
+			return "sudo apt-get install tmux"
+		}
+		return "sudo apt-get install tmux   # or: sudo dnf install tmux / sudo pacman -S tmux"
+	default:
+		return "see https://github.com/tmux/tmux/wiki/Installing"
+	}
+}
+
+// ok reports whether agent spawn/dispatch will work: tmux installed AND in a session.
+func (s tmuxState) ok() bool { return s.installed && s.inSession }
+
+// guidance returns the actionable one-line remedy for the current state,
+// used both by the banner and by the on-action status guards so the user
+// sees one consistent instruction. Empty when ok().
+func (s tmuxState) guidance() string {
+	switch {
+	case s.ok():
+		return ""
+	case !s.installed:
+		return "tmux not installed — run: " + s.installCmd
+	default: // installed but not in a session
+		return "not in a tmux session — relaunch: " + s.relaunchCmd
+	}
+}

--- a/cmd/cmdtui/tmux_test.go
+++ b/cmd/cmdtui/tmux_test.go
@@ -1,0 +1,101 @@
+package cmdtui
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// stubLooker is an injectable pathLooker: a nil err reports tmux as installed.
+type stubLooker struct{ err error }
+
+func (s stubLooker) LookPath(string) (string, error) {
+	if s.err != nil {
+		return "", s.err
+	}
+	return "/usr/bin/tmux", nil
+}
+
+func TestDetectTmux_notInstalled_darwin(t *testing.T) {
+	st := detectTmux(stubLooker{err: exec.ErrNotFound}, "", "darwin")
+	assert.False(t, st.installed)
+	assert.False(t, st.inSession)
+	assert.Equal(t, "brew install tmux", st.installCmd)
+	assert.False(t, st.ok())
+}
+
+func TestDetectTmux_installedNoSession(t *testing.T) {
+	st := detectTmux(stubLooker{}, "", "darwin")
+	assert.True(t, st.installed)
+	assert.False(t, st.inSession)
+	assert.Empty(t, st.installCmd)
+	assert.False(t, st.ok())
+	assert.Contains(t, st.guidance(), relaunchCommand)
+}
+
+func TestDetectTmux_installedInSession(t *testing.T) {
+	st := detectTmux(stubLooker{}, "/tmp/tmux-1000/default,1,0", "linux")
+	assert.True(t, st.ok())
+	assert.Empty(t, st.guidance())
+}
+
+func TestTmuxInstallCommand_linux(t *testing.T) {
+	// On darwin/CI /proc/version is absent, so IsWSL() is false.
+	assert.Contains(t, tmuxInstallCommand("linux"), "apt-get install tmux")
+}
+
+func TestTmuxInstallCommand_unknown(t *testing.T) {
+	assert.Contains(t, tmuxInstallCommand("plan9"), "tmux/tmux/wiki/Installing")
+}
+
+func TestTmuxState_guidance_notInstalled(t *testing.T) {
+	st := tmuxState{installed: false, installCmd: "brew install tmux"}
+	assert.Equal(t, "tmux not installed — run: brew install tmux", st.guidance())
+}
+
+func TestTmuxState_guidance_noSession(t *testing.T) {
+	st := tmuxState{installed: true, inSession: false, relaunchCmd: relaunchCommand}
+	assert.Equal(t, "not in a tmux session — relaunch: "+relaunchCommand, st.guidance())
+}
+
+func TestTmuxState_guidance_ok(t *testing.T) {
+	st := tmuxState{installed: true, inSession: true}
+	assert.Empty(t, st.guidance())
+}
+
+func TestOSPathLooker_LookPath(t *testing.T) {
+	// Exercise the real looker against a binary that is virtually always present
+	// so the concrete implementation is covered without asserting a fixed path.
+	_, err := osPathLooker{}.LookPath("go")
+	assert.NoError(t, err)
+	_, err = osPathLooker{}.LookPath("definitely-not-a-real-binary-xyz")
+	assert.Error(t, err)
+}
+
+func TestRenderTmuxBanner_notInstalled(t *testing.T) {
+	out := renderTmuxBanner(tmuxState{installed: false, installCmd: "brew install tmux"})
+	assert.Contains(t, out, "not installed")
+	assert.Contains(t, out, "brew install tmux")
+}
+
+func TestRenderTmuxBanner_noSession(t *testing.T) {
+	out := renderTmuxBanner(tmuxState{installed: true, relaunchCmd: relaunchCommand})
+	assert.Contains(t, out, "tmux session")
+	assert.Contains(t, out, relaunchCommand)
+}
+
+func TestRenderTmuxBanner_ok(t *testing.T) {
+	assert.Empty(t, renderTmuxBanner(tmuxState{installed: true, inSession: true}))
+}
+
+func TestRenderFooter_tmuxAnnotation(t *testing.T) {
+	out := renderFooter(80, "", "", false, false)
+	assert.Contains(t, out, "need tmux")
+}
+
+func TestRenderFooter_tmuxOK_noAnnotation(t *testing.T) {
+	out := renderFooter(80, "", "", false, true)
+	assert.False(t, strings.Contains(out, "need tmux"))
+}

--- a/cmd/cmdtui/tui.go
+++ b/cmd/cmdtui/tui.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -164,6 +165,7 @@ type model struct {
 	fetching     bool                         // true while a fetch command is in flight
 	showSplash   bool                         // true during the initial logo display period
 	logMode      string                       // traffic log mode: "off", "meta", "full"
+	tmux         tmuxState                    // cached launch-time tmux preflight (SC-124)
 	daemonEvents <-chan daemon.SubscribeEvent // push notifications from daemon
 	daemonUnsub  func()                       // closes daemon subscription
 
@@ -203,7 +205,7 @@ type model struct {
 func newModel(mon *monitor.Monitor) model {
 	sp := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	sp.Style = lipgloss.NewStyle().Foreground(humanRed)
-	m := model{mon: mon, spinner: sp, width: defaultWidth, fetchGen: 1, fetching: true, showSplash: true, logMode: "off", prevStatuses: make(map[string]logparser.SessionStatus)}
+	m := model{mon: mon, spinner: sp, width: defaultWidth, fetchGen: 1, fetching: true, showSplash: true, logMode: "off", prevStatuses: make(map[string]logparser.SessionStatus), tmux: detectTmux(osPathLooker{}, os.Getenv("TMUX"), runtime.GOOS)}
 	// Subscribe to daemon push notifications (best-effort; falls back to polling).
 	if info, err := daemon.ReadInfo(); err == nil && info.Addr != "" {
 		if ch, unsub, subErr := daemon.Subscribe(info.Addr, info.Token); subErr == nil {
@@ -503,8 +505,8 @@ func (m model) handleDispatch() (tea.Model, tea.Cmd) {
 	if m.issueCursor >= len(flat) {
 		return m, nil
 	}
-	if os.Getenv("TMUX") == "" {
-		m.dispatchStatus = "Not in tmux"
+	if !m.tmux.ok() {
+		m.dispatchStatus = m.tmux.guidance()
 		m.dispatchAt = time.Now()
 		return m, nil
 	}
@@ -663,8 +665,8 @@ type spawnAgentMsg struct {
 }
 
 func (m model) handleSpawnAgent() (tea.Model, tea.Cmd) {
-	if os.Getenv("TMUX") == "" {
-		m.dispatchStatus = "Not in tmux"
+	if !m.tmux.ok() {
+		m.dispatchStatus = m.tmux.guidance()
 		m.dispatchAt = time.Now()
 		return m, nil
 	}
@@ -1003,7 +1005,7 @@ func (m model) handleCreateResult(msg createResultMsg) (tea.Model, tea.Cmd) {
 	m.issuesLoading = true
 
 	// Auto-dispatch /human-ready via a new agent.
-	if !m.dispatching && os.Getenv("TMUX") != "" {
+	if !m.dispatching && m.tmux.ok() {
 		name := nextAgentName()
 		projectDir := m.activeProjectDir()
 		var tmuxTarget string
@@ -1102,6 +1104,12 @@ func (m model) View() string {
 		return b.String()
 	}
 
+	// tmux preflight banner: persistent, non-blocking guidance (SC-124).
+	if banner := renderTmuxBanner(m.tmux); banner != "" {
+		b.WriteString(banner)
+		b.WriteByte('\n')
+	}
+
 	// Status line: daemon left, telegram right.
 	b.WriteString(renderStatusLine(m.snap, w))
 	b.WriteByte('\n')
@@ -1146,7 +1154,7 @@ func (m model) View() string {
 // budgeting the issues panel; the domains panel then fills whatever space is
 // left above the footer.
 func (m model) renderBottomPanels(b *strings.Builder, w int) {
-	footer := renderFooter(w, m.logMode, m.dispatchStatus, len(m.tabs()) > 0)
+	footer := renderFooter(w, m.logMode, m.dispatchStatus, len(m.tabs()) > 0, m.tmux.ok())
 	const footerLines = 2 // one blank separator + the footer line itself
 
 	toolStats := renderToolStatsPanel(m.snap.ToolStats, w)
@@ -1601,7 +1609,7 @@ func renderConfirmDialog(prompt string, width, height int) string {
 	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, dialog)
 }
 
-func renderFooter(w int, logMode, dispatchStatus string, showTabs bool) string {
+func renderFooter(w int, logMode, dispatchStatus string, showTabs, tmuxOK bool) string {
 	left := subtleStyle.Render("  ↻ live")
 	if logMode != "" {
 		left += "  " + subtleStyle.Render("log:"+logMode)
@@ -1610,6 +1618,10 @@ func renderFooter(w int, logMode, dispatchStatus string, showTabs bool) string {
 		left += "  " + specialStyle.Render(dispatchStatus)
 	}
 	keys := "j/k nav  ⏎ send  o open  n new  a agent  l log  q quit"
+	if !tmuxOK {
+		// Keep the spawn/dispatch affordances visible but flag that they need tmux.
+		keys += "  " + warningStyle.Render("(⏎/a need tmux)")
+	}
 	if showTabs {
 		keys = "Tab switch  " + keys
 	}
@@ -1619,6 +1631,26 @@ func renderFooter(w int, logMode, dispatchStatus string, showTabs bool) string {
 		gap = 1
 	}
 	return left + strings.Repeat(" ", gap) + right
+}
+
+// renderTmuxBanner produces the persistent, non-blocking tmux guidance banner.
+// Returns "" when the preflight is satisfied so a healthy setup shows no chrome.
+// The two failure states get distinct, copy-pasteable remedies (SC-124).
+func renderTmuxBanner(st tmuxState) string {
+	if st.ok() {
+		return ""
+	}
+	var headline, cmd string
+	if !st.installed {
+		headline = "⚠ tmux is required for agent spawn (a) and dispatch (⏎), but is not installed."
+		cmd = st.installCmd
+	} else {
+		headline = "⚠ Agent spawn (a) and dispatch (⏎) need a tmux session; you're not in one."
+		cmd = st.relaunchCmd
+	}
+	line1 := warningStyle.Render("  " + headline)
+	line2 := subtleStyle.Render("    ") + specialStyle.Render(cmd)
+	return line1 + "\n" + line2
 }
 
 // --- render: icon ---

--- a/cmd/cmdtui/tui_test.go
+++ b/cmd/cmdtui/tui_test.go
@@ -3,6 +3,7 @@ package cmdtui
 import (
 	"context"
 	"fmt"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -193,6 +194,18 @@ func TestModelView_WithData(t *testing.T) {
 	}
 	if !strings.Contains(view, "Host") {
 		t.Errorf("expected 'Host' in view, got:\n%s", view)
+	}
+}
+
+func TestModelView_TmuxBannerShown(t *testing.T) {
+	m := testModel()
+	// Past the loading state (snap set) with a not-ok tmux preflight.
+	m.snap = testSnapshot()
+	m.tmux = detectTmux(stubLooker{err: exec.ErrNotFound}, "", "darwin")
+
+	view := m.View()
+	if !strings.Contains(view, "brew install tmux") {
+		t.Errorf("expected tmux guidance command in view, got:\n%s", view)
 	}
 }
 
@@ -450,7 +463,7 @@ func TestModelUpdate_LogModeMsg(t *testing.T) {
 }
 
 func TestRenderFooter_ShowsLogMode(t *testing.T) {
-	footer := renderFooter(80, "meta", "", false)
+	footer := renderFooter(80, "meta", "", false, true)
 	assert.Contains(t, footer, "log:meta")
 	assert.Contains(t, footer, "l log")
 	assert.Contains(t, footer, "q quit")
@@ -760,23 +773,25 @@ func TestDispatch_NoIssues(t *testing.T) {
 	assert.Nil(t, cmd)
 }
 
-func TestDispatch_NotInTmux(t *testing.T) {
-	t.Setenv("TMUX", "")
+func TestHandleDispatch_notOk_guidance(t *testing.T) {
 	m := testModel()
+	// Installed but no session: guidance should point at the relaunch command.
+	m.tmux = detectTmux(stubLooker{}, "", "darwin")
 	m.issues = []trackerIssues{
 		{TrackerKind: "linear", Project: "HUM", Issues: []tracker.Issue{{Key: "HUM-1"}}},
 	}
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	um := updated.(model)
-	assert.Equal(t, "Not in tmux", um.dispatchStatus)
+	assert.Contains(t, um.dispatchStatus, "relaunch")
 	assert.Nil(t, cmd)
 }
 
 func TestDispatch_LinearIssue(t *testing.T) {
-	t.Setenv("TMUX", "/tmp/tmux-1000/default,12345,0")
 	t.Setenv("HOME", t.TempDir())
 	m := testModel()
+	// Guard reads cached m.tmux, not $TMUX directly — inject an ok state.
+	m.tmux = detectTmux(stubLooker{}, "/tmp/tmux-1000/default,12345,0", "darwin")
 	m.issues = []trackerIssues{
 		{TrackerKind: "linear", Project: "HUM", Issues: []tracker.Issue{{Key: "HUM-42"}}},
 	}
@@ -790,9 +805,10 @@ func TestDispatch_LinearIssue(t *testing.T) {
 }
 
 func TestDispatch_ShortcutIssue(t *testing.T) {
-	t.Setenv("TMUX", "/tmp/tmux-1000/default,12345,0")
 	t.Setenv("HOME", t.TempDir())
 	m := testModel()
+	// Guard reads cached m.tmux, not $TMUX directly — inject an ok state.
+	m.tmux = detectTmux(stubLooker{}, "/tmp/tmux-1000/default,12345,0", "darwin")
 	m.issues = []trackerIssues{
 		{TrackerKind: "shortcut", Project: "PM", Issues: []tracker.Issue{{Key: "99"}}},
 	}
@@ -879,13 +895,13 @@ func TestRenderIssuesPanelCursor(t *testing.T) {
 }
 
 func TestRenderFooter_ShowsDispatchStatus(t *testing.T) {
-	footer := renderFooter(120, "off", "Spawned agent-3 for HUM-42", false)
+	footer := renderFooter(120, "off", "Spawned agent-3 for HUM-42", false, true)
 	assert.Contains(t, footer, "Spawned agent-3 for HUM-42")
 	assert.Contains(t, footer, "⏎ send")
 }
 
 func TestRenderFooter_ShowsNavKeys(t *testing.T) {
-	footer := renderFooter(120, "", "", false)
+	footer := renderFooter(120, "", "", false, true)
 	assert.Contains(t, footer, "j/k nav")
 	assert.Contains(t, footer, "⏎ send")
 }
@@ -943,17 +959,17 @@ func TestOpenBrowserMsg_Error(t *testing.T) {
 }
 
 func TestRenderFooter_ShowsOpenKey(t *testing.T) {
-	footer := renderFooter(120, "", "", false)
+	footer := renderFooter(120, "", "", false, true)
 	assert.Contains(t, footer, "o open")
 }
 
 func TestRenderFooter_ShowsTabHint(t *testing.T) {
-	footer := renderFooter(120, "", "", true)
+	footer := renderFooter(120, "", "", true, true)
 	assert.Contains(t, footer, "Tab switch")
 }
 
 func TestRenderFooter_NoTabHint(t *testing.T) {
-	footer := renderFooter(120, "", "", false)
+	footer := renderFooter(120, "", "", false, true)
 	assert.NotContains(t, footer, "Tab switch")
 }
 
@@ -1246,15 +1262,16 @@ func TestNextAgentName(t *testing.T) {
 	assert.Equal(t, "agent-1", name)
 }
 
-func TestHandleSpawnAgent_NotInTmux(t *testing.T) {
-	t.Setenv("TMUX", "")
-
+func TestHandleSpawnAgent_notOk_guidance(t *testing.T) {
 	m := testModel()
+	// tmux not installed: guidance should name the missing dependency.
+	m.tmux = detectTmux(stubLooker{err: exec.ErrNotFound}, "", "darwin")
+
 	result, cmd := m.handleSpawnAgent()
 	resultModel := result.(model)
 
 	assert.Nil(t, cmd)
-	assert.Contains(t, resultModel.dispatchStatus, "Not in tmux")
+	assert.Contains(t, resultModel.dispatchStatus, "tmux not installed")
 }
 
 func TestHandleSpawnAgentResult_Success(t *testing.T) {
@@ -1274,7 +1291,7 @@ func TestHandleSpawnAgentResult_Error(t *testing.T) {
 }
 
 func TestFooterContainsAgentHint(t *testing.T) {
-	footer := renderFooter(80, "", "", false)
+	footer := renderFooter(80, "", "", false, true)
 	assert.Contains(t, footer, "a agent")
 }
 


### PR DESCRIPTION
## What

Adds a launch-time tmux preflight to the TUI so a new evaluator running `human tui` outside tmux gets a clear, actionable signal instead of a silent broken spawn.

PM ticket: SC-124 (Shortcut, refines SC-98)
Engineering ticket: HUM-149

## Changes

- **`cmd/cmdtui/tmux.go`** (new) — pure, injectable `detectTmux(looker, tmuxEnv, goos)` running two independent checks (`LookPath("tmux")` + `$TMUX`); GOOS-branched `tmuxInstallCommand`; `ok()`/`guidance()` state methods.
- **`cmd/cmdtui/tui.go`** — cache `tmuxState` at model construction; repoint the three spawn/dispatch guards at the shared `guidance()`; add a persistent non-blocking banner and the `(⏎/a need tmux)` footer annotation.
- **`README.md`** — document tmux as a required host dependency with the same install/relaunch guidance.
- Full unit coverage in `cmd/cmdtui/tmux_test.go` + updated `tui_test.go`.

## Behavior

- **tmux not installed** → banner with a platform-appropriate install command (`brew install tmux` on darwin, distro hints on linux).
- **installed but not in a session** → distinct banner with a copy-pasteable relaunch command `tmux new -s human "human tui"`.
- **in a session** → no banner; spawn/dispatch work normally.
- Advisory only: nothing auto-installs or re-execs; every non-spawn feature works without tmux.

## Verification

- `make test` — 2910 pass; `make lint` — 0 issues.
- New-code coverage ~100% (only the WSL branch unreachable on a non-WSL host).
- Manual: all three tmux states + both on-action guards confirmed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)