### PR TITLE
[HUM-165] Parse model families from ids instead of defaulting to sonnet

### DIFF
--- a/cmd/cmdtui/theme.go
+++ b/cmd/cmdtui/theme.go
@@ -1,6 +1,10 @@
 package cmdtui
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
 
 // Human brand colors.
 const (
@@ -14,11 +18,14 @@ const (
 	humanOrange = lipgloss.Color("#f0a050") // orange — confirmation pending
 )
 
-// Model-specific progress bar colors.
-var modelColors = map[string]string{
-	"opus 4.6":   "#fac86a", // gold
-	"sonnet 4.6": "#4ee8c4", // teal
-	"haiku 4.5":  "#555598", // purple
+// Model progress-bar colors, keyed by family prefix of the display name
+// ("opus 4.8" → "opus") so new versions inherit their family's color
+// without a map update.
+var modelFamilyColors = []struct{ prefix, color string }{
+	{"opus", "#fac86a"},   // gold
+	{"sonnet", "#4ee8c4"}, // teal
+	{"haiku", "#555598"},  // purple
+	{"fable", "#c86afa"},  // violet
 }
 
 // Styles used across the TUI.
@@ -43,8 +50,10 @@ var (
 )
 
 func modelColor(name string) string {
-	if c, ok := modelColors[name]; ok {
-		return c
+	for _, fc := range modelFamilyColors {
+		if strings.HasPrefix(name, fc.prefix) {
+			return fc.color
+		}
 	}
 	return "#fac86a" // default gold
 }

--- a/internal/claude/usage.go
+++ b/internal/claude/usage.go
@@ -38,34 +38,63 @@ type jsonlLine struct {
 	} `json:"message"`
 }
 
+// classifyModel derives a short display name ("opus 4.8", "fable 5") from a
+// model id. The family is parsed from the id's shape rather than matched
+// against a fixed list, so a new model family labels itself instead of
+// falling back to a wrong name; ids that don't look like Claude ids pass
+// through verbatim for the same reason.
 func classifyModel(model string) string {
-	m := strings.ToLower(model)
-
-	// Determine the family name.
-	var family string
-	switch {
-	case strings.Contains(m, "opus"):
-		family = "opus"
-	case strings.Contains(m, "haiku"):
-		family = "haiku"
-	default:
-		family = "sonnet"
+	m := strings.ToLower(strings.TrimSpace(model))
+	if m == "" {
+		return "unknown"
 	}
-
-	// Extract version from patterns like "claude-opus-4-6" or "claude-sonnet-4-5-20250929".
-	// After the family name there should be "-major-minor" digits.
-	idx := strings.Index(m, family)
+	// "claude" may be prefixed (Bedrock: "us.anthropic.claude-…").
+	idx := strings.Index(m, "claude")
 	if idx < 0 {
+		return m
+	}
+	family, version := parseClaudeID(m[idx:])
+	if family == "" {
+		return m
+	}
+	if version == "" {
 		return family
 	}
-	rest := m[idx+len(family):]
-	// rest should start with "-<major>-<minor>..." e.g. "-4-6" or "-4-5-20250929"
-	parts := strings.Split(strings.TrimPrefix(rest, "-"), "-")
-	if len(parts) >= 2 && isVersionDigit(parts[0]) && isVersionDigit(parts[1]) {
-		return family + " " + parts[0] + "." + parts[1]
-	}
+	return family + " " + version
+}
 
-	return family
+// parseClaudeID splits "claude-<family>-<version…>" — and the legacy
+// version-first shape "claude-3-5-sonnet-…" — into family and a dotted
+// version. Date stamps and suffixes like "v1:0" end the version run
+// (isVersionDigit rejects them), so they never masquerade as versions.
+func parseClaudeID(id string) (family, version string) {
+	segments := strings.FieldsFunc(id, func(r rune) bool {
+		return r == '-' || r == '.' || r == ':'
+	})
+	var pre, post []string
+	for _, seg := range segments[1:] { // segments[0] is "claude" itself
+		if isVersionDigit(seg) {
+			if family == "" {
+				pre = append(pre, seg)
+			} else {
+				post = append(post, seg)
+			}
+			continue
+		}
+		if family == "" {
+			family = seg
+			continue
+		}
+		break
+	}
+	digits := post
+	if len(digits) == 0 {
+		digits = pre
+	}
+	if len(digits) > 2 {
+		digits = digits[:2]
+	}
+	return family, strings.Join(digits, ".")
 }
 
 // isVersionDigit returns true for short numeric strings (1-2 digits)

--- a/internal/claude/usage_test.go
+++ b/internal/claude/usage_test.go
@@ -184,15 +184,29 @@ func TestClassifyModel(t *testing.T) {
 	}{
 		{"claude-opus-4-6", "opus 4.6"},
 		{"claude-opus-4-5-20251101", "opus 4.5"},
-		{"claude-opus-4-20250514", "opus"},
+		{"claude-opus-4-8", "opus 4.8"},
+		{"claude-opus-4-20250514", "opus 4"},
 		{"claude-sonnet-4-6", "sonnet 4.6"},
 		{"claude-sonnet-4-5-20250929", "sonnet 4.5"},
-		{"claude-sonnet-4-20250514", "sonnet"},
+		{"claude-sonnet-4-20250514", "sonnet 4"},
 		{"claude-haiku-4-5-20251001", "haiku 4.5"},
 		{"claude-haiku-3-5-20241022", "haiku 3.5"},
+		// New families label themselves — no enumeration, no sonnet fallback.
+		{"claude-fable-5", "fable 5"},
+		{"us.anthropic.claude-fable-5-v1:0", "fable 5"},
+		// Future point releases and siblings must keep working unchanged.
+		{"claude-fable-5-1", "fable 5.1"},
+		{"claude-fable-5-1-20260315", "fable 5.1"},
+		{"claude-fable-5-1-2", "fable 5.1"}, // patch digit beyond major.minor is dropped
+		{"claude-mythos-5", "mythos 5"},
+		// Legacy version-first shape.
+		{"claude-3-5-sonnet-20241022", "sonnet 3.5"},
+		// Non-Claude ids pass through verbatim instead of being guessed.
 		{"sonnet", "sonnet"},
 		{"haiku", "haiku"},
-		{"some-unknown-model", "sonnet"},
+		{"some-unknown-model", "some-unknown-model"},
+		{"gpt-4o", "gpt-4o"},
+		{"", "unknown"},
 	}
 	for _, tt := range tests {
 		got := classifyModel(tt.model)


### PR DESCRIPTION
Fixes HUM-165: `classifyModel` enumerated opus/haiku and labeled every other model "sonnet", so `claude-fable-5` was misreported in the desktop agents view and TUI usage stats.

Family and version now derive from the id shape — single-digit versions (`fable 5`), point releases (`fable 5.1`), Bedrock prefixes, and the legacy version-first form all covered by tests; non-Claude ids pass through verbatim. TUI bar colors match by family prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)