### PR TITLE
[HUM-166] Fix flaky stats writer test: events dropped when insert races cancellation

### DIFF
--- a/internal/stats/writer.go
+++ b/internal/stats/writer.go
@@ -56,15 +56,20 @@ func (w *Writer) Send(evt hookevents.Event) {
 
 func (w *Writer) run(ctx context.Context) {
 	defer close(w.done)
+	// ctx only decides when the loop stops, never whether an accepted event
+	// is persisted: after cancellation, select still picks randomly between
+	// the ready channel case and ctx.Done(), so inserting with ctx would
+	// silently drop events that the drain contract promises to keep.
+	writeCtx := context.WithoutCancel(ctx)
 	for {
 		select {
 		case evt := <-w.ch:
-			w.insert(ctx, evt)
+			w.insert(writeCtx, evt)
 		case <-ctx.Done():
-			w.drain()
+			w.drain(writeCtx)
 			return
 		case <-w.quit:
-			w.drain()
+			w.drain(writeCtx)
 			return
 		}
 	}
@@ -73,11 +78,11 @@ func (w *Writer) run(ctx context.Context) {
 // drain inserts any buffered events without blocking. The channel is never
 // closed, so the default case (not a closed-channel receive) is what bounds
 // the loop — avoiding the busy-spin that a closed channel would cause.
-func (w *Writer) drain() {
+func (w *Writer) drain(ctx context.Context) {
 	for {
 		select {
 		case evt := <-w.ch:
-			w.insert(context.Background(), evt)
+			w.insert(ctx, evt)
 		default:
 			return
 		}

--- a/internal/stats/writer_test.go
+++ b/internal/stats/writer_test.go
@@ -86,9 +86,9 @@ func TestWriter_ContextCancellationDrains(t *testing.T) {
 
 	total, err := store.QueryTotal(context.Background(), now.Add(-time.Hour), now.Add(time.Hour))
 	require.NoError(t, err)
-	// All 5 events should be persisted (some via normal loop, rest via drain).
-	assert.GreaterOrEqual(t, total, 1, "at least some events should be persisted")
-	assert.LessOrEqual(t, total, 5, "at most 5 events should be persisted")
+	// All 5 events must be persisted (some via normal loop, rest via drain):
+	// cancellation stops the loop but must never lose an accepted event.
+	assert.Equal(t, 5, total, "all buffered events should be persisted")
 }
 
 func TestWriter_CloseAfterContextCancelDoesNotHang(t *testing.T) {


### PR DESCRIPTION
Fixes the intermittent `TestWriter_ContextCancellationDrains` failure in `internal/stats` (last seen breaking CI on PR #55, which does not touch this package).

## Root cause

`Writer.run` inserted events with its lifecycle `ctx`. After cancellation, Go's `select` still picks randomly between the ready channel case and `ctx.Done()`, so buffered events could be consumed through the normal path and inserted with an already-cancelled context — SQLite rejects the write and the event is silently dropped instead of drained. If all buffered events took that path, none persisted and the test failed.

## Fix

Use `context.WithoutCancel(ctx)` for all DB inserts: the lifecycle context now only decides when the loop stops, never whether an accepted event is persisted. `drain()` takes that same write context instead of constructing its own `context.Background()`.

The test now deterministically asserts all 5 buffered events persist (previously `>= 1`, which encoded the lossy behavior).

## Verification

- `go test ./internal/stats/ -count=500` — pass (previously failed within ~200 runs)
- `go test ./internal/stats/ -race -count=50` — pass
- `make check` — green

Issue HUM-166

🤖 Generated with [Claude Code](https://claude.com/claude-code)