### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #60)

### DIFF
--- a/internal/claude/embed/human-brainstorm-skill.md
+++ b/internal/claude/embed/human-brainstorm-skill.md
@@ -1,7 +1,7 @@
 ---
 name: human-brainstorm
 description: Discover missing features by analyzing the project's code and completed work using a multi-agent pipeline
-argument-hint: [focus-area]
+argument-hint: "[focus-area]"
 ---
 
 # Missing Feature Discovery

--- a/internal/claude/embed/human-features-skill.md
+++ b/internal/claude/embed/human-features-skill.md
@@ -1,7 +1,7 @@
 ---
 name: human-features
 description: Generate FEATURE.json — a grouped, human-readable map of what this codebase can do — from the code, git history, and tickets
-argument-hint: [since]
+argument-hint: "[since]"
 ---
 
 # Feature Map Generation


### PR DESCRIPTION
Closes #60.

## Summary

Purely mechanical single-character transform to 2 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (2)

- `internal/claude/embed/human-brainstorm-skill.md`
- `internal/claude/embed/human-features-skill.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
