### PR TITLE
[SC-133] [HUM-151] Add daemon reachability indicator to desktop board header

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -15,7 +15,8 @@ re-derives a stage.
 - The Done column uses a guarded inner drop zone (not the whole column) so a stray drop cannot push a pull request.
 - Optimistic move on drop, then reconcile from the daemon (which is authoritative: it re-derives the card from live comments and enforces forward-only/gated rules server-side).
 - When Docker is unavailable the planning/implementation/verification drop targets are disabled (Done stays enabled, since it only pushes a branch and opens a PR).
-- Live updates: subscribes to the daemon and refetches on every change event — no independent polling loop, mirroring the TUI.
+- Live updates: subscribes to the daemon and refetches board cards on every change event. A small independent poll (every 3s) drives only the header daemon-reachability dot, since there is no daemon-pushed event to subscribe to when the daemon itself is down — this mirrors how the TUI itself layers periodic ticks on top of its daemon subscribe channel.
+- Header daemon indicator: a two-state dot (reachable/unreachable) in the header, sourced from `daemon.ReadInfo()` / `IsReachable()` / `ReadAlivePid()` — display-only, no daemon version, proxy stats, agent count, or start/stop action.
 
 ## Architecture
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -115,6 +115,23 @@ func (a *App) Cards() (BoardData, error) {
 	return data, nil
 }
 
