### PR TITLE
[HUM-167] Bind permission decisions to the operation, not the nonce

### DIFF
--- a/internal/daemon/pending_confirm.go
+++ b/internal/daemon/pending_confirm.go
@@ -113,6 +113,38 @@ func (s *PendingConfirmStore) FindPending(operation, trackerKind, key string) (P
 	return PendingConfirmation{}, false
 }
 
+// ConsumeApprovedFor redeems an approved grant by the operation it covers,
+// regardless of which nonce created it. The user's consent is operation-
+// level (the prompt says "TransitionIssue 158?", not which client asked),
+// so a requester that lost its original ID — crash, restart, legacy build —
+// redeems the approval instead of prompting the user a second time. Match
+// and removal are one atomic step, same as Consume.
+func (s *PendingConfirmStore) ConsumeApprovedFor(operation, trackerKind, key string) (PendingConfirmation, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, pc := range s.ops {
+		if pc.State == ConfirmApproved && pc.Operation == operation && pc.Tracker == trackerKind && pc.Key == key {
+			delete(s.ops, id)
+			return *pc, true
+		}
+	}
+	return PendingConfirmation{}, false
+}
+
+// FindDenied returns the denied entry for the given operation/tracker/key,
+// if any. A denial is the user's decision about the operation itself, so a
+// retry under a fresh nonce must see it instead of opening a new prompt.
+func (s *PendingConfirmStore) FindDenied(operation, trackerKind, key string) (PendingConfirmation, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, pc := range s.ops {
+		if pc.State == ConfirmDenied && pc.Operation == operation && pc.Tracker == trackerKind && pc.Key == key {
+			return *pc, true
+		}
+	}
+	return PendingConfirmation{}, false
+}
+
 // Consume redeems an approved grant by its unique ID: the entry is removed
 // and returned, but only if it is approved AND covers the given operation/
 // tracker/key — the grant authorizes exactly what the user saw in the

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -874,12 +874,26 @@ func (s *Server) handleDestructiveConfirm(conn net.Conn, req Request, op destruc
 				s.writeAwaitConfirm(conn, pc.ID, pc.Prompt)
 				return
 			case ConfirmDenied:
-				resp := Response{Stderr: "Operation aborted: the user denied permission. Do not retry; ask the user how to proceed.\n", ExitCode: 1}
-				enc := json.NewEncoder(conn)
-				_ = enc.Encode(resp)
+				s.writeDenied(conn)
 				return
 			}
 		}
+	}
+
+	// Decisions are operation-level, so a request arriving under a fresh
+	// nonce — after a client crash, restart, or from a legacy build — must
+	// resume the operation's existing decision instead of prompting again.
+	// An approved grant is redeemed (one-time) exactly as the exact-nonce
+	// path would; a denial is final for its retention window.
+	if pc, ok := s.PendingConfirms.ConsumeApprovedFor(op.Operation, op.Tracker, op.Key); ok {
+		s.Logger.Info().Str("id", pc.ID).Str("key", op.Key).Msg("permission grant redeemed by operation, executing")
+		req.Args = append(req.Args, "--yes")
+		s.executeCommand(conn, req, projectDir)
+		return
+	}
+	if _, ok := s.PendingConfirms.FindDenied(op.Operation, op.Tracker, op.Key); ok {
+		s.writeDenied(conn)
+		return
 	}
 
 	prompt := fmt.Sprintf("%s %s?", op.Operation, op.Key)
@@ -910,6 +924,19 @@ func (s *Server) handleDestructiveConfirm(conn net.Conn, req Request, op destruc
 	})
 	s.Logger.Info().Str("id", id).Str("prompt", prompt).Msg("destructive operation awaiting confirmation")
 	s.writeAwaitConfirm(conn, id, prompt)
+}
+
+// writeDenied reports a user denial. The wording is agent-facing on purpose:
+// a denial is the user's decision about the operation, not a transient
+// failure, so the requester must stop retrying and bring the question back
+// to the human instead of routing around the refusal.
+func (s *Server) writeDenied(conn net.Conn) {
+	resp := Response{
+		Stderr:   "Operation aborted: the user denied permission for this operation. Back off — do not retry it in any form; rethink the approach and ask the user how to proceed.\n",
+		ExitCode: 1,
+	}
+	enc := json.NewEncoder(conn)
+	_ = enc.Encode(resp)
 }
 
 // writeAwaitConfirm tells the client its operation is queued for permission.

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -766,6 +766,61 @@ func TestServer_DestructiveConfirm_ResubmitIsIdempotent(t *testing.T) {
 	assert.Equal(t, 1, store.Len())
 }
 
