### PR TITLE
[SC-157] [HUM-158] Start Project wizard in the desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Each module ships a short `README.md` describing what it does for you, in plain 
 **User interfaces**
 
 - [Workflow Board (desktop)](desktop/README.md) — drag-to-trigger 5-stage pipeline board (Wails)
+- [Project Starters](internal/starter/README.md) — scaffold empty directories from starter templates
 
 **Infrastructure & security**
 

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -479,6 +479,9 @@ async function reconcile() {
     boardLoading = false;
     stagesLoading = false;
     render();
+    // Offered at most once per session, and only off a confirmed-empty board —
+    // see the Start Project wizard section for the guards.
+    void maybeOfferStartProject();
 }
 function errMessage(err) {
     if (err instanceof Error)
@@ -757,6 +760,193 @@ async function approveIdeation() {
     renderIdeation();
     if (ideation.state !== "thinking")
         stopIdeationPoll();
+}
+// wizardChecked is the re-trigger guard: set before any await in
+// maybeOfferStartProject so overlapping reconciles (board:changed storms)
+// cannot probe or open twice. Dismissal therefore lasts for the session.
+let wizardChecked = false;
+let wizardOverlay = null;
+let wizardTemplates = [];
+let wizardStep = "type";
+let wizardType = "";
+let wizardError = "";
+let wizardCreated = 0;
+async function maybeOfferStartProject() {
+    if (wizardChecked || current.error)
+        return;
+    // Cards on the board mean a project exists — settle without the FS probe,
+    // but leave wizardChecked set: a non-empty board can only gain cards.
+    wizardChecked = true;
+    if (current.cards.length > 0)
+        return;
+    let info;
+    try {
+        info = await go().StartProjectStatus();
+    }
+    catch {
+        return;
+    }
+    // A failed probe (info.error) means "don't offer", never a broken app.
+    if (info.error || !info.emptyProject)
+        return;
+    wizardTemplates = info.templates || [];
+    if (wizardTemplates.length === 0)
+        return;
+    openStartWizard();
+}
+function wizardTypeChoices() {
+    const seen = new Set();
+    const choices = [];
+    wizardTemplates.forEach((t) => {
+        if (seen.has(t.type))
+            return;
+        seen.add(t.type);
+        choices.push({ type: t.type, label: t.typeLabel });
+    });
+    return choices;
+}
+function wizardLanguageChoices(type) {
+    return wizardTemplates.filter((t) => t.type === type);
+}
+function openStartWizard() {
+    if (wizardOverlay)
+        return;
+    wizardStep = "type";
+    wizardType = "";
+    wizardError = "";
+    wizardCreated = 0;
+    const overlay = document.createElement("div");
+    overlay.className = "modal-overlay";
+    const modal = document.createElement("div");
+    modal.className = "modal wizard";
+    overlay.appendChild(modal);
+    document.body.appendChild(overlay);
+    wizardOverlay = overlay;
+    const onKey = (e) => {
+        // No escape while the download runs: the state is not cancellable from
+        // here and a hidden in-flight scaffold would be surprising.
+        if (e.key === "Escape" && wizardStep !== "creating")
+            closeStartWizard();
+    };
+    overlay.addEventListener("click", (e) => {
+        if (e.target === overlay && wizardStep !== "creating")
+            closeStartWizard();
+    });
+    document.addEventListener("keydown", onKey);
+    overlay.dataset.bound = "true";
+    // Store the handler so closeStartWizard can unbind it.
+    overlay._onKey = onKey;
+    renderStartWizard();
+}
+function closeStartWizard() {
+    if (!wizardOverlay)
+        return;
+    const onKey = wizardOverlay._onKey;
+    if (onKey)
+        document.removeEventListener("keydown", onKey);
+    wizardOverlay.remove();
+    wizardOverlay = null;
+}
+function renderStartWizard() {
+    if (!wizardOverlay)
+        return;
+    const modal = wizardOverlay.querySelector(".wizard");
+    if (!modal)
+        return;
+    if (wizardStep === "type") {
+        modal.innerHTML = `
+      <div class="modal-title">Start a new project</div>
+      <div class="modal-body">This folder has no project yet. What do you want to build?</div>
+      <div class="wizard-options"></div>
+    `;
+        const options = modal.querySelector(".wizard-options");
+        wizardTypeChoices().forEach((choice) => {
+            const btn = document.createElement("button");
+            btn.type = "button";
+            btn.className = "wizard-option";
+            btn.textContent = choice.label;
+            btn.addEventListener("click", () => {
+                wizardType = choice.type;
+                wizardStep = "language";
+                renderStartWizard();
+            });
+            options.appendChild(btn);
+        });
+        return;
+    }
+    if (wizardStep === "language") {
+        modal.innerHTML = `
+      <div class="modal-title">Choose a language</div>
+      <div class="modal-body">The project is set up ready to run.</div>
+      <div class="wizard-options"></div>
+      <div class="wizard-nav"><button class="wizard-back" type="button">Back</button></div>
+    `;
+        const options = modal.querySelector(".wizard-options");
+        wizardLanguageChoices(wizardType).forEach((tpl) => {
+            const btn = document.createElement("button");
+            btn.type = "button";
+            btn.className = "wizard-option";
+            btn.textContent = tpl.languageLabel;
+            btn.addEventListener("click", () => void createStartProject(tpl));
+            options.appendChild(btn);
+        });
+        modal.querySelector(".wizard-back").addEventListener("click", () => {
+            wizardStep = "type";
+            renderStartWizard();
+        });
+        return;
+    }
+    if (wizardStep === "creating") {
+        modal.innerHTML = `
+      <div class="modal-title">Creating project…</div>
+      <div class="wizard-status"><span class="spinner"></span><span>Downloading starter template</span></div>
+    `;
+        return;
+    }
+    if (wizardStep === "done") {
+        modal.innerHTML = `
+      <div class="modal-title">Project created</div>
+      <div class="modal-body">${escapeHtml(`${wizardCreated} files added. Create a first ticket to start working on it.`)}</div>
+      <div class="modal-actions">
+        <button class="modal-cancel" type="button">Close</button>
+        <button class="modal-confirm" type="button">Create first ticket</button>
+      </div>
+    `;
+        modal.querySelector(".modal-cancel").addEventListener("click", () => closeStartWizard());
+        modal.querySelector(".modal-confirm").addEventListener("click", () => {
+            closeStartWizard();
+            void openIdeation();
+        });
+        return;
+    }
+    // error
+    modal.innerHTML = `
+    <div class="modal-title">Could not create project</div>
+    <div class="modal-body wizard-error">${escapeHtml(wizardError)}</div>
+    <div class="modal-actions">
+      <button class="modal-cancel" type="button">Close</button>
+      <button class="modal-confirm" type="button">Try again</button>
+    </div>
+  `;
+    modal.querySelector(".modal-cancel").addEventListener("click", () => closeStartWizard());
+    modal.querySelector(".modal-confirm").addEventListener("click", () => {
+        wizardStep = "language";
+        renderStartWizard();
+    });
+}
+async function createStartProject(tpl) {
+    wizardStep = "creating";
+    renderStartWizard();
+    try {
+        const res = await go().StartProject(tpl.type, tpl.language);
+        wizardCreated = res.filesCreated;
+        wizardStep = "done";
+    }
+    catch (err) {
+        wizardError = errMessage(err);
+        wizardStep = "error";
+    }
+    renderStartWizard();
 }
 // --- Running agents view -----------------------------------------------
 //

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -336,6 +336,72 @@ body {
   filter: brightness(1.1);
 }
 
+/* Start Project wizard: a .modal variant. Its confirm action is constructive
+   (create/scaffold), so it uses the accent color instead of the destructive
+   red the shared .modal-confirm carries for close-ticket confirmation. */
+.wizard {
+  width: 380px;
+}
+
+.wizard .modal-confirm {
+  background: var(--accent);
+}
+
+.wizard-options {
+  margin-top: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.wizard-option {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.wizard-option:hover {
+  border-color: var(--accent);
+}
+
+.wizard-nav {
+  margin-top: 14px;
+}
+
+.wizard-back {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--muted);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.wizard-back:hover {
+  color: var(--text);
+}
+
+.wizard-status {
+  margin-top: 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.wizard-error {
+  color: var(--failed);
+}
+
 .card {
   background: var(--card-bg);
   border: 1px solid var(--card-border);

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -125,6 +125,24 @@ interface FeatureDoc {
   error?: string;
 }
 
+interface StarterTemplate {
+  id: string;
+  type: string;
+  typeLabel: string;
+  language: string;
+  languageLabel: string;
+}
+
+interface StartProjectInfo {
+  emptyProject: boolean;
+  templates: StarterTemplate[] | null;
+  error?: string;
+}
+
+interface StartProjectResult {
+  filesCreated: number;
+}
+
 interface AppBindings {
   Cards(): Promise<BoardData>;
   CardsQuick(): Promise<BoardData>;
@@ -138,6 +156,8 @@ interface AppBindings {
   Instances(): Promise<InstancesData>;
   Features(): Promise<FeatureDoc>;
   GenerateFeatures(): Promise<void>;
+  StartProjectStatus(): Promise<StartProjectInfo>;
+  StartProject(projectType: string, language: string): Promise<StartProjectResult>;
 }
 
 // This file is a module (see the trailing `export {}`) so the global
@@ -651,6 +671,9 @@ async function reconcile(): Promise<void> {
   boardLoading = false;
   stagesLoading = false;
   render();
+  // Offered at most once per session, and only off a confirmed-empty board —
+  // see the Start Project wizard section for the guards.
+  void maybeOfferStartProject();
 }
 
 function errMessage(err: unknown): string {
@@ -935,6 +958,207 @@ async function approveIdeation(): Promise<void> {
   }
   renderIdeation();
   if (ideation.state !== "thinking") stopIdeationPoll();
+}
+
+// --- Start Project wizard ------------------------------------------------
+//
+// Offered exactly once per session, and only when the board is a *confirmed*
+// empty board (successful fetch, zero cards) AND the project directory holds
+// no source files — i.e. there is genuinely no project yet, just tool config.
+// The steps are static local choices derived from the Go-side template
+// registry, so unlike ideation there is no per-step backend round-trip: only
+// the final scaffold call goes to Go.
+
+type WizardStep = "type" | "language" | "creating" | "done" | "error";
+
+// wizardChecked is the re-trigger guard: set before any await in
+// maybeOfferStartProject so overlapping reconciles (board:changed storms)
+// cannot probe or open twice. Dismissal therefore lasts for the session.
+let wizardChecked = false;
+let wizardOverlay: HTMLElement | null = null;
+let wizardTemplates: StarterTemplate[] = [];
+let wizardStep: WizardStep = "type";
+let wizardType = "";
+let wizardError = "";
+let wizardCreated = 0;
+
+async function maybeOfferStartProject(): Promise<void> {
+  if (wizardChecked || current.error) return;
+  // Cards on the board mean a project exists — settle without the FS probe,
+  // but leave wizardChecked set: a non-empty board can only gain cards.
+  wizardChecked = true;
+  if (current.cards.length > 0) return;
+
+  let info: StartProjectInfo;
+  try {
+    info = await go().StartProjectStatus();
+  } catch {
+    return;
+  }
+  // A failed probe (info.error) means "don't offer", never a broken app.
+  if (info.error || !info.emptyProject) return;
+  wizardTemplates = info.templates || [];
+  if (wizardTemplates.length === 0) return;
+  openStartWizard();
+}
+
+function wizardTypeChoices(): { type: string; label: string }[] {
+  const seen = new Set<string>();
+  const choices: { type: string; label: string }[] = [];
+  wizardTemplates.forEach((t) => {
+    if (seen.has(t.type)) return;
+    seen.add(t.type);
+    choices.push({ type: t.type, label: t.typeLabel });
+  });
+  return choices;
+}
+
+function wizardLanguageChoices(type: string): StarterTemplate[] {
+  return wizardTemplates.filter((t) => t.type === type);
+}
+
+function openStartWizard(): void {
+  if (wizardOverlay) return;
+  wizardStep = "type";
+  wizardType = "";
+  wizardError = "";
+  wizardCreated = 0;
+
+  const overlay = document.createElement("div");
+  overlay.className = "modal-overlay";
+  const modal = document.createElement("div");
+  modal.className = "modal wizard";
+  overlay.appendChild(modal);
+  document.body.appendChild(overlay);
+  wizardOverlay = overlay;
+
+  const onKey = (e: KeyboardEvent): void => {
+    // No escape while the download runs: the state is not cancellable from
+    // here and a hidden in-flight scaffold would be surprising.
+    if (e.key === "Escape" && wizardStep !== "creating") closeStartWizard();
+  };
+  overlay.addEventListener("click", (e: MouseEvent) => {
+    if (e.target === overlay && wizardStep !== "creating") closeStartWizard();
+  });
+  document.addEventListener("keydown", onKey);
+  overlay.dataset.bound = "true";
+  // Store the handler so closeStartWizard can unbind it.
+  (overlay as HTMLElement & { _onKey?: (e: KeyboardEvent) => void })._onKey = onKey;
+
+  renderStartWizard();
+}
+
+function closeStartWizard(): void {
+  if (!wizardOverlay) return;
+  const onKey = (wizardOverlay as HTMLElement & { _onKey?: (e: KeyboardEvent) => void })._onKey;
+  if (onKey) document.removeEventListener("keydown", onKey);
+  wizardOverlay.remove();
+  wizardOverlay = null;
+}
+
+function renderStartWizard(): void {
+  if (!wizardOverlay) return;
+  const modal = wizardOverlay.querySelector<HTMLElement>(".wizard");
+  if (!modal) return;
+
+  if (wizardStep === "type") {
+    modal.innerHTML = `
+      <div class="modal-title">Start a new project</div>
+      <div class="modal-body">This folder has no project yet. What do you want to build?</div>
+      <div class="wizard-options"></div>
+    `;
+    const options = modal.querySelector<HTMLElement>(".wizard-options")!;
+    wizardTypeChoices().forEach((choice) => {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "wizard-option";
+      btn.textContent = choice.label;
+      btn.addEventListener("click", () => {
+        wizardType = choice.type;
+        wizardStep = "language";
+        renderStartWizard();
+      });
+      options.appendChild(btn);
+    });
+    return;
+  }
+
+  if (wizardStep === "language") {
+    modal.innerHTML = `
+      <div class="modal-title">Choose a language</div>
+      <div class="modal-body">The project is set up ready to run.</div>
+      <div class="wizard-options"></div>
+      <div class="wizard-nav"><button class="wizard-back" type="button">Back</button></div>
+    `;
+    const options = modal.querySelector<HTMLElement>(".wizard-options")!;
+    wizardLanguageChoices(wizardType).forEach((tpl) => {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "wizard-option";
+      btn.textContent = tpl.languageLabel;
+      btn.addEventListener("click", () => void createStartProject(tpl));
+      options.appendChild(btn);
+    });
+    modal.querySelector(".wizard-back")!.addEventListener("click", () => {
+      wizardStep = "type";
+      renderStartWizard();
+    });
+    return;
+  }
+
+  if (wizardStep === "creating") {
+    modal.innerHTML = `
+      <div class="modal-title">Creating project…</div>
+      <div class="wizard-status"><span class="spinner"></span><span>Downloading starter template</span></div>
+    `;
+    return;
+  }
+
+  if (wizardStep === "done") {
+    modal.innerHTML = `
+      <div class="modal-title">Project created</div>
+      <div class="modal-body">${escapeHtml(`${wizardCreated} files added. Create a first ticket to start working on it.`)}</div>
+      <div class="modal-actions">
+        <button class="modal-cancel" type="button">Close</button>
+        <button class="modal-confirm" type="button">Create first ticket</button>
+      </div>
+    `;
+    modal.querySelector(".modal-cancel")!.addEventListener("click", () => closeStartWizard());
+    modal.querySelector(".modal-confirm")!.addEventListener("click", () => {
+      closeStartWizard();
+      void openIdeation();
+    });
+    return;
+  }
+
+  // error
+  modal.innerHTML = `
+    <div class="modal-title">Could not create project</div>
+    <div class="modal-body wizard-error">${escapeHtml(wizardError)}</div>
+    <div class="modal-actions">
+      <button class="modal-cancel" type="button">Close</button>
+      <button class="modal-confirm" type="button">Try again</button>
+    </div>
+  `;
+  modal.querySelector(".modal-cancel")!.addEventListener("click", () => closeStartWizard());
+  modal.querySelector(".modal-confirm")!.addEventListener("click", () => {
+    wizardStep = "language";
+    renderStartWizard();
+  });
+}
+
+async function createStartProject(tpl: StarterTemplate): Promise<void> {
+  wizardStep = "creating";
+  renderStartWizard();
+  try {
+    const res = await go().StartProject(tpl.type, tpl.language);
+    wizardCreated = res.filesCreated;
+    wizardStep = "done";
+  } catch (err) {
+    wizardError = errMessage(err);
+    wizardStep = "error";
+  }
+  renderStartWizard();
 }
 
 // --- Running agents view -----------------------------------------------

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -336,6 +336,72 @@ body {
   filter: brightness(1.1);
 }
 
+/* Start Project wizard: a .modal variant. Its confirm action is constructive
+   (create/scaffold), so it uses the accent color instead of the destructive
+   red the shared .modal-confirm carries for close-ticket confirmation. */
+.wizard {
+  width: 380px;
+}
+
+.wizard .modal-confirm {
+  background: var(--accent);
+}
+
+.wizard-options {
+  margin-top: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.wizard-option {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.wizard-option:hover {
+  border-color: var(--accent);
+}
+
+.wizard-nav {
+  margin-top: 14px;
+}
+
+.wizard-back {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--muted);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.wizard-back:hover {
+  color: var(--text);
+}
+
+.wizard-status {
+  margin-top: 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.wizard-error {
+  color: var(--failed);
+}
+
 .card {
   background: var(--card-bg);
   border: 1px solid var(--card-border);

--- a/desktop/startproject.go
+++ b/desktop/startproject.go
@@ -1,0 +1,88 @@
+//go:build wailsapp
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/starter"
+)
+
+// humanconfigNames are the accepted project-config filenames (the same set
+// internal/config resolves via viper); any of them marks the project root.
+var humanconfigNames = []string{".humanconfig.yaml", ".humanconfig.yml", ".humanconfig"}
+
+// StartProjectInfo tells the frontend whether the Start Project wizard applies
+// and which templates it can offer. Error is soft (FeatureDoc.Error convention):
+// a failed probe means "don't show the wizard", never a broken app.
+type StartProjectInfo struct {
+	EmptyProject bool               `json:"emptyProject"`
+	Templates    []starter.Template `json:"templates"`
+	Error        string             `json:"error,omitempty"`
+}
+
+// StartProjectResult reports the scaffolding outcome for the wizard's success
+// message.
+type StartProjectResult struct {
+	FilesCreated int `json:"filesCreated"`
+}
+
+// StartProjectStatus probes the project root for source files. Like Features()
+// it is a plain local-FS read — no daemon, no credentials — because the answer
+// must reflect the directory the desktop app actually runs in, not whatever
+// namespace the daemon lives in.
+func (a *App) StartProjectStatus() (StartProjectInfo, error) {
+	info := StartProjectInfo{Templates: starter.Templates()}
+	dir, err := projectRoot()
+	if err != nil {
+		info.Error = err.Error()
+		return info, nil
+	}
+	empty, err := starter.IsEmptyProject(dir)
+	if err != nil {
+		info.Error = err.Error()
+		return info, nil
+	}
+	info.EmptyProject = empty
+	return info, nil
+}
+
+// StartProject scaffolds the chosen starter template into the project root.
+func (a *App) StartProject(projectType, language string) (StartProjectResult, error) {
+	tpl, ok := starter.Lookup(projectType, language)
+	if !ok {
+		return StartProjectResult{}, errors.WithDetails("unknown starter template", "type", projectType, "language", language)
+	}
+	dir, err := projectRoot()
+	if err != nil {
+		return StartProjectResult{}, err
+	}
+	res, err := starter.Fetch(a.ctx, tpl, dir)
+	if err != nil {
+		return StartProjectResult{}, err
+	}
+	return StartProjectResult{FilesCreated: res.Created}, nil
+}
+
+// projectRoot resolves the directory to scaffold into: the nearest ancestor
+// holding a .humanconfig (so launching from a subdirectory still targets the
+// project root, consistent with Features()' findUp), falling back to the
+// working directory when no config exists yet.
+func projectRoot() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", errors.WrapWithDetails(err, "resolving working directory")
+	}
+	for dir := cwd; ; dir = filepath.Dir(dir) {
+		for _, name := range humanconfigNames {
+			if _, statErr := os.Stat(filepath.Join(dir, name)); statErr == nil {
+				return dir, nil
+			}
+		}
+		if filepath.Dir(dir) == dir {
+			return cwd, nil
+		}
+	}
+}

--- a/internal/starter/README.md
+++ b/internal/starter/README.md
@@ -1,0 +1,24 @@
+# Project Starters
+
+Detects directories that contain no project yet — only tool configuration like
+`.humanconfig.yaml`, `CLAUDE.md`, or `.claude/` — and scaffolds them from
+curated starter templates. The desktop app uses this to offer a Start Project
+wizard on an empty board instead of leaving new users staring at nothing.
+
+Templates live in the public [gethuman-sh/starters](https://github.com/gethuman-sh/starters)
+repository, one per `<type>/<language>/` subdirectory (v1 ships `web/go`, a
+minimal Go web server). The wizard's choices are generated from the template
+registry, so new project types and languages are registry additions — no UI
+changes required.
+
+## Capabilities
+
+- **Empty-project detection** — walks the directory and reports whether any
+  source file or build manifest exists; dot-directories and dependency/output
+  directories (`node_modules`, `vendor`, `dist`, …) never count.
+- **Template registry** — the available starters with display labels for the
+  wizard's type and language steps.
+- **Safe scaffolding** — downloads the starters tarball from GitHub and
+  extracts only the chosen template into the project directory: existing files
+  are never overwritten, archive paths are validated against traversal,
+  symlinks are dropped, and decompression is size-capped.

--- a/internal/starter/detect.go
+++ b/internal/starter/detect.go
@@ -1,0 +1,99 @@
+package starter
+
+import (
+	"errors"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	humanerrors "github.com/gethuman-sh/human/errors"
+)
+
+// skipDirs are dependency and output directories whose contents say nothing
+// about whether the user has written a project of their own (a stray
+// node_modules must not suppress the wizard). Dot-directories are skipped by a
+// blanket rule in IsEmptyProject, which also covers .git, .claude, .vscode etc.
+var skipDirs = map[string]bool{
+	"node_modules": true,
+	"vendor":       true,
+	"dist":         true,
+	"build":        true,
+	"target":       true,
+	"__pycache__":  true,
+	"venv":         true,
+	".venv":        true,
+}
+
+// sourceExtensions marks a file as project source by extension. The set is
+// deliberately broad across languages: one hit anywhere means "there is a
+// project here" and the wizard must stay away.
+var sourceExtensions = map[string]bool{
+	".go": true, ".rs": true, ".js": true, ".jsx": true, ".ts": true,
+	".tsx": true, ".py": true, ".java": true, ".kt": true, ".rb": true,
+	".php": true, ".c": true, ".h": true, ".cpp": true, ".cc": true,
+	".hpp": true, ".cs": true, ".swift": true, ".scala": true, ".ex": true,
+	".exs": true, ".zig": true, ".dart": true, ".vue": true, ".svelte": true,
+}
+
+// projectManifests are build/dependency manifests that prove a project exists
+// even before any source file does (e.g. a fresh `go mod init`). Matched by
+// basename because their extensions (.mod, .json, .toml, none) are useless as
+// a signal on their own.
+var projectManifests = map[string]bool{
+	"go.mod": true, "go.sum": true, "Cargo.toml": true, "package.json": true,
+	"pyproject.toml": true, "requirements.txt": true, "pom.xml": true,
+	"build.gradle": true, "build.gradle.kts": true, "Gemfile": true,
+	"composer.json": true, "CMakeLists.txt": true, "Makefile": true,
+}
+
+// errSourceFound is the walk's early-exit sentinel: the first source file
+// settles the question, so scanning further is wasted work.
+var errSourceFound = errors.New("source file found")
+
+// IsEmptyProject reports whether dir contains no source files — only
+// configuration, docs and tooling (.humanconfig.yaml, CLAUDE.md, README.md,
+// dotfiles, ...). Dot-directories and dependency/output directories are never
+// descended into, so tool state and stray installs cannot mask emptiness or
+// fake a project.
+func IsEmptyProject(dir string) (bool, error) {
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			// The root must be readable — otherwise the answer is meaningless.
+			// Deeper unreadable entries are tolerated like the codenav walk
+			// does: a permission-denied subdir must not break detection.
+			if path == dir {
+				return humanerrors.WrapWithDetails(walkErr, "reading project directory", "dir", dir)
+			}
+			return nil
+		}
+		if d.IsDir() {
+			if path == dir {
+				return nil
+			}
+			if skipDirs[d.Name()] || strings.HasPrefix(d.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if isSourceFile(d.Name()) {
+			return errSourceFound
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, errSourceFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// isSourceFile decides whether a file proves a project exists: source by
+// extension, or a build manifest by basename.
+func isSourceFile(name string) bool {
+	if projectManifests[name] {
+		return true
+	}
+	return sourceExtensions[strings.ToLower(filepath.Ext(name))]
+}

--- a/internal/starter/detect_test.go
+++ b/internal/starter/detect_test.go
@@ -1,0 +1,77 @@
+package starter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeTree creates the given relative file paths (with parent dirs) under
+// root, each with trivial content.
+func writeTree(t *testing.T, root string, paths ...string) {
+	t.Helper()
+	for _, p := range paths {
+		full := filepath.Join(root, filepath.FromSlash(p))
+		if err := os.MkdirAll(filepath.Dir(full), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestIsEmptyProject(t *testing.T) {
+	cases := []struct {
+		name  string
+		files []string
+		want  bool
+	}{
+		{name: "empty dir", files: nil, want: true},
+		{
+			name: "config only",
+			files: []string{
+				".humanconfig.yaml", "CLAUDE.md", "README.md", ".gitignore",
+				".git/HEAD", ".claude/settings.json",
+				".devcontainer/devcontainer.json", ".vscode/settings.json",
+				"FEATURE.json",
+			},
+			want: true,
+		},
+		{name: "go.mod only", files: []string{"go.mod"}, want: false},
+		{name: "root source file", files: []string{"main.go"}, want: false},
+		{name: "nested source file", files: []string{"src/index.js"}, want: false},
+		{name: "uppercase extension", files: []string{"Main.GO"}, want: false},
+		{
+			name:  "source only under skip dir",
+			files: []string{"node_modules/lib/index.js", "vendor/pkg/mod.go"},
+			want:  true,
+		},
+		{
+			name:  "source only under dot dir",
+			files: []string{".claude/hooks/check.py"},
+			want:  true,
+		},
+		{name: "manifest in subdirectory", files: []string{"backend/package.json"}, want: false},
+		{name: "makefile counts as project", files: []string{"Makefile"}, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeTree(t, dir, tc.files...)
+			got, err := IsEmptyProject(dir)
+			if err != nil {
+				t.Fatalf("IsEmptyProject: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("IsEmptyProject = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsEmptyProjectMissingDir(t *testing.T) {
+	if _, err := IsEmptyProject(filepath.Join(t.TempDir(), "nope")); err == nil {
+		t.Fatal("expected error for nonexistent directory")
+	}
+}

--- a/internal/starter/fetch.go
+++ b/internal/starter/fetch.go
@@ -1,0 +1,189 @@
+package starter
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	humanerrors "github.com/gethuman-sh/human/errors"
+)
+
+const (
+	// tarballURL and tarballRoot are pinned together: codeload prefixes every
+	// archive entry with <repo>-<ref>/, so renaming the repo or its default
+	// branch must update both.
+	tarballURL  = "https://codeload.github.com/gethuman-sh/starters/tar.gz/refs/heads/main"
+	tarballRoot = "starters-main/"
+
+	// Decompression caps: a starter is a handful of small files, so anything
+	// near these limits is a corrupt or hostile archive, not a template
+	// (gosec G110 decompression-bomb guard).
+	maxEntryBytes = 10 << 20
+	maxTotalBytes = 100 << 20
+)
+
+// fetchHTTPClient bounds the download so a black-holed connection cannot hang
+// the wizard's "creating" state forever.
+var fetchHTTPClient = &http.Client{Timeout: 60 * time.Second}
+
+// httpGet is the HTTP entry point — replaced with a stub in tests so no test
+// ever touches the network.
+var httpGet = func(ctx context.Context, url string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return fetchHTTPClient.Do(req)
+}
+
+// FetchResult reports what scaffolding changed so the UI can say
+// "N files created" and surface untouched pre-existing files.
+type FetchResult struct {
+	Created int `json:"created"`
+	Skipped int `json:"skipped"`
+}
+
+// Fetch downloads the starters tarball and extracts only tpl.Path into
+// destDir, stripping the repo/template prefix. Existing files are skipped,
+// never overwritten: the wizard runs in directories that may already hold a
+// README or .gitignore the user wants to keep.
+func Fetch(ctx context.Context, tpl Template, destDir string) (FetchResult, error) {
+	resp, err := httpGet(ctx, tarballURL)
+	if err != nil {
+		return FetchResult{}, humanerrors.WrapWithDetails(err, "downloading starter archive", "url", tarballURL)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return FetchResult{}, humanerrors.WithDetails("starter archive request failed", "url", tarballURL, "status", resp.StatusCode)
+	}
+	prefix := tarballRoot + tpl.Path + "/"
+	res, err := extractTemplate(resp.Body, prefix, destDir)
+	if err != nil {
+		return FetchResult{}, err
+	}
+	if res.Created == 0 && res.Skipped == 0 {
+		// Zero matching entries means the repo layout drifted (template moved,
+		// branch renamed) — fail loudly instead of reporting an empty success.
+		return FetchResult{}, humanerrors.WithDetails("template not found in starter archive", "path", tpl.Path)
+	}
+	return res, nil
+}
+
+// extractTemplate streams the gzipped tarball, writing only entries under
+// prefix into destDir.
+func extractTemplate(r io.Reader, prefix, destDir string) (FetchResult, error) {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return FetchResult{}, humanerrors.WrapWithDetails(err, "decompressing starter archive")
+	}
+	defer func() { _ = gz.Close() }()
+
+	var res FetchResult
+	var total int64
+	tr := tar.NewReader(gz)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			return res, nil
+		}
+		if err != nil {
+			return FetchResult{}, humanerrors.WrapWithDetails(err, "reading starter archive")
+		}
+		if !strings.HasPrefix(header.Name, prefix) {
+			continue
+		}
+		dest, ok := safeDestPath(destDir, header.Name, prefix)
+		if !ok {
+			return FetchResult{}, humanerrors.WithDetails("unsafe path in starter archive", "entry", header.Name)
+		}
+		if dest == "" {
+			// The template root directory itself — destDir already exists.
+			continue
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(dest, 0o750); err != nil {
+				return FetchResult{}, humanerrors.WrapWithDetails(err, "creating starter directory", "path", dest)
+			}
+		case tar.TypeReg:
+			created, err := writeEntry(tr, header, dest, &total)
+			if err != nil {
+				return FetchResult{}, err
+			}
+			if created {
+				res.Created++
+			} else {
+				res.Skipped++
+			}
+		default:
+			// Symlinks, hardlinks and device nodes have no legitimate place in
+			// a starter template — drop them rather than materialize anything
+			// that could point outside destDir.
+		}
+	}
+}
+
+// writeEntry writes one regular file, skipping pre-existing files and
+// enforcing the decompression caps. Returns whether the file was created.
+func writeEntry(tr io.Reader, header *tar.Header, dest string, total *int64) (bool, error) {
+	if _, err := os.Lstat(dest); err == nil {
+		return false, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o750); err != nil {
+		return false, humanerrors.WrapWithDetails(err, "creating starter directory", "path", filepath.Dir(dest))
+	}
+	// Preserve only the exec bit: templates may ship scripts, but archive
+	// modes are otherwise untrusted input.
+	mode := os.FileMode(0o600)
+	if header.FileInfo().Mode()&0o100 != 0 {
+		mode = 0o700
+	}
+	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode) // #nosec G304 -- dest is validated by safeDestPath to stay inside destDir
+	if err != nil {
+		return false, humanerrors.WrapWithDetails(err, "creating starter file", "path", dest)
+	}
+	n, err := io.Copy(f, io.LimitReader(tr, maxEntryBytes+1))
+	closeErr := f.Close()
+	if err != nil {
+		return false, humanerrors.WrapWithDetails(err, "writing starter file", "path", dest)
+	}
+	if closeErr != nil {
+		return false, humanerrors.WrapWithDetails(closeErr, "writing starter file", "path", dest)
+	}
+	if n > maxEntryBytes {
+		return false, humanerrors.WithDetails("starter file exceeds size limit", "entry", header.Name, "limit", maxEntryBytes)
+	}
+	*total += n
+	if *total > maxTotalBytes {
+		return false, humanerrors.WithDetails("starter archive exceeds size limit", "limit", maxTotalBytes)
+	}
+	return true, nil
+}
+
+// safeDestPath maps an archive entry name to its destination path, rejecting
+// anything that would escape destDir (path traversal, absolute paths). The
+// empty-string/true return marks the template root entry itself.
+func safeDestPath(destDir, name, prefix string) (string, bool) {
+	rel := path.Clean(strings.TrimPrefix(name, prefix))
+	if rel == "." || rel == "" {
+		return "", true
+	}
+	if rel == ".." || strings.HasPrefix(rel, "../") || path.IsAbs(rel) {
+		return "", false
+	}
+	dest := filepath.Join(destDir, filepath.FromSlash(rel))
+	// Belt and suspenders: the Clean checks above should already guarantee
+	// containment, but verify against the final joined path.
+	root := filepath.Clean(destDir)
+	if dest != root && !strings.HasPrefix(dest, root+string(os.PathSeparator)) {
+		return "", false
+	}
+	return dest, true
+}

--- a/internal/starter/fetch_test.go
+++ b/internal/starter/fetch_test.go
@@ -1,0 +1,268 @@
+package starter
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type tarEntry struct {
+	name     string
+	body     string
+	mode     int64
+	typeflag byte
+	linkname string
+}
+
+func makeTarGz(t *testing.T, entries []tarEntry) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, e := range entries {
+		typeflag := e.typeflag
+		if typeflag == 0 {
+			typeflag = tar.TypeReg
+		}
+		mode := e.mode
+		if mode == 0 {
+			mode = 0o644
+		}
+		hdr := &tar.Header{
+			Name:     e.name,
+			Mode:     mode,
+			Typeflag: typeflag,
+			Linkname: e.linkname,
+		}
+		if typeflag == tar.TypeReg {
+			hdr.Size = int64(len(e.body))
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if typeflag == tar.TypeReg {
+			if _, err := tw.Write([]byte(e.body)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// stubDownload replaces httpGet for the test, serving the given body with the
+// given status.
+func stubDownload(t *testing.T, status int, body []byte) {
+	t.Helper()
+	orig := httpGet
+	httpGet = func(_ context.Context, _ string) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: status,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+		}, nil
+	}
+	t.Cleanup(func() { httpGet = orig })
+}
+
+func webGoTemplate() Template {
+	tpl, ok := Lookup("web", "go")
+	if !ok {
+		panic("web/go template missing")
+	}
+	return tpl
+}
+
+func TestFetchExtractsOnlyTemplateSubdir(t *testing.T) {
+	archive := makeTarGz(t, []tarEntry{
+		{name: "starters-main/", typeflag: tar.TypeDir},
+		{name: "starters-main/README.md", body: "layout contract"},
+		{name: "starters-main/web/", typeflag: tar.TypeDir},
+		{name: "starters-main/web/go/", typeflag: tar.TypeDir},
+		{name: "starters-main/web/go/go.mod", body: "module webapp"},
+		{name: "starters-main/web/go/main.go", body: "package main"},
+		{name: "starters-main/web/go/static/", typeflag: tar.TypeDir},
+		{name: "starters-main/web/go/static/index.html", body: "<html>"},
+		{name: "starters-main/web/rust/main.rs", body: "fn main() {}"},
+	})
+	stubDownload(t, http.StatusOK, archive)
+	dir := t.TempDir()
+
+	res, err := Fetch(context.Background(), webGoTemplate(), dir)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if res.Created != 3 || res.Skipped != 0 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+	if err != nil || string(got) != "module webapp" {
+		t.Fatalf("go.mod = %q, err %v", got, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "static", "index.html")); err != nil {
+		t.Fatalf("nested file missing: %v", err)
+	}
+	// Sibling templates and repo-root files must not leak into the project.
+	for _, absent := range []string{"main.rs", "README.md", "web"} {
+		if _, err := os.Stat(filepath.Join(dir, absent)); !os.IsNotExist(err) {
+			t.Fatalf("unexpected entry %q extracted", absent)
+		}
+	}
+}
+
+func TestFetchPreservesExecBit(t *testing.T) {
+	archive := makeTarGz(t, []tarEntry{
+		{name: "starters-main/web/go/run.sh", body: "#!/bin/sh", mode: 0o755},
+		{name: "starters-main/web/go/main.go", body: "package main"},
+	})
+	stubDownload(t, http.StatusOK, archive)
+	dir := t.TempDir()
+
+	if _, err := Fetch(context.Background(), webGoTemplate(), dir); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dir, "run.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o100 == 0 {
+		t.Fatalf("exec bit lost: %v", info.Mode())
+	}
+	plain, err := os.Stat(filepath.Join(dir, "main.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plain.Mode().Perm() != 0o600 {
+		t.Fatalf("regular file mode = %v, want 0600", plain.Mode().Perm())
+	}
+}
+
+func TestFetchSkipsExistingFiles(t *testing.T) {
+	archive := makeTarGz(t, []tarEntry{
+		{name: "starters-main/web/go/README.md", body: "template readme"},
+		{name: "starters-main/web/go/main.go", body: "package main"},
+	})
+	stubDownload(t, http.StatusOK, archive)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("mine"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Fetch(context.Background(), webGoTemplate(), dir)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if res.Created != 1 || res.Skipped != 1 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, "README.md"))
+	if string(got) != "mine" {
+		t.Fatalf("existing file overwritten: %q", got)
+	}
+}
+
+func TestFetchRejectsTraversalEntries(t *testing.T) {
+	cases := []string{
+		"starters-main/web/go/../../../evil.go",
+		"starters-main/web/go/../../evil.go",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			archive := makeTarGz(t, []tarEntry{{name: name, body: "evil"}})
+			stubDownload(t, http.StatusOK, archive)
+			dir := t.TempDir()
+
+			if _, err := Fetch(context.Background(), webGoTemplate(), dir); err == nil {
+				t.Fatal("expected traversal entry to be rejected")
+			}
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("files written despite rejection: %v", entries)
+			}
+		})
+	}
+}
+
+func TestFetchIgnoresSymlinks(t *testing.T) {
+	archive := makeTarGz(t, []tarEntry{
+		{name: "starters-main/web/go/main.go", body: "package main"},
+		{name: "starters-main/web/go/evil", typeflag: tar.TypeSymlink, linkname: "/etc/passwd"},
+	})
+	stubDownload(t, http.StatusOK, archive)
+	dir := t.TempDir()
+
+	res, err := Fetch(context.Background(), webGoTemplate(), dir)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if res.Created != 1 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if _, err := os.Lstat(filepath.Join(dir, "evil")); !os.IsNotExist(err) {
+		t.Fatal("symlink entry materialized")
+	}
+}
+
+func TestFetchTemplateMissingFromArchive(t *testing.T) {
+	archive := makeTarGz(t, []tarEntry{
+		{name: "starters-main/web/rust/main.rs", body: "fn main() {}"},
+	})
+	stubDownload(t, http.StatusOK, archive)
+
+	_, err := Fetch(context.Background(), webGoTemplate(), t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "template not found") {
+		t.Fatalf("expected template-not-found error, got %v", err)
+	}
+}
+
+func TestFetchHTTPError(t *testing.T) {
+	stubDownload(t, http.StatusNotFound, nil)
+	if _, err := Fetch(context.Background(), webGoTemplate(), t.TempDir()); err == nil {
+		t.Fatal("expected error for HTTP 404")
+	}
+}
+
+func TestFetchCorruptGzip(t *testing.T) {
+	stubDownload(t, http.StatusOK, []byte("not a gzip stream"))
+	if _, err := Fetch(context.Background(), webGoTemplate(), t.TempDir()); err == nil {
+		t.Fatal("expected error for corrupt archive")
+	}
+}
+
+func TestFetchEntrySizeCap(t *testing.T) {
+	archive := makeTarGz(t, []tarEntry{
+		{name: "starters-main/web/go/huge.bin", body: strings.Repeat("a", maxEntryBytes+2)},
+	})
+	stubDownload(t, http.StatusOK, archive)
+
+	_, err := Fetch(context.Background(), webGoTemplate(), t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "size limit") {
+		t.Fatalf("expected size-limit error, got %v", err)
+	}
+}
+
+func TestFetchDownloadFailure(t *testing.T) {
+	orig := httpGet
+	httpGet = func(_ context.Context, _ string) (*http.Response, error) {
+		return nil, context.Canceled
+	}
+	t.Cleanup(func() { httpGet = orig })
+
+	if _, err := Fetch(context.Background(), webGoTemplate(), t.TempDir()); err == nil {
+		t.Fatal("expected error when download fails")
+	}
+}

--- a/internal/starter/templates.go
+++ b/internal/starter/templates.go
@@ -1,0 +1,50 @@
+// Package starter detects directories that contain no project yet and
+// scaffolds them from curated starter templates hosted on GitHub.
+package starter
+
+// Template is one scaffoldable starter project. Type/Language are the stable
+// identifiers the frontend sends back to StartProject; the *Label fields are
+// what the wizard displays. Path is the template's subdirectory inside the
+// gethuman-sh/starters repo — backend-only, so it never leaks into the UI
+// contract and the repo layout can change without a frontend release.
+type Template struct {
+	ID            string `json:"id"`
+	Type          string `json:"type"`
+	TypeLabel     string `json:"typeLabel"`
+	Language      string `json:"language"`
+	LanguageLabel string `json:"languageLabel"`
+	Path          string `json:"-"`
+}
+
+// templates is the registry the wizard is generated from: the frontend derives
+// its step-1 choices from the unique Types and step-2 from the Languages of
+// the chosen Type, so adding a starter here is the only change needed to offer
+// it in the app.
+var templates = []Template{
+	{
+		ID:            "web-go",
+		Type:          "web",
+		TypeLabel:     "Web Project",
+		Language:      "go",
+		LanguageLabel: "Go",
+		Path:          "web/go",
+	},
+}
+
+// Templates returns the available starter templates. It returns a copy so
+// callers cannot mutate the registry.
+func Templates() []Template {
+	out := make([]Template, len(templates))
+	copy(out, templates)
+	return out
+}
+
+// Lookup resolves the template for a type/language pair chosen in the wizard.
+func Lookup(projectType, language string) (Template, bool) {
+	for _, t := range templates {
+		if t.Type == projectType && t.Language == language {
+			return t, true
+		}
+	}
+	return Template{}, false
+}

--- a/internal/starter/templates_test.go
+++ b/internal/starter/templates_test.go
@@ -1,0 +1,50 @@
+package starter
+
+import "testing"
+
+func TestLookupFindsRegisteredTemplate(t *testing.T) {
+	tpl, ok := Lookup("web", "go")
+	if !ok {
+		t.Fatal("expected web/go template to be registered")
+	}
+	if tpl.ID != "web-go" || tpl.Path != "web/go" {
+		t.Fatalf("unexpected template resolved: %+v", tpl)
+	}
+}
+
+func TestLookupUnknownCombination(t *testing.T) {
+	if _, ok := Lookup("web", "rust"); ok {
+		t.Fatal("expected unregistered combination to miss")
+	}
+	if _, ok := Lookup("ios", "swift"); ok {
+		t.Fatal("expected unregistered type to miss")
+	}
+}
+
+// Every registry entry must be fully populated: the frontend renders labels
+// verbatim and Fetch needs a repo path, so an empty field is a silent UI or
+// download failure waiting to happen when new templates get added.
+func TestTemplatesRegistryComplete(t *testing.T) {
+	tpls := Templates()
+	if len(tpls) == 0 {
+		t.Fatal("expected at least one registered template")
+	}
+	seen := map[string]bool{}
+	for _, tpl := range tpls {
+		if tpl.ID == "" || tpl.Type == "" || tpl.TypeLabel == "" ||
+			tpl.Language == "" || tpl.LanguageLabel == "" || tpl.Path == "" {
+			t.Fatalf("template with empty field: %+v", tpl)
+		}
+		if seen[tpl.ID] {
+			t.Fatalf("duplicate template id %q", tpl.ID)
+		}
+		seen[tpl.ID] = true
+	}
+}
+
+func TestTemplatesReturnsCopy(t *testing.T) {
+	Templates()[0].ID = "mutated"
+	if templates[0].ID == "mutated" {
+		t.Fatal("Templates() must not expose the registry for mutation")
+	}
+}


### PR DESCRIPTION
Implements SC-157 (PM) / HUM-158 (engineering): when the desktop app opens on a directory that holds only tool config — no source files, no tickets — it offers a Start Project wizard (step 1: Web Project, step 2: Go) and scaffolds a runnable Go web starter from [gethuman-sh/starters](https://github.com/gethuman-sh/starters).

## Changes

- **`internal/starter`** (new): empty-project detection (deny-list walk over source extensions + build manifests, dot/dependency dirs never counted), template registry (wizard choices derive from it — future starters are one-line additions), and tarball fetch from codeload with path-traversal rejection, symlink dropping, decompression caps, and skip-never-overwrite semantics. 88% test coverage, no network in tests (stubbed httpGet).
- **`desktop/startproject.go`** (new): `StartProjectStatus` / `StartProject` bindings; local-FS only (Features() precedent), project root via .humanconfig findUp with cwd fallback.
- **Frontend**: wizard modal on the confirmDialog pattern, offered at most once per session and only on a *confirmed* empty board (successful fetch, zero cards) plus an empty directory; success state links into the ideation flow ("Create first ticket"). Daemon down, existing tickets, or any source file suppress it.

## Verification

- `make check` green; live fetch against the real starters repo verified (6 files, server runs).
- Known v1 trade-offs (in HUM-158): fixed `go.mod` module name, tarball pinned to starters@main, session-scoped dismissal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)