### PR TITLE
[SC-154] Fancy demo style for the desktop board, toggled with F8

### DIFF
--- a/FEATURE.json
+++ b/FEATURE.json
@@ -1,0 +1,198 @@
+{
+  "product": "human",
+  "tagline": "Your team's AI dev rig — trackers, docs, designs, analytics, a secure sandbox, and the full dev lifecycle, already wired around the coding agent you run.",
+  "generated": "2026-07-10",
+  "groups": [
+    {
+      "group": "Connected to your whole stack",
+      "groups": [
+        {
+          "group": "Issue trackers",
+          "features": [
+            {
+              "name": "Cross-tracker issue operations",
+              "description": "List, read, create, comment, edit, assign, and move issues across Jira, Linear, GitHub, GitLab, Shortcut, Azure DevOps, and ClickUp through one interface",
+              "tickets": ["SC-90", "SC-86", "SC-78", "SC-76", "HUM-90"]
+            },
+            {
+              "name": "Zero-config tracker routing",
+              "description": "Commands land on the right tracker automatically from an issue key or a pasted issue URL",
+              "tickets": ["SC-86", "HUM-90"]
+            },
+            {
+              "name": "Open pull requests",
+              "description": "Open a PR from one branch to another on GitHub and get back its number and URL",
+              "tickets": ["SC-86", "HUM-105", "HUM-104"]
+            }
+          ]
+        },
+        {
+          "group": "Knowledge & insights",
+          "features": [
+            {
+              "name": "Notion docs",
+              "description": "Search and read Notion pages as markdown and browse database rows and properties",
+              "tickets": ["SC-89"]
+            },
+            {
+              "name": "Figma designs",
+              "description": "Inspect files, screens, and components, read comments, and export images",
+              "tickets": ["HUM-99"]
+            },
+            {
+              "name": "Amplitude analytics",
+              "description": "Explore events, funnels, retention, and cohorts and look up individual users",
+              "tickets": ["HUM-99"]
+            }
+          ]
+        },
+        {
+          "group": "Team messaging",
+          "features": [
+            {
+              "name": "Slack and Telegram",
+              "description": "Post and read Slack channels and take in tasks from a Telegram bot inbox, with a default-deny allowlist and approval prompts on destructive actions",
+              "tickets": ["SC-77", "#41"]
+            },
+            {
+              "name": "Chat-driven task dispatch",
+              "description": "Route tasks from a Telegram chat to idle agents and notify results back over Telegram or Slack",
+              "tickets": ["SC-77", "SC-71", "SC-40"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "group": "Token-efficient context",
+      "features": [
+        {
+          "name": "Code navigation index",
+          "description": "One local index across many repos powering go-to-definition, find-references, call graphs, blast-radius impact, route listing, and full-text code search — structural answers instead of raw file dumps",
+          "tickets": ["HUM-133", "HUM-131"]
+        },
+        {
+          "name": "Cross-source search",
+          "description": "One relevance-ranked, filterable search over every tracker plus Notion, kept current with incremental refresh",
+          "tickets": ["HUM-130"]
+        }
+      ]
+    },
+    {
+      "group": "Secure, sandboxed autonomy",
+      "features": [
+        {
+          "name": "Outbound domain firewall",
+          "description": "Block-all-by-default egress filtered by allow/blocklist over TLS SNI, with a per-host record of what each agent tried to reach",
+          "tickets": ["SC-71", "HUM-63"]
+        },
+        {
+          "name": "Secret-redacting filesystem",
+          "description": "A filesystem view that blanks secrets in env, JSON, YAML, keys, and certs and blocks writes to sensitive files, so the agent works on your code but never sees your tokens",
+          "tickets": ["HUM-63"]
+        },
+        {
+          "name": "Vault-resolved credentials",
+          "description": "Resolve 1Password references to real secrets only at startup, never cached to disk",
+          "tickets": ["HUM-85"]
+        },
+        {
+          "name": "Devcontainer sandbox",
+          "description": "Run agents in an isolated container built from devcontainer.json, with source mounted and the daemon wired in",
+          "tickets": ["HUM-125", "HUM-122", "HUM-121"]
+        },
+        {
+          "name": "Containerized Chrome bridge",
+          "description": "Give sandboxed agents token-gated control of host Chrome for screenshots and page snapshots",
+          "tickets": ["HUM-96"]
+        }
+      ]
+    },
+    {
+      "group": "Your AI development lifecycle",
+      "groups": [
+        {
+          "group": "Lifecycle skills",
+          "features": [
+            {
+              "name": "Ideate to review workflow",
+              "description": "Guided skills that carry work from idea to shipped: ideate, ready check, brainstorm, plan, execute, and review, or run the whole pipeline with one sprint command",
+              "tickets": ["HUM-66", "HUM-61", "HUM-60"]
+            },
+            {
+              "name": "Autonomous bug fixing",
+              "description": "Triage, root-cause, fix, verify, and open a PR for a bug end to end, plus a bug-planning skill for supervised fixes",
+              "tickets": ["HUM-103", "SC-86"]
+            },
+            {
+              "name": "Code-health scans",
+              "description": "Multi-agent pipelines for logic and race-condition bugs, an OWASP-style security audit, and refactoring-triage gardening"
+            }
+          ]
+        },
+        {
+          "group": "Agents & Claude Code",
+          "features": [
+            {
+              "name": "Run agents on tickets",
+              "description": "Launch a named Claude Code agent on a task or straight from a tracker ticket, pick the model, and run it unattended or interactively",
+              "tickets": ["HUM-84", "HUM-74", "HUM-71", "SC-63"]
+            },
+            {
+              "name": "Manage running agents",
+              "description": "List agents with status and runtime, attach to a live one, and stop or delete it with its container",
+              "tickets": ["HUM-84", "HUM-74"]
+            },
+            {
+              "name": "Claude Code setup & priming",
+              "description": "Install human's skills and agents into Claude Code and prime each session with the right task context",
+              "tickets": ["HUM-134", "HUM-133", "HUM-60"]
+            },
+            {
+              "name": "Live session monitoring",
+              "description": "Discover running Claude sessions across host and containers and see status, current tool, subagents, and token usage",
+              "tickets": ["HUM-92", "HUM-88", "HUM-86"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "group": "You in control",
+      "features": [
+        {
+          "name": "Desktop workflow board",
+          "description": "A five-stage board — Backlog, Product planning, Implementation, Verification, Done — where dragging a card triggers the next pipeline stage, with per-card status badges, a guarded Done drop, a running-agents view, and an agent-driven ideation chat to open new tickets",
+          "tickets": ["SC-148", "SC-146", "SC-143", "SC-141", "SC-137"],
+          "recent": true
+        },
+        {
+          "name": "Credential-holding daemon",
+          "description": "Hold tracker tokens once on the host and route every command instantly with no per-call auth, pausing for confirmation on destructive operations and driving the board pipeline backend",
+          "tickets": ["SC-137", "SC-117", "HUM-154", "HUM-152", "HUM-88"],
+          "recent": true
+        },
+        {
+          "name": "Audit trail",
+          "description": "Record every mutating tracker action as CloudEvents — actor, resource, operation, outcome, rationale, model — retained 90 days and readable as a table, raw JSON, or single envelope",
+          "tickets": ["SC-102", "HUM-137"]
+        },
+        {
+          "name": "Agent usage stats",
+          "description": "Track every agent tool call in a rolling 30-day history to answer usage and trend questions",
+          "tickets": ["SC-81", "HUM-69"]
+        }
+      ]
+    },
+    {
+      "group": "One install, kept current",
+      "features": [
+        {
+          "name": "Guided onboarding",
+          "description": "human init checks your tools, connects trackers, generates config, builds the devcontainer, sets up the vault, installs language servers, and carries over Claude sessions",
+          "tickets": ["HUM-83", "HUM-82", "HUM-75", "SC-71"]
+        }
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ This writes skill and agent files to `.claude/` in the current directory. Re-run
 | `/human-findbugs` | Multi-agent pipeline to find logic errors, race conditions, and security issues |
 | `/human-security` | Deep security audit with attack chain analysis and OWASP Top 10 coverage |
 | `/human-gardening` | Multi-agent pipeline for codebase health analysis, refactoring triage, and automated fixes |
+| `/human-features` | Generate `FEATURE.json` — a grouped, human-readable map of what the codebase can do, with per-feature tickets and recent-change markers |
 
 ```bash
 # Full pipeline in one command

--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -242,6 +242,7 @@ func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, de
 		VaultResolver:     vaultResolver,
 		BoardTransitioner: boardTransitionerFunc(projectRegistry, vaultResolver),
 		CloseTicketer:     closeTicketerFunc(projectRegistry, vaultResolver),
+		FeaturesGenerator: featuresGeneratorFunc(projectRegistry),
 		Ideation:          ideationEngine(projectRegistry, vaultResolver, hookStore, logger),
 	}
 
@@ -263,6 +264,18 @@ func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, de
 // runDaemonForeground runs the daemon in the current process (blocking).
 // It writes a PID file on start and removes it on shutdown.
 func runDaemonForeground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, interactive, safe, debug bool, projectDirs []string, cmdFactory func() *cobra.Command, version string) error {
+	// Bind the daemon, chrome bridge, and HTTPS proxy on the interface
+	// containers can reach without exposing them to the LAN (never 0.0.0.0): the
+	// docker bridge gateway on native Linux Docker, loopback on Docker Desktop
+	// (host.docker.internal forwards to loopback) and when Docker is down. An
+	// explicit non-loopback override is respected. Doing this at startup means an
+	// agent launch never has to restart the daemon mid-request for container
+	// access — the sharp edge that used to abort the first containerized launch.
+	reachHost := devcontainer.ContainerReachableHost()
+	addr = swapLoopbackHost(addr, reachHost)
+	chromeAddr = swapLoopbackHost(chromeAddr, reachHost)
+	proxyAddr = swapLoopbackHost(proxyAddr, reachHost)
+
 	ds, err := initDaemon(cmd, addr, chromeAddr, proxyAddr, safe, debug, projectDirs, cmdFactory, version)
 	if err != nil {
 		return err
@@ -435,6 +448,10 @@ func runDaemonBackground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string,
 	// Detach so we don't wait for the child.
 	_ = child.Process.Release()
 
+	// The child (runDaemonForeground → initDaemon) binds the container-reachable
+	// host, so poll and advertise that same address rather than a bare loopback.
+	bindAddr := swapLoopbackHost(addr, devcontainer.ContainerReachableHost())
+
 	// Poll for TCP readiness (up to 3s).
 	const (
 		pollInterval = 50 * time.Millisecond
@@ -443,7 +460,7 @@ func runDaemonBackground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string,
 	deadline := time.Now().Add(pollTimeout)
 	ready := false
 	for time.Now().Before(deadline) {
-		conn, dialErr := net.DialTimeout("tcp", "localhost"+addr, 200*time.Millisecond)
+		conn, dialErr := net.DialTimeout("tcp", bindAddr, 200*time.Millisecond)
 		if dialErr == nil {
 			_ = conn.Close()
 			ready = true
@@ -453,7 +470,7 @@ func runDaemonBackground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string,
 	}
 
 	hostIP := resolveHostIP()
-	daemonAddr := replaceHost(addr, hostIP)
+	daemonAddr := replaceHost(bindAddr, hostIP)
 
 	if !ready {
 		_, _ = fmt.Fprintf(out, "Daemon started (PID %d) but not yet reachable\n", pid)
@@ -898,6 +915,21 @@ func buildVaultResolver(reg *daemon.ProjectRegistry, logger zerolog.Logger) *vau
 		}
 	}
 	return nil
+}
+
+// swapLoopbackHost replaces a loopback or empty host in addr with reachHost —
+// the interface containers can reach the daemon on. An explicit non-loopback
+// host (an operator's --addr override, or a bridge gateway carried over from a
+// restart) is left untouched, so it never silently widens a deliberate bind.
+func swapLoopbackHost(addr, reachHost string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	if host == "" || host == "127.0.0.1" || host == "localhost" {
+		return net.JoinHostPort(reachHost, port)
+	}
+	return addr
 }
 
 // replaceHost replaces an empty or wildcard host in addr with the given host.
@@ -1379,6 +1411,28 @@ func boardTransitionerFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver
 			ConfigDir:    entry.Dir,
 		}
 		return deps.ApplyTransition(context.Background(), req)
+	}
+}
+
+// featuresGeneratorFunc builds the daemon's FeaturesGenerator closure: it
+// launches the human-features skill in the registered project's devcontainer,
+// exactly like a board stage transition, so the desktop Features pane's
+// Generate/Refresh button reuses the same containerized agent path.
+func featuresGeneratorFunc(reg *daemon.ProjectRegistry) func() error {
+	return func() error {
+		entries := reg.Entries()
+		if len(entries) == 0 {
+			return errors.WithDetails("no project registered for feature generation")
+		}
+		entry := entries[0]
+		// Tear down any prior "features" agent first so Generate/Refresh is
+		// idempotent — Manager.Start refuses to start over a still-running agent,
+		// so without this a second click fails with "agent already running".
+		if docker, err := devcontainer.NewDockerClient(); err == nil {
+			_ = (&agent.Manager{Docker: docker}).Delete(context.Background(), "features")
+			_ = docker.Close()
+		}
+		return dockerAgentLauncher{}.Launch(context.Background(), "features", "/human-features", entry.Dir, entry.Dir)
 	}
 }
 

--- a/cmd/cmddaemon/daemon_test.go
+++ b/cmd/cmddaemon/daemon_test.go
@@ -158,3 +158,25 @@ func TestDaemonCmd_StopRegistered(t *testing.T) {
 	}
 	assert.True(t, found, "expected stop subcommand to be registered")
 }
+
+func TestSwapLoopbackHost(t *testing.T) {
+	tests := []struct {
+		name  string
+		addr  string
+		reach string
+		want  string
+	}{
+		{"loopback swapped to bridge", "127.0.0.1:19285", "172.17.0.1", "172.17.0.1:19285"},
+		{"localhost swapped", "localhost:19285", "172.17.0.1", "172.17.0.1:19285"},
+		{"empty host swapped", ":19285", "172.17.0.1", "172.17.0.1:19285"},
+		{"loopback stays loopback on desktop", "127.0.0.1:19285", "127.0.0.1", "127.0.0.1:19285"},
+		{"explicit non-loopback respected", "192.168.1.5:19285", "172.17.0.1", "192.168.1.5:19285"},
+		{"wildcard respected (operator override)", "0.0.0.0:19285", "172.17.0.1", "0.0.0.0:19285"},
+		{"malformed addr returned as-is", "not-an-addr", "172.17.0.1", "not-an-addr"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, swapLoopbackHost(tt.addr, tt.reach))
+		})
+	}
+}

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -17,6 +17,7 @@ re-derives a stage.
 - When Docker is unavailable the planning/implementation/verification drop targets are disabled (Done stays enabled, since it only pushes a branch and opens a PR).
 - Live updates: subscribes to the daemon and refetches board cards on every change event. A small independent poll (every 3s) drives only the header daemon-reachability dot, since there is no daemon-pushed event to subscribe to when the daemon itself is down — this mirrors how the TUI itself layers periodic ticks on top of its daemon subscribe channel.
 - Header daemon indicator: a two-state dot (reachable/unreachable) in the header, sourced from `daemon.ReadInfo()` / `IsReachable()` / `ReadAlivePid()` — display-only, no daemon version, proxy stats, agent count, or start/stop action.
+- Two visual styles, toggled with **F8** and persisted across restarts: the default calm style, and a demo-oriented "fancy" style (animated gradient, per-column pastel hues, fireworks/confetti drop celebrations — see the `FANCY THEME` section of `frontend/static/style.css` and `frontend/src/fancy.ts`). Classic rendering is untouched when fancy is off; `prefers-reduced-motion` keeps the fancy colors but disables all movement. Closing a ticket is never celebrated.
 
 ## Architecture
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -189,6 +189,19 @@ func (a *App) Transition(pmKey, pmTitle, from, to string) error {
 	})
 }
 
+// GenerateFeatures asks the daemon to launch the human-features skill, which
+// regenerates FEATURE.json. Like Transition it goes through the daemon so it
+// runs the skill in the project's devcontainer — the same containerized agent
+// path a kanban stage transition uses. It returns once the agent is launched,
+// not when generation finishes; the pane polls Features() for the new file.
+func (a *App) GenerateFeatures() error {
+	info, err := daemon.ReadInfo()
+	if err != nil {
+		return err
+	}
+	return daemon.GenerateFeatures(info.Addr, info.Token)
+}
+
 // CloseTicket closes a PM ticket (transitions it to Done) via the daemon's
 // dedicated close-ticket route. Like Transition it goes through the daemon, so
 // the close is prompt-free — it never hits the interactive `issue status`

--- a/desktop/features.go
+++ b/desktop/features.go
@@ -1,0 +1,98 @@
+//go:build wailsapp
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/gethuman-sh/human/errors"
+)
+
+// featureFile is the project-root document the Features view renders. It is read
+// from disk at call time (not embedded) so it always reflects the current repo.
+const featureFile = "FEATURE.json"
+
+// FeatureItem is one feature: a short name and a one-line description. Recent
+// flags a capability changed since the last release (for a "new" badge) and is
+// omitempty so older flat FEATURE.json files still unmarshal cleanly. The
+// document's per-feature ticket keys are intentionally not modelled here: the
+// desktop pane presents features from a user's point of view, not their
+// engineering trail, so the binding never carries them to the frontend
+// (json.Unmarshal simply ignores the unmapped "tickets" field).
+type FeatureItem struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Recent      bool   `json:"recent,omitempty"`
+}
+
+// FeatureGroup is a titled cluster of related features. Groups nests sub-groups
+// for larger projects (the generator scales nesting depth to project size); it
+// is omitempty so a flat, single-level document is equally valid.
+type FeatureGroup struct {
+	Group    string         `json:"group"`
+	Features []FeatureItem  `json:"features"`
+	Groups   []FeatureGroup `json:"groups,omitempty"`
+}
+
+// FeatureDoc is the full FEATURE.json payload the frontend renders. Error carries
+// a read/parse failure to the view as an empty-state message rather than failing
+// the binding, mirroring BoardData.Error's banner convention. Exists tells the
+// pane whether FEATURE.json is present so its action button can read "Generate"
+// (absent) vs "Refresh" (present) — a clean signal independent of Error, so a
+// missing file is a friendly prompt rather than a red error banner.
+type FeatureDoc struct {
+	Product string         `json:"product"`
+	Tagline string         `json:"tagline"`
+	Groups  []FeatureGroup `json:"groups"`
+	Exists  bool           `json:"exists"`
+	Error   string         `json:"error,omitempty"`
+}
+
+// Features reads FEATURE.json from the project root and returns its grouped
+// feature list for the desktop board's Features pane. Like Instances() it needs
+// no daemon or credentials — it is a plain file read. A missing or malformed file
+// is surfaced via FeatureDoc.Error (not a hard error) so the view can show an
+// empty state instead of the app breaking.
+func (a *App) Features() (FeatureDoc, error) {
+	path, err := findUp(featureFile)
+	if err != nil {
+		// A missing file is not an error state — it is the "not generated yet"
+		// case. Leave Error empty (Exists=false) so the pane shows a friendly
+		// Generate prompt rather than a red banner.
+		return FeatureDoc{Exists: false}, nil
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- path is the fixed FEATURE.json resolved from the project tree
+	if err != nil {
+		return FeatureDoc{Error: errors.WrapWithDetails(err, "reading feature document", "path", path).Error()}, nil
+	}
+	var doc FeatureDoc
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return FeatureDoc{Error: errors.WrapWithDetails(err, "parsing feature document", "path", path).Error()}, nil
+	}
+	doc.Exists = true
+	return doc, nil
+}
+
+// findUp resolves name by walking up from the working directory to the
+// filesystem root, so the Features view works whether the app is launched from
+// the project root or a subdirectory. It returns an error (not a path) when the
+// file is nowhere in the ancestry.
+func findUp(name string) (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", errors.WrapWithDetails(err, "resolving working directory", "name", name)
+	}
+	for {
+		candidate := filepath.Join(dir, name)
+		if _, statErr := os.Stat(candidate); statErr == nil {
+			return candidate, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.WithDetails("feature document not found", "name", name)
+		}
+		dir = parent
+	}
+}

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -764,6 +764,174 @@ function renderAgents() {
     host.innerHTML =
         `<div class="agents-header">Running agents</div>` + agentsData.agents.map(renderAgentRow).join("");
 }
+// --- Features view -----------------------------------------------------
+//
+// Renders the project's FEATURE.json (grouped product features) from the Go
+// App.Features() binding — a plain file read, no daemon. Unlike the agents view
+// this is a static document, so it loads once on activation with no poll.
+let featuresLoaded = false;
+// Generation runs as a detached agent (like a kanban stage), so the button
+// can't block on completion. We capture the currently-shown doc's signature
+// when generation starts, then poll Features() until it changes — the file
+// appearing (Generate) or its content shifting (Refresh) both flip the button
+// back and re-render. currentFeatureDoc is the last doc rendered; featuresNote
+// carries a transient status/error line without wiping the rendered map.
+let featuresGenerating = false;
+let featuresBaselineSig = "";
+let featuresNote = "";
+let currentFeatureDoc = {};
+let featuresPollTimer;
+async function loadFeatures() {
+    let doc;
+    try {
+        doc = await go().Features();
+    }
+    catch (err) {
+        doc = { error: errMessage(err) };
+    }
+    renderFeatures(doc);
+}
+// featureSig is a stable fingerprint of the rendered doc: presence plus product,
+// tagline, and the recursive group/feature names+descriptions. Two runs that
+// produce the same map yield the same signature, so polling only reacts to a
+// real change.
+function featureSig(doc) {
+    if (!doc.exists)
+        return "«sent»";
+    const walk = (gs = []) => gs
+        .map((g) => g.group +
+        "|" +
+        (g.features ?? []).map((f) => f.name + ":" + f.description + (f.recent ? "*" : "")).join(",") +
+        "|" +
+        walk(g.groups))
+        .join(";");
+    return (doc.product ?? "") + "¦" + (doc.tagline ?? "") + "¦" + walk(doc.groups);
+}
+function stopFeaturesPoll() {
+    if (featuresPollTimer !== undefined) {
+        clearInterval(featuresPollTimer);
+        featuresPollTimer = undefined;
+    }
+}
+// startFeaturesPoll watches for the generation agent's output. It re-reads
+// FEATURE.json every 4s and, when the doc's signature differs from the baseline
+// captured at click time, stops and re-renders. A 10-minute cap avoids polling
+// forever if the agent is slow or fails silently.
+function startFeaturesPoll() {
+    stopFeaturesPoll();
+    const started = Date.now();
+    const timeoutMs = 10 * 60 * 1000;
+    featuresPollTimer = window.setInterval(() => {
+        void (async () => {
+            let doc;
+            try {
+                doc = await go().Features();
+            }
+            catch {
+                return; // transient; keep polling
+            }
+            if (featureSig(doc) !== featuresBaselineSig) {
+                stopFeaturesPoll();
+                featuresGenerating = false;
+                featuresNote = "";
+                renderFeatures(doc);
+                return;
+            }
+            if (Date.now() - started > timeoutMs) {
+                stopFeaturesPoll();
+                featuresGenerating = false;
+                featuresNote = "Agent still running — click Refresh when it finishes.";
+                renderFeatures(currentFeatureDoc);
+            }
+        })();
+    }, 4000);
+}
+// onGenerateFeatures drives both Generate and Refresh: it launches the
+// human-features skill through the daemon (the same containerized agent path as
+// a kanban drag-and-drop), flips the button to a disabled "Generating…" state,
+// and starts polling for the result.
+async function onGenerateFeatures() {
+    if (featuresGenerating)
+        return;
+    featuresBaselineSig = featureSig(currentFeatureDoc);
+    featuresGenerating = true;
+    // Generation runs a coding agent in a container (survey → synthesis), so it
+    // is not instant — set expectations up front and keep the note up while the
+    // poll waits for FEATURE.json.
+    featuresNote = "Running the generation agent — this can take several minutes…";
+    renderFeatures(currentFeatureDoc);
+    try {
+        await go().GenerateFeatures();
+    }
+    catch (err) {
+        featuresGenerating = false;
+        featuresNote = "Couldn't start generation: " + errMessage(err);
+        renderFeatures(currentFeatureDoc);
+        return;
+    }
+    startFeaturesPoll();
+}
+function renderFeatureRow(f) {
+    // A "recent" badge flags a capability changed since the last release. Ticket
+    // keys in FEATURE.json are deliberately not surfaced here — the desktop pane
+    // presents features from a user's point of view, not their engineering trail.
+    const badge = f.recent ? `<span class="feature-badge">recent</span>` : "";
+    return `<div class="feature-row">
+    <span class="feature-name">${escapeHtml(f.name)}${badge}</span>
+    <span class="feature-desc">${escapeHtml(f.description)}</span>
+  </div>`;
+}
+// Recursive: a group renders its own features, then any nested sub-groups. depth
+// drives indentation so a deeper tree (larger projects) reads as a shallow
+// hierarchy rather than a flat wall.
+function renderFeatureGroup(g, depth = 0) {
+    const rows = (g.features ?? []).map(renderFeatureRow).join("");
+    const subgroups = (g.groups ?? []).map((sg) => renderFeatureGroup(sg, depth + 1)).join("");
+    return `<div class="feature-group" data-depth="${depth}">
+    <div class="feature-group-title">${escapeHtml(g.group)}</div>
+    ${rows}
+    ${subgroups}
+  </div>`;
+}
+function renderFeatures(doc) {
+    currentFeatureDoc = doc;
+    const host = document.getElementById("features");
+    if (!host)
+        return;
+    // The action button reads "Generate" when FEATURE.json is absent and "Refresh"
+    // when present; while an agent runs it is a disabled "Generating…" spinner.
+    const label = featuresGenerating ? "Generating…" : doc.exists ? "Refresh" : "Generate";
+    const spinner = featuresGenerating ? `<span class="spinner"></span> ` : "";
+    const btn = `<button class="features-btn" ${featuresGenerating ? "disabled" : ""}>${spinner}${escapeHtml(label)}</button>`;
+    const header = `<div class="agents-header features-header"><span>Features</span>${btn}</div>`;
+    const note = featuresNote ? `<div class="features-note">${escapeHtml(featuresNote)}</div>` : "";
+    const attach = () => host.querySelector(".features-btn")?.addEventListener("click", () => void onGenerateFeatures());
+    if (doc.error) {
+        host.innerHTML = header + note + `<div class="banner">${escapeHtml(doc.error)}</div>`;
+        attach();
+        return;
+    }
+    if (!doc.exists) {
+        host.innerHTML =
+            header + note + `<div class="features-empty">No FEATURE.json yet — click Generate to build it.</div>`;
+        attach();
+        return;
+    }
+    const groups = doc.groups ?? [];
+    if (groups.length === 0) {
+        host.innerHTML = header + note + `<div class="features-empty">No features to show</div>`;
+        attach();
+        return;
+    }
+    const intro = doc.product || doc.tagline
+        ? `<div class="features-intro">
+          ${doc.product ? `<div class="features-product">${escapeHtml(doc.product)}</div>` : ""}
+          ${doc.tagline ? `<div class="features-tagline">${escapeHtml(doc.tagline)}</div>` : ""}
+        </div>`
+        : "";
+    host.innerHTML = header + note + intro + groups.map(renderFeatureGroup).join("");
+    attach();
+}
 // --- Left activity rail ------------------------------------------------
 //
 // "board" and "agents" are real views swapped in the main area; other rail
@@ -781,14 +949,22 @@ function selectView(view) {
     // Toggle main-area containers: exactly one top-level view is visible.
     const board = document.getElementById("board");
     const agents = document.getElementById("agents");
+    const features = document.getElementById("features");
     board?.classList.toggle("hidden", view !== "board");
     agents?.classList.toggle("hidden", view !== "agents");
+    features?.classList.toggle("hidden", view !== "features");
     if (view === "agents") {
         void pollAgents(); // immediate fetch so the view isn't blank until the first tick
         startAgentsPoll();
     }
     else {
         stopAgentsPoll();
+    }
+    // The features doc is static — load it once on first activation, then leave
+    // the rendered pane in place (no poll, unlike agents).
+    if (view === "features" && !featuresLoaded) {
+        featuresLoaded = true;
+        void loadFeatures();
     }
 }
 function wireRail() {

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -6,6 +6,9 @@
 //
 // The shipped runtime is desktop/frontend/dist/board.js; `npm run build`
 // (tsc + bundle.mjs) regenerates dist/ from this source for `wails build`.
+// The fancy hooks no-op while the classic theme is active, so they are safe to
+// call unconditionally on the hot paths below.
+import { celebrateDrop, ghostTilt, initFancy, isThemeToggleChord, toggleTheme, trail, } from "./fancy.js";
 const STAGES = ["backlog", "planning", "implementation", "verification", "done"];
 const STAGE_LABELS = {
     backlog: "Backlog",
@@ -200,6 +203,7 @@ function beginPointerDrag(el, card) {
             return;
         const info = { key: card.key, title: card.title, stage: card.stage };
         let started = false;
+        let lastX = down.clientX;
         const onMove = (ev) => {
             if (!started) {
                 if (Math.hypot(ev.clientX - down.clientX, ev.clientY - down.clientY) < DRAG_THRESHOLD_PX)
@@ -212,7 +216,10 @@ function beginPointerDrag(el, card) {
             if (dragGhost) {
                 dragGhost.style.left = `${ev.clientX}px`;
                 dragGhost.style.top = `${ev.clientY}px`;
+                ghostTilt(dragGhost, ev.clientX - lastX);
+                trail({ x: ev.clientX, y: ev.clientY });
             }
+            lastX = ev.clientX;
             setHoverTarget(dropTargetAt(ev.clientX, ev.clientY));
         };
         const teardown = () => {
@@ -236,13 +243,15 @@ function beginPointerDrag(el, card) {
             const target = started ? dropTargetAt(ev.clientX, ev.clientY) : null;
             const allowed = !!target && dropAllowed(target);
             teardown();
-            dragging = null;
+            endDrag();
+            // `target` may have been replaced by the flushed render, but performDrop
+            // only reads its dataset, which a detached node still carries.
             if (target && allowed)
-                performDrop(target, info);
+                performDrop(target, info, { x: ev.clientX, y: ev.clientY });
         };
         const onCancel = () => {
             teardown();
-            dragging = null;
+            endDrag();
         };
         try {
             el.setPointerCapture(down.pointerId);
@@ -255,13 +264,26 @@ function beginPointerDrag(el, card) {
         el.addEventListener("pointercancel", onCancel);
     });
 }
+// endDrag closes the drag lifecycle and flushes any board rebuild that was
+// deferred while the drag was in flight.
+function endDrag() {
+    dragging = null;
+    if (pendingRender) {
+        pendingRender = false;
+        render();
+    }
+}
 // performDrop runs the action for a completed drop on an allowed target.
-function performDrop(target, info) {
+function performDrop(target, info, pt) {
     if (target.dataset.drop === "close") {
+        // Closing is destructive and still awaits a confirm dialog — never a
+        // moment to celebrate, so the fancy theme stays silent here.
         void requestClose(info.key, info.title);
         return;
     }
-    void transition(info.key, info.title, info.stage, target.dataset.dropStage || "");
+    const to = target.dataset.dropStage || "";
+    celebrateDrop(pt, { key: info.key, fromStage: info.stage, done: to === "done" });
+    void transition(info.key, info.title, info.stage, to);
 }
 async function transition(key, title, from, to) {
     const card = current.cards.find((c) => c.key === key);
@@ -353,7 +375,15 @@ function restoreColumnScroll(board, scroll) {
             body.scrollTop = scroll[stage];
     });
 }
+// A render mid-drag would replace the dragged card's DOM element, silently
+// killing its pointer listeners (frozen ghost, drop never lands). Rebuilds
+// requested during a drag are deferred and flushed by endDrag().
+let pendingRender = false;
 function render() {
+    if (dragging) {
+        pendingRender = true;
+        return;
+    }
     const board = document.getElementById("board");
     // Capture each column's scroll position before the full rebuild below wipes
     // it. A reconcile (board:changed / post-transition) must not snap a column the
@@ -995,6 +1025,13 @@ function init() {
     void pollDaemonStatus();
     setInterval(() => void pollDaemonStatus(), DAEMON_POLL_MS);
     wireRail();
+    initFancy();
+    document.addEventListener("keydown", (e) => {
+        if (isThemeToggleChord(e)) {
+            e.preventDefault();
+            toggleTheme();
+        }
+    });
     document.getElementById("ideation-close")?.addEventListener("click", () => closeIdeation());
     document.getElementById("ideation-form")?.addEventListener("submit", (e) => {
         e.preventDefault();
@@ -1007,4 +1044,3 @@ if (document.readyState === "loading") {
 else {
     init();
 }
-export {};

--- a/desktop/frontend/dist/fancy.js
+++ b/desktop/frontend/dist/fancy.js
@@ -1,0 +1,413 @@
+// fancy.ts — the optional "fancy" presentation layer: a second, demo-oriented
+// theme (animated gradient, pastel rainbow columns — see the FANCY THEME
+// section of style.css) plus celebration effects driven from here: fireworks,
+// confetti, comet trail, dust motes, drop ripples and streak toasts.
+//
+// Design constraints, in priority order:
+//   - Classic stays untouched: every exported hook no-ops unless the fancy
+//     theme is active, so board.ts may call them unconditionally.
+//   - One canvas, one rAF loop, zero idle work: the loop stops the moment the
+//     particle pool drains; ambient motes keep it alive only while the fancy
+//     theme is on AND the window is visible.
+//   - prefers-reduced-motion keeps the fancy colors but disables all motion
+//     (CSS handles its own animations via the same media query).
+//
+// Removing one effect = delete its EFFECTS flag, its call site and its CSS
+// block; tsc's noUnusedLocals then points at any leftover helper.
+const EFFECTS = {
+    fireworks: true,
+    confetti: true,
+    trail: true,
+    motes: true,
+    ripple: true,
+    tilt: true,
+    spotlight: true,
+    sheen: true,
+    streak: true,
+    sweep: true,
+};
+const THEME_KEY = "human.theme";
+const MOTE_TARGET = 32;
+const STREAK_WINDOW_MS = 10000;
+// --- Theme state --------------------------------------------------------
+export function isFancy() {
+    return document.documentElement.dataset.theme === "fancy";
+}
+export function toggleTheme() {
+    const fancy = !isFancy();
+    if (fancy)
+        document.documentElement.dataset.theme = "fancy";
+    else
+        delete document.documentElement.dataset.theme;
+    try {
+        localStorage.setItem(THEME_KEY, fancy ? "fancy" : "classic");
+    }
+    catch {
+        // Storage may be unavailable; the toggle still works for this session.
+    }
+    syncAmbient();
+}
+// isThemeToggleChord matches the style-toggle key (F8). Guarded against firing
+// while the user types, so a future rebind to a printable key stays safe.
+export function isThemeToggleChord(e) {
+    const t = e.target;
+    if (t && t.closest("input, textarea, select, [contenteditable]"))
+        return false;
+    return e.key === "F8";
+}
+// initFancy wires the always-on listeners (cheap no-ops in classic) and starts
+// ambient effects when the pre-paint script already applied the fancy theme.
+export function initFancy() {
+    document.addEventListener("visibilitychange", syncAmbient);
+    document.addEventListener("pointermove", onPointerMove);
+    syncAmbient();
+}
+// --- Board hooks (called unconditionally from board.ts) ------------------
+// celebrateDrop fires the drop celebration at the release point: ripple always,
+// confetti (escalated by the done-streak) for Done drops, fireworks otherwise.
+// Runs before the optimistic re-render, so DOM lookups are deferred a tick.
+export function celebrateDrop(pt, info) {
+    if (!isFancy() || reducedMotion())
+        return;
+    if (EFFECTS.ripple)
+        ripple(pt);
+    if (info.done && EFFECTS.confetti) {
+        const streak = EFFECTS.streak ? bumpStreak() : 1;
+        spawnConfetti(pt, Math.min(70 + (streak - 1) * 50, 240));
+        if (streak >= 2)
+            toast(`${streak}×!`);
+        goldGlow(info.key);
+    }
+    else if (EFFECTS.fireworks) {
+        spawnFirework(pt);
+    }
+    if (EFFECTS.sweep)
+        scheduleClearSweep(info.fromStage);
+}
+// ghostTilt leans the drag ghost into the pointer's horizontal velocity, like
+// a card picked up by one corner. The CSS transition springs it back upright.
+export function ghostTilt(ghost, dx) {
+    if (!EFFECTS.tilt || !isFancy() || reducedMotion())
+        return;
+    const deg = Math.max(-10, Math.min(10, dx * 0.7));
+    ghost.style.setProperty("--tilt", `${deg.toFixed(1)}deg`);
+}
+// trail sprinkles comet sparkles along the drag path. Throttled by distance so
+// fast drags don't flood the pool.
+let lastTrail = null;
+export function trail(pt) {
+    if (!EFFECTS.trail || !isFancy() || reducedMotion())
+        return;
+    if (lastTrail && Math.hypot(pt.x - lastTrail.x, pt.y - lastTrail.y) < 14)
+        return;
+    lastTrail = pt;
+    spawn({
+        kind: "fx",
+        x: pt.x + rand(-6, 6),
+        y: pt.y + rand(-6, 6),
+        vx: rand(-12, 12),
+        vy: rand(-4, 20),
+        age: 0,
+        ttl: rand(0.3, 0.6),
+        size: rand(1.2, 2.6),
+        hue: rand(0, 360),
+        sat: 90,
+        lum: 75,
+        alpha: 0.9,
+        gravity: 40,
+        drag: 1,
+        shape: "dot",
+        rot: 0,
+        vr: 0,
+    });
+}
+// --- Streak tracking ------------------------------------------------------
+let doneDrops = [];
+function bumpStreak() {
+    const now = performance.now();
+    doneDrops = doneDrops.filter((t) => now - t < STREAK_WINDOW_MS);
+    doneDrops.push(now);
+    return doneDrops.length;
+}
+// --- DOM effects (ripple, toast, gold glow, column-clear sweep) -----------
+function ripple(pt) {
+    const el = document.createElement("div");
+    el.className = "fx-ripple";
+    el.style.left = `${pt.x}px`;
+    el.style.top = `${pt.y}px`;
+    removeAfterAnimation(el, 700);
+    document.body.appendChild(el);
+}
+function toast(text) {
+    const el = document.createElement("div");
+    el.className = "fx-toast";
+    el.textContent = text;
+    removeAfterAnimation(el, 1600);
+    document.body.appendChild(el);
+}
+// goldGlow crowns the card that just landed in Done. The card element is
+// rebuilt by the optimistic render right after the drop, so look it up late.
+function goldGlow(key) {
+    window.setTimeout(() => {
+        const card = document.querySelector(`.card[data-key="${cssEscape(key)}"]`);
+        if (!card)
+            return;
+        card.classList.add("fx-gold");
+        window.setTimeout(() => card.classList.remove("fx-gold"), 1600);
+    }, 60);
+}
+// scheduleClearSweep celebrates emptying a column: checked after the optimistic
+// render has moved the dropped card out of its source column.
+function scheduleClearSweep(fromStage) {
+    window.setTimeout(() => {
+        if (!isFancy() || reducedMotion())
+            return;
+        const left = document.querySelector(`.column[data-stage="${cssEscape(fromStage)}"] .card`);
+        if (left)
+            return;
+        const el = document.createElement("div");
+        el.className = "fx-sweep";
+        removeAfterAnimation(el, 1400);
+        document.body.appendChild(el);
+    }, 80);
+}
+function removeAfterAnimation(el, fallbackMs) {
+    el.addEventListener("animationend", () => el.remove());
+    // Fallback: reduced-motion or a dropped animation must not leak the node.
+    window.setTimeout(() => el.remove(), fallbackMs);
+}
+function cssEscape(v) {
+    return typeof CSS !== "undefined" && CSS.escape ? CSS.escape(v) : v.replace(/["\\]/g, "\\$&");
+}
+// --- Cursor spotlight + holographic sheen (shared pointermove) ------------
+let spotlight = null;
+function onPointerMove(e) {
+    if (!isFancy() || reducedMotion()) {
+        if (spotlight) {
+            spotlight.style.opacity = "0";
+            spotlight.style.display = "none";
+        }
+        return;
+    }
+    if (EFFECTS.spotlight) {
+        if (!spotlight) {
+            spotlight = document.createElement("div");
+            spotlight.className = "fx-spotlight";
+            document.body.appendChild(spotlight);
+        }
+        spotlight.style.display = "";
+        spotlight.style.opacity = "1";
+        spotlight.style.transform = `translate(${e.clientX}px, ${e.clientY}px)`;
+    }
+    if (EFFECTS.sheen) {
+        const card = e.target?.closest?.(".card");
+        if (card) {
+            const r = card.getBoundingClientRect();
+            card.style.setProperty("--mx", `${(((e.clientX - r.left) / r.width) * 100).toFixed(1)}%`);
+            card.style.setProperty("--my", `${(((e.clientY - r.top) / r.height) * 100).toFixed(1)}%`);
+        }
+    }
+}
+// --- Particle engine ------------------------------------------------------
+let canvas = null;
+let ctx = null;
+let pool = [];
+let raf = 0;
+let lastTs = 0;
+function reducedMotion() {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+function rand(min, max) {
+    return min + Math.random() * (max - min);
+}
+function ensureCanvas() {
+    if (canvas)
+        return;
+    canvas = document.createElement("canvas");
+    canvas.className = "fx-canvas";
+    document.body.appendChild(canvas);
+    ctx = canvas.getContext("2d");
+    const fit = () => {
+        if (!canvas || !ctx)
+            return;
+        const dpr = window.devicePixelRatio || 1;
+        canvas.width = Math.floor(window.innerWidth * dpr);
+        canvas.height = Math.floor(window.innerHeight * dpr);
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+    fit();
+    window.addEventListener("resize", fit);
+}
+function spawn(p) {
+    if (!isFancy() || reducedMotion())
+        return;
+    ensureCanvas();
+    pool.push(p);
+    if (!raf) {
+        lastTs = 0;
+        raf = requestAnimationFrame(tick);
+    }
+}
+function spawnFirework(pt) {
+    const baseHue = rand(0, 360);
+    for (let i = 0; i < 44; i++) {
+        const angle = rand(0, Math.PI * 2);
+        const speed = rand(60, 340);
+        spawn({
+            kind: "fx",
+            x: pt.x,
+            y: pt.y,
+            vx: Math.cos(angle) * speed,
+            vy: Math.sin(angle) * speed - 40,
+            age: 0,
+            ttl: rand(0.5, 1.1),
+            size: rand(1.5, 3),
+            hue: (baseHue + rand(-30, 30) + 360) % 360,
+            sat: 95,
+            lum: 68,
+            alpha: 1,
+            gravity: 260,
+            drag: 1.6,
+            shape: "dot",
+            rot: 0,
+            vr: 0,
+        });
+    }
+}
+function spawnConfetti(pt, count) {
+    for (let i = 0; i < count; i++) {
+        const angle = rand(-Math.PI * 0.85, -Math.PI * 0.15); // upward fan
+        const speed = rand(140, 480);
+        spawn({
+            kind: "fx",
+            x: pt.x,
+            y: pt.y,
+            vx: Math.cos(angle) * speed,
+            vy: Math.sin(angle) * speed,
+            age: 0,
+            ttl: rand(0.9, 1.8),
+            size: rand(3, 6),
+            hue: rand(0, 360),
+            sat: 85,
+            lum: 70,
+            alpha: 1,
+            gravity: 420,
+            drag: 1.2,
+            shape: "rect",
+            rot: rand(0, Math.PI),
+            vr: rand(-8, 8),
+        });
+    }
+}
+function makeMote(atBottom) {
+    return {
+        kind: "mote",
+        x: rand(0, window.innerWidth),
+        y: atBottom ? window.innerHeight + 4 : rand(0, window.innerHeight),
+        vx: rand(-4, 4),
+        vy: rand(-14, -5),
+        age: 0,
+        ttl: Infinity,
+        size: rand(0.8, 2.2),
+        hue: rand(0, 360),
+        sat: 60,
+        lum: 80,
+        alpha: rand(0.1, 0.32),
+        gravity: 0,
+        drag: 0,
+        shape: "dot",
+        rot: 0,
+        vr: 0,
+    };
+}
+// syncAmbient reconciles the particle layer with the current theme and window
+// visibility: motes drift only while fancy is on-screen, leaving fancy kills
+// every particle at once, and the loop pauses (with a wiped frame) while the
+// window is hidden so a stale frame is never left on screen.
+function syncAmbient() {
+    const visible = document.visibilityState === "visible";
+    const ambientOn = isFancy() && !reducedMotion() && visible;
+    if (spotlight && !ambientOn) {
+        // display:none instead of a fade: classic must be pristine the instant
+        // the theme switches, not 0.3s later. onPointerMove re-shows it in fancy.
+        spotlight.style.opacity = "0";
+        spotlight.style.display = "none";
+    }
+    if (!isFancy()) {
+        // Leaving fancy: classic must be pristine instantly, so kill mid-flight
+        // celebrations (particles AND overlay nodes) instead of letting them fade.
+        pool = [];
+        document.querySelectorAll(".fx-ripple, .fx-toast, .fx-sweep").forEach((n) => n.remove());
+    }
+    else if (ambientOn && EFFECTS.motes && !pool.some((p) => p.kind === "mote")) {
+        ensureCanvas();
+        for (let i = 0; i < MOTE_TARGET; i++)
+            pool.push(makeMote(false));
+    }
+    else if (!ambientOn) {
+        pool = pool.filter((p) => p.kind !== "mote");
+    }
+    if (!visible || pool.length === 0) {
+        if (raf) {
+            cancelAnimationFrame(raf);
+            raf = 0;
+        }
+        if (ctx)
+            ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
+    }
+    else if (!raf) {
+        lastTs = 0;
+        raf = requestAnimationFrame(tick);
+    }
+}
+function tick(ts) {
+    if (!ctx || !canvas) {
+        raf = 0;
+        return;
+    }
+    const dt = lastTs ? Math.min((ts - lastTs) / 1000, 0.05) : 0.016;
+    lastTs = ts;
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    ctx.clearRect(0, 0, w, h);
+    const alive = [];
+    for (const p of pool) {
+        p.age += dt;
+        if (p.age >= p.ttl)
+            continue;
+        p.vx -= p.vx * p.drag * dt;
+        p.vy += p.gravity * dt - p.vy * p.drag * dt;
+        p.x += p.vx * dt;
+        p.y += p.vy * dt;
+        p.rot += p.vr * dt;
+        if (p.kind === "mote") {
+            // Motes recycle: drift off the top, re-enter from the bottom.
+            if (p.y < -6)
+                Object.assign(p, makeMote(true));
+        }
+        else if (p.y > h + 20 || p.x < -20 || p.x > w + 20) {
+            continue;
+        }
+        const fade = p.ttl === Infinity ? 1 : 1 - p.age / p.ttl;
+        ctx.globalAlpha = Math.max(0, p.alpha * fade);
+        ctx.fillStyle = `hsl(${p.hue} ${p.sat}% ${p.lum}%)`;
+        if (p.shape === "rect") {
+            ctx.save();
+            ctx.translate(p.x, p.y);
+            ctx.rotate(p.rot);
+            ctx.fillRect(-p.size / 2, -p.size, p.size, p.size * 2);
+            ctx.restore();
+        }
+        else {
+            ctx.beginPath();
+            ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        alive.push(p);
+    }
+    ctx.globalAlpha = 1;
+    pool = alive;
+    raf = pool.length ? requestAnimationFrame(tick) : 0;
+    if (!raf)
+        ctx.clearRect(0, 0, w, h);
+}

--- a/desktop/frontend/dist/index.html
+++ b/desktop/frontend/dist/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>human — workflow board</title>
+    <!-- Apply the persisted theme before first paint so a fancy user never sees a classic flash. -->
+    <script>try{if(localStorage.getItem("human.theme")==="fancy")document.documentElement.dataset.theme="fancy"}catch(e){}</script>
     <link rel="stylesheet" href="/style.css" />
   </head>
   <body>

--- a/desktop/frontend/dist/index.html
+++ b/desktop/frontend/dist/index.html
@@ -23,6 +23,14 @@
             <path d="M7.5 2.5C10.2614 2.5 12.5 4.73858 12.5 7.5V13.5C12.5 14.0523 12.0523 14.5 11.5 14.5H3.5C2.94772 14.5 2.5 14.0523 2.5 13.5V7.5C2.5 4.73858 4.73858 2.5 7.5 2.5ZM7.5 2.5V0M4 11.5H11M0.5 8V12M14.5 8V12M5.5 9.5C4.94772 9.5 4.5 9.05228 4.5 8.5C4.5 7.94772 4.94772 7.5 5.5 7.5C6.05228 7.5 6.5 7.94772 6.5 8.5C6.5 9.05228 6.05228 9.5 5.5 9.5ZM9.5 9.5C8.94772 9.5 8.5 9.05228 8.5 8.5C8.5 7.94772 8.94772 7.5 9.5 7.5C10.0523 7.5 10.5 7.94772 10.5 8.5C10.5 9.05228 10.0523 9.5 9.5 9.5Z" stroke="currentColor"/>
           </svg>
         </button>
+        <button class="rail-item" data-view="features" title="Features">
+          <svg class="rail-icon" width="22" height="22" viewBox="0 0 24 24" fill="none"
+               stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+               xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+            <path d="M14 2v6h6"/><path d="M9 13h6"/><path d="M9 17h6"/>
+          </svg>
+        </button>
         <button class="rail-item ghost rail-bottom" data-view="settings"
                 title="Settings — coming soon" disabled aria-disabled="true">
           <svg class="rail-icon" width="22" height="22" viewBox="0 0 24 24" fill="none"
@@ -39,6 +47,7 @@
         <div id="banner" class="banner hidden"></div>
         <main id="board" class="board" aria-label="Workflow pipeline board"></main>
         <section id="agents" class="agents-view hidden" aria-label="Running agents"></section>
+        <section id="features" class="features-view hidden" aria-label="Features"></section>
         <footer id="statusbar" class="statusbar" aria-label="Status bar">
           <span id="daemon-indicator" class="status-dot"></span>
           <span id="daemon-text" class="status-text">Daemon…</span>

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -688,6 +688,142 @@ body {
   font-size: 13px;
 }
 
+/* Features view — renders FEATURE.json. Shares the agents-view scroll container
+   and header; the group/row treatment reuses the card look via --card-* vars. */
+.features-view {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px 20px;
+}
+
+.features-view.hidden {
+  display: none;
+}
+
+.features-empty {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.features-intro {
+  margin-bottom: 18px;
+}
+
+.features-product {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.features-tagline {
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--muted);
+  max-width: 70ch;
+}
+
+.feature-group {
+  margin-bottom: 20px;
+}
+
+.feature-group-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 8px;
+}
+
+.feature-row {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  padding: 10px 14px;
+  margin-bottom: 8px;
+}
+
+.feature-name {
+  flex: 0 0 auto;
+  min-width: 180px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.feature-desc {
+  flex: 1;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+/* Features header carries the Generate/Refresh action button on the right. */
+.features-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+/* Primary action button, mirroring the ideation send button. */
+.features-btn {
+  background: var(--accent);
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.features-btn:hover {
+  opacity: 0.9;
+}
+
+.features-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* Transient status/error line under the header (launch failure, slow agent). */
+.features-note {
+  padding: 6px 14px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+/* Nested sub-groups (larger projects) indent under their parent so the tree
+   reads as a shallow hierarchy; the top level (depth 0) stays flush. */
+.feature-group .feature-group {
+  margin-left: 14px;
+  margin-top: 8px;
+  margin-bottom: 0;
+  padding-left: 12px;
+  border-left: 1px solid var(--card-border);
+}
+
+/* "recent" badge on features changed since the last release. */
+.feature-badge {
+  margin-left: 8px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  vertical-align: middle;
+}
+
 .agent-row {
   background: var(--card-bg);
   border: 1px solid var(--card-border);

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -962,3 +962,370 @@ body {
 .subagent-meta {
   color: var(--muted);
 }
+
+/* =========================================================================
+   FANCY THEME — the demo "wow" style, toggled with F8 (see src/fancy.ts).
+   Everything below is scoped to [data-theme="fancy"] (or to fx-* elements
+   that only fancy.ts creates), so the classic theme above stays untouched.
+   Each effect is one delimited block: delete a block to drop that effect.
+   Continuous animations live behind prefers-reduced-motion so the fancy
+   look degrades to a static (but still colorful) style.
+   ========================================================================= */
+
+/* [FANCY:palette] Per-stage pastel rainbow hue, inherited by everything inside
+   a column (drop zones, glows, card shadows) via var(--fancy-hue). */
+[data-theme="fancy"] .column[data-stage="backlog"] {
+  --fancy-hue: 330;
+}
+[data-theme="fancy"] .column[data-stage="planning"] {
+  --fancy-hue: 45;
+}
+[data-theme="fancy"] .column[data-stage="implementation"] {
+  --fancy-hue: 165;
+}
+[data-theme="fancy"] .column[data-stage="verification"] {
+  --fancy-hue: 210;
+}
+[data-theme="fancy"] .column[data-stage="done"] {
+  --fancy-hue: 280;
+}
+
+/* [FANCY:gradient-bg] Aurora gradient background. The static gradient always
+   applies; only the slow drift is motion-gated. */
+[data-theme="fancy"] body {
+  background: linear-gradient(130deg, #241a3d, #12294a, #3d1a3d, #123a3a, #241a3d);
+  background-size: 400% 400%;
+}
+@media (prefers-reduced-motion: no-preference) {
+  [data-theme="fancy"] body {
+    animation: fancy-bg 26s ease infinite;
+  }
+}
+@keyframes fancy-bg {
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+}
+
+/* [FANCY:glass] Frosted-glass chrome over the gradient. The translucent
+   backgrounds alone keep everything readable where WebKitGTK lacks
+   backdrop-filter; the blur is progressive enhancement. */
+[data-theme="fancy"] .column {
+  background: hsl(var(--fancy-hue, 220) 35% 16% / 0.62);
+  border-color: hsl(var(--fancy-hue, 220) 60% 65% / 0.35);
+  -webkit-backdrop-filter: blur(14px) saturate(1.3);
+  backdrop-filter: blur(14px) saturate(1.3);
+}
+[data-theme="fancy"] .rail,
+[data-theme="fancy"] .app-header,
+[data-theme="fancy"] .statusbar {
+  background: rgba(16, 14, 30, 0.55);
+  -webkit-backdrop-filter: blur(14px) saturate(1.3);
+  backdrop-filter: blur(14px) saturate(1.3);
+}
+[data-theme="fancy"] .column-header {
+  border-bottom-color: hsl(var(--fancy-hue, 220) 60% 70% / 0.3);
+}
+[data-theme="fancy"] .column-header > span:first-child {
+  color: hsl(var(--fancy-hue, 220) 80% 82%);
+}
+
+/* [FANCY:rainbow-drop] Pastel drop zones: accepting targets glow in their
+   column's hue instead of the classic flat green/red. */
+[data-theme="fancy"] .column-body.drop-ok,
+[data-theme="fancy"] .done-zone.drop-ok {
+  background: hsl(var(--fancy-hue, 220) 75% 80% / 0.32);
+}
+[data-theme="fancy"] .done-zone {
+  border-color: hsl(var(--fancy-hue, 220) 60% 70% / 0.5);
+}
+[data-theme="fancy"] .done-zone.drop-ok {
+  border-color: hsl(var(--fancy-hue, 220) 85% 75%);
+}
+
+/* [FANCY:breathe] Drop-zone breathing glow while a drag hovers a valid target. */
+@media (prefers-reduced-motion: no-preference) {
+  [data-theme="fancy"] .column-body.drop-ok,
+  [data-theme="fancy"] .done-zone.drop-ok {
+    animation: fancy-breathe 1.1s ease-in-out infinite;
+  }
+}
+@keyframes fancy-breathe {
+  0%,
+  100% {
+    box-shadow: inset 0 0 18px hsl(var(--fancy-hue, 220) 90% 75% / 0.25);
+  }
+  50% {
+    box-shadow: inset 0 0 34px hsl(var(--fancy-hue, 220) 90% 75% / 0.55);
+  }
+}
+
+/* [FANCY:cards] Stacked pastel depth shadows + hover lift. The transform
+   transition doubles as the squish-spring return. */
+[data-theme="fancy"] .card {
+  position: relative;
+  overflow: hidden;
+  background: hsl(var(--fancy-hue, 220) 30% 22% / 0.85);
+  border-color: hsl(var(--fancy-hue, 220) 60% 60% / 0.45);
+  box-shadow:
+    0 2px 6px rgba(0, 0, 0, 0.35),
+    0 6px 18px hsl(var(--fancy-hue, 220) 70% 30% / 0.35);
+  transition: transform 0.25s cubic-bezier(0.34, 1.8, 0.5, 1), box-shadow 0.25s ease;
+}
+[data-theme="fancy"] .card:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    0 4px 10px rgba(0, 0, 0, 0.4),
+    0 12px 28px hsl(var(--fancy-hue, 220) 70% 35% / 0.5);
+}
+
+/* [FANCY:squish] Press squish on cards, rail icons and buttons; the bouncy
+   cubic-bezier above (and on .rail-item) springs them back. */
+[data-theme="fancy"] .card:active {
+  transform: scale(0.96);
+}
+[data-theme="fancy"] .rail-item {
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    border-radius 0.15s ease,
+    transform 0.25s cubic-bezier(0.34, 1.8, 0.5, 1);
+}
+[data-theme="fancy"] .rail-item:active:not(:disabled) {
+  transform: scale(0.88);
+}
+[data-theme="fancy"] .modal-actions button:active,
+[data-theme="fancy"] .add-card:active {
+  transform: scale(0.92);
+}
+
+/* [FANCY:sheen] Holographic foil sweep following the pointer across a card
+   (fancy.ts feeds --mx/--my from the shared pointermove handler). */
+[data-theme="fancy"] .card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  background: radial-gradient(
+    140px circle at var(--mx, 50%) var(--my, 50%),
+    hsl(var(--fancy-hue, 220) 100% 85% / 0.22),
+    transparent 60%
+  );
+}
+[data-theme="fancy"] .card:hover::after {
+  opacity: 1;
+}
+
+/* [FANCY:tilt] Drag ghost leans into pointer velocity (fancy.ts sets --tilt);
+   the transition springs it upright when the pointer slows. */
+[data-theme="fancy"] .drag-ghost {
+  transform: translate(-50%, -50%) rotate(var(--tilt, 0deg));
+  transition: transform 0.15s ease-out;
+  border-color: hsl(var(--fancy-hue, 220) 80% 70%);
+  box-shadow: 0 10px 30px hsl(var(--fancy-hue, 220) 70% 30% / 0.6);
+}
+
+/* [FANCY:beam] A slow rainbow beam circles the hovered column. Implemented as
+   an animated border-box gradient so it needs no mask support. */
+@media (prefers-reduced-motion: no-preference) {
+  [data-theme="fancy"] .column:hover {
+    border-color: transparent;
+    background:
+      linear-gradient(hsl(var(--fancy-hue, 220) 35% 16% / 0.92), hsl(var(--fancy-hue, 220) 35% 16% / 0.92))
+        padding-box,
+      linear-gradient(
+          120deg,
+          hsl(330 90% 75%),
+          hsl(45 90% 75%),
+          hsl(165 90% 75%),
+          hsl(210 90% 75%),
+          hsl(280 90% 75%),
+          hsl(330 90% 75%)
+        )
+        border-box;
+    background-size: 100% 100%, 300% 300%;
+    animation: fancy-beam 4s linear infinite;
+  }
+}
+@keyframes fancy-beam {
+  0% {
+    background-position: 0 0, 0% 0%;
+  }
+  50% {
+    background-position: 0 0, 100% 100%;
+  }
+  100% {
+    background-position: 0 0, 0% 0%;
+  }
+}
+
+/* [FANCY:rail-glow] Active rail icon gets a soft pastel halo. */
+[data-theme="fancy"] .rail-item.active {
+  box-shadow: 0 0 18px hsl(265 85% 70% / 0.7);
+  background: linear-gradient(135deg, hsl(265 80% 62%), hsl(210 85% 60%));
+}
+[data-theme="fancy"] .rail-item:hover:not(:disabled) {
+  background: linear-gradient(135deg, hsl(265 80% 62%), hsl(210 85% 60%));
+}
+
+/* [FANCY:eq] Daemon status dot becomes a tiny pastel equalizer while the
+   daemon is reachable. Bars are the dot's pseudo-elements. */
+[data-theme="fancy"] .status-dot.reachable {
+  background: hsl(150 80% 65%);
+  position: relative;
+}
+@media (prefers-reduced-motion: no-preference) {
+  [data-theme="fancy"] .status-dot.reachable {
+    border-radius: 2px;
+    width: 4px;
+    height: 10px;
+    animation: fancy-eq 0.9s ease-in-out infinite;
+  }
+  [data-theme="fancy"] .status-dot.reachable::before,
+  [data-theme="fancy"] .status-dot.reachable::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    width: 4px;
+    border-radius: 2px;
+  }
+  [data-theme="fancy"] .status-dot.reachable::before {
+    left: -6px;
+    height: 7px;
+    background: hsl(280 80% 72%);
+    animation: fancy-eq 0.9s ease-in-out infinite 0.2s;
+  }
+  [data-theme="fancy"] .status-dot.reachable::after {
+    left: 6px;
+    height: 5px;
+    background: hsl(45 90% 70%);
+    animation: fancy-eq 0.9s ease-in-out infinite 0.4s;
+  }
+}
+@keyframes fancy-eq {
+  0%,
+  100% {
+    transform: scaleY(0.5);
+  }
+  50% {
+    transform: scaleY(1);
+  }
+}
+
+/* [FANCY:canvas] Shared particle canvas (fireworks, confetti, comet trail,
+   dust motes). pointer-events:none keeps drag hit-testing intact; it sits
+   above the modal because celebrations are transient and non-interactive. */
+.fx-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+  z-index: 9999;
+}
+
+/* [FANCY:spotlight] Soft cursor-following light over the board. */
+.fx-spotlight {
+  position: fixed;
+  left: -300px;
+  top: -300px;
+  width: 600px;
+  height: 600px;
+  pointer-events: none;
+  z-index: 5;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.06), transparent 60%);
+  transition: opacity 0.3s ease;
+}
+
+/* [FANCY:ripple] Shockwave ring expanding from the drop point. */
+.fx-ripple {
+  position: fixed;
+  width: 12px;
+  height: 12px;
+  margin: -6px 0 0 -6px;
+  pointer-events: none;
+  z-index: 9998;
+  border-radius: 50%;
+  border: 2px solid hsl(200 100% 80% / 0.9);
+  animation: fancy-ripple 0.6s ease-out forwards;
+}
+@keyframes fancy-ripple {
+  to {
+    transform: scale(14);
+    opacity: 0;
+  }
+}
+
+/* [FANCY:gold] Golden crown glow on the card that just landed in Done. */
+[data-theme="fancy"] .card.fx-gold {
+  border-color: hsl(48 95% 65%);
+  box-shadow:
+    0 0 22px hsl(48 95% 60% / 0.8),
+    0 6px 18px hsl(var(--fancy-hue, 220) 70% 30% / 0.35);
+}
+
+/* [FANCY:toast] Streak combo toast ("3×!") floating up from the bottom. */
+.fx-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 18%;
+  pointer-events: none;
+  z-index: 9998;
+  font-size: 44px;
+  font-weight: 800;
+  background: linear-gradient(90deg, hsl(330 90% 75%), hsl(45 90% 70%), hsl(165 85% 70%), hsl(210 90% 75%));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: fancy-toast 1.4s ease-out forwards;
+}
+@keyframes fancy-toast {
+  0% {
+    transform: translate(-50%, 20px) scale(0.6);
+    opacity: 0;
+  }
+  20% {
+    transform: translate(-50%, 0) scale(1.15);
+    opacity: 1;
+  }
+  35% {
+    transform: translate(-50%, 0) scale(1);
+  }
+  100% {
+    transform: translate(-50%, -60px) scale(1);
+    opacity: 0;
+  }
+}
+
+/* [FANCY:sweep] One-time aurora wave when a column is emptied. */
+.fx-sweep {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9997;
+  background: linear-gradient(
+    100deg,
+    transparent 20%,
+    hsl(280 90% 75% / 0.18) 40%,
+    hsl(180 90% 75% / 0.22) 50%,
+    hsl(45 90% 75% / 0.18) 60%,
+    transparent 80%
+  );
+  background-size: 300% 100%;
+  animation: fancy-sweep 1.2s ease-in-out forwards;
+}
+@keyframes fancy-sweep {
+  from {
+    background-position: 120% 0;
+  }
+  to {
+    background-position: -20% 0;
+  }
+}

--- a/desktop/frontend/scripts/bundle.mjs
+++ b/desktop/frontend/scripts/bundle.mjs
@@ -1,8 +1,8 @@
 // Minimal "bundler" for the board frontend: tsc emits ES modules to build/, and
 // this script assembles the dist/ that Wails embeds (//go:embed all:frontend/dist).
-// It copies the compiled board.js plus the static index.html and style.css.
+// It copies every compiled module plus the static index.html and style.css.
 // Kept dependency-free on purpose so `wails build` needs only Node + tsc.
-import { copyFileSync, mkdirSync, existsSync } from "node:fs";
+import { copyFileSync, mkdirSync, existsSync, readdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -11,9 +11,13 @@ const root = resolve(here, "..");
 const dist = resolve(root, "dist");
 mkdirSync(dist, { recursive: true });
 
-const compiled = resolve(root, "build", "board.js");
-if (existsSync(compiled)) {
-  copyFileSync(compiled, resolve(dist, "board.js"));
+// Copy every emitted module: board.ts imports sibling modules (e.g. fancy.js),
+// and a missing one would leave the embedded app with a broken import.
+const build = resolve(root, "build");
+if (existsSync(build)) {
+  for (const f of readdirSync(build).filter((f) => f.endsWith(".js"))) {
+    copyFileSync(resolve(build, f), resolve(dist, f));
+  }
 }
 
 for (const f of ["index.html", "style.css"]) {

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -80,6 +80,26 @@ interface InstancesData {
   error?: string;
 }
 
+interface FeatureItem {
+  name: string;
+  description: string;
+  recent?: boolean;
+}
+
+interface FeatureGroup {
+  group: string;
+  features: FeatureItem[];
+  groups?: FeatureGroup[];
+}
+
+interface FeatureDoc {
+  product?: string;
+  tagline?: string;
+  groups?: FeatureGroup[];
+  exists?: boolean;
+  error?: string;
+}
+
 interface AppBindings {
   Cards(): Promise<BoardData>;
   CardsQuick(): Promise<BoardData>;
@@ -90,6 +110,8 @@ interface AppBindings {
   ReplyIdeation(sessionId: string, message: string): Promise<IdeationView>;
   IdeationStatus(): Promise<IdeationView>;
   Instances(): Promise<InstancesData>;
+  Features(): Promise<FeatureDoc>;
+  GenerateFeatures(): Promise<void>;
 }
 
 // This file is a module (see the trailing `export {}`) so the global
@@ -882,6 +904,187 @@ function renderAgents(): void {
     `<div class="agents-header">Running agents</div>` + agentsData.agents.map(renderAgentRow).join("");
 }
 
+// --- Features view -----------------------------------------------------
+//
+// Renders the project's FEATURE.json (grouped product features) from the Go
+// App.Features() binding — a plain file read, no daemon. Unlike the agents view
+// this is a static document, so it loads once on activation with no poll.
+
+let featuresLoaded = false;
+// Generation runs as a detached agent (like a kanban stage), so the button
+// can't block on completion. We capture the currently-shown doc's signature
+// when generation starts, then poll Features() until it changes — the file
+// appearing (Generate) or its content shifting (Refresh) both flip the button
+// back and re-render. currentFeatureDoc is the last doc rendered; featuresNote
+// carries a transient status/error line without wiping the rendered map.
+let featuresGenerating = false;
+let featuresBaselineSig = "";
+let featuresNote = "";
+let currentFeatureDoc: FeatureDoc = {};
+let featuresPollTimer: number | undefined;
+
+async function loadFeatures(): Promise<void> {
+  let doc: FeatureDoc;
+  try {
+    doc = await go().Features();
+  } catch (err) {
+    doc = { error: errMessage(err) };
+  }
+  renderFeatures(doc);
+}
+
+// featureSig is a stable fingerprint of the rendered doc: presence plus product,
+// tagline, and the recursive group/feature names+descriptions. Two runs that
+// produce the same map yield the same signature, so polling only reacts to a
+// real change.
+function featureSig(doc: FeatureDoc): string {
+  if (!doc.exists) return "«sent»";
+  const walk = (gs: FeatureGroup[] = []): string =>
+    gs
+      .map(
+        (g) =>
+          g.group +
+          "|" +
+          (g.features ?? []).map((f) => f.name + ":" + f.description + (f.recent ? "*" : "")).join(",") +
+          "|" +
+          walk(g.groups),
+      )
+      .join(";");
+  return (doc.product ?? "") + "¦" + (doc.tagline ?? "") + "¦" + walk(doc.groups);
+}
+
+function stopFeaturesPoll(): void {
+  if (featuresPollTimer !== undefined) {
+    clearInterval(featuresPollTimer);
+    featuresPollTimer = undefined;
+  }
+}
+
+// startFeaturesPoll watches for the generation agent's output. It re-reads
+// FEATURE.json every 4s and, when the doc's signature differs from the baseline
+// captured at click time, stops and re-renders. A 10-minute cap avoids polling
+// forever if the agent is slow or fails silently.
+function startFeaturesPoll(): void {
+  stopFeaturesPoll();
+  const started = Date.now();
+  const timeoutMs = 10 * 60 * 1000;
+  featuresPollTimer = window.setInterval(() => {
+    void (async () => {
+      let doc: FeatureDoc;
+      try {
+        doc = await go().Features();
+      } catch {
+        return; // transient; keep polling
+      }
+      if (featureSig(doc) !== featuresBaselineSig) {
+        stopFeaturesPoll();
+        featuresGenerating = false;
+        featuresNote = "";
+        renderFeatures(doc);
+        return;
+      }
+      if (Date.now() - started > timeoutMs) {
+        stopFeaturesPoll();
+        featuresGenerating = false;
+        featuresNote = "Agent still running — click Refresh when it finishes.";
+        renderFeatures(currentFeatureDoc);
+      }
+    })();
+  }, 4000);
+}
+
+// onGenerateFeatures drives both Generate and Refresh: it launches the
+// human-features skill through the daemon (the same containerized agent path as
+// a kanban drag-and-drop), flips the button to a disabled "Generating…" state,
+// and starts polling for the result.
+async function onGenerateFeatures(): Promise<void> {
+  if (featuresGenerating) return;
+  featuresBaselineSig = featureSig(currentFeatureDoc);
+  featuresGenerating = true;
+  // Generation runs a coding agent in a container (survey → synthesis), so it
+  // is not instant — set expectations up front and keep the note up while the
+  // poll waits for FEATURE.json.
+  featuresNote = "Running the generation agent — this can take several minutes…";
+  renderFeatures(currentFeatureDoc);
+  try {
+    await go().GenerateFeatures();
+  } catch (err) {
+    featuresGenerating = false;
+    featuresNote = "Couldn't start generation: " + errMessage(err);
+    renderFeatures(currentFeatureDoc);
+    return;
+  }
+  startFeaturesPoll();
+}
+
+function renderFeatureRow(f: FeatureItem): string {
+  // A "recent" badge flags a capability changed since the last release. Ticket
+  // keys in FEATURE.json are deliberately not surfaced here — the desktop pane
+  // presents features from a user's point of view, not their engineering trail.
+  const badge = f.recent ? `<span class="feature-badge">recent</span>` : "";
+  return `<div class="feature-row">
+    <span class="feature-name">${escapeHtml(f.name)}${badge}</span>
+    <span class="feature-desc">${escapeHtml(f.description)}</span>
+  </div>`;
+}
+
+// Recursive: a group renders its own features, then any nested sub-groups. depth
+// drives indentation so a deeper tree (larger projects) reads as a shallow
+// hierarchy rather than a flat wall.
+function renderFeatureGroup(g: FeatureGroup, depth = 0): string {
+  const rows = (g.features ?? []).map(renderFeatureRow).join("");
+  const subgroups = (g.groups ?? []).map((sg) => renderFeatureGroup(sg, depth + 1)).join("");
+  return `<div class="feature-group" data-depth="${depth}">
+    <div class="feature-group-title">${escapeHtml(g.group)}</div>
+    ${rows}
+    ${subgroups}
+  </div>`;
+}
+
+function renderFeatures(doc: FeatureDoc): void {
+  currentFeatureDoc = doc;
+  const host = document.getElementById("features");
+  if (!host) return;
+
+  // The action button reads "Generate" when FEATURE.json is absent and "Refresh"
+  // when present; while an agent runs it is a disabled "Generating…" spinner.
+  const label = featuresGenerating ? "Generating…" : doc.exists ? "Refresh" : "Generate";
+  const spinner = featuresGenerating ? `<span class="spinner"></span> ` : "";
+  const btn = `<button class="features-btn" ${featuresGenerating ? "disabled" : ""}>${spinner}${escapeHtml(label)}</button>`;
+  const header = `<div class="agents-header features-header"><span>Features</span>${btn}</div>`;
+  const note = featuresNote ? `<div class="features-note">${escapeHtml(featuresNote)}</div>` : "";
+
+  const attach = () =>
+    host.querySelector(".features-btn")?.addEventListener("click", () => void onGenerateFeatures());
+
+  if (doc.error) {
+    host.innerHTML = header + note + `<div class="banner">${escapeHtml(doc.error)}</div>`;
+    attach();
+    return;
+  }
+  if (!doc.exists) {
+    host.innerHTML =
+      header + note + `<div class="features-empty">No FEATURE.json yet — click Generate to build it.</div>`;
+    attach();
+    return;
+  }
+  const groups = doc.groups ?? [];
+  if (groups.length === 0) {
+    host.innerHTML = header + note + `<div class="features-empty">No features to show</div>`;
+    attach();
+    return;
+  }
+  const intro =
+    doc.product || doc.tagline
+      ? `<div class="features-intro">
+          ${doc.product ? `<div class="features-product">${escapeHtml(doc.product)}</div>` : ""}
+          ${doc.tagline ? `<div class="features-tagline">${escapeHtml(doc.tagline)}</div>` : ""}
+        </div>`
+      : "";
+  host.innerHTML = header + note + intro + groups.map(renderFeatureGroup).join("");
+  attach();
+}
+
 // --- Left activity rail ------------------------------------------------
 //
 // "board" and "agents" are real views swapped in the main area; other rail
@@ -899,14 +1102,23 @@ function selectView(view: string): void {
   // Toggle main-area containers: exactly one top-level view is visible.
   const board = document.getElementById("board");
   const agents = document.getElementById("agents");
+  const features = document.getElementById("features");
   board?.classList.toggle("hidden", view !== "board");
   agents?.classList.toggle("hidden", view !== "agents");
+  features?.classList.toggle("hidden", view !== "features");
 
   if (view === "agents") {
     void pollAgents(); // immediate fetch so the view isn't blank until the first tick
     startAgentsPoll();
   } else {
     stopAgentsPoll();
+  }
+
+  // The features doc is static — load it once on first activation, then leave
+  // the rendered pane in place (no poll, unlike agents).
+  if (view === "features" && !featuresLoaded) {
+    featuresLoaded = true;
+    void loadFeatures();
   }
 }
 

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -7,6 +7,17 @@
 // The shipped runtime is desktop/frontend/dist/board.js; `npm run build`
 // (tsc + bundle.mjs) regenerates dist/ from this source for `wails build`.
 
+// The fancy hooks no-op while the classic theme is active, so they are safe to
+// call unconditionally on the hot paths below.
+import {
+  celebrateDrop,
+  ghostTilt,
+  initFancy,
+  isThemeToggleChord,
+  toggleTheme,
+  trail,
+} from "./fancy.js";
+
 interface Card {
   key: string;
   title: string;
@@ -335,6 +346,7 @@ function beginPointerDrag(el: HTMLElement, card: Card): void {
 
     const info = { key: card.key, title: card.title, stage: card.stage };
     let started = false;
+    let lastX = down.clientX;
 
     const onMove = (ev: PointerEvent): void => {
       if (!started) {
@@ -347,7 +359,10 @@ function beginPointerDrag(el: HTMLElement, card: Card): void {
       if (dragGhost) {
         dragGhost.style.left = `${ev.clientX}px`;
         dragGhost.style.top = `${ev.clientY}px`;
+        ghostTilt(dragGhost, ev.clientX - lastX);
+        trail({ x: ev.clientX, y: ev.clientY });
       }
+      lastX = ev.clientX;
       setHoverTarget(dropTargetAt(ev.clientX, ev.clientY));
     };
 
@@ -372,13 +387,15 @@ function beginPointerDrag(el: HTMLElement, card: Card): void {
       const target = started ? dropTargetAt(ev.clientX, ev.clientY) : null;
       const allowed = !!target && dropAllowed(target);
       teardown();
-      dragging = null;
-      if (target && allowed) performDrop(target, info);
+      endDrag();
+      // `target` may have been replaced by the flushed render, but performDrop
+      // only reads its dataset, which a detached node still carries.
+      if (target && allowed) performDrop(target, info, { x: ev.clientX, y: ev.clientY });
     };
 
     const onCancel = (): void => {
       teardown();
-      dragging = null;
+      endDrag();
     };
 
     try {
@@ -392,13 +409,31 @@ function beginPointerDrag(el: HTMLElement, card: Card): void {
   });
 }
 
+// endDrag closes the drag lifecycle and flushes any board rebuild that was
+// deferred while the drag was in flight.
+function endDrag(): void {
+  dragging = null;
+  if (pendingRender) {
+    pendingRender = false;
+    render();
+  }
+}
+
 // performDrop runs the action for a completed drop on an allowed target.
-function performDrop(target: HTMLElement, info: { key: string; title: string; stage: string }): void {
+function performDrop(
+  target: HTMLElement,
+  info: { key: string; title: string; stage: string },
+  pt: { x: number; y: number },
+): void {
   if (target.dataset.drop === "close") {
+    // Closing is destructive and still awaits a confirm dialog — never a
+    // moment to celebrate, so the fancy theme stays silent here.
     void requestClose(info.key, info.title);
     return;
   }
-  void transition(info.key, info.title, info.stage, target.dataset.dropStage || "");
+  const to = target.dataset.dropStage || "";
+  celebrateDrop(pt, { key: info.key, fromStage: info.stage, done: to === "done" });
+  void transition(info.key, info.title, info.stage, to);
 }
 
 async function transition(key: string, title: string, from: string, to: string): Promise<void> {
@@ -497,7 +532,16 @@ function restoreColumnScroll(board: HTMLElement, scroll: Record<string, number>)
   });
 }
 
+// A render mid-drag would replace the dragged card's DOM element, silently
+// killing its pointer listeners (frozen ghost, drop never lands). Rebuilds
+// requested during a drag are deferred and flushed by endDrag().
+let pendingRender = false;
+
 function render(): void {
+  if (dragging) {
+    pendingRender = true;
+    return;
+  }
   const board = document.getElementById("board")!;
   // Capture each column's scroll position before the full rebuild below wipes
   // it. A reconcile (board:changed / post-transition) must not snap a column the
@@ -1150,6 +1194,13 @@ function init(): void {
   setInterval(() => void pollDaemonStatus(), DAEMON_POLL_MS);
 
   wireRail();
+  initFancy();
+  document.addEventListener("keydown", (e: KeyboardEvent) => {
+    if (isThemeToggleChord(e)) {
+      e.preventDefault();
+      toggleTheme();
+    }
+  });
   document.getElementById("ideation-close")?.addEventListener("click", () => closeIdeation());
   document.getElementById("ideation-form")?.addEventListener("submit", (e: Event) => {
     e.preventDefault();

--- a/desktop/frontend/src/fancy.ts
+++ b/desktop/frontend/src/fancy.ts
@@ -1,0 +1,448 @@
+// fancy.ts — the optional "fancy" presentation layer: a second, demo-oriented
+// theme (animated gradient, pastel rainbow columns — see the FANCY THEME
+// section of style.css) plus celebration effects driven from here: fireworks,
+// confetti, comet trail, dust motes, drop ripples and streak toasts.
+//
+// Design constraints, in priority order:
+//   - Classic stays untouched: every exported hook no-ops unless the fancy
+//     theme is active, so board.ts may call them unconditionally.
+//   - One canvas, one rAF loop, zero idle work: the loop stops the moment the
+//     particle pool drains; ambient motes keep it alive only while the fancy
+//     theme is on AND the window is visible.
+//   - prefers-reduced-motion keeps the fancy colors but disables all motion
+//     (CSS handles its own animations via the same media query).
+//
+// Removing one effect = delete its EFFECTS flag, its call site and its CSS
+// block; tsc's noUnusedLocals then points at any leftover helper.
+
+const EFFECTS = {
+  fireworks: true,
+  confetti: true,
+  trail: true,
+  motes: true,
+  ripple: true,
+  tilt: true,
+  spotlight: true,
+  sheen: true,
+  streak: true,
+  sweep: true,
+};
+
+const THEME_KEY = "human.theme";
+const MOTE_TARGET = 32;
+const STREAK_WINDOW_MS = 10_000;
+
+type Pt = { x: number; y: number };
+
+interface Particle {
+  kind: "fx" | "mote";
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  age: number;
+  ttl: number; // seconds; motes are ageless and live until the theme turns off
+  size: number;
+  hue: number;
+  sat: number;
+  lum: number;
+  alpha: number;
+  gravity: number;
+  drag: number;
+  shape: "dot" | "rect";
+  rot: number;
+  vr: number;
+}
+
+// --- Theme state --------------------------------------------------------
+
+export function isFancy(): boolean {
+  return document.documentElement.dataset.theme === "fancy";
+}
+
+export function toggleTheme(): void {
+  const fancy = !isFancy();
+  if (fancy) document.documentElement.dataset.theme = "fancy";
+  else delete document.documentElement.dataset.theme;
+  try {
+    localStorage.setItem(THEME_KEY, fancy ? "fancy" : "classic");
+  } catch {
+    // Storage may be unavailable; the toggle still works for this session.
+  }
+  syncAmbient();
+}
+
+// isThemeToggleChord matches the style-toggle key (F8). Guarded against firing
+// while the user types, so a future rebind to a printable key stays safe.
+export function isThemeToggleChord(e: KeyboardEvent): boolean {
+  const t = e.target as HTMLElement | null;
+  if (t && t.closest("input, textarea, select, [contenteditable]")) return false;
+  return e.key === "F8";
+}
+
+// initFancy wires the always-on listeners (cheap no-ops in classic) and starts
+// ambient effects when the pre-paint script already applied the fancy theme.
+export function initFancy(): void {
+  document.addEventListener("visibilitychange", syncAmbient);
+  document.addEventListener("pointermove", onPointerMove);
+  syncAmbient();
+}
+
+// --- Board hooks (called unconditionally from board.ts) ------------------
+
+// celebrateDrop fires the drop celebration at the release point: ripple always,
+// confetti (escalated by the done-streak) for Done drops, fireworks otherwise.
+// Runs before the optimistic re-render, so DOM lookups are deferred a tick.
+export function celebrateDrop(pt: Pt, info: { key: string; fromStage: string; done: boolean }): void {
+  if (!isFancy() || reducedMotion()) return;
+  if (EFFECTS.ripple) ripple(pt);
+  if (info.done && EFFECTS.confetti) {
+    const streak = EFFECTS.streak ? bumpStreak() : 1;
+    spawnConfetti(pt, Math.min(70 + (streak - 1) * 50, 240));
+    if (streak >= 2) toast(`${streak}×!`);
+    goldGlow(info.key);
+  } else if (EFFECTS.fireworks) {
+    spawnFirework(pt);
+  }
+  if (EFFECTS.sweep) scheduleClearSweep(info.fromStage);
+}
+
+// ghostTilt leans the drag ghost into the pointer's horizontal velocity, like
+// a card picked up by one corner. The CSS transition springs it back upright.
+export function ghostTilt(ghost: HTMLElement, dx: number): void {
+  if (!EFFECTS.tilt || !isFancy() || reducedMotion()) return;
+  const deg = Math.max(-10, Math.min(10, dx * 0.7));
+  ghost.style.setProperty("--tilt", `${deg.toFixed(1)}deg`);
+}
+
+// trail sprinkles comet sparkles along the drag path. Throttled by distance so
+// fast drags don't flood the pool.
+let lastTrail: Pt | null = null;
+
+export function trail(pt: Pt): void {
+  if (!EFFECTS.trail || !isFancy() || reducedMotion()) return;
+  if (lastTrail && Math.hypot(pt.x - lastTrail.x, pt.y - lastTrail.y) < 14) return;
+  lastTrail = pt;
+  spawn({
+    kind: "fx",
+    x: pt.x + rand(-6, 6),
+    y: pt.y + rand(-6, 6),
+    vx: rand(-12, 12),
+    vy: rand(-4, 20),
+    age: 0,
+    ttl: rand(0.3, 0.6),
+    size: rand(1.2, 2.6),
+    hue: rand(0, 360),
+    sat: 90,
+    lum: 75,
+    alpha: 0.9,
+    gravity: 40,
+    drag: 1,
+    shape: "dot",
+    rot: 0,
+    vr: 0,
+  });
+}
+
+// --- Streak tracking ------------------------------------------------------
+
+let doneDrops: number[] = [];
+
+function bumpStreak(): number {
+  const now = performance.now();
+  doneDrops = doneDrops.filter((t) => now - t < STREAK_WINDOW_MS);
+  doneDrops.push(now);
+  return doneDrops.length;
+}
+
+// --- DOM effects (ripple, toast, gold glow, column-clear sweep) -----------
+
+function ripple(pt: Pt): void {
+  const el = document.createElement("div");
+  el.className = "fx-ripple";
+  el.style.left = `${pt.x}px`;
+  el.style.top = `${pt.y}px`;
+  removeAfterAnimation(el, 700);
+  document.body.appendChild(el);
+}
+
+function toast(text: string): void {
+  const el = document.createElement("div");
+  el.className = "fx-toast";
+  el.textContent = text;
+  removeAfterAnimation(el, 1600);
+  document.body.appendChild(el);
+}
+
+// goldGlow crowns the card that just landed in Done. The card element is
+// rebuilt by the optimistic render right after the drop, so look it up late.
+function goldGlow(key: string): void {
+  window.setTimeout(() => {
+    const card = document.querySelector<HTMLElement>(`.card[data-key="${cssEscape(key)}"]`);
+    if (!card) return;
+    card.classList.add("fx-gold");
+    window.setTimeout(() => card.classList.remove("fx-gold"), 1600);
+  }, 60);
+}
+
+// scheduleClearSweep celebrates emptying a column: checked after the optimistic
+// render has moved the dropped card out of its source column.
+function scheduleClearSweep(fromStage: string): void {
+  window.setTimeout(() => {
+    if (!isFancy() || reducedMotion()) return;
+    const left = document.querySelector(`.column[data-stage="${cssEscape(fromStage)}"] .card`);
+    if (left) return;
+    const el = document.createElement("div");
+    el.className = "fx-sweep";
+    removeAfterAnimation(el, 1400);
+    document.body.appendChild(el);
+  }, 80);
+}
+
+function removeAfterAnimation(el: HTMLElement, fallbackMs: number): void {
+  el.addEventListener("animationend", () => el.remove());
+  // Fallback: reduced-motion or a dropped animation must not leak the node.
+  window.setTimeout(() => el.remove(), fallbackMs);
+}
+
+function cssEscape(v: string): string {
+  return typeof CSS !== "undefined" && CSS.escape ? CSS.escape(v) : v.replace(/["\\]/g, "\\$&");
+}
+
+// --- Cursor spotlight + holographic sheen (shared pointermove) ------------
+
+let spotlight: HTMLElement | null = null;
+
+function onPointerMove(e: PointerEvent): void {
+  if (!isFancy() || reducedMotion()) {
+    if (spotlight) {
+      spotlight.style.opacity = "0";
+      spotlight.style.display = "none";
+    }
+    return;
+  }
+  if (EFFECTS.spotlight) {
+    if (!spotlight) {
+      spotlight = document.createElement("div");
+      spotlight.className = "fx-spotlight";
+      document.body.appendChild(spotlight);
+    }
+    spotlight.style.display = "";
+    spotlight.style.opacity = "1";
+    spotlight.style.transform = `translate(${e.clientX}px, ${e.clientY}px)`;
+  }
+  if (EFFECTS.sheen) {
+    const card = (e.target as HTMLElement | null)?.closest?.(".card") as HTMLElement | null;
+    if (card) {
+      const r = card.getBoundingClientRect();
+      card.style.setProperty("--mx", `${(((e.clientX - r.left) / r.width) * 100).toFixed(1)}%`);
+      card.style.setProperty("--my", `${(((e.clientY - r.top) / r.height) * 100).toFixed(1)}%`);
+    }
+  }
+}
+
+// --- Particle engine ------------------------------------------------------
+
+let canvas: HTMLCanvasElement | null = null;
+let ctx: CanvasRenderingContext2D | null = null;
+let pool: Particle[] = [];
+let raf = 0;
+let lastTs = 0;
+
+function reducedMotion(): boolean {
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+function rand(min: number, max: number): number {
+  return min + Math.random() * (max - min);
+}
+
+function ensureCanvas(): void {
+  if (canvas) return;
+  canvas = document.createElement("canvas");
+  canvas.className = "fx-canvas";
+  document.body.appendChild(canvas);
+  ctx = canvas.getContext("2d");
+  const fit = (): void => {
+    if (!canvas || !ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.floor(window.innerWidth * dpr);
+    canvas.height = Math.floor(window.innerHeight * dpr);
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  };
+  fit();
+  window.addEventListener("resize", fit);
+}
+
+function spawn(p: Particle): void {
+  if (!isFancy() || reducedMotion()) return;
+  ensureCanvas();
+  pool.push(p);
+  if (!raf) {
+    lastTs = 0;
+    raf = requestAnimationFrame(tick);
+  }
+}
+
+function spawnFirework(pt: Pt): void {
+  const baseHue = rand(0, 360);
+  for (let i = 0; i < 44; i++) {
+    const angle = rand(0, Math.PI * 2);
+    const speed = rand(60, 340);
+    spawn({
+      kind: "fx",
+      x: pt.x,
+      y: pt.y,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed - 40,
+      age: 0,
+      ttl: rand(0.5, 1.1),
+      size: rand(1.5, 3),
+      hue: (baseHue + rand(-30, 30) + 360) % 360,
+      sat: 95,
+      lum: 68,
+      alpha: 1,
+      gravity: 260,
+      drag: 1.6,
+      shape: "dot",
+      rot: 0,
+      vr: 0,
+    });
+  }
+}
+
+function spawnConfetti(pt: Pt, count: number): void {
+  for (let i = 0; i < count; i++) {
+    const angle = rand(-Math.PI * 0.85, -Math.PI * 0.15); // upward fan
+    const speed = rand(140, 480);
+    spawn({
+      kind: "fx",
+      x: pt.x,
+      y: pt.y,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed,
+      age: 0,
+      ttl: rand(0.9, 1.8),
+      size: rand(3, 6),
+      hue: rand(0, 360),
+      sat: 85,
+      lum: 70,
+      alpha: 1,
+      gravity: 420,
+      drag: 1.2,
+      shape: "rect",
+      rot: rand(0, Math.PI),
+      vr: rand(-8, 8),
+    });
+  }
+}
+
+function makeMote(atBottom: boolean): Particle {
+  return {
+    kind: "mote",
+    x: rand(0, window.innerWidth),
+    y: atBottom ? window.innerHeight + 4 : rand(0, window.innerHeight),
+    vx: rand(-4, 4),
+    vy: rand(-14, -5),
+    age: 0,
+    ttl: Infinity,
+    size: rand(0.8, 2.2),
+    hue: rand(0, 360),
+    sat: 60,
+    lum: 80,
+    alpha: rand(0.1, 0.32),
+    gravity: 0,
+    drag: 0,
+    shape: "dot",
+    rot: 0,
+    vr: 0,
+  };
+}
+
+// syncAmbient reconciles the particle layer with the current theme and window
+// visibility: motes drift only while fancy is on-screen, leaving fancy kills
+// every particle at once, and the loop pauses (with a wiped frame) while the
+// window is hidden so a stale frame is never left on screen.
+function syncAmbient(): void {
+  const visible = document.visibilityState === "visible";
+  const ambientOn = isFancy() && !reducedMotion() && visible;
+  if (spotlight && !ambientOn) {
+    // display:none instead of a fade: classic must be pristine the instant
+    // the theme switches, not 0.3s later. onPointerMove re-shows it in fancy.
+    spotlight.style.opacity = "0";
+    spotlight.style.display = "none";
+  }
+  if (!isFancy()) {
+    // Leaving fancy: classic must be pristine instantly, so kill mid-flight
+    // celebrations (particles AND overlay nodes) instead of letting them fade.
+    pool = [];
+    document.querySelectorAll(".fx-ripple, .fx-toast, .fx-sweep").forEach((n) => n.remove());
+  } else if (ambientOn && EFFECTS.motes && !pool.some((p) => p.kind === "mote")) {
+    ensureCanvas();
+    for (let i = 0; i < MOTE_TARGET; i++) pool.push(makeMote(false));
+  } else if (!ambientOn) {
+    pool = pool.filter((p) => p.kind !== "mote");
+  }
+  if (!visible || pool.length === 0) {
+    if (raf) {
+      cancelAnimationFrame(raf);
+      raf = 0;
+    }
+    if (ctx) ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
+  } else if (!raf) {
+    lastTs = 0;
+    raf = requestAnimationFrame(tick);
+  }
+}
+
+function tick(ts: number): void {
+  if (!ctx || !canvas) {
+    raf = 0;
+    return;
+  }
+  const dt = lastTs ? Math.min((ts - lastTs) / 1000, 0.05) : 0.016;
+  lastTs = ts;
+
+  const w = window.innerWidth;
+  const h = window.innerHeight;
+  ctx.clearRect(0, 0, w, h);
+
+  const alive: Particle[] = [];
+  for (const p of pool) {
+    p.age += dt;
+    if (p.age >= p.ttl) continue;
+    p.vx -= p.vx * p.drag * dt;
+    p.vy += p.gravity * dt - p.vy * p.drag * dt;
+    p.x += p.vx * dt;
+    p.y += p.vy * dt;
+    p.rot += p.vr * dt;
+
+    if (p.kind === "mote") {
+      // Motes recycle: drift off the top, re-enter from the bottom.
+      if (p.y < -6) Object.assign(p, makeMote(true));
+    } else if (p.y > h + 20 || p.x < -20 || p.x > w + 20) {
+      continue;
+    }
+
+    const fade = p.ttl === Infinity ? 1 : 1 - p.age / p.ttl;
+    ctx.globalAlpha = Math.max(0, p.alpha * fade);
+    ctx.fillStyle = `hsl(${p.hue} ${p.sat}% ${p.lum}%)`;
+    if (p.shape === "rect") {
+      ctx.save();
+      ctx.translate(p.x, p.y);
+      ctx.rotate(p.rot);
+      ctx.fillRect(-p.size / 2, -p.size, p.size, p.size * 2);
+      ctx.restore();
+    } else {
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    alive.push(p);
+  }
+  ctx.globalAlpha = 1;
+  pool = alive;
+
+  raf = pool.length ? requestAnimationFrame(tick) : 0;
+  if (!raf) ctx.clearRect(0, 0, w, h);
+}

--- a/desktop/frontend/static/index.html
+++ b/desktop/frontend/static/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>human — workflow board</title>
+    <!-- Apply the persisted theme before first paint so a fancy user never sees a classic flash. -->
+    <script>try{if(localStorage.getItem("human.theme")==="fancy")document.documentElement.dataset.theme="fancy"}catch(e){}</script>
     <link rel="stylesheet" href="/style.css" />
   </head>
   <body>

--- a/desktop/frontend/static/index.html
+++ b/desktop/frontend/static/index.html
@@ -23,6 +23,14 @@
             <path d="M7.5 2.5C10.2614 2.5 12.5 4.73858 12.5 7.5V13.5C12.5 14.0523 12.0523 14.5 11.5 14.5H3.5C2.94772 14.5 2.5 14.0523 2.5 13.5V7.5C2.5 4.73858 4.73858 2.5 7.5 2.5ZM7.5 2.5V0M4 11.5H11M0.5 8V12M14.5 8V12M5.5 9.5C4.94772 9.5 4.5 9.05228 4.5 8.5C4.5 7.94772 4.94772 7.5 5.5 7.5C6.05228 7.5 6.5 7.94772 6.5 8.5C6.5 9.05228 6.05228 9.5 5.5 9.5ZM9.5 9.5C8.94772 9.5 8.5 9.05228 8.5 8.5C8.5 7.94772 8.94772 7.5 9.5 7.5C10.0523 7.5 10.5 7.94772 10.5 8.5C10.5 9.05228 10.0523 9.5 9.5 9.5Z" stroke="currentColor"/>
           </svg>
         </button>
+        <button class="rail-item" data-view="features" title="Features">
+          <svg class="rail-icon" width="22" height="22" viewBox="0 0 24 24" fill="none"
+               stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+               xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+            <path d="M14 2v6h6"/><path d="M9 13h6"/><path d="M9 17h6"/>
+          </svg>
+        </button>
         <button class="rail-item ghost rail-bottom" data-view="settings"
                 title="Settings — coming soon" disabled aria-disabled="true">
           <svg class="rail-icon" width="22" height="22" viewBox="0 0 24 24" fill="none"
@@ -39,6 +47,7 @@
         <div id="banner" class="banner hidden"></div>
         <main id="board" class="board" aria-label="Workflow pipeline board"></main>
         <section id="agents" class="agents-view hidden" aria-label="Running agents"></section>
+        <section id="features" class="features-view hidden" aria-label="Features"></section>
         <footer id="statusbar" class="statusbar" aria-label="Status bar">
           <span id="daemon-indicator" class="status-dot"></span>
           <span id="daemon-text" class="status-text">Daemon…</span>

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -688,6 +688,142 @@ body {
   font-size: 13px;
 }
 
+/* Features view — renders FEATURE.json. Shares the agents-view scroll container
+   and header; the group/row treatment reuses the card look via --card-* vars. */
+.features-view {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px 20px;
+}
+
+.features-view.hidden {
+  display: none;
+}
+
+.features-empty {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.features-intro {
+  margin-bottom: 18px;
+}
+
+.features-product {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.features-tagline {
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--muted);
+  max-width: 70ch;
+}
+
+.feature-group {
+  margin-bottom: 20px;
+}
+
+.feature-group-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 8px;
+}
+
+.feature-row {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  padding: 10px 14px;
+  margin-bottom: 8px;
+}
+
+.feature-name {
+  flex: 0 0 auto;
+  min-width: 180px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.feature-desc {
+  flex: 1;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+/* Features header carries the Generate/Refresh action button on the right. */
+.features-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+/* Primary action button, mirroring the ideation send button. */
+.features-btn {
+  background: var(--accent);
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.features-btn:hover {
+  opacity: 0.9;
+}
+
+.features-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* Transient status/error line under the header (launch failure, slow agent). */
+.features-note {
+  padding: 6px 14px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+/* Nested sub-groups (larger projects) indent under their parent so the tree
+   reads as a shallow hierarchy; the top level (depth 0) stays flush. */
+.feature-group .feature-group {
+  margin-left: 14px;
+  margin-top: 8px;
+  margin-bottom: 0;
+  padding-left: 12px;
+  border-left: 1px solid var(--card-border);
+}
+
+/* "recent" badge on features changed since the last release. */
+.feature-badge {
+  margin-left: 8px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  vertical-align: middle;
+}
+
 .agent-row {
   background: var(--card-bg);
   border: 1px solid var(--card-border);

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -962,3 +962,370 @@ body {
 .subagent-meta {
   color: var(--muted);
 }
+
+/* =========================================================================
+   FANCY THEME — the demo "wow" style, toggled with F8 (see src/fancy.ts).
+   Everything below is scoped to [data-theme="fancy"] (or to fx-* elements
+   that only fancy.ts creates), so the classic theme above stays untouched.
+   Each effect is one delimited block: delete a block to drop that effect.
+   Continuous animations live behind prefers-reduced-motion so the fancy
+   look degrades to a static (but still colorful) style.
+   ========================================================================= */
+
+/* [FANCY:palette] Per-stage pastel rainbow hue, inherited by everything inside
+   a column (drop zones, glows, card shadows) via var(--fancy-hue). */
+[data-theme="fancy"] .column[data-stage="backlog"] {
+  --fancy-hue: 330;
+}
+[data-theme="fancy"] .column[data-stage="planning"] {
+  --fancy-hue: 45;
+}
+[data-theme="fancy"] .column[data-stage="implementation"] {
+  --fancy-hue: 165;
+}
+[data-theme="fancy"] .column[data-stage="verification"] {
+  --fancy-hue: 210;
+}
+[data-theme="fancy"] .column[data-stage="done"] {
+  --fancy-hue: 280;
+}
+
+/* [FANCY:gradient-bg] Aurora gradient background. The static gradient always
+   applies; only the slow drift is motion-gated. */
+[data-theme="fancy"] body {
+  background: linear-gradient(130deg, #241a3d, #12294a, #3d1a3d, #123a3a, #241a3d);
+  background-size: 400% 400%;
+}
+@media (prefers-reduced-motion: no-preference) {
+  [data-theme="fancy"] body {
+    animation: fancy-bg 26s ease infinite;
+  }
+}
+@keyframes fancy-bg {
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+}
+
+/* [FANCY:glass] Frosted-glass chrome over the gradient. The translucent
+   backgrounds alone keep everything readable where WebKitGTK lacks
+   backdrop-filter; the blur is progressive enhancement. */
+[data-theme="fancy"] .column {
+  background: hsl(var(--fancy-hue, 220) 35% 16% / 0.62);
+  border-color: hsl(var(--fancy-hue, 220) 60% 65% / 0.35);
+  -webkit-backdrop-filter: blur(14px) saturate(1.3);
+  backdrop-filter: blur(14px) saturate(1.3);
+}
+[data-theme="fancy"] .rail,
+[data-theme="fancy"] .app-header,
+[data-theme="fancy"] .statusbar {
+  background: rgba(16, 14, 30, 0.55);
+  -webkit-backdrop-filter: blur(14px) saturate(1.3);
+  backdrop-filter: blur(14px) saturate(1.3);
+}
+[data-theme="fancy"] .column-header {
+  border-bottom-color: hsl(var(--fancy-hue, 220) 60% 70% / 0.3);
+}
+[data-theme="fancy"] .column-header > span:first-child {
+  color: hsl(var(--fancy-hue, 220) 80% 82%);
+}
+
+/* [FANCY:rainbow-drop] Pastel drop zones: accepting targets glow in their
+   column's hue instead of the classic flat green/red. */
+[data-theme="fancy"] .column-body.drop-ok,
+[data-theme="fancy"] .done-zone.drop-ok {
+  background: hsl(var(--fancy-hue, 220) 75% 80% / 0.32);
+}
+[data-theme="fancy"] .done-zone {
+  border-color: hsl(var(--fancy-hue, 220) 60% 70% / 0.5);
+}
+[data-theme="fancy"] .done-zone.drop-ok {
+  border-color: hsl(var(--fancy-hue, 220) 85% 75%);
+}
+
+/* [FANCY:breathe] Drop-zone breathing glow while a drag hovers a valid target. */
+@media (prefers-reduced-motion: no-preference) {
+  [data-theme="fancy"] .column-body.drop-ok,
+  [data-theme="fancy"] .done-zone.drop-ok {
+    animation: fancy-breathe 1.1s ease-in-out infinite;
+  }
+}
+@keyframes fancy-breathe {
+  0%,
+  100% {
+    box-shadow: inset 0 0 18px hsl(var(--fancy-hue, 220) 90% 75% / 0.25);
+  }
+  50% {
+    box-shadow: inset 0 0 34px hsl(var(--fancy-hue, 220) 90% 75% / 0.55);
+  }
+}
+
+/* [FANCY:cards] Stacked pastel depth shadows + hover lift. The transform
+   transition doubles as the squish-spring return. */
+[data-theme="fancy"] .card {
+  position: relative;
+  overflow: hidden;
+  background: hsl(var(--fancy-hue, 220) 30% 22% / 0.85);
+  border-color: hsl(var(--fancy-hue, 220) 60% 60% / 0.45);
+  box-shadow:
+    0 2px 6px rgba(0, 0, 0, 0.35),
+    0 6px 18px hsl(var(--fancy-hue, 220) 70% 30% / 0.35);
+  transition: transform 0.25s cubic-bezier(0.34, 1.8, 0.5, 1), box-shadow 0.25s ease;
+}
+[data-theme="fancy"] .card:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    0 4px 10px rgba(0, 0, 0, 0.4),
+    0 12px 28px hsl(var(--fancy-hue, 220) 70% 35% / 0.5);
+}
+
+/* [FANCY:squish] Press squish on cards, rail icons and buttons; the bouncy
+   cubic-bezier above (and on .rail-item) springs them back. */
+[data-theme="fancy"] .card:active {
+  transform: scale(0.96);
+}
+[data-theme="fancy"] .rail-item {
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    border-radius 0.15s ease,
+    transform 0.25s cubic-bezier(0.34, 1.8, 0.5, 1);
+}
+[data-theme="fancy"] .rail-item:active:not(:disabled) {
+  transform: scale(0.88);
+}
+[data-theme="fancy"] .modal-actions button:active,
+[data-theme="fancy"] .add-card:active {
+  transform: scale(0.92);
+}
+
+/* [FANCY:sheen] Holographic foil sweep following the pointer across a card
+   (fancy.ts feeds --mx/--my from the shared pointermove handler). */
+[data-theme="fancy"] .card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  background: radial-gradient(
+    140px circle at var(--mx, 50%) var(--my, 50%),
+    hsl(var(--fancy-hue, 220) 100% 85% / 0.22),
+    transparent 60%
+  );
+}
+[data-theme="fancy"] .card:hover::after {
+  opacity: 1;
+}
+
+/* [FANCY:tilt] Drag ghost leans into pointer velocity (fancy.ts sets --tilt);
+   the transition springs it upright when the pointer slows. */
+[data-theme="fancy"] .drag-ghost {
+  transform: translate(-50%, -50%) rotate(var(--tilt, 0deg));
+  transition: transform 0.15s ease-out;
+  border-color: hsl(var(--fancy-hue, 220) 80% 70%);
+  box-shadow: 0 10px 30px hsl(var(--fancy-hue, 220) 70% 30% / 0.6);
+}
+
+/* [FANCY:beam] A slow rainbow beam circles the hovered column. Implemented as
+   an animated border-box gradient so it needs no mask support. */
+@media (prefers-reduced-motion: no-preference) {
+  [data-theme="fancy"] .column:hover {
+    border-color: transparent;
+    background:
+      linear-gradient(hsl(var(--fancy-hue, 220) 35% 16% / 0.92), hsl(var(--fancy-hue, 220) 35% 16% / 0.92))
+        padding-box,
+      linear-gradient(
+          120deg,
+          hsl(330 90% 75%),
+          hsl(45 90% 75%),
+          hsl(165 90% 75%),
+          hsl(210 90% 75%),
+          hsl(280 90% 75%),
+          hsl(330 90% 75%)
+        )
+        border-box;
+    background-size: 100% 100%, 300% 300%;
+    animation: fancy-beam 4s linear infinite;
+  }
+}
+@keyframes fancy-beam {
+  0% {
+    background-position: 0 0, 0% 0%;
+  }
+  50% {
+    background-position: 0 0, 100% 100%;
+  }
+  100% {
+    background-position: 0 0, 0% 0%;
+  }
+}
+
+/* [FANCY:rail-glow] Active rail icon gets a soft pastel halo. */
+[data-theme="fancy"] .rail-item.active {
+  box-shadow: 0 0 18px hsl(265 85% 70% / 0.7);
+  background: linear-gradient(135deg, hsl(265 80% 62%), hsl(210 85% 60%));
+}
+[data-theme="fancy"] .rail-item:hover:not(:disabled) {
+  background: linear-gradient(135deg, hsl(265 80% 62%), hsl(210 85% 60%));
+}
+
+/* [FANCY:eq] Daemon status dot becomes a tiny pastel equalizer while the
+   daemon is reachable. Bars are the dot's pseudo-elements. */
+[data-theme="fancy"] .status-dot.reachable {
+  background: hsl(150 80% 65%);
+  position: relative;
+}
+@media (prefers-reduced-motion: no-preference) {
+  [data-theme="fancy"] .status-dot.reachable {
+    border-radius: 2px;
+    width: 4px;
+    height: 10px;
+    animation: fancy-eq 0.9s ease-in-out infinite;
+  }
+  [data-theme="fancy"] .status-dot.reachable::before,
+  [data-theme="fancy"] .status-dot.reachable::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    width: 4px;
+    border-radius: 2px;
+  }
+  [data-theme="fancy"] .status-dot.reachable::before {
+    left: -6px;
+    height: 7px;
+    background: hsl(280 80% 72%);
+    animation: fancy-eq 0.9s ease-in-out infinite 0.2s;
+  }
+  [data-theme="fancy"] .status-dot.reachable::after {
+    left: 6px;
+    height: 5px;
+    background: hsl(45 90% 70%);
+    animation: fancy-eq 0.9s ease-in-out infinite 0.4s;
+  }
+}
+@keyframes fancy-eq {
+  0%,
+  100% {
+    transform: scaleY(0.5);
+  }
+  50% {
+    transform: scaleY(1);
+  }
+}
+
+/* [FANCY:canvas] Shared particle canvas (fireworks, confetti, comet trail,
+   dust motes). pointer-events:none keeps drag hit-testing intact; it sits
+   above the modal because celebrations are transient and non-interactive. */
+.fx-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+  z-index: 9999;
+}
+
+/* [FANCY:spotlight] Soft cursor-following light over the board. */
+.fx-spotlight {
+  position: fixed;
+  left: -300px;
+  top: -300px;
+  width: 600px;
+  height: 600px;
+  pointer-events: none;
+  z-index: 5;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.06), transparent 60%);
+  transition: opacity 0.3s ease;
+}
+
+/* [FANCY:ripple] Shockwave ring expanding from the drop point. */
+.fx-ripple {
+  position: fixed;
+  width: 12px;
+  height: 12px;
+  margin: -6px 0 0 -6px;
+  pointer-events: none;
+  z-index: 9998;
+  border-radius: 50%;
+  border: 2px solid hsl(200 100% 80% / 0.9);
+  animation: fancy-ripple 0.6s ease-out forwards;
+}
+@keyframes fancy-ripple {
+  to {
+    transform: scale(14);
+    opacity: 0;
+  }
+}
+
+/* [FANCY:gold] Golden crown glow on the card that just landed in Done. */
+[data-theme="fancy"] .card.fx-gold {
+  border-color: hsl(48 95% 65%);
+  box-shadow:
+    0 0 22px hsl(48 95% 60% / 0.8),
+    0 6px 18px hsl(var(--fancy-hue, 220) 70% 30% / 0.35);
+}
+
+/* [FANCY:toast] Streak combo toast ("3×!") floating up from the bottom. */
+.fx-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 18%;
+  pointer-events: none;
+  z-index: 9998;
+  font-size: 44px;
+  font-weight: 800;
+  background: linear-gradient(90deg, hsl(330 90% 75%), hsl(45 90% 70%), hsl(165 85% 70%), hsl(210 90% 75%));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: fancy-toast 1.4s ease-out forwards;
+}
+@keyframes fancy-toast {
+  0% {
+    transform: translate(-50%, 20px) scale(0.6);
+    opacity: 0;
+  }
+  20% {
+    transform: translate(-50%, 0) scale(1.15);
+    opacity: 1;
+  }
+  35% {
+    transform: translate(-50%, 0) scale(1);
+  }
+  100% {
+    transform: translate(-50%, -60px) scale(1);
+    opacity: 0;
+  }
+}
+
+/* [FANCY:sweep] One-time aurora wave when a column is emptied. */
+.fx-sweep {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9997;
+  background: linear-gradient(
+    100deg,
+    transparent 20%,
+    hsl(280 90% 75% / 0.18) 40%,
+    hsl(180 90% 75% / 0.22) 50%,
+    hsl(45 90% 75% / 0.18) 60%,
+    transparent 80%
+  );
+  background-size: 300% 100%;
+  animation: fancy-sweep 1.2s ease-in-out forwards;
+}
+@keyframes fancy-sweep {
+  from {
+    background-position: 120% 0;
+  }
+  to {
+    background-position: -20% 0;
+  }
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -289,24 +289,32 @@ func (m *Manager) BuildClaudeArgs(opts StartOpts) []string {
 // ensureDaemonForContainers makes sure the daemon is running and accessible
 // from Docker containers (listening on 0.0.0.0, not just 127.0.0.1).
 func (m *Manager) ensureDaemonForContainers(projectDir string) *daemon.DaemonInfo {
+	// The host containers can reach the daemon on, without exposing it to the
+	// LAN (never 0.0.0.0): the docker bridge gateway on native Linux Docker,
+	// loopback on Docker Desktop (host.docker.internal forwards to loopback).
+	want := devcontainer.ContainerReachableHost()
+
 	info, err := daemon.ReadInfo()
 	if err == nil && info.IsReachable() {
-		// Daemon is running. Check if it's on localhost only.
 		host, _, _ := strings.Cut(info.Addr, ":")
-		if host == "127.0.0.1" || host == "localhost" {
-			// Restart on 0.0.0.0 so containers can reach it.
-			_, _ = fmt.Fprintln(os.Stderr, "Restarting daemon on 0.0.0.0 for container access...")
-			m.restartDaemon(projectDir, "0.0.0.0")
-			if newInfo, readErr := daemon.ReadInfo(); readErr == nil {
-				return &newInfo
-			}
+		if host == want {
+			// Already container-reachable — no restart. On Docker Desktop the
+			// daemon starts on loopback and stays there, so this is a no-op.
+			return &info
+		}
+		// Bound to a different interface (e.g. loopback while Docker started
+		// after the daemon on Linux) — rebind so containers can reach it.
+		_, _ = fmt.Fprintf(os.Stderr, "Restarting daemon on %s for container access...\n", want)
+		m.restartDaemon(projectDir, want)
+		if newInfo, readErr := daemon.ReadInfo(); readErr == nil {
+			return &newInfo
 		}
 		return &info
 	}
 
-	// Daemon not running. Start it on 0.0.0.0.
-	_, _ = fmt.Fprintln(os.Stderr, "Starting daemon for container access...")
-	m.restartDaemon(projectDir, "0.0.0.0")
+	// Daemon not running. Start it on the container-reachable host.
+	_, _ = fmt.Fprintf(os.Stderr, "Starting daemon for container access on %s...\n", want)
+	m.restartDaemon(projectDir, want)
 	if newInfo, readErr := daemon.ReadInfo(); readErr == nil {
 		return &newInfo
 	}

--- a/internal/claude/embed/features-recon-agent.md
+++ b/internal/claude/embed/features-recon-agent.md
@@ -1,0 +1,91 @@
+---
+name: features-recon
+description: Surveys a repository for its product positioning and a code-grounded capability inventory, flagging user-facing capabilities vs internal plumbing
+tools: Bash, Read, Grep, Glob
+model: inherit
+---
+
+# Features Recon Agent
+
+You survey a repository and produce two things for the synthesis agent: the product's **positioning**
+(so it can group by value, not by code) and a code-grounded **capability inventory** with each item
+flagged user-facing or internal. Gather facts thoroughly; do not group or editorialize — synthesis
+does the product framing.
+
+## Process
+
+1. **Capture the product positioning.** Read `README.md` (especially the top/hero section), the
+   website or landing copy if present, `CLAUDE.md`, and any `docs/`. Extract, in the product's own
+   words: the `product` name, a one-sentence `tagline`, **who the target users are**, and the **value
+   propositions / jobs-to-be-done** the product markets itself on. This positioning is what lets
+   synthesis organize by value pillars rather than subsystems — capture the marketing framing, not
+   just "it's a CLI tool."
+
+2. **Map the capability inventory** — A *capability* is something the product does; find them the way
+   that fits the project:
+   - **Per-module capability lists** — Many projects document capabilities in per-package/module
+     `README.md` files. Glob for them (`**/README.md`) and read their bullet lists; each bullet is
+     usually one capability. This is the richest source when present.
+   - **CLI commands** — command/subcommand registrations (cobra `AddCommand`, click, argparse, …).
+   - **Web/API** — route and handler definitions.
+   - **Library** — exported/public interfaces and functions.
+   - **UI** — routes, pages, views, panes.
+   Use Glob and Grep; confirm against code. For each capability capture: a short **name**, a terse
+   **one-line description**, its **representative file paths** (synthesis needs these to map commits
+   and tickets), and a **user-facing vs. plumbing** flag — mark it *plumbing* when it is an internal
+   enabler a customer/PM would never discuss (CLI flag parsing, banners, platform/OS detection,
+   config parsing, git detection, per-request settings, update checks, OAuth callbacks, internal
+   networking, logging). Synthesis will cut the plumbing; your job is to flag it, not drop it.
+
+3. **Gauge size** — Count the distinct functional areas (e.g. top-level feature packages/modules)
+   and the total feature count. The synthesis agent uses this to decide nesting depth.
+
+4. **Determine the recency boundary** — This marks which features count as "recently changed":
+   - If the prompt carries a recency override, record it verbatim (a tag, a date, or a duration).
+   - Otherwise find the latest release tag: `git describe --tags --abbrev=0` (or
+     `git tag --sort=-creatordate | head -1`). If a tag exists, the boundary is
+     `git log <tag>..HEAD` — commits after the last release.
+   - If there are no tags, fall back to the last 30 days (`--since='30 days ago'`).
+   Record the resolved boundary (the ref or date) explicitly so synthesis can reuse it.
+
+5. **Collect recent git history** — Run `git log --oneline -50` to show recent development
+   direction, and note commit-message ticket-reference conventions you observe (e.g. `[SC-148]`,
+   `[HUM-153]`, `Issue #42`).
+
+6. **Write the inventory** to `.human/features/.features-inventory.md`:
+
+```markdown
+# Features Inventory
+
+## Product positioning
+- **Product**: <candidate product name>
+- **Tagline**: <one-sentence pitch>
+- **Target users**: <who it is for>
+- **Value propositions / jobs-to-be-done**: <the value themes the product markets, in its own words>
+
+## Size
+- Functional areas: <N>
+- Total capabilities: <N> (user-facing: <N>, plumbing: <N>)
+
+## Recency boundary
+- <e.g. "since tag v0.19.0 (git log v0.19.0..HEAD)" or "last 30 days (no tags)">
+
+## Capability inventory
+| Capability | One-line description | Paths | Kind |
+|---|---|---|---|
+| <name> | <what it does> | <dir/or/files> | user-facing / plumbing |
+
+## Recent git history
+<git log --oneline -50 output>
+
+## Ticket-reference convention
+<observed formats, e.g. [SC-###] PM (Shortcut), [HUM-###] engineering (Linear)>
+```
+
+## Principles
+
+- Be thorough but fast. Gather facts; do not group, rank, or invent — synthesis does the thinking.
+- Ground every feature in code you actually found. Do not list capabilities the code does not have.
+- Capture accurate **paths** per feature — the whole ticket/recency mapping depends on them.
+- If git or tracker commands fail, note it and continue; never retry endlessly.
+- Do NOT use `AskUserQuestion` — return structured output only.

--- a/internal/claude/embed/features-synthesis-agent.md
+++ b/internal/claude/embed/features-synthesis-agent.md
@@ -1,0 +1,178 @@
+---
+name: features-synthesis
+description: Translates the feature inventory into FEATURE.json — a product capability map grouped by value pillars, with per-feature tickets and recent-change markers
+tools: Bash, Read, Grep, Glob, Write
+model: inherit
+---
+
+# Features Synthesis Agent
+
+You turn the raw feature inventory into `FEATURE.json` — a **capability map** that the product's own
+audience could put on a slide and discuss in a meeting. It is NOT an inventory of the code: translate
+what the engineers built into what the product *does for the people who use it*.
+
+**Frame it for the actual audience — not always a consumer.** First decide who uses this product,
+then write for them:
+- **End users / business buyers** (a SaaS app, a consumer product) → product/marketing framing;
+  pillars are benefits; the litmus test is "could this appear on a pricing page or roadmap?"
+- **Developers who integrate it** (a library, SDK, API, or backend service) → engineer-facing
+  framing; pillars are the jobs a consuming developer does (e.g. "Ingestion API", "Auth &
+  tenancy", "Webhooks & events", "Client SDKs"); the litmus test is "would this appear in the API
+  reference, integration guide, or changelog?"
+- **Operators who run it** (infra, a platform, a daemon) → operational framing; pillars are what an
+  operator relies on (e.g. "Deployment & scaling", "Observability", "Security & compliance").
+
+In every case the goal is the same: **capabilities at the right altitude, grouped by the value they
+deliver to that audience — never the raw code/package tree.** Engineer-facing is fine and often
+correct; "mirrors the source layout" never is. If a line reads like an internal subsystem or an
+implementation detail its audience does not care about, it does not belong.
+
+## Inputs
+
+- The inventory at `.human/features/.features-inventory.md` — capabilities, their paths, which are
+  user-facing vs. internal plumbing, the product positioning, and the recency boundary.
+- The **existing `FEATURE.json`** at the repository root, if one exists — read it first (see Stability).
+- The prompt names the PM and engineering trackers (or `none`) and any recency override.
+
+## Available commands
+
+```bash
+# Best-effort ticket title enrichment (skip silently on failure)
+human get <TICKET_KEY>
+```
+
+## Process
+
+1. **Identify the audience, then the product.** From the inventory's positioning (product name,
+   tagline, README hero copy, target users, docs), decide **who uses this product** — end users,
+   business buyers, developers integrating it, operators running it — and what jobs they do with it.
+   The audience sets the language and altitude for everything below. Read the existing `FEATURE.json`
+   if present as your baseline (see Stability).
+
+2. **Infer 3–5 value pillars — these are your top-level groups.** A pillar is a big
+   job-to-be-done in the *audience's* language, not a subsystem. Derive them from the positioning.
+   Good pillars answer "what does this let me do?" — benefit-framed for consumers ("Works with your
+   stack", "Safe, governed autonomy") or capability-framed for developers/operators ("Ingestion
+   API", "Auth & tenancy", "Observability"). Bad pillars name code areas ("Infrastructure",
+   "Foundations", "Messaging & Agents") regardless of audience.
+
+3. **Cut what this audience doesn't care about.** Drop internal enablers that the product's actual
+   users would never discuss. What counts as plumbing is **audience-relative**: startup banners,
+   platform/OS detection, git-repo detection, per-request settings, update checks, internal logging
+   are plumbing for almost everyone; but config, protocols, auth, and connection handling can be
+   *first-class capabilities* for a library, API, or infra product and must be kept there. Use the
+   inventory's flags as a starting point, then judge against the audience. Keep infrastructure when
+   it is a value the audience relies on (sandboxing, governance, audit, secrets, scaling) — under a
+   trust/operations pillar, not a "Foundations" bucket.
+
+4. **Consolidate to the right altitude.** Collapse many like implementations into ONE capability.
+   Seven issue-tracker backends are not seven features — they are one "Issue tracker integration"
+   whose description names them (Jira, Linear, GitHub, …). Likewise fold docs/design/analytics
+   connectors and chat channels each into a single capability. Prefer one capability with a named
+   list over N sibling line items. When you merge items, union their paths for the ticket/recency
+   steps below.
+
+5. **Build a 3-level product hierarchy.** Use nested `groups`: **pillar** (top group) › **capability
+   area** (sub-group) › **feature** (leaf). Depth follows the product story, not code size. A rich
+   product should read as a shallow tree of 3 levels; only a genuinely small product stays at 2.
+   This replaces any size-based splitting — nest by narrative, not by item count.
+
+6. **Write in the audience's value language.** Each `description` states the *outcome* for the user,
+   at the altitude that audience thinks in — not the mechanism. For consumers that means benefits
+   ("Keep agents from reaching unapproved hosts"); for developers it means precise capability terms
+   they'd recognize ("Idempotent webhook delivery with signed payloads") — which is their benefit.
+   Either way, avoid restating the implementation ("Filter outbound traffic by domain").
+
+7. **Map tickets to each feature.** For each leaf feature, inspect the commits that touched its
+   paths (for a consolidated capability, union all merged paths):
+
+   ```bash
+   git log --format=%s -- <path> [<path> ...]
+   ```
+
+   Extract ticket keys from those commit subjects with these patterns (dedupe, keep PM keys first):
+   - Bracketed / bare project keys: `[SC-148]`, `SC-148`, `HUM-153`, `Issue HUM-30` → regex
+     `\[?([A-Z]{2,}-[0-9]+)\]?`
+   - GitHub-style numeric refs: `#42` → `#([0-9]+)`
+
+   Then **prune to what is meaningful** — a long ticket dump obscures rather than informs:
+   - **Drop repo-wide sweep tickets.** A key that touches a large share of features is a mechanical
+     change (mass rename, format, dependency bump), not a feature's origin. Compute how many
+     features each key touches across the whole inventory and **drop any key that appears on more
+     than ~40% of features** (e.g. a `gofmt`/import-cleanup commit that hit every package). These
+     tell the reader nothing about the feature.
+   - **Cap each feature at its ~5 most relevant tickets.** Prefer the tickets that most specifically
+     shaped the feature: most recent first, PM keys ahead of engineering keys. It is fine for a
+     large feature to show 5 tickets rather than 30.
+
+   Set the feature's `tickets` to the pruned, capped list. Omit `tickets` entirely when there are
+   none. Optionally confirm a key exists via `human get <KEY>` (best-effort; never block on it).
+
+8. **Mark recent features.** Using the recency boundary from the inventory, a feature is `recent`
+   when any commit touching its paths is at/after the boundary:
+
+   ```bash
+   # tag boundary
+   git log --oneline <TAG>..HEAD -- <path> [<path> ...]
+   # or date boundary
+   git log --oneline --since='30 days ago' -- <path> [<path> ...]
+   ```
+
+   Set `"recent": true` on those features; omit `recent` otherwise (never write `false`).
+
+9. **Write `FEATURE.json`** at the repository root. A group has a `group` title and may carry
+   `features` and/or nested `groups`; the example shows the pillar › area › feature shape:
+
+   ```json
+   {
+     "product": "<name>",
+     "tagline": "<one-sentence pitch>",
+     "generated": "<YYYY-MM-DD, today>",
+     "groups": [
+       {
+         "group": "Works with your stack",
+         "groups": [
+           {
+             "group": "Issue trackers",
+             "features": [
+               { "name": "Issue tracker sync", "description": "Two-way sync with Jira, Linear, GitHub, GitLab, Shortcut, Azure DevOps, ClickUp", "tickets": ["SC-102"] }
+             ]
+           }
+         ]
+       }
+     ]
+   }
+   ```
+
+   - `recent`, `tickets`, and nested `groups` are optional — omit them when empty rather than
+     writing empty/false values.
+   - Descriptions are terse, benefit-oriented one-liners.
+
+10. **Validate and clean up.** Confirm the file parses: `jq empty FEATURE.json`. Then remove the
+    scratch directory: `rm -rf .human/features`.
+
+## Stability (change only what changed)
+
+The pillars, group titles, and wording are a product artifact people reuse in meetings, so they must
+be **stable across runs** — a reader's diff should reflect real capability changes, not re-phrasings.
+
+- **No baseline (fresh start):** build the product taxonomy — pillars, areas, benefit wording — from
+  scratch. This is the one time you set the structure; get it right.
+- **With a baseline:** treat the existing `FEATURE.json` as the default. Preserve pillar/group titles
+  and feature `name`s/`description`s verbatim when the underlying capability is unchanged. **Add** new
+  capabilities, **remove** retired ones, and **reword** only when the capability itself changed — do
+  not re-pillar or reword for style.
+- Only `recent` and `tickets` are expected to shift run-to-run (new commits/tickets) — that is fine.
+
+## Principles
+
+- You are writing for the product's actual audience — which may be consumers, business buyers,
+  integrating developers, or operators. Match their language and altitude. Pillars, names, and
+  descriptions describe user value, never subsystem names or mechanisms — but "value" for a developer
+  audience is legitimately technical.
+- Fewer, higher-altitude capabilities beat a long flat inventory. Consolidate and cut what the
+  audience won't care about.
+- Ground every feature and its tickets in the inventory's paths and real git history — product
+  framing on top, but never invent a capability the code does not have.
+- Do NOT use `AskUserQuestion` — return structured output only. Report a one-line summary
+  (pillars, capabilities, nesting depth, recent count) as your final message.

--- a/internal/claude/embed/human-features-skill.md
+++ b/internal/claude/embed/human-features-skill.md
@@ -1,0 +1,53 @@
+---
+name: human-features
+description: Generate FEATURE.json — a grouped, human-readable map of what this codebase can do — from the code, git history, and tickets
+argument-hint: [since]
+---
+
+# Feature Map Generation
+
+Build `FEATURE.json` at the repository root: a grouped, user-facing catalogue of what this
+codebase does, so a reader understands its capabilities at a glance. Two agents do the work —
+a recon pass that inventories features from the code, and a synthesis pass that groups them,
+maps tickets, marks recent changes, and writes the file.
+
+The optional `$ARGUMENTS` is a **recency override** (e.g. `v0.19.0`, `2026-06-01`, or `30 days`).
+When omitted, "recent" means *changed since the latest release tag* (fallback: last 30 days).
+
+## Phase 0: Resolve trackers
+
+Run `human tracker list` to see configured trackers. Note the tracker with `"role": "pm"`
+(product tickets, e.g. Shortcut) and the one with `"role": "engineering"` (e.g. Linear) — the
+synthesis agent uses them to enrich ticket references. If the command fails or no trackers are
+configured, continue anyway: ticket mapping falls back to keys parsed from commit messages.
+
+## Phase 1: Reconnaissance
+
+Create the scratch directory, then run the recon agent:
+
+```bash
+mkdir -p .human/features
+```
+
+```
+Task(subagent_type="features-recon", prompt="Survey this repository and build a feature inventory grounded in the code. Recency override (if any): $ARGUMENTS. Write your inventory to .human/features/.features-inventory.md")
+```
+
+Wait for the recon agent to finish before proceeding.
+
+## Phase 2: Synthesis
+
+Run the synthesis agent to group the inventory, map tickets, mark recent features, and write the
+file. Pass along the tracker roles resolved in Phase 0 so it can enrich ticket titles.
+
+```
+Task(subagent_type="features-synthesis", prompt="Read the inventory at .human/features/.features-inventory.md and the existing FEATURE.json (if present). Produce a capability map framed for the product's actual audience — decide from the positioning whether that is consumers, integrating developers, or operators, and match their language. Infer 3–5 value pillars, organize capabilities as pillar › area › feature (aim for 3 levels), cut internal plumbing that audience wouldn't discuss, consolidate granular integrations into single capabilities, and use the audience's value language. Attach the tickets that created or changed each feature, mark recently changed ones, and write FEATURE.json to the repository root. PM tracker: <pm-tracker-or-none>. Engineering tracker: <eng-tracker-or-none>. Recency override (if any): $ARGUMENTS")
+```
+
+## After completion
+
+Tell the user:
+- The path (`FEATURE.json`), how many groups and features it holds, and the nesting depth used.
+- How many features are marked recent (changed since the recency boundary).
+- If this is the `human` repo (or any project with the desktop board), remind them to rebuild the
+  desktop frontend so the Features pane picks up the change: `cd desktop/frontend && npm run build`.

--- a/internal/claude/install.go
+++ b/internal/claude/install.go
@@ -160,6 +160,15 @@ var bugVerifyAgentContent []byte
 //go:embed embed/codenav-skill.md
 var codenavSkillContent []byte
 
+//go:embed embed/human-features-skill.md
+var featuresSkillContent []byte
+
+//go:embed embed/features-recon-agent.md
+var featuresReconAgentContent []byte
+
+//go:embed embed/features-synthesis-agent.md
+var featuresSynthesisAgentContent []byte
+
 var userHomeDir = os.UserHomeDir
 
 // FileWriter abstracts filesystem operations for testability.
@@ -252,6 +261,9 @@ func Install(w io.Writer, fw FileWriter, personal bool) error {
 		{content: bugFixerAgentContent, relPath: filepath.Join("agents", "human-bug-fixer.md")},
 		{content: bugVerifyAgentContent, relPath: filepath.Join("agents", "human-bug-verify.md")},
 		{content: codenavSkillContent, relPath: filepath.Join("skills", "codenav", "SKILL.md")},
+		{content: featuresSkillContent, relPath: filepath.Join("skills", "human-features", "SKILL.md")},
+		{content: featuresReconAgentContent, relPath: filepath.Join("agents", "features-recon.md")},
+		{content: featuresSynthesisAgentContent, relPath: filepath.Join("agents", "features-synthesis.md")},
 	}
 
 	for _, f := range files {

--- a/internal/claude/install_test.go
+++ b/internal/claude/install_test.go
@@ -117,6 +117,9 @@ func TestInstall_CreatesNewFiles(t *testing.T) {
 	bugTriageAgentPath := filepath.Join(".claude", "agents", "human-bug-triage.md")
 	bugFixerAgentPath := filepath.Join(".claude", "agents", "human-bug-fixer.md")
 	bugVerifyAgentPath := filepath.Join(".claude", "agents", "human-bug-verify.md")
+	featuresSkillPath := filepath.Join(".claude", "skills", "human-features", "SKILL.md")
+	featuresReconAgentPath := filepath.Join(".claude", "agents", "features-recon.md")
+	featuresSynthesisAgentPath := filepath.Join(".claude", "agents", "features-synthesis.md")
 
 	assert.Equal(t, string(skillContent), string(fw.files[skillPath]))
 	assert.Equal(t, string(agentContent), string(fw.files[agentPath]))
@@ -167,6 +170,9 @@ func TestInstall_CreatesNewFiles(t *testing.T) {
 	assert.Equal(t, string(bugTriageAgentContent), string(fw.files[bugTriageAgentPath]))
 	assert.Equal(t, string(bugFixerAgentContent), string(fw.files[bugFixerAgentPath]))
 	assert.Equal(t, string(bugVerifyAgentContent), string(fw.files[bugVerifyAgentPath]))
+	assert.Equal(t, string(featuresSkillContent), string(fw.files[featuresSkillPath]))
+	assert.Equal(t, string(featuresReconAgentContent), string(fw.files[featuresReconAgentPath]))
+	assert.Equal(t, string(featuresSynthesisAgentContent), string(fw.files[featuresSynthesisAgentPath]))
 }
 
 func TestInstall_OverwritesIdenticalFiles(t *testing.T) {
@@ -218,6 +224,7 @@ func TestInstall_CreatesParentDirectories(t *testing.T) {
 	sprintSkillDir := filepath.Join(".claude", "skills", "human-sprint")
 	gardeningSkillDir := filepath.Join(".claude", "skills", "human-gardening")
 	autofixSkillDir := filepath.Join(".claude", "skills", "human-autofix")
+	featuresSkillDir := filepath.Join(".claude", "skills", "human-features")
 	agentDir := filepath.Join(".claude", "agents")
 	assert.True(t, fw.dirs[skillDir], "expected plan skill parent directory to be created")
 	assert.True(t, fw.dirs[readySkillDir], "expected ready skill parent directory to be created")
@@ -231,6 +238,7 @@ func TestInstall_CreatesParentDirectories(t *testing.T) {
 	assert.True(t, fw.dirs[sprintSkillDir], "expected sprint skill parent directory to be created")
 	assert.True(t, fw.dirs[gardeningSkillDir], "expected gardening skill parent directory to be created")
 	assert.True(t, fw.dirs[autofixSkillDir], "expected autofix skill parent directory to be created")
+	assert.True(t, fw.dirs[featuresSkillDir], "expected features skill parent directory to be created")
 	assert.True(t, fw.dirs[agentDir], "expected agent parent directory to be created")
 }
 

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -273,6 +273,15 @@ func BoardTransition(addr, token string, req BoardTransitionRequest) error {
 	return err
 }
 
+// GenerateFeatures asks the daemon to launch the human-features skill, which
+// regenerates FEATURE.json for the registered project. It takes no arguments —
+// the daemon resolves the project directory itself — and returns once the agent
+// is launched, not when generation finishes.
+func GenerateFeatures(addr, token string) error {
+	_, err := RunRemoteCapture(addr, token, []string{"features-generate"})
+	return err
+}
+
 // CloseTicket asks the daemon to close a PM ticket (transition it to Done). The
 // request is a single JSON arg, matching BoardTransition. This is a dedicated
 // route, so it never hits the interactive `issue status` confirmation.

--- a/internal/daemon/features_route_test.go
+++ b/internal/daemon/features_route_test.go
@@ -1,0 +1,82 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func startFeaturesServer(t *testing.T, token string, generator func() error) string {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	srv := &Server{
+		Addr:              "127.0.0.1:0",
+		Token:             token,
+		CmdFactory:        echoCmd,
+		Logger:            zerolog.Nop(),
+		FeaturesGenerator: generator,
+	}
+	ln, err := net.Listen("tcp", srv.Addr)
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	_ = ln.Close()
+	srv.Addr = addr
+	go func() { _ = srv.ListenAndServe(ctx) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if derr == nil {
+			_ = conn.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Cleanup(cancel)
+	return addr
+}
+
+func TestHandleFeaturesGenerateNilGenerator(t *testing.T) {
+	token := "tok"
+	addr := startFeaturesServer(t, token, nil)
+	resp := sendRequest(t, addr, Request{Token: token, Args: []string{"features-generate"}})
+	assert.Equal(t, 1, resp.ExitCode)
+	assert.Contains(t, resp.Stderr, "feature generation not available")
+}
+
+func TestHandleFeaturesGenerateValid(t *testing.T) {
+	token := "tok"
+	called := false
+	addr := startFeaturesServer(t, token, func() error {
+		called = true
+		return nil
+	})
+	resp := sendRequest(t, addr, Request{Token: token, Args: []string{"features-generate"}})
+	assert.Equal(t, 0, resp.ExitCode)
+	assert.Equal(t, "ok\n", resp.Stdout)
+	assert.True(t, called, "generator should have been invoked")
+}
+
+func TestHandleFeaturesGenerateError(t *testing.T) {
+	token := "tok"
+	addr := startFeaturesServer(t, token, func() error {
+		return errors.New("launch failed: docker down")
+	})
+	resp := sendRequest(t, addr, Request{Token: token, Args: []string{"features-generate"}})
+	assert.Equal(t, 1, resp.ExitCode)
+	assert.Contains(t, resp.Stderr, "launch failed: docker down")
+}
+
+// The features-generate route must NOT trip the interactive destructive-confirm
+// gate; the pane's Generate/Refresh button press is the user's consent, matching
+// board-transition.
+func TestDetectDestructiveBypassesFeaturesGenerate(t *testing.T) {
+	_, ok := detectDestructive([]string{"features-generate"})
+	assert.False(t, ok)
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -65,6 +65,10 @@ type Server struct {
 	// CloseTicketer closes a PM ticket (transitions it to Done) for the
 	// board's Close-Ticket drop zone. nil disables the close-ticket route.
 	CloseTicketer func(req CloseTicketRequest) error
+	// FeaturesGenerator launches the human-features skill (regenerating
+	// FEATURE.json) for the registered project. nil disables the
+	// features-generate route.
+	FeaturesGenerator func() error
 	// Ideation owns the board's single agent-driven ideation session. nil
 	// disables the ideation-start/reply/status routes.
 	Ideation *IdeationEngine
@@ -371,6 +375,8 @@ func (s *Server) routeIdeationCommand(conn net.Conn, args []string) bool {
 		s.handleIdeationReply(conn, args[1:])
 	case "ideation-status":
 		s.handleIdeationStatus(conn)
+	case "features-generate":
+		s.handleFeaturesGenerate(conn)
 	default:
 		return false
 	}
@@ -507,6 +513,24 @@ func (s *Server) handleBoardTransition(conn net.Conn, args []string) {
 		return
 	}
 	if err := s.BoardTransitioner(req); err != nil {
+		s.writeError(conn, err.Error(), 1)
+		return
+	}
+	resp := Response{Stdout: "ok\n"}
+	enc := json.NewEncoder(conn)
+	_ = enc.Encode(resp)
+}
+
+// handleFeaturesGenerate launches the human-features skill via the injected
+// FeaturesGenerator. Like board-transition it is a dedicated route (the button
+// press is the user's consent), and it takes no argument — the daemon resolves
+// the project directory itself. It returns as soon as the agent is launched.
+func (s *Server) handleFeaturesGenerate(conn net.Conn) {
+	if s.FeaturesGenerator == nil {
+		s.writeError(conn, "feature generation not available", 1)
+		return
+	}
+	if err := s.FeaturesGenerator(); err != nil {
 		s.writeError(conn, err.Error(), 1)
 		return
 	}

--- a/internal/devcontainer/docker_engine.go
+++ b/internal/devcontainer/docker_engine.go
@@ -12,8 +12,6 @@ import (
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
-
-	"github.com/gethuman-sh/human/internal/dockerhost"
 )
 
 // NewDockerClient creates a DockerClient backed by the Docker Engine API.
@@ -24,14 +22,9 @@ import (
 // DOCKER_HOST / DOCKER_CONTEXT always win. The resolution is shared with
 // claude.NewEngineDockerClient via internal/dockerhost so the two never diverge.
 func NewDockerClient() (DockerClient, error) {
-	opts := []client.Opt{client.FromEnv, client.WithAPIVersionNegotiation()}
-	// A non-empty host means the active context resolved to a concrete
-	// endpoint; layer it on top of FromEnv. Empty means "use env/platform
-	// default", so we leave FromEnv to do its job.
-	if host := dockerhost.Resolve().Host; host != "" {
-		opts = append(opts, client.WithHost(host))
-	}
-	cli, err := client.NewClientWithOpts(opts...)
+	// newRawDockerClient (host.go) applies the shared dockerhost.Resolve()
+	// endpoint resolution; explicit DOCKER_HOST / DOCKER_CONTEXT still win.
+	cli, err := newRawDockerClient()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/devcontainer/host.go
+++ b/internal/devcontainer/host.go
@@ -1,0 +1,81 @@
+package devcontainer
+
+import (
+	"context"
+	"runtime"
+	"time"
+
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
+
+	"github.com/gethuman-sh/human/internal/dockerhost"
+)
+
+// LoopbackHost is the loopback address the daemon binds when containers reach it
+// via loopback (Docker Desktop forwards host.docker.internal to the host
+// loopback) or when Docker is unavailable.
+const LoopbackHost = "127.0.0.1"
+
+// ContainerReachableHost returns the host address the human daemon should listen
+// on so that agents running inside Docker containers can reach it — WITHOUT
+// binding 0.0.0.0, which would expose the credential-holding daemon to the LAN.
+//
+//   - Docker Desktop (macOS/Windows): loopback. The Desktop VM forwards
+//     host.docker.internal to the host loopback, so 127.0.0.1 is reachable from
+//     containers and never needs widening.
+//   - Linux native Docker: the docker bridge gateway (e.g. 172.17.0.1).
+//     host.docker.internal:host-gateway resolves to it, and it is a host-only
+//     interface, not LAN-routable. Falls back to loopback when the gateway
+//     can't be determined.
+//   - Docker unavailable: loopback (no container will run until Docker is up).
+//
+// Note the trade-off on Linux: the bridge gateway lives on docker0, so if the
+// Docker daemon stops, that interface disappears and the daemon must be
+// restarted to rebind. That is acceptable for a container-first workflow.
+func ContainerReachableHost() string {
+	// Only native Linux Docker exposes a host-side bridge whose gateway the
+	// daemon must bind; on Docker Desktop the loopback is already reachable.
+	if runtime.GOOS != "linux" {
+		return LoopbackHost
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if gw := dockerBridgeGateway(ctx); gw != "" {
+		return gw
+	}
+	return LoopbackHost
+}
+
+// dockerBridgeGateway returns the gateway IP of Docker's default bridge network,
+// or "" if Docker is unreachable or the gateway is unknown.
+func dockerBridgeGateway(ctx context.Context) string {
+	cli, err := newRawDockerClient()
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = cli.Close() }()
+	if _, err := cli.Ping(ctx); err != nil {
+		return "" // Docker not running
+	}
+	insp, err := cli.NetworkInspect(ctx, "bridge", network.InspectOptions{})
+	if err != nil {
+		return ""
+	}
+	for _, cfg := range insp.IPAM.Config {
+		if cfg.Gateway != "" {
+			return cfg.Gateway
+		}
+	}
+	return ""
+}
+
+// newRawDockerClient builds a raw Docker SDK client with the same host
+// resolution as NewDockerClient, for the operations (ping, network inspect) not
+// exposed by the DockerClient interface.
+func newRawDockerClient() (*client.Client, error) {
+	opts := []client.Opt{client.FromEnv, client.WithAPIVersionNegotiation()}
+	if host := dockerhost.Resolve().Host; host != "" {
+		opts = append(opts, client.WithHost(host))
+	}
+	return client.NewClientWithOpts(opts...)
+}


### PR DESCRIPTION
Adds a second, demo-oriented visual style to the desktop workflow board, switched at runtime with **F8** and persisted across restarts.

## Fancy style (SC-154)
- Animated aurora gradient background, frosted-glass columns/rail/status bar (with readable fallbacks where `backdrop-filter` is unavailable)
- Per-column pastel rainbow hues tinting cards and drop zones, breathing glow on hovered drop targets
- Celebrations: fireworks at the drop point, confetti + golden card glow on Done drops, escalating streak toast, aurora sweep when a column empties — all on one shared canvas with a single rAF loop that idles at zero work
- Drag ghost tilts with pointer velocity and leaves a sparkle trail; cursor spotlight, holographic card sheen, squish-and-spring presses, equalizer status dot
- Classic stays pixel-identical (the CSS section is append-only); `prefers-reduced-motion` keeps the colors, disables all movement; closing a ticket is never celebrated

## Drag fix
Board rebuilds landing mid-drag replaced the dragged card's DOM node, killing its pointer listeners (frozen ghost, dead drop). `render()` now defers while a drag is in flight and `endDrag()` flushes it — fixes both styles.

Also carries the SC-153 desktop Features pane commits that were already on this branch.

Verified with a headless Playwright harness (Chromium + WebKit) driving the built frontend with stubbed Wails bindings: theme toggle, restart persistence, input-focus guard, drop celebrations, mid-drag re-render survival, and pixel-clean classic after toggling back. `make test` green (3058 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)