+func TestServer_DestructiveConfirm_ApprovedGrantRedeemedByOperation(t *testing.T) {
+	token := "test-token"
+	addr, _, store := startTestServerWithConfirm(t, token)
+
+	// Queue and approve under one nonce.
+	_ = sendRequest(t, addr, Request{Token: token, ClientPID: 1111, ConfirmID: "cid-op", Args: []string{"jira", "issue", "delete", "KAN-7"}})
+	_ = sendRequest(t, addr, Request{Token: token, ClientPID: 2222, Args: []string{"confirm-op", "cid-op", "yes"}})
+
+	// The same operation arriving under a FRESH nonce (client crashed and
+	// restarted) redeems the grant and executes — it must not prompt again.
+	resp := sendRequest(t, addr, Request{Token: token, ClientPID: 1111, ConfirmID: "cid-fresh", Args: []string{"jira", "issue", "delete", "KAN-7"}})
+	assert.False(t, resp.AwaitConfirm, "approved operation must execute, not re-prompt")
+	assert.Equal(t, 0, store.Len(), "grant is consumed")
+
+	// One approval covers exactly one execution: the next attempt prompts.
+	again := sendRequest(t, addr, Request{Token: token, ClientPID: 1111, ConfirmID: "cid-later", Args: []string{"jira", "issue", "delete", "KAN-7"}})
+	assert.True(t, again.AwaitConfirm, "consumed grant must not be redeemable twice")
+}
+
+func TestServer_DestructiveConfirm_ApprovedGrantRedeemedByLegacyClient(t *testing.T) {
+	token := "test-token"
+	addr, _, store := startTestServerWithConfirm(t, token)
+
+	_ = sendRequest(t, addr, Request{Token: token, ClientPID: 1111, ConfirmID: "cid-legacy", Args: []string{"jira", "issue", "delete", "KAN-8"}})
+	_ = sendRequest(t, addr, Request{Token: token, ClientPID: 2222, Args: []string{"confirm-op", "cid-legacy", "yes"}})
+
+	// A nonce-less request (legacy build) for the approved operation
+	// redeems the grant instead of piling a second prompt onto the user.
+	resp := sendRequest(t, addr, Request{Token: token, ClientPID: 1111, Args: []string{"jira", "issue", "delete", "KAN-8"}})
+	assert.False(t, resp.AwaitConfirm)
+	assert.Equal(t, 0, store.Len())
+}
+
+func TestServer_DestructiveConfirm_DenialBindsToOperation(t *testing.T) {
+	token := "test-token"
+	addr, _, store := startTestServerWithConfirm(t, token)
+
+	_ = sendRequest(t, addr, Request{Token: token, ClientPID: 1111, ConfirmID: "cid-no", Args: []string{"jira", "issue", "delete", "KAN-6"}})
+	_ = sendRequest(t, addr, Request{Token: token, ClientPID: 2222, Args: []string{"confirm-op", "cid-no", "no"}})
+
+	// A retry under a fresh nonce gets the denial and a back-off
+	// instruction — the user's "no" is about the operation, not the nonce.
+	resp := sendRequest(t, addr, Request{Token: token, ClientPID: 1111, ConfirmID: "cid-retry-no", Args: []string{"jira", "issue", "delete", "KAN-6"}})
+	assert.False(t, resp.AwaitConfirm, "denied operation must not re-prompt")
+	assert.Equal(t, 1, resp.ExitCode)
+	assert.Contains(t, resp.Stderr, "denied permission")
+	assert.Contains(t, resp.Stderr, "Back off")
+	assert.Equal(t, 1, store.Len(), "no new queue entry for a denied operation")
+
+	// Nonce-less retries see the same denial.
+	legacy := sendRequest(t, addr, Request{Token: token, ClientPID: 1111, Args: []string{"jira", "issue", "delete", "KAN-6"}})
+	assert.False(t, legacy.AwaitConfirm)
+	assert.Contains(t, legacy.Stderr, "Back off")
+}
+
 func TestServer_DestructiveYes_StillRequiresConfirmation(t *testing.T) {
 	token := "test-token"
 	addr, _, store := startTestServerWithConfirm(t, token)


### PR DESCRIPTION
Fixes HUM-167 (the duplicate-prompt pileup): approved grants are now redeemable operation-level under any nonce (one-time consumption preserved), and denials bind to the operation too — a retry gets "the user denied this; back off, rethink, ask the user" instead of a fresh prompt.

Check order in `handleDestructiveConfirm`: exact nonce → approved-by-op (redeem+execute) → denied-by-op (back-off) → pending-by-op (reattach) → queue new.

The version handshake for stale clients is split out as HUM-168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)