+// DaemonStatus reports whether the human daemon is currently reachable. The
+// frontend polls this independently of Cards() because Cards() returns an
+// error the instant the daemon is unreachable and stops there — the one case
+// this indicator exists to show would otherwise never populate a "reachable"
+// field. Combines IsReachable() (authoritative TCP dial, works across process
+// namespaces e.g. host <-> devcontainer) with ReadAlivePid() (same-host
+// PID-file liveness) so a daemon that is alive but momentarily not yet
+// listening still reads as reachable, matching the TUI's dual-source check.
+func (a *App) DaemonStatus() bool {
+	info, err := daemon.ReadInfo()
+	if err == nil && info.IsReachable() {
+		return true
+	}
+	_, alive := daemon.ReadAlivePid()
+	return alive
+}
+
 // Transition advances a card one stage by delegating to the daemon's
 // board-transition route. The daemon is authoritative: it re-derives the card
 // from live comments and enforces forward-only/gated rules, so an out-of-date

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -17,6 +17,10 @@ const STAGE_LABELS = {
 const AGENT_STAGES = new Set(["planning", "implementation", "verification"]);
 let current = { cards: [], dockerAvailable: true, error: "" };
 let dragging = null;
+// Matches the daemon subscribe-retry backoff (desktop/main.go backoff(), 2s)
+// rounded up slightly so the poll never races the retry loop.
+const DAEMON_POLL_MS = 3000;
+let daemonReachable = false;
 function go() {
     const app = window.go?.main?.App;
     if (!app)
@@ -164,6 +168,22 @@ function showError(msg) {
     current.error = msg;
     render();
 }
+function renderDaemonStatus() {
+    const dot = document.getElementById("daemon-status");
+    dot.classList.toggle("reachable", daemonReachable);
+    dot.classList.toggle("unreachable", !daemonReachable);
+    dot.title = daemonReachable ? "Daemon reachable" : "Daemon unreachable";
+}
+async function pollDaemonStatus() {
+    try {
+        daemonReachable = await go().DaemonStatus();
+    }
+    catch {
+        // Wails bindings not ready yet or call failed — treat as unreachable.
+        daemonReachable = false;
+    }
+    renderDaemonStatus();
+}
 async function refresh() {
     try {
         const data = await go().Cards();
@@ -199,6 +219,8 @@ function init() {
         });
     }
     void refresh();
+    void pollDaemonStatus();
+    setInterval(() => void pollDaemonStatus(), DAEMON_POLL_MS);
 }
 if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", init);

--- a/desktop/frontend/dist/index.html
+++ b/desktop/frontend/dist/index.html
@@ -7,6 +7,10 @@
     <link rel="stylesheet" href="/style.css" />
   </head>
   <body>
+    <header id="app-header" class="app-header">
+      <span class="app-title">human — workflow board</span>
+      <span id="daemon-status" class="daemon-dot" title="Daemon status"></span>
+    </header>
     <div id="banner" class="banner hidden"></div>
     <main id="board" class="board" aria-label="Workflow pipeline board"></main>
     <script type="module" src="/board.js"></script>

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -194,3 +194,34 @@ body {
 .disabled-target {
   opacity: 0.5;
 }
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 14px;
+  background: var(--col-bg);
+  border-bottom: 1px solid var(--col-border);
+  font-weight: 600;
+}
+
+.app-title {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.daemon-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+  background: var(--muted);
+}
+
+.daemon-dot.reachable {
+  background: var(--done);
+}
+
+.daemon-dot.unreachable {
+  background: var(--failed);
+}

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -28,6 +28,7 @@ interface BoardData {
 interface AppBindings {
   Cards(): Promise<BoardData>;
   Transition(pmKey: string, pmTitle: string, from: string, to: string): Promise<void>;
+  DaemonStatus(): Promise<boolean>;
 }
 
 // This file is a module (see the trailing `export {}`) so the global
@@ -55,6 +56,12 @@ const AGENT_STAGES = new Set(["planning", "implementation", "verification"]);
 
 let current: BoardData = { cards: [], dockerAvailable: true, error: "" };
 let dragging: { key: string; title: string; stage: string } | null = null;
+
+// Matches the daemon subscribe-retry backoff (desktop/main.go backoff(), 2s)
+// rounded up slightly so the poll never races the retry loop.
+const DAEMON_POLL_MS = 3000;
+
+let daemonReachable = false;
 
 function go(): AppBindings {
   const app = window.go?.main?.App;
@@ -205,6 +212,23 @@ function showError(msg: string): void {
   render();
 }
 
+function renderDaemonStatus(): void {
+  const dot = document.getElementById("daemon-status")!;
+  dot.classList.toggle("reachable", daemonReachable);
+  dot.classList.toggle("unreachable", !daemonReachable);
+  dot.title = daemonReachable ? "Daemon reachable" : "Daemon unreachable";
+}
+
+async function pollDaemonStatus(): Promise<void> {
+  try {
+    daemonReachable = await go().DaemonStatus();
+  } catch {
+    // Wails bindings not ready yet or call failed — treat as unreachable.
+    daemonReachable = false;
+  }
+  renderDaemonStatus();
+}
+
 async function refresh(): Promise<void> {
   try {
     const data = await go().Cards();
@@ -242,6 +266,8 @@ function init(): void {
     });
   }
   void refresh();
+  void pollDaemonStatus();
+  setInterval(() => void pollDaemonStatus(), DAEMON_POLL_MS);
 }
 
 if (document.readyState === "loading") {

--- a/desktop/frontend/static/index.html
+++ b/desktop/frontend/static/index.html
@@ -7,6 +7,10 @@
     <link rel="stylesheet" href="/style.css" />
   </head>
   <body>
+    <header id="app-header" class="app-header">
+      <span class="app-title">human — workflow board</span>
+      <span id="daemon-status" class="daemon-dot" title="Daemon status"></span>
+    </header>
     <div id="banner" class="banner hidden"></div>
     <main id="board" class="board" aria-label="Workflow pipeline board"></main>
     <script type="module" src="/board.js"></script>

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -194,3 +194,34 @@ body {
 .disabled-target {
   opacity: 0.5;
 }
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 14px;
+  background: var(--col-bg);
+  border-bottom: 1px solid var(--col-border);
+  font-weight: 600;
+}
+
+.app-title {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.daemon-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+  background: var(--muted);
+}
+
+.daemon-dot.reachable {
+  background: var(--done);
+}
+
+.daemon-dot.unreachable {
+  background: var(--failed);
+}


### PR DESCRIPTION
## Summary
- Adds `App.DaemonStatus()` (Go backend) combining `daemon.IsReachable()` and `daemon.ReadAlivePid()`
- Desktop board header now polls daemon reachability every 3s and shows a reachable/unreachable dot
- No new daemon RPC/HTTP endpoint — reuses existing primitives, matching the TUI's status indicator

## Tickets
- PM: SC-133
- Engineering: HUM-151

## Test plan
- [x] `make check` (tests pass; one unrelated flaky failure confirmed pre-existing)
- [x] `make lint` clean
- [x] `wails build -tags wailsapp` succeeds, bindings regenerated
- [x] Manually verified in the built app: dot shows reachable with daemon up, flips to unreachable within ~3s of `human daemon stop`, recovers on restart