### PR TITLE
[HUM-168] Reject protocol-stale clients with a version handshake

### DIFF
--- a/internal/daemon/README.md
+++ b/internal/daemon/README.md
@@ -9,6 +9,7 @@ A long-running background service that holds your tracker credentials once and a
 - Completes browser OAuth sign-in flows automatically
 - Surfaces ready-for-review handoffs to the TUI
 - Queues destructive operations as permission requests; an approval is a one-time grant the client redeems by re-submitting the command, and decisions stay queryable by ID for 24 hours
+- Rejects clients older than the wire protocol it speaks with a clear "upgrade the human CLI" error, before any side effects
 - Records tool activity for later statistics
 - Derives each PM ticket's workflow-board placement and applies drag-to-trigger pipeline transitions for the desktop board
 - Runs the board's agent-driven ideation chat (start/reply/status) and creates the resulting PM ticket on the PM-role tracker

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -24,6 +24,12 @@ import (
 
 const dialTimeout = 5 * time.Second
 
+// ClientVersion is stamped into every request this process sends so the
+// daemon can reject protocol-stale clients up front (see the server's
+// version gate). The CLI overwrites it at startup with its build version;
+// the "dev" default keeps same-tree builds (tests, desktop app) passing.
+var ClientVersion = "dev"
+
 // RunRemote connects to the daemon at addr, sends the CLI args, and returns
 // the exit code. Stdout and stderr are written to os.Stdout and os.Stderr.
 //
@@ -219,6 +225,7 @@ func RunRemoteCapture(addr, token string, args []string) ([]byte, error) {
 
 	cwd, _ := os.Getwd()
 	req := Request{
+		Version:   ClientVersion,
 		Token:     token,
 		Args:      args,
 		ClientPID: os.Getpid(),
@@ -506,6 +513,7 @@ func Subscribe(addr, token string) (<-chan SubscribeEvent, func(), error) {
 
 	cwd, _ := os.Getwd()
 	req := Request{
+		Version:   ClientVersion,
 		Token:     token,
 		Args:      []string{"subscribe"},
 		ClientPID: os.Getpid(),

--- a/internal/daemon/oauth_relay_test.go
+++ b/internal/daemon/oauth_relay_test.go
@@ -165,7 +165,7 @@ func TestOAuthRelayEndToEnd(t *testing.T) {
 		}
 		defer func() { _ = conn.Close() }()
 
-		req := Request{Token: token, Args: []string{"browser", oauthURL}}
+		req := Request{Version: "dev", Token: token, Args: []string{"browser", oauthURL}}
 		if encErr := json.NewEncoder(conn).Encode(req); encErr != nil {
 			resultCh <- twoLineClientResult{err: encErr}
 			return

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -168,6 +168,17 @@ func (s *Server) handleConn(conn net.Conn) {
 		return
 	}
 
+	// Version gate before ANY routing or side effect: a protocol-stale
+	// client must get one clear "upgrade" error, not a cryptic mid-handshake
+	// failure after the daemon already acted (e.g. queued a permission
+	// prompt it can never redeem).
+	if !clientVersionSupported(req.Version) {
+		s.writeError(conn, fmt.Sprintf(
+			"client version %q is older than this daemon supports (need >= %s) — upgrade the human CLI so client and daemon speak the same protocol",
+			req.Version, MinClientVersion), 1)
+		return
+	}
+
 	if req.ClientPID > 0 && s.ConnectedPIDs != nil {
 		s.ConnectedPIDs.Touch(req.ClientPID)
 	}

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -95,6 +95,11 @@ func startTestServer(t *testing.T, token string) (addr string, cancel context.Ca
 
 func sendRequest(t *testing.T, addr string, req Request) Response {
 	t.Helper()
+	// Tests exercise routes, not the version gate — stamp the dev version
+	// like a real same-tree client unless a test sets one explicitly.
+	if req.Version == "" {
+		req.Version = "dev"
+	}
 	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
 	require.NoError(t, err)
 	defer func() { _ = conn.Close() }()

--- a/internal/daemon/version_gate.go
+++ b/internal/daemon/version_gate.go
@@ -1,0 +1,74 @@
+package daemon
+
+import "strings"
+
+// MinClientVersion is the oldest client wire protocol this daemon accepts.
+// Bump it whenever the protocol changes incompatibly, so stale clients get
+// one clear "upgrade" error instead of failing mid-handshake with side
+// effects already applied (last incompatible change: the HUM-160
+// permission-grant cycle, shipping in 0.21.0).
+const MinClientVersion = "0.21.0"
+
+// clientVersionSupported reports whether a client's self-reported version may
+// talk to this daemon. Dev builds pass — they are built from the same tree as
+// the daemon they test against. Empty or unparseable versions are rejected: a
+// client that cannot state its version predates the handshake itself.
+func clientVersionSupported(version string) bool {
+	v := strings.TrimSpace(version)
+	if v == "dev" || strings.HasPrefix(v, "dev ") {
+		return true
+	}
+	got, ok := parseSemver(v)
+	if !ok {
+		return false
+	}
+	want, _ := parseSemver(MinClientVersion)
+	return !semverLess(got, want)
+}
+
+// parseSemver reads up to major.minor.patch from a version string, tolerating
+// a leading "v" and trailing non-numeric suffixes ("0.21.0-rc1", "0.21.0
+// (abc123) 2026-…"). Missing parts default to zero.
+func parseSemver(s string) ([3]int, bool) {
+	s = strings.TrimPrefix(s, "v")
+	if cut := strings.IndexAny(s, " -+("); cut >= 0 {
+		s = s[:cut]
+	}
+	var out [3]int
+	parts := strings.SplitN(s, ".", 3)
+	for i, p := range parts {
+		n, ok := leadingInt(p)
+		if !ok {
+			return [3]int{}, false
+		}
+		out[i] = n
+	}
+	return out, len(parts) > 0 && parts[0] != ""
+}
+
+func leadingInt(s string) (int, bool) {
+	if s == "" {
+		return 0, false
+	}
+	n := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			if i == 0 {
+				return 0, false
+			}
+			break
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n, true
+}
+
+func semverLess(a, b [3]int) bool {
+	for i := 0; i < 3; i++ {
+		if a[i] != b[i] {
+			return a[i] < b[i]
+		}
+	}
+	return false
+}

--- a/internal/daemon/version_gate_test.go
+++ b/internal/daemon/version_gate_test.go
@@ -1,0 +1,72 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientVersionSupported(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"dev", true},
+		{"dev (abc123) 2026-07-13", true},
+		{MinClientVersion, true},
+		{"v" + MinClientVersion, true},
+		{"0.21.0-rc1", true},
+		{"0.21.1", true},
+		{"0.22.0", true},
+		{"1.0.0", true},
+		{"99.0", true},
+		// Pre-handshake and pre-grant-protocol clients.
+		{"", false},
+		{"0.20.0", false},
+		{"0.20.9", false},
+		{"0.9.9", false},
+		{"garbage", false},
+		{"v.x", false},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, clientVersionSupported(tt.version), "version %q", tt.version)
+	}
+}
+
+func TestServer_VersionGate_RejectsStaleClientBeforeSideEffects(t *testing.T) {
+	token := "test-token"
+	addr, _, store := startTestServerWithConfirm(t, token)
+
+	// A destructive op from a pre-grant-protocol client: rejected with a
+	// clear upgrade message and — critically — NOTHING queued.
+	resp := sendRequest(t, addr, Request{Version: "0.20.0", Token: token, ClientPID: 1111, Args: []string{"jira", "issue", "delete", "KAN-1"}})
+	assert.Equal(t, 1, resp.ExitCode)
+	assert.False(t, resp.AwaitConfirm)
+	assert.Contains(t, resp.Stderr, "older than this daemon supports")
+	assert.Contains(t, resp.Stderr, MinClientVersion)
+	assert.Equal(t, 0, store.Len(), "stale client must not create queue entries")
+}
+
+func TestServer_VersionGate_DevAndCurrentPass(t *testing.T) {
+	token := "test-token"
+	addr, _, _ := startTestServerWithConfirm(t, token)
+
+	// Non-destructive request with dev version reaches routing (echoCmd
+	// runs and echoes the args back).
+	devResp := sendRequest(t, addr, Request{Version: "dev", Token: token, Args: []string{"echo", "hello"}})
+	require.Equal(t, 0, devResp.ExitCode, "stderr: %s", devResp.Stderr)
+
+	relResp := sendRequest(t, addr, Request{Version: MinClientVersion, Token: token, Args: []string{"echo", "hello"}})
+	assert.Equal(t, 0, relResp.ExitCode, "stderr: %s", relResp.Stderr)
+}
+
+func TestServer_VersionGate_RunsAfterAuth(t *testing.T) {
+	token := "test-token"
+	addr, _, _ := startTestServerWithConfirm(t, token)
+
+	// Wrong token + stale version: authentication wins, so the gate leaks
+	// no protocol details to unauthenticated callers.
+	resp := sendRequest(t, addr, Request{Version: "0.20.0", Token: "wrong", Args: []string{"echo", "hello"}})
+	assert.Contains(t, resp.Stderr, "authentication failed")
+}

--- a/main.go
+++ b/main.go
@@ -599,6 +599,10 @@ func applyDaemonInfo(info daemon.DaemonInfo, token string) (string, string) {
 func main() {
 	log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger()
 
+	// Stamp the build version into every daemon request so the daemon's
+	// version gate can reject a protocol-stale client with a clear error.
+	daemon.ClientVersion = version
+
 	// Busybox-style dispatch: "human-browser URL" → "human browser URL".
 	args := os.Args[1:] //nolint:nilaway // os.Args is always set in main
 	if sub := subcmdFromBinary(); sub != "" {


### PR DESCRIPTION
Fixes HUM-168: the client already sent its version on RunRemote but not on RunRemoteCapture/Subscribe — now every request is stamped, and the daemon gates on `MinClientVersion` (0.21.0, the first release with the HUM-160 grant protocol) right after token auth, before any routing or side effects.

A v0.20.0 client now gets: `client version "0.20.0" is older than this daemon supports (need >= 0.21.0) — upgrade the human CLI so client and daemon speak the same protocol` instead of `failed to read confirmation response: EOF` plus stranded queue entries.

Dev builds pass (same-tree); empty/unparseable versions are rejected as pre-handshake. Companion to #58 (HUM-167).

🤖 Generated with [Claude Code](https://claude.com/claude-code)