### PR TITLE
[SC-159] [HUM-169] Label capability layer across all tracker providers

### DIFF
--- a/cmd/cmdprovider/provider.go
+++ b/cmd/cmdprovider/provider.go
@@ -96,6 +96,7 @@ func buildIssueGetCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 
 func buildIssueCreateCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 	var project, typ, description, parent string
+	var labels []string
 
 	cmd := &cobra.Command{
 		Use:     "create TITLE",
@@ -108,7 +109,7 @@ func buildIssueCreateCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 				return err
 			}
 			defer cleanup()
-			return RunCreateIssue(cmd.Context(), p, cmd.OutOrStdout(), project, typ, args[0], description, parent)
+			return RunCreateIssue(cmd.Context(), p, cmd.OutOrStdout(), project, typ, args[0], description, parent, labels)
 		},
 	}
 	cmd.Flags().StringVar(&project, "project", "", "Project key (Jira: KAN, GitHub: owner/repo, GitLab: group/project, Linear: ENG)")
@@ -116,6 +117,7 @@ func buildIssueCreateCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 	cmd.Flags().StringVar(&typ, "type", "Task", "Issue type (Jira only, e.g. Task, Bug, Story)")
 	cmd.Flags().StringVar(&description, "description", "", "Issue description in markdown (separate from title)")
 	cmd.Flags().StringVar(&parent, "parent", "", "Parent issue key to create this as a subtask (Linear, Jira, Shortcut, Azure DevOps, GitHub, ClickUp; not supported on GitLab)")
+	cmd.Flags().StringArrayVar(&labels, "label", nil, "Label to attach (repeatable), e.g. --label human/idea")
 	return cmd
 }
 
@@ -154,15 +156,17 @@ func buildPRCreateCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 
 func buildIssueEditCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 	var title, description string
+	var addLabels, removeLabels []string
 
 	cmd := &cobra.Command{
 		Use:     "edit KEY",
-		Short:   "Edit an issue's title and/or description",
-		Example: `  human jira issue edit KAN-1 --title "New title" --description "Updated description"`,
+		Short:   "Edit an issue's title, description, and/or labels",
+		Example: `  human jira issue edit KAN-1 --title "New title" --remove-label human/idea`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("title") && !cmd.Flags().Changed("description") {
-				return errors.WithDetails("at least one of --title or --description is required")
+			if !cmd.Flags().Changed("title") && !cmd.Flags().Changed("description") &&
+				len(addLabels) == 0 && len(removeLabels) == 0 {
+				return errors.WithDetails("at least one of --title, --description, --add-label, or --remove-label is required")
 			}
 			p, cleanup, err := cmdutil.ResolveProvider(cmd, kind, deps)
 			if err != nil {
@@ -170,7 +174,7 @@ func buildIssueEditCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 			}
 			defer cleanup()
 
-			var opts tracker.EditOptions
+			opts := tracker.EditOptions{AddLabels: addLabels, RemoveLabels: removeLabels}
 			if cmd.Flags().Changed("title") {
 				opts.Title = &title
 			}
@@ -183,6 +187,8 @@ func buildIssueEditCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&title, "title", "", "New issue title")
 	cmd.Flags().StringVar(&description, "description", "", "New issue description (markdown)")
+	cmd.Flags().StringArrayVar(&addLabels, "add-label", nil, "Label to add (repeatable)")
+	cmd.Flags().StringArrayVar(&removeLabels, "remove-label", nil, "Label to remove (repeatable; absent labels are ignored)")
 	return cmd
 }
 
@@ -354,13 +360,14 @@ func RunGetIssue(ctx context.Context, p tracker.Provider, out io.Writer, key str
 // RunCreateIssue creates a new issue. When parent is non-empty, the issue is
 // created as a subtask of the given parent key. Subtask support is
 // provider-specific (see the --parent flag help); GitLab rejects it.
-func RunCreateIssue(ctx context.Context, p tracker.Provider, out io.Writer, project, typ, title, description, parent string) error {
+func RunCreateIssue(ctx context.Context, p tracker.Provider, out io.Writer, project, typ, title, description, parent string, labels []string) error {
 	issue, err := p.CreateIssue(ctx, &tracker.Issue{
 		Project:     project,
 		Type:        typ,
 		Title:       title,
 		Description: description,
 		ParentKey:   parent,
+		Labels:      labels,
 	})
 	if err != nil {
 		return err

--- a/cmd/cmdprovider/provider_test.go
+++ b/cmd/cmdprovider/provider_test.go
@@ -262,7 +262,7 @@ func TestRunCreateIssue_Success(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := RunCreateIssue(context.Background(), p, &buf, "KAN", "Task", "New feature", "Details here", "")
+	err := RunCreateIssue(context.Background(), p, &buf, "KAN", "Task", "New feature", "Details here", "", nil)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "KAN-10")
 	assert.Contains(t, buf.String(), "New feature")
@@ -276,7 +276,7 @@ func TestRunCreateIssue_Error(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := RunCreateIssue(context.Background(), p, &buf, "KAN", "Task", "Title", "", "")
+	err := RunCreateIssue(context.Background(), p, &buf, "KAN", "Task", "Title", "", "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "create failed")
 }
@@ -1021,7 +1021,7 @@ func TestCmd_IssueEdit_NoFlags(t *testing.T) {
 	root.SetArgs([]string{"jira", "issue", "edit", "KAN-1"})
 	err := root.Execute()
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "at least one of --title or --description is required")
+	assert.Contains(t, err.Error(), "at least one of --title, --description, --add-label, or --remove-label is required")
 }
 
 func TestCmd_IssueDelete_Success(t *testing.T) {

--- a/internal/tracker/azuredevops/client.go
+++ b/internal/tracker/azuredevops/client.go
@@ -150,6 +150,9 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 	if issue.Description != "" {
 		ops = append(ops, patchOp{Op: "add", Path: "/fields/System.Description", Value: issue.Description})
 	}
+	if len(issue.Labels) > 0 {
+		ops = append(ops, patchOp{Op: "add", Path: "/fields/System.Tags", Value: joinTags(issue.Labels)})
+	}
 	// Azure models a subtask as a hierarchy link to the parent work item
 	// (Hierarchy-Reverse points from child to parent), added at create time.
 	if issue.ParentKey != "" {
@@ -189,6 +192,7 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 		Description: wi.Fields.Description,
 		URL:         fmt.Sprintf("https://dev.azure.com/%s/%s/_workitems/edit/%d", c.org, project, wi.ID),
 		ParentKey:   issue.ParentKey,
+		Labels:      splitTags(wi.Fields.Tags),
 	}, nil
 }
 
@@ -331,6 +335,18 @@ func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOpt
 	if opts.Description != nil {
 		ops = append(ops, patchOp{Op: "replace", Path: "/fields/System.Description", Value: *opts.Description})
 	}
+	// System.Tags has no per-tag patch semantics — "add" on a field path
+	// overwrites the whole value — so the live tag set is read and merged
+	// first. Skipped entirely when the edit doesn't touch labels, keeping
+	// title/description-only edits from clobbering tags.
+	if len(opts.AddLabels) > 0 || len(opts.RemoveLabels) > 0 {
+		tags, tErr := c.currentTags(ctx, project, id)
+		if tErr != nil {
+			return nil, tErr
+		}
+		merged := mergeLabels(tags, opts.AddLabels, opts.RemoveLabels)
+		ops = append(ops, patchOp{Op: "add", Path: "/fields/System.Tags", Value: joinTags(merged)})
+	}
 
 	body, err := json.Marshal(ops)
 	if err != nil {
@@ -349,6 +365,65 @@ func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOpt
 
 	issue := c.toTrackerIssue(wi, project)
 	return &issue, nil
+}
+
+// currentTags reads the work item's live tag set so a label edit can merge
+// against it before the full-replacement System.Tags write.
+func (c *Client) currentTags(ctx context.Context, project string, id int) ([]string, error) {
+	path := fmt.Sprintf("/%s/%s/_apis/wit/workitems/%d", url.PathEscape(c.org), url.PathEscape(project), id)
+	resp, err := c.doRequest(ctx, http.MethodGet, path, "api-version=7.1", nil, "")
+	if err != nil {
+		return nil, err
+	}
+	var wi adoWorkItem
+	if err := apiclient.DecodeJSON(resp, &wi, "project", project, "id", id); err != nil {
+		return nil, err
+	}
+	return splitTags(wi.Fields.Tags), nil
+}
+
+// mergeLabels applies add/remove requests to an existing label set. Existing
+// order is preserved, additions are appended, duplicates are dropped, and
+// removing an absent label is a no-op so label swaps stay idempotent.
+func mergeLabels(existing, add, remove []string) []string {
+	removed := make(map[string]bool, len(remove))
+	for _, name := range remove {
+		removed[name] = true
+	}
+	seen := make(map[string]bool, len(existing)+len(add))
+	merged := make([]string, 0, len(existing)+len(add))
+	keep := func(name string) {
+		if removed[name] || seen[name] {
+			return
+		}
+		seen[name] = true
+		merged = append(merged, name)
+	}
+	for _, name := range existing {
+		keep(name)
+	}
+	for _, name := range add {
+		keep(name)
+	}
+	return merged
+}
+
+// splitTags parses Azure's "; "-joined System.Tags value into label names.
+// Splitting on the bare ";" and trimming tolerates the missing space Azure
+// sometimes omits.
+func splitTags(tags string) []string {
+	var names []string
+	for _, part := range strings.Split(tags, ";") {
+		if name := strings.TrimSpace(part); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// joinTags renders label names in the "; "-joined form System.Tags expects.
+func joinTags(names []string) string {
+	return strings.Join(names, "; ")
 }
 
 // DeleteIssue implements tracker.Deleter by transitioning the work item to "Done".
@@ -489,6 +564,7 @@ func (c *Client) toTrackerIssue(wi adoWorkItem, project string) tracker.Issue {
 		Status:      wi.Fields.State,
 		Description: wi.Fields.Description,
 		URL:         fmt.Sprintf("https://dev.azure.com/%s/%s/_workitems/edit/%d", c.org, project, wi.ID),
+		Labels:      splitTags(wi.Fields.Tags),
 	}
 
 	if wi.Fields.ChangedDate != "" {

--- a/internal/tracker/azuredevops/client_test.go
+++ b/internal/tracker/azuredevops/client_test.go
@@ -852,3 +852,118 @@ func TestGetIssue_withParent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Human/42", issue.ParentKey)
 }
+
+func TestGetIssue_withTags(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `{"id":7,"fields":{"System.Title":"Tagged","System.State":"New","System.WorkItemType":"Issue","System.TeamProject":"Human","System.Tags":"alpha; beta;gamma"}}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "myorg", "pat-test")
+	issue, err := client.GetIssue(context.Background(), "Human/7")
+
+	require.NoError(t, err)
+	// The join uses "; " but Azure occasionally omits the space, so both
+	// separator forms must parse.
+	assert.Equal(t, []string{"alpha", "beta", "gamma"}, issue.Labels)
+}
+
+func Test_splitJoinTags(t *testing.T) {
+	assert.Nil(t, splitTags(""))
+	assert.Equal(t, []string{"a", "b"}, splitTags("a; b"))
+	assert.Equal(t, []string{"a", "b"}, splitTags("a;b"))
+	assert.Equal(t, []string{"a"}, splitTags(" a ; "))
+	// Round trip: parse and re-render reproduces the canonical form.
+	assert.Equal(t, "a; b", joinTags(splitTags("a;b")))
+	assert.Equal(t, "", joinTags(nil))
+}
+
+func TestEditIssue_labelsMerged(t *testing.T) {
+	var gotOps []patchOp
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			// The live tag set read before the full-replacement tags write.
+			assert.Equal(t, "/myorg/Human/_apis/wit/workitems/5", r.URL.Path)
+			_, _ = fmt.Fprint(w, `{"id":5,"fields":{"System.Title":"Item","System.State":"New","System.WorkItemType":"Issue","System.TeamProject":"Human","System.Tags":"alpha; beta"}}`)
+		case http.MethodPatch:
+			assert.Equal(t, "/myorg/Human/_apis/wit/workitems/5", r.URL.Path)
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &gotOps))
+			_, _ = fmt.Fprint(w, `{"id":5,"fields":{"System.Title":"Item","System.State":"New","System.WorkItemType":"Issue","System.TeamProject":"Human","System.Tags":"alpha; gamma"}}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "myorg", "pat-test")
+	issue, err := client.EditIssue(context.Background(), "Human/5", tracker.EditOptions{
+		AddLabels:    []string{"gamma", "alpha"}, // "alpha" duplicate must dedupe
+		RemoveLabels: []string{"beta", "ghost"},  // "ghost" absent must be a no-op
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpha", "gamma"}, issue.Labels)
+
+	// One "add" op carries the fully merged set — "add" replaces for fields.
+	require.Len(t, gotOps, 1)
+	assert.Equal(t, "add", gotOps[0].Op)
+	assert.Equal(t, "/fields/System.Tags", gotOps[0].Path)
+	assert.Equal(t, "alpha; gamma", gotOps[0].Value)
+}
+
+func TestEditIssue_noLabelChangeSkipsTagsOp(t *testing.T) {
+	title := "New title"
+	var gotOps []patchOp
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			t.Error("title-only edit must not fetch the work item for tag merging")
+			w.WriteHeader(http.StatusNotFound)
+		case http.MethodPatch:
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &gotOps))
+			_, _ = fmt.Fprint(w, `{"id":5,"fields":{"System.Title":"New title","System.State":"New","System.WorkItemType":"Issue","System.TeamProject":"Human","System.Tags":"alpha"}}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "myorg", "pat-test")
+	_, err := client.EditIssue(context.Background(), "Human/5", tracker.EditOptions{Title: &title})
+
+	require.NoError(t, err)
+	require.Len(t, gotOps, 1)
+	assert.Equal(t, "/fields/System.Title", gotOps[0].Path)
+}
+
+func TestCreateIssue_withTags(t *testing.T) {
+	var gotOps []patchOp
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotOps))
+		_, _ = fmt.Fprint(w, `{"id":101,"fields":{"System.Title":"Tagged","System.State":"New","System.WorkItemType":"Issue","System.TeamProject":"Human","System.Tags":"idea; backend"}}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "myorg", "pat-test")
+	issue, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Project: "Human",
+		Title:   "Tagged",
+		Labels:  []string{"idea", "backend"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"idea", "backend"}, issue.Labels)
+
+	require.Len(t, gotOps, 2)
+	assert.Equal(t, "add", gotOps[1].Op)
+	assert.Equal(t, "/fields/System.Tags", gotOps[1].Path)
+	assert.Equal(t, "idea; backend", gotOps[1].Value)
+}

--- a/internal/tracker/azuredevops/types.go
+++ b/internal/tracker/azuredevops/types.go
@@ -26,6 +26,7 @@ type adoFields struct {
 	Priority     int             `json:"Microsoft.VSTS.Common.Priority"`
 	TeamProject  string          `json:"System.TeamProject"`
 	ChangedDate  string          `json:"System.ChangedDate"`
+	Tags         string          `json:"System.Tags"` // "; "-joined tag names
 }
 
 // adoIdentityRef is an Azure DevOps identity reference.

--- a/internal/tracker/clickup/client.go
+++ b/internal/tracker/clickup/client.go
@@ -38,6 +38,10 @@ func New(baseURL, token string, teamID string) *Client {
 			apiclient.WithAuth(apiclient.HeaderAuth("Authorization", token)),
 			apiclient.WithHeader("Accept", "application/json"),
 			apiclient.WithProviderName("clickup"),
+			// Paths are assembled from url.PathEscape'd segments; the raw
+			// builder keeps that encoding on the wire so tag names with
+			// spaces or slashes (e.g. "human/idea") stay one path segment.
+			apiclient.WithURLBuilder(apiclient.RawPathURL()),
 		),
 		teamID:        teamID,
 		statusesCache: make(map[string][]cuStatus),
@@ -127,6 +131,9 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 	if issue.ParentKey != "" {
 		body["parent"] = issue.ParentKey
 	}
+	if len(issue.Labels) > 0 {
+		body["tags"] = issue.Labels
+	}
 
 	payload, err := json.Marshal(body)
 	if err != nil {
@@ -149,6 +156,7 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 		Title:       task.Name,
 		Description: task.Description,
 		URL:         task.URL,
+		Labels:      tagNames(task.Tags),
 	}, nil
 }
 
@@ -267,7 +275,9 @@ func (c *Client) GetCurrentUser(ctx context.Context) (string, error) {
 	return strconv.FormatInt(cu.User.ID, 10), nil
 }
 
-// EditIssue implements tracker.Editor.
+// EditIssue implements tracker.Editor. Title/description go through the task
+// PUT; labels use ClickUp's dedicated per-tag endpoints, so a labels-only
+// edit skips the field update entirely.
 func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOptions) (*tracker.Issue, error) {
 	fields := make(map[string]string)
 	if opts.Title != nil {
@@ -277,6 +287,28 @@ func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOpt
 		fields["description"] = *opts.Description
 	}
 
+	labelsChanged := len(opts.AddLabels) > 0 || len(opts.RemoveLabels) > 0
+	if len(fields) > 0 || !labelsChanged {
+		issue, err := c.putTaskFields(ctx, key, fields)
+		if err != nil {
+			return nil, err
+		}
+		if !labelsChanged {
+			return issue, nil
+		}
+	}
+
+	if err := c.applyTagChanges(ctx, key, opts.AddLabels, opts.RemoveLabels); err != nil {
+		return nil, err
+	}
+	// Any field-update response predates the tag operations, so the task is
+	// re-read to return the final label set.
+	return c.GetIssue(ctx, key)
+}
+
+// putTaskFields updates task fields via the task PUT and returns the
+// resulting issue.
+func (c *Client) putTaskFields(ctx context.Context, key string, fields map[string]string) (*tracker.Issue, error) {
 	payload, err := json.Marshal(fields)
 	if err != nil {
 		return nil, errors.WrapWithDetails(err, "marshalling edit request", "key", key)
@@ -295,6 +327,42 @@ func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOpt
 
 	issue := c.toTrackerIssue(ctx, task)
 	return &issue, nil
+}
+
+// applyTagChanges drives ClickUp's dedicated tag endpoints: one POST per
+// added tag, one DELETE per removed tag. Removing a tag the task does not
+// carry counts as already done, so label swaps stay idempotent.
+func (c *Client) applyTagChanges(ctx context.Context, key string, add, remove []string) error {
+	for _, name := range add {
+		if err := c.tagRequest(ctx, http.MethodPost, key, name); err != nil {
+			return err
+		}
+	}
+	for _, name := range remove {
+		if err := c.tagRequest(ctx, http.MethodDelete, key, name); err != nil && !isAbsentTagError(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// tagRequest issues a single tag add/remove call against a task.
+func (c *Client) tagRequest(ctx context.Context, method, key, tag string) error {
+	path := fmt.Sprintf("/api/v2/task/%s/tag/%s", url.PathEscape(key), url.PathEscape(tag))
+	resp, err := c.doRequest(ctx, method, path, c.customIDQuery(key), nil, "")
+	if err != nil {
+		return err
+	}
+	_ = resp.Body.Close()
+	return nil
+}
+
+// isAbsentTagError reports whether the error is ClickUp rejecting an
+// operation on a tag the task does not carry (400/404), which a remove
+// treats as success.
+func isAbsentTagError(err error) bool {
+	code, ok := errors.AllDetails(err)["statusCode"].(int)
+	return ok && (code == http.StatusNotFound || code == http.StatusBadRequest)
 }
 
 // ListStatuses implements tracker.StatusLister.
@@ -431,11 +499,6 @@ func (c *Client) toTrackerIssue(ctx context.Context, task cuTask) tracker.Issue 
 		priority = task.Priority.Priority
 	}
 
-	var labels []string
-	for _, tag := range task.Tags {
-		labels = append(labels, tag.Name)
-	}
-
 	issue := tracker.Issue{
 		Key:         task.ID,
 		Title:       task.Name,
@@ -447,12 +510,21 @@ func (c *Client) toTrackerIssue(ctx context.Context, task cuTask) tracker.Issue 
 		Description: task.Description,
 		URL:         task.URL,
 		ParentKey:   task.Parent,
-		Labels:      labels,
+		Labels:      tagNames(task.Tags),
 	}
 	if task.DateUpdated != "" {
 		issue.UpdatedAt = parseUnixMs(task.DateUpdated)
 	}
 	return issue
+}
+
+// tagNames flattens ClickUp tag objects to their plain names.
+func tagNames(tags []cuTag) []string {
+	var names []string
+	for _, tag := range tags {
+		names = append(names, tag.Name)
+	}
+	return names
 }
 
 // toTrackerComment converts a ClickUp comment to a tracker.Comment.

--- a/internal/tracker/clickup/client_test.go
+++ b/internal/tracker/clickup/client_test.go
@@ -1195,3 +1195,142 @@ func TestGetMarkdownDescription_withCustomID(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "# Custom ID markdown", md)
 }
+
+func TestEditIssue_labels(t *testing.T) {
+	var calls []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// EscapedPath preserves the %20 so the test locks in tag-name escaping.
+		calls = append(calls, r.Method+" "+r.URL.EscapedPath())
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v2/task/abc123":
+			var gotBody map[string]string
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &gotBody))
+			assert.Equal(t, "New title", gotBody["name"])
+			_, _ = fmt.Fprint(w, `{"id":"abc123","name":"New title","status":{"status":"open","type":"open"},"list":{"id":"901"}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v2/task/abc123/tag/urgent fix":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/v2/task/abc123/tag/old":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v2/task/abc123":
+			_, _ = fmt.Fprint(w, `{"id":"abc123","name":"New title","status":{"status":"open","type":"open"},"list":{"id":"901"},"tags":[{"name":"urgent fix"}]}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	title := "New title"
+	client := New(srv.URL, "tok-test", "")
+	issue, err := client.EditIssue(context.Background(), "abc123", tracker.EditOptions{
+		Title:        &title,
+		AddLabels:    []string{"urgent fix"},
+		RemoveLabels: []string{"old"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"urgent fix"}, issue.Labels)
+
+	// Field PUT first, then per-tag operations, then the final re-read.
+	assert.Equal(t, []string{
+		"PUT /api/v2/task/abc123",
+		"POST /api/v2/task/abc123/tag/urgent%20fix",
+		"DELETE /api/v2/task/abc123/tag/old",
+		"GET /api/v2/task/abc123",
+	}, calls)
+}
+
+func TestEditIssue_labelsOnlySkipsFieldPut(t *testing.T) {
+	var calls []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.Method+" "+r.URL.Path)
+		switch {
+		case r.Method == http.MethodPut:
+			t.Error("labels-only edit must not touch the task field PUT")
+			w.WriteHeader(http.StatusBadRequest)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v2/task/abc123/tag/backend":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v2/task/abc123":
+			_, _ = fmt.Fprint(w, `{"id":"abc123","name":"Task","status":{"status":"open","type":"open"},"list":{"id":"901"},"tags":[{"name":"backend"}]}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "tok-test", "")
+	issue, err := client.EditIssue(context.Background(), "abc123", tracker.EditOptions{
+		AddLabels: []string{"backend"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"backend"}, issue.Labels)
+	assert.Equal(t, []string{
+		"POST /api/v2/task/abc123/tag/backend",
+		"GET /api/v2/task/abc123",
+	}, calls)
+}
+
+func TestEditIssue_removeAbsentTagIgnored(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/v2/task/abc123/tag/ghost":
+			// ClickUp rejects removing a tag the task doesn't carry; the
+			// client must treat that as already done.
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v2/task/abc123":
+			_, _ = fmt.Fprint(w, `{"id":"abc123","name":"Task","status":{"status":"open","type":"open"},"list":{"id":"901"}}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "tok-test", "")
+	issue, err := client.EditIssue(context.Background(), "abc123", tracker.EditOptions{
+		RemoveLabels: []string{"ghost"},
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, issue.Labels)
+}
+
+func TestEditIssue_addTagError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "tok-test", "")
+	_, err := client.EditIssue(context.Background(), "abc123", tracker.EditOptions{
+		AddLabels: []string{"backend"},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "returned")
+}
+
+func TestCreateIssue_withTags(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+		_, _ = fmt.Fprint(w, `{"id":"xyz1","name":"Tagged","status":{"status":"open","type":"open"},"list":{"id":"901"},"tags":[{"name":"idea"},{"name":"backend"}]}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "tok-test", "")
+	issue, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Project: "901",
+		Title:   "Tagged",
+		Labels:  []string{"idea", "backend"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"idea", "backend"}, issue.Labels)
+	assert.Equal(t, []any{"idea", "backend"}, gotBody["tags"])
+}

--- a/internal/tracker/github/client.go
+++ b/internal/tracker/github/client.go
@@ -161,8 +161,9 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 	}
 
 	payload := createRequest{
-		Title: issue.Title,
-		Body:  issue.Description,
+		Title:  issue.Title,
+		Body:   issue.Description,
+		Labels: issue.Labels,
 	}
 
 	body, err := json.Marshal(payload)
@@ -367,12 +368,40 @@ func (c *Client) GetCurrentUser(ctx context.Context) (string, error) {
 }
 
 // EditIssue implements tracker.Editor.
+// Labels go through GitHub's dedicated add/remove endpoints instead of the
+// PATCH labels array: PATCHing the full array would silently drop labels
+// another editor set between our read and our write.
 func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOptions) (*tracker.Issue, error) {
 	owner, repo, number, err := parseIssueKey(key)
 	if err != nil {
 		return nil, err
 	}
 
+	var patched *tracker.Issue
+	if opts.Title != nil || opts.Description != nil {
+		patched, err = c.patchIssue(ctx, key, owner, repo, number, opts)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := c.addLabels(ctx, owner, repo, number, opts.AddLabels); err != nil {
+		return nil, err
+	}
+	if err := c.removeLabels(ctx, owner, repo, number, opts.RemoveLabels); err != nil {
+		return nil, err
+	}
+
+	// The label endpoints return bare label arrays, so any label change makes
+	// the PATCH response stale — re-fetch to hand back the issue's final state.
+	if patched == nil || len(opts.AddLabels) > 0 || len(opts.RemoveLabels) > 0 {
+		return c.GetIssue(ctx, key)
+	}
+	return patched, nil
+}
+
+// patchIssue updates title and/or body and returns the resulting issue.
+func (c *Client) patchIssue(ctx context.Context, key, owner, repo string, number int, opts tracker.EditOptions) (*tracker.Issue, error) {
 	fields := make(map[string]string)
 	if opts.Title != nil {
 		fields["title"] = *opts.Title
@@ -398,6 +427,50 @@ func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOpt
 
 	issue := toTrackerIssue(owner, repo, gi)
 	return &issue, nil
+}
+
+// addLabels attaches labels via the additive labels endpoint; one call covers
+// all labels and GitHub creates missing label entities on the fly.
+func (c *Client) addLabels(ctx context.Context, owner, repo string, number int, labels []string) error {
+	if len(labels) == 0 {
+		return nil
+	}
+
+	payload, err := json.Marshal(map[string][]string{"labels": labels})
+	if err != nil {
+		return errors.WrapWithDetails(err, "marshalling add-labels request",
+			"owner", owner, "repo", repo)
+	}
+
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/labels", url.PathEscape(owner), url.PathEscape(repo), number)
+	resp, err := c.doRequest(ctx, http.MethodPost, path, "", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	_ = resp.Body.Close()
+	return nil
+}
+
+// removeLabels deletes each label individually; GitHub answers 404 for a
+// label the issue does not carry, which the EditOptions contract treats as
+// success so that label swaps stay idempotent.
+func (c *Client) removeLabels(ctx context.Context, owner, repo string, number int, labels []string) error {
+	for _, label := range labels {
+		// The label stays unescaped here: the client's URL builder treats the
+		// path as decoded and escapes it on serialization, so pre-escaping
+		// would double-encode names with spaces.
+		path := fmt.Sprintf("/repos/%s/%s/issues/%d/labels/%s",
+			url.PathEscape(owner), url.PathEscape(repo), number, label)
+		resp, err := c.doRequest(ctx, http.MethodDelete, path, "", nil)
+		if err != nil {
+			if statusCode, ok := errors.AllDetails(err)["statusCode"].(int); ok && statusCode == http.StatusNotFound {
+				continue
+			}
+			return err
+		}
+		_ = resp.Body.Close()
+	}
+	return nil
 }
 
 // DeleteIssue implements tracker.Deleter by closing the issue.

--- a/internal/tracker/github/client_test.go
+++ b/internal/tracker/github/client_test.go
@@ -1036,3 +1036,142 @@ func TestCreateIssue_invalidParent(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid parent key")
 }
+
+func TestEditIssue_labelsOnly(t *testing.T) {
+	var addBody map[string][]string
+	var deletePaths []string
+	patchCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPatch:
+			patchCalled = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/octocat/repo/issues/1/labels":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &addBody))
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `[{"name":"feature"},{"name":"help wanted"}]`)
+		case r.Method == http.MethodDelete:
+			deletePaths = append(deletePaths, r.URL.EscapedPath())
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `[]`)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/octocat/repo/issues/1":
+			_, _ = fmt.Fprint(w, `{"number":1,"title":"The answer","body":"desc","state":"open","labels":[{"name":"feature"},{"name":"help wanted"}]}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "ghp_test")
+	issue, err := client.EditIssue(context.Background(), "octocat/repo#1", tracker.EditOptions{
+		AddLabels:    []string{"feature", "help wanted"},
+		RemoveLabels: []string{"bug", "wont fix"},
+	})
+
+	require.NoError(t, err)
+	assert.False(t, patchCalled, "a labels-only edit must not PATCH the issue")
+	assert.Equal(t, map[string][]string{"labels": {"feature", "help wanted"}}, addBody)
+	assert.Equal(t, []string{
+		"/repos/octocat/repo/issues/1/labels/bug",
+		"/repos/octocat/repo/issues/1/labels/wont%20fix",
+	}, deletePaths)
+	assert.Equal(t, []string{"feature", "help wanted"}, issue.Labels)
+}
+
+func TestEditIssue_removeLabelNotPresentIgnored(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodDelete:
+			// GitHub answers 404 when the issue does not carry the label.
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = fmt.Fprint(w, `{"message":"Label does not exist"}`)
+		case http.MethodGet:
+			_, _ = fmt.Fprint(w, `{"number":1,"title":"The answer","body":"desc","state":"open","labels":[]}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "ghp_test")
+	issue, err := client.EditIssue(context.Background(), "octocat/repo#1", tracker.EditOptions{
+		RemoveLabels: []string{"ghost"},
+	})
+
+	require.NoError(t, err, "removing an absent label must be idempotent, not an error")
+	assert.Empty(t, issue.Labels)
+}
+
+func TestEditIssue_removeLabelHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "ghp_test")
+	_, err := client.EditIssue(context.Background(), "octocat/repo#1", tracker.EditOptions{
+		RemoveLabels: []string{"bug"},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "returned")
+}
+
+func TestEditIssue_titleAndLabelsRefetches(t *testing.T) {
+	title := "Updated Title"
+	getCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPatch:
+			_, _ = fmt.Fprint(w, `{"number":1,"title":"Updated Title","body":"desc","state":"open","labels":[]}`)
+		case http.MethodPost:
+			_, _ = fmt.Fprint(w, `[{"name":"bug"}]`)
+		case http.MethodGet:
+			getCalled = true
+			_, _ = fmt.Fprint(w, `{"number":1,"title":"Updated Title","body":"desc","state":"open","labels":[{"name":"bug"}]}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "ghp_test")
+	issue, err := client.EditIssue(context.Background(), "octocat/repo#1", tracker.EditOptions{
+		Title:     &title,
+		AddLabels: []string{"bug"},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, getCalled, "label change must re-fetch so the result reflects final labels")
+	assert.Equal(t, "Updated Title", issue.Title)
+	assert.Equal(t, []string{"bug"}, issue.Labels)
+}
+
+func TestCreateIssue_withLabels(t *testing.T) {
+	var gotRaw map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotRaw))
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"number":101,"title":"Labelled issue","body":""}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "ghp_test")
+	_, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Project: "octocat/hello-world",
+		Title:   "Labelled issue",
+		Labels:  []string{"bug", "urgent"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []any{"bug", "urgent"}, gotRaw["labels"])
+}

--- a/internal/tracker/github/types.go
+++ b/internal/tracker/github/types.go
@@ -23,8 +23,9 @@ type ghLabel struct {
 }
 
 type createRequest struct {
-	Title string `json:"title"`
-	Body  string `json:"body,omitempty"`
+	Title  string   `json:"title"`
+	Body   string   `json:"body,omitempty"`
+	Labels []string `json:"labels,omitempty"`
 }
 
 type createResponse struct {

--- a/internal/tracker/gitlab/client.go
+++ b/internal/tracker/gitlab/client.go
@@ -150,6 +150,7 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 	payload := createRequest{
 		Title:       issue.Title,
 		Description: issue.Description,
+		Labels:      strings.Join(issue.Labels, ","),
 	}
 
 	body, err := json.Marshal(payload)
@@ -377,6 +378,14 @@ func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOpt
 	}
 	if opts.Description != nil {
 		fields["description"] = *opts.Description
+	}
+	// GitLab's PUT applies add/remove atomically on the server, so a label
+	// swap needs no read-modify-write round trip that could race other editors.
+	if len(opts.AddLabels) > 0 {
+		fields["add_labels"] = strings.Join(opts.AddLabels, ",")
+	}
+	if len(opts.RemoveLabels) > 0 {
+		fields["remove_labels"] = strings.Join(opts.RemoveLabels, ",")
 	}
 
 	payload, err := json.Marshal(fields)

--- a/internal/tracker/gitlab/client_test.go
+++ b/internal/tracker/gitlab/client_test.go
@@ -788,3 +788,78 @@ func TestCreateIssue_parentUnsupported(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not support subtasks")
 }
+
+func TestEditIssue_labels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v4/projects/mygroup%2Fmyproject/issues/42", r.URL.RawPath)
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var got map[string]string
+		require.NoError(t, json.Unmarshal(body, &got))
+		assert.Equal(t, "feature,ui", got["add_labels"])
+		assert.Equal(t, "bug", got["remove_labels"])
+		_, hasTitle := got["title"]
+		assert.False(t, hasTitle, "title should not be present on a labels-only edit")
+
+		_, _ = fmt.Fprint(w, `{"iid":42,"title":"The answer","description":"desc","state":"opened","labels":["feature","ui"]}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "glpat-test")
+	issue, err := client.EditIssue(context.Background(), "mygroup/myproject#42", tracker.EditOptions{
+		AddLabels:    []string{"feature", "ui"},
+		RemoveLabels: []string{"bug"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"feature", "ui"}, issue.Labels)
+}
+
+func TestEditIssue_noLabelFieldsWithoutLabelChange(t *testing.T) {
+	title := "Updated Title"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var got map[string]string
+		require.NoError(t, json.Unmarshal(body, &got))
+		_, hasAdd := got["add_labels"]
+		assert.False(t, hasAdd, "add_labels should be absent when no labels are added")
+		_, hasRemove := got["remove_labels"]
+		assert.False(t, hasRemove, "remove_labels should be absent when no labels are removed")
+
+		_, _ = fmt.Fprint(w, `{"iid":42,"title":"Updated Title","description":"desc","state":"opened"}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "glpat-test")
+	_, err := client.EditIssue(context.Background(), "mygroup/myproject#42", tracker.EditOptions{Title: &title})
+
+	require.NoError(t, err)
+}
+
+func TestCreateIssue_withLabels(t *testing.T) {
+	var gotBody createRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"iid":99,"title":"Labelled issue","description":""}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "glpat-test")
+	_, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Project: "mygroup/myproject",
+		Title:   "Labelled issue",
+		Labels:  []string{"bug", "urgent"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "bug,urgent", gotBody.Labels)
+}

--- a/internal/tracker/gitlab/types.go
+++ b/internal/tracker/gitlab/types.go
@@ -38,6 +38,9 @@ type glNote struct {
 type createRequest struct {
 	Title       string `json:"title"`
 	Description string `json:"description,omitempty"`
+	// Labels is comma-joined because GitLab's REST create endpoint takes a
+	// single comma-separated string rather than a JSON array.
+	Labels string `json:"labels,omitempty"`
 }
 
 type createResponse struct {

--- a/internal/tracker/jira/client.go
+++ b/internal/tracker/jira/client.go
@@ -83,6 +83,7 @@ func (c *Client) ListIssues(ctx context.Context, opts tracker.ListOptions) ([]tr
 			Title:   iss.Fields.Summary,
 			Type:    iss.Fields.IssueType.Name,
 			Status:  iss.Fields.Status.Name,
+			Labels:  iss.Fields.Labels,
 			URL:     c.baseURL + "/browse/" + iss.Key,
 		}
 		if iss.Fields.Updated != "" {
@@ -96,7 +97,7 @@ func (c *Client) ListIssues(ctx context.Context, opts tracker.ListOptions) ([]tr
 func (c *Client) GetIssue(ctx context.Context, key string) (*tracker.Issue, error) {
 	path := fmt.Sprintf("/rest/api/3/issue/%s", url.PathEscape(key))
 	query := url.Values{
-		"fields": {"summary,status,description,assignee,reporter,priority,issuetype,parent"},
+		"fields": {"summary,status,description,assignee,reporter,priority,issuetype,parent,labels"},
 	}
 
 	resp, err := c.doRequest(ctx, http.MethodGet, path, query.Encode(), nil)
@@ -133,6 +134,7 @@ func (c *Client) GetIssue(ctx context.Context, key string) (*tracker.Issue, erro
 		Assignee:    nameOrEmpty(f.Assignee),
 		Reporter:    nameOrEmpty(f.Reporter),
 		Description: desc,
+		Labels:      f.Labels,
 		URL:         c.baseURL + "/browse/" + detail.Key,
 		ParentKey:   parentKey,
 	}, nil
@@ -140,12 +142,17 @@ func (c *Client) GetIssue(ctx context.Context, key string) (*tracker.Issue, erro
 
 // CreateIssue implements tracker.Creator.
 func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracker.Issue, error) {
+	if err := validateLabels(issue.Labels); err != nil {
+		return nil, err
+	}
+
 	payload := createRequest{
 		Fields: createFields{
 			Project:     keyField{Key: issue.Project},
 			Summary:     issue.Title,
 			IssueType:   nameOnly{Name: issue.Type},
 			Description: adf.FromMarkdown(issue.Description),
+			Labels:      issue.Labels,
 		},
 	}
 	// Jira models subtasks as a parent link; the issue type must be a
@@ -348,6 +355,10 @@ func (c *Client) GetCurrentUser(ctx context.Context) (string, error) {
 
 // EditIssue implements tracker.Editor.
 func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOptions) (*tracker.Issue, error) {
+	if err := validateLabels(opts.AddLabels); err != nil {
+		return nil, err
+	}
+
 	fields := make(map[string]any)
 	if opts.Title != nil {
 		fields["summary"] = *opts.Title
@@ -356,7 +367,15 @@ func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOpt
 		fields["description"] = adf.FromMarkdown(*opts.Description)
 	}
 
-	payload, err := json.Marshal(map[string]any{"fields": fields})
+	body := map[string]any{"fields": fields}
+	// Labels go through the update section's atomic add/remove operations
+	// rather than a full-field set, so a label swap cannot clobber labels a
+	// concurrent editor added in between.
+	if ops := labelUpdateOps(opts.AddLabels, opts.RemoveLabels); len(ops) > 0 {
+		body["update"] = map[string]any{"labels": ops}
+	}
+
+	payload, err := json.Marshal(body)
 	if err != nil {
 		return nil, errors.WrapWithDetails(err, "marshalling edit request", "issueKey", key)
 	}
@@ -384,6 +403,31 @@ func (c *Client) DeleteIssue(ctx context.Context, key string) error {
 
 func (c *Client) doRequest(ctx context.Context, method, path, rawQuery string, body io.Reader) (*http.Response, error) {
 	return c.api.Do(ctx, method, path, rawQuery, body)
+}
+
+// labelUpdateOps builds Jira's per-label add/remove operation list for the
+// PUT body's update section.
+func labelUpdateOps(add, remove []string) []map[string]string {
+	ops := make([]map[string]string, 0, len(add)+len(remove))
+	for _, l := range add {
+		ops = append(ops, map[string]string{"add": l})
+	}
+	for _, l := range remove {
+		ops = append(ops, map[string]string{"remove": l})
+	}
+	return ops
+}
+
+// validateLabels rejects labels Jira cannot store; Jira refuses the whole
+// request when a label contains whitespace, so failing early gives the caller
+// an actionable error instead of an opaque 400.
+func validateLabels(labels []string) error {
+	for _, l := range labels {
+		if strings.ContainsAny(l, " \t") {
+			return errors.WithDetails("jira labels cannot contain spaces", "label", l)
+		}
+	}
+	return nil
 }
 
 func hasDescription(raw json.RawMessage) bool {

--- a/internal/tracker/jira/client_test.go
+++ b/internal/tracker/jira/client_test.go
@@ -698,3 +698,166 @@ func TestGetIssue_withParent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "KAN-1", issue.ParentKey)
 }
+
+func TestEditIssue_labels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/rest/api/3/issue/KAN-1":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			var got map[string]any
+			require.NoError(t, json.Unmarshal(body, &got))
+			update, ok := got["update"].(map[string]any)
+			require.True(t, ok, "labels must go through the update section")
+			assert.Equal(t, []any{
+				map[string]any{"add": "feature"},
+				map[string]any{"add": "ui"},
+				map[string]any{"remove": "bug"},
+			}, update["labels"])
+
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && r.URL.Path == "/rest/api/3/issue/KAN-1":
+			_, _ = fmt.Fprint(w, `{
+				"key": "KAN-1",
+				"fields": {
+					"summary": "The answer",
+					"status": {"name": "Open"},
+					"description": null,
+					"labels": ["feature", "ui"]
+				}
+			}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "user@example.com", "token")
+	issue, err := client.EditIssue(context.Background(), "KAN-1", tracker.EditOptions{
+		AddLabels:    []string{"feature", "ui"},
+		RemoveLabels: []string{"bug"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"feature", "ui"}, issue.Labels)
+}
+
+func TestEditIssue_noUpdateSectionWithoutLabelChange(t *testing.T) {
+	title := "Updated Title"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			var got map[string]any
+			require.NoError(t, json.Unmarshal(body, &got))
+			_, hasUpdate := got["update"]
+			assert.False(t, hasUpdate, "update section should be absent without label changes")
+
+			w.WriteHeader(http.StatusNoContent)
+		case http.MethodGet:
+			_, _ = fmt.Fprint(w, `{"key":"KAN-1","fields":{"summary":"Updated Title","status":{"name":"Open"},"description":null}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "user@example.com", "token")
+	_, err := client.EditIssue(context.Background(), "KAN-1", tracker.EditOptions{Title: &title})
+
+	require.NoError(t, err)
+}
+
+func TestEditIssue_labelWithSpaceRejected(t *testing.T) {
+	client := New("http://localhost", "user@example.com", "token")
+	_, err := client.EditIssue(context.Background(), "KAN-1", tracker.EditOptions{
+		AddLabels: []string{"help wanted"},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot contain spaces")
+}
+
+func TestCreateIssue_withLabels(t *testing.T) {
+	var gotBody createRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"id":"10003","key":"KAN-44"}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "user@example.com", "token")
+	_, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Project: "KAN",
+		Type:    "Task",
+		Title:   "Labelled issue",
+		Labels:  []string{"bug", "urgent"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"bug", "urgent"}, gotBody.Fields.Labels)
+}
+
+func TestCreateIssue_labelWithSpaceRejected(t *testing.T) {
+	client := New("http://localhost", "user@example.com", "token")
+	_, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Project: "KAN",
+		Type:    "Task",
+		Title:   "Bad label",
+		Labels:  []string{"help wanted"},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot contain spaces")
+}
+
+func TestListIssues_labels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `{"issues":[
+			{"key":"KAN-1","fields":{"summary":"First issue","status":{"name":"To Do"},"issuetype":{"name":"Bug"},"labels":["backend","urgent"]}},
+			{"key":"KAN-2","fields":{"summary":"Second issue","status":{"name":"In Progress"},"issuetype":{"name":"Task"}}}
+		]}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "user@example.com", "token")
+	issues, err := client.ListIssues(context.Background(), tracker.ListOptions{
+		Project:    "KAN",
+		MaxResults: 10,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, issues, 2)
+	assert.Equal(t, []string{"backend", "urgent"}, issues[0].Labels)
+	assert.Empty(t, issues[1].Labels)
+}
+
+func TestGetIssue_labels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.RawQuery, "labels", "GetIssue must request labels so they reach the caller")
+		_, _ = fmt.Fprint(w, `{
+			"key": "KAN-42",
+			"fields": {
+				"summary": "The answer",
+				"status": {"name": "Done"},
+				"description": null,
+				"issuetype": {"name": "Bug"},
+				"labels": ["backend", "urgent"]
+			}
+		}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "user@example.com", "token")
+	issue, err := client.GetIssue(context.Background(), "KAN-42")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"backend", "urgent"}, issue.Labels)
+}

--- a/internal/tracker/jira/types.go
+++ b/internal/tracker/jira/types.go
@@ -16,6 +16,7 @@ type issueFields struct {
 	Status    statusField `json:"status"`
 	Updated   string      `json:"updated"`
 	IssueType nameOnly    `json:"issuetype"`
+	Labels    []string    `json:"labels"`
 }
 
 type statusField struct {
@@ -36,6 +37,7 @@ type issueDetailFields struct {
 	Description json.RawMessage `json:"description"`
 	IssueType   nameOnly        `json:"issuetype"`
 	Parent      *keyField       `json:"parent"`
+	Labels      []string        `json:"labels"`
 }
 
 type nameField struct {
@@ -53,6 +55,7 @@ type createFields struct {
 	IssueType   nameOnly       `json:"issuetype"`
 	Description map[string]any `json:"description,omitempty"`
 	Parent      *keyField      `json:"parent,omitempty"`
+	Labels      []string       `json:"labels,omitempty"`
 }
 
 type keyField struct {

--- a/internal/tracker/linear/client.go
+++ b/internal/tracker/linear/client.go
@@ -119,10 +119,35 @@ const deleteIssueMutation = `mutation($id: String!) {
 	issueDelete(id: $id) { success }
 }`
 
-const createIssueMutation = `mutation($teamId: String!, $title: String!, $description: String, $projectId: String, $parentId: String) {
-	issueCreate(input: { teamId: $teamId, title: $title, description: $description, projectId: $projectId, parentId: $parentId }) {
+const createIssueMutation = `mutation($teamId: String!, $title: String!, $description: String, $projectId: String, $parentId: String, $labelIds: [String!]) {
+	issueCreate(input: { teamId: $teamId, title: $title, description: $description, projectId: $projectId, parentId: $parentId, labelIds: $labelIds }) {
 		success
 		issue { identifier url title description }
+	}
+}`
+
+// getIssueLabelContextQuery fetches everything a label edit needs in one round
+// trip: the issue's internal id, its team (labels are team-scoped in Linear),
+// and the labels it currently carries. Linear's issueUpdate labelIds is
+// full-replacement, so the current set is required to compute the new one.
+const getIssueLabelContextQuery = `query($id: String!) {
+	issue(id: $id) {
+		id
+		team { id }
+		labels { nodes { id name } }
+	}
+}`
+
+const getTeamLabelsQuery = `query($teamId: String!) {
+	team(id: $teamId) {
+		labels { nodes { id name } }
+	}
+}`
+
+const createLabelMutation = `mutation($name: String!, $teamId: String!) {
+	issueLabelCreate(input: { name: $name, teamId: $teamId }) {
+		success
+		issueLabel { id name }
 	}
 }`
 
@@ -266,6 +291,15 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 			return nil, err
 		}
 		vars["parentId"] = parentID
+	}
+	// Labels are team-scoped entities in Linear, so names must be resolved to
+	// ids against the team the issue is created in (creating missing ones).
+	if len(issue.Labels) > 0 {
+		labelIDs, err := c.resolveLabelIDs(ctx, teamID, issue.Labels)
+		if err != nil {
+			return nil, err
+		}
+		vars["labelIds"] = labelIDs
 	}
 
 	data, err := c.doGraphQL(ctx, createIssueMutation, vars)
@@ -484,17 +518,9 @@ func (c *Client) GetCurrentUser(ctx context.Context) (string, error) {
 
 // EditIssue implements tracker.Editor.
 func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOptions) (*tracker.Issue, error) {
-	issueID, err := c.resolveIssueID(ctx, key)
+	issueID, input, err := c.buildEditInput(ctx, key, opts)
 	if err != nil {
 		return nil, err
-	}
-
-	input := make(map[string]string)
-	if opts.Title != nil {
-		input["title"] = *opts.Title
-	}
-	if opts.Description != nil {
-		input["description"] = *opts.Description
 	}
 
 	data, err := c.doGraphQL(ctx, issueUpdateMutation, map[string]any{
@@ -514,6 +540,166 @@ func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOpt
 	}
 
 	return c.GetIssue(ctx, key)
+}
+
+// buildEditInput assembles the issueUpdate input and resolves the issue's
+// internal id. Linear's labelIds field is full-replacement, so it is only
+// included when the caller asked for label changes — otherwise a title-only
+// edit would silently wipe the issue's labels.
+func (c *Client) buildEditInput(ctx context.Context, key string, opts tracker.EditOptions) (string, map[string]any, error) {
+	input := make(map[string]any)
+	if opts.Title != nil {
+		input["title"] = *opts.Title
+	}
+	if opts.Description != nil {
+		input["description"] = *opts.Description
+	}
+
+	if len(opts.AddLabels) == 0 && len(opts.RemoveLabels) == 0 {
+		issueID, err := c.resolveIssueID(ctx, key)
+		return issueID, input, err
+	}
+
+	issueID, teamID, current, err := c.fetchIssueLabelContext(ctx, key)
+	if err != nil {
+		return "", nil, err
+	}
+	addIDs, err := c.resolveLabelIDs(ctx, teamID, opts.AddLabels)
+	if err != nil {
+		return "", nil, err
+	}
+	input["labelIds"] = mergedLabelIDs(current, opts.RemoveLabels, addIDs)
+	return issueID, input, nil
+}
+
+// fetchIssueLabelContext returns the issue's internal id, its team id, and its
+// current labels — the minimum context needed to compute a full-replacement
+// labelIds set for issueUpdate.
+func (c *Client) fetchIssueLabelContext(ctx context.Context, key string) (string, string, []idNameNode, error) {
+	data, err := c.doGraphQL(ctx, getIssueLabelContextQuery, map[string]any{"id": key})
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	var result issueLabelContextData
+	if err := json.Unmarshal(data, &result); err != nil {
+		return "", "", nil, errors.WrapWithDetails(err, "decoding issue label context response",
+			"issueKey", key)
+	}
+
+	if result.Issue.ID == "" {
+		return "", "", nil, errors.WithDetails("linear issue not found", "identifier", key)
+	}
+	if result.Issue.Team.ID == "" {
+		return "", "", nil, errors.WithDetails("cannot determine team for issue", "issueKey", key)
+	}
+
+	return result.Issue.ID, result.Issue.Team.ID, result.Issue.Labels.Nodes, nil
+}
+
+// resolveLabelIDs maps label names to label ids within a team, matching
+// existing labels case-insensitively and creating labels that do not exist yet
+// (Linear requires label entities to exist before they can be attached).
+func (c *Client) resolveLabelIDs(ctx context.Context, teamID string, names []string) ([]string, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	existing, err := c.fetchTeamLabels(ctx, teamID)
+	if err != nil {
+		return nil, err
+	}
+
+	byName := make(map[string]string, len(existing))
+	for _, l := range existing {
+		byName[strings.ToLower(l.Name)] = l.ID
+	}
+
+	ids := make([]string, 0, len(names))
+	for _, name := range names {
+		if id, ok := byName[strings.ToLower(name)]; ok {
+			ids = append(ids, id)
+			continue
+		}
+		id, err := c.createLabel(ctx, teamID, name)
+		if err != nil {
+			return nil, err
+		}
+		// Remember the fresh label so a duplicate name in the same call does
+		// not trigger a second create.
+		byName[strings.ToLower(name)] = id
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+// fetchTeamLabels lists a team's existing labels for name→id resolution.
+func (c *Client) fetchTeamLabels(ctx context.Context, teamID string) ([]idNameNode, error) {
+	data, err := c.doGraphQL(ctx, getTeamLabelsQuery, map[string]any{"teamId": teamID})
+	if err != nil {
+		return nil, err
+	}
+
+	var result teamLabelsData
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, errors.WrapWithDetails(err, "decoding team labels response",
+			"teamID", teamID)
+	}
+
+	return result.Team.Labels.Nodes, nil
+}
+
+// createLabel creates a team-scoped label and returns its id.
+func (c *Client) createLabel(ctx context.Context, teamID, name string) (string, error) {
+	data, err := c.doGraphQL(ctx, createLabelMutation, map[string]any{
+		"name":   name,
+		"teamId": teamID,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var result issueLabelCreateData
+	if err := json.Unmarshal(data, &result); err != nil {
+		return "", errors.WrapWithDetails(err, "decoding label create response",
+			"label", name)
+	}
+
+	if !result.IssueLabelCreate.Success || result.IssueLabelCreate.IssueLabel.ID == "" {
+		return "", errors.WithDetails("linear label creation failed",
+			"label", name, "teamID", teamID)
+	}
+
+	return result.IssueLabelCreate.IssueLabel.ID, nil
+}
+
+// mergedLabelIDs computes the full-replacement label set: current labels minus
+// the ones removed by name (case-insensitive; absent names are ignored so a
+// label swap is idempotent), plus the resolved add ids, deduplicated while
+// preserving order.
+func mergedLabelIDs(current []idNameNode, removeNames, addIDs []string) []string {
+	removed := make(map[string]bool, len(removeNames))
+	for _, name := range removeNames {
+		removed[strings.ToLower(name)] = true
+	}
+
+	seen := make(map[string]bool, len(current)+len(addIDs))
+	merged := make([]string, 0, len(current)+len(addIDs))
+	for _, l := range current {
+		if removed[strings.ToLower(l.Name)] || seen[l.ID] {
+			continue
+		}
+		seen[l.ID] = true
+		merged = append(merged, l.ID)
+	}
+	for _, id := range addIDs {
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		merged = append(merged, id)
+	}
+	return merged
 }
 
 // DeleteIssue implements tracker.Deleter.

--- a/internal/tracker/linear/client_test.go
+++ b/internal/tracker/linear/client_test.go
@@ -1631,6 +1631,289 @@ func TestCreateIssue_withParent(t *testing.T) {
 	assert.Equal(t, "ENG-2", issue.Key)
 }
 
+func TestEditIssue_addAndRemoveLabels(t *testing.T) {
+	// The issue carries "old-label" and "keep"; the edit removes "old-label"
+	// (plus an absent name, which must be ignored), adds "Bug" (exists on the
+	// team under different casing) and "human/idea" (missing — must be
+	// created). Linear's labelIds is full-replacement, so the update must send
+	// exactly: keep + resolved bug + created idea.
+	var createdLabel bool
+	srv := httptest.NewServer(&graphQLHandler{
+		t: t,
+		handlers: map[string]func(vars map[string]any) string{
+			"team { id }": func(vars map[string]any) string {
+				assert.Equal(t, "ENG-42", vars["id"])
+				return `{"data":{"issue":{"id":"issue-uuid-1","team":{"id":"team-uuid-1"},
+					"labels":{"nodes":[{"id":"lbl-old","name":"old-label"},{"id":"lbl-keep","name":"keep"}]}}}}`
+			},
+			"team(id:": func(vars map[string]any) string {
+				assert.Equal(t, "team-uuid-1", vars["teamId"])
+				return `{"data":{"team":{"labels":{"nodes":[{"id":"lbl-bug","name":"bug"}]}}}}`
+			},
+			"issueLabelCreate(": func(vars map[string]any) string {
+				createdLabel = true
+				assert.Equal(t, "human/idea", vars["name"])
+				assert.Equal(t, "team-uuid-1", vars["teamId"])
+				return `{"data":{"issueLabelCreate":{"success":true,"issueLabel":{"id":"lbl-idea","name":"human/idea"}}}}`
+			},
+			"issueUpdate": func(vars map[string]any) string {
+				assert.Equal(t, "issue-uuid-1", vars["id"])
+				input := vars["input"].(map[string]any)
+				assert.Equal(t, []any{"lbl-keep", "lbl-bug", "lbl-idea"}, input["labelIds"])
+				_, hasTitle := input["title"]
+				assert.False(t, hasTitle, "label-only edit must not touch the title")
+				return `{"data":{"issueUpdate":{"success":true}}}`
+			},
+			"identifier": func(vars map[string]any) string {
+				assert.Equal(t, "ENG-42", vars["id"])
+				return `{"data":{"issue":{
+					"identifier":"ENG-42","title":"Labeled","description":"",
+					"state":{"name":"Todo","type":"unstarted"},"priorityLabel":"",
+					"assignee":null,"creator":null,
+					"labels":{"nodes":[{"name":"keep"},{"name":"bug"},{"name":"human/idea"}]}
+				}}}`
+			},
+		},
+	})
+	defer srv.Close()
+
+	client := New(srv.URL, "lin_test")
+	issue, err := client.EditIssue(context.Background(), "ENG-42", tracker.EditOptions{
+		AddLabels:    []string{"Bug", "human/idea"},
+		RemoveLabels: []string{"old-label", "not-present"},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, createdLabel, "missing label must be created via issueLabelCreate")
+	assert.Equal(t, []string{"keep", "bug", "human/idea"}, issue.Labels)
+}
+
+func TestEditIssue_removeOnlySkipsTeamLabelLookup(t *testing.T) {
+	// With no labels to add there is nothing to resolve or create — the team
+	// label query and issueLabelCreate must not be issued (the handler fatals
+	// on unexpected queries), and the update sends the remaining set.
+	srv := httptest.NewServer(&graphQLHandler{
+		t: t,
+		handlers: map[string]func(vars map[string]any) string{
+			"team { id }": func(_ map[string]any) string {
+				return `{"data":{"issue":{"id":"issue-uuid-1","team":{"id":"team-uuid-1"},
+					"labels":{"nodes":[{"id":"lbl-bug","name":"bug"},{"id":"lbl-keep","name":"keep"}]}}}}`
+			},
+			"issueUpdate": func(vars map[string]any) string {
+				input := vars["input"].(map[string]any)
+				assert.Equal(t, []any{"lbl-keep"}, input["labelIds"])
+				return `{"data":{"issueUpdate":{"success":true}}}`
+			},
+			"identifier": func(_ map[string]any) string {
+				return `{"data":{"issue":{
+					"identifier":"ENG-42","title":"Labeled","description":"",
+					"state":{"name":"Todo","type":"unstarted"},"priorityLabel":"",
+					"assignee":null,"creator":null,"labels":{"nodes":[{"name":"keep"}]}
+				}}}`
+			},
+		},
+	})
+	defer srv.Close()
+
+	client := New(srv.URL, "lin_test")
+	issue, err := client.EditIssue(context.Background(), "ENG-42", tracker.EditOptions{
+		RemoveLabels: []string{"Bug"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"keep"}, issue.Labels)
+}
+
+func TestEditIssue_titleOnlyOmitsLabelIDs(t *testing.T) {
+	// labelIds is full-replacement in Linear — a title-only edit including it
+	// would wipe the issue's labels, so it must be absent from the input.
+	title := "Renamed"
+	callCount := 0
+	srv := httptest.NewServer(&graphQLHandler{
+		t: t,
+		handlers: map[string]func(vars map[string]any) string{
+			"issueUpdate": func(vars map[string]any) string {
+				input := vars["input"].(map[string]any)
+				_, hasLabelIDs := input["labelIds"]
+				assert.False(t, hasLabelIDs, "title-only edit must not include labelIds")
+				assert.Equal(t, "Renamed", input["title"])
+				return `{"data":{"issueUpdate":{"success":true}}}`
+			},
+			"issue(": func(_ map[string]any) string {
+				callCount++
+				if callCount == 1 {
+					// resolveIssueID call
+					return `{"data":{"issue":{"id":"uuid-1"}}}`
+				}
+				// GetIssue call after edit
+				return `{"data":{"issue":{
+					"identifier":"ENG-42","title":"Renamed","description":"",
+					"state":{"name":"Todo","type":"unstarted"},"priorityLabel":"",
+					"assignee":null,"creator":null,"labels":{"nodes":[{"name":"keep"}]}
+				}}}`
+			},
+		},
+	})
+	defer srv.Close()
+
+	client := New(srv.URL, "lin_test")
+	issue, err := client.EditIssue(context.Background(), "ENG-42", tracker.EditOptions{Title: &title})
+
+	require.NoError(t, err)
+	assert.Equal(t, "Renamed", issue.Title)
+	assert.Equal(t, []string{"keep"}, issue.Labels, "existing labels must survive a title-only edit")
+}
+
+func TestEditIssue_labelCreateFailure(t *testing.T) {
+	srv := httptest.NewServer(&graphQLHandler{
+		t: t,
+		handlers: map[string]func(vars map[string]any) string{
+			"team { id }": func(_ map[string]any) string {
+				return `{"data":{"issue":{"id":"issue-uuid-1","team":{"id":"team-uuid-1"},
+					"labels":{"nodes":[]}}}}`
+			},
+			"team(id:": func(_ map[string]any) string {
+				return `{"data":{"team":{"labels":{"nodes":[]}}}}`
+			},
+			"issueLabelCreate(": func(_ map[string]any) string {
+				return `{"data":{"issueLabelCreate":{"success":false,"issueLabel":null}}}`
+			},
+		},
+	})
+	defer srv.Close()
+
+	client := New(srv.URL, "lin_test")
+	_, err := client.EditIssue(context.Background(), "ENG-42", tracker.EditOptions{
+		AddLabels: []string{"human/idea"},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "label creation failed")
+}
+
+func TestEditIssue_labelContextTeamMissing(t *testing.T) {
+	srv := httptest.NewServer(&graphQLHandler{
+		t: t,
+		handlers: map[string]func(vars map[string]any) string{
+			"team { id }": func(_ map[string]any) string {
+				return `{"data":{"issue":{"id":"issue-uuid-1","team":null,"labels":{"nodes":[]}}}}`
+			},
+		},
+	})
+	defer srv.Close()
+
+	client := New(srv.URL, "lin_test")
+	_, err := client.EditIssue(context.Background(), "ENG-42", tracker.EditOptions{
+		AddLabels: []string{"bug"},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot determine team")
+}
+
+func TestCreateIssue_withLabels(t *testing.T) {
+	srv := httptest.NewServer(&graphQLHandler{
+		t: t,
+		handlers: map[string]func(vars map[string]any) string{
+			"teams(": func(_ map[string]any) string {
+				return `{"data":{"teams":{"nodes":[{"id":"team-uuid-1"}]}}}`
+			},
+			"projects(": func(_ map[string]any) string {
+				return `{"data":{"projects":{"nodes":[]}}}`
+			},
+			"team(id:": func(vars map[string]any) string {
+				assert.Equal(t, "team-uuid-1", vars["teamId"])
+				return `{"data":{"team":{"labels":{"nodes":[{"id":"lbl-bug","name":"Bug"}]}}}}`
+			},
+			"issueLabelCreate(": func(vars map[string]any) string {
+				assert.Equal(t, "human/idea", vars["name"])
+				return `{"data":{"issueLabelCreate":{"success":true,"issueLabel":{"id":"lbl-idea","name":"human/idea"}}}}`
+			},
+			"issueCreate(": func(vars map[string]any) string {
+				assert.Equal(t, []any{"lbl-bug", "lbl-idea"}, vars["labelIds"])
+				return `{"data":{"issueCreate":{"success":true,"issue":{
+					"identifier":"ENG-101","title":"Labeled","description":"",
+					"state":{"name":""},"priorityLabel":"","assignee":null,"creator":null,
+					"labels":{"nodes":[{"name":"Bug"},{"name":"human/idea"}]}
+				}}}}`
+			},
+		},
+	})
+	defer srv.Close()
+
+	client := New(srv.URL, "lin_test")
+	issue, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Project: "ENG",
+		Title:   "Labeled",
+		Labels:  []string{"bug", "human/idea"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "ENG-101", issue.Key)
+	assert.Equal(t, []string{"Bug", "human/idea"}, issue.Labels)
+}
+
+func TestCreateIssue_withoutLabelsOmitsLabelIDs(t *testing.T) {
+	srv := httptest.NewServer(&graphQLHandler{
+		t: t,
+		handlers: map[string]func(vars map[string]any) string{
+			"teams(": func(_ map[string]any) string {
+				return `{"data":{"teams":{"nodes":[{"id":"team-uuid-1"}]}}}`
+			},
+			"projects(": func(_ map[string]any) string {
+				return `{"data":{"projects":{"nodes":[]}}}`
+			},
+			"issueCreate(": func(vars map[string]any) string {
+				_, hasLabelIDs := vars["labelIds"]
+				assert.False(t, hasLabelIDs, "labelIds should be omitted when no labels requested")
+				return `{"data":{"issueCreate":{"success":true,"issue":{
+					"identifier":"ENG-102","title":"Plain","description":"",
+					"state":{"name":""},"priorityLabel":"","assignee":null,"creator":null,
+					"labels":{"nodes":[]}
+				}}}}`
+			},
+		},
+	})
+	defer srv.Close()
+
+	client := New(srv.URL, "lin_test")
+	issue, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Project: "ENG",
+		Title:   "Plain",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "ENG-102", issue.Key)
+}
+
+func Test_mergedLabelIDs(t *testing.T) {
+	current := []idNameNode{
+		{ID: "l1", Name: "bug"},
+		{ID: "l2", Name: "keep"},
+	}
+
+	tests := []struct {
+		name        string
+		removeNames []string
+		addIDs      []string
+		want        []string
+	}{
+		{"no changes", nil, nil, []string{"l1", "l2"}},
+		{"remove by name case-insensitive", []string{"BUG"}, nil, []string{"l2"}},
+		{"remove absent is ignored", []string{"nope"}, nil, []string{"l1", "l2"}},
+		{"add new", nil, []string{"l3"}, []string{"l1", "l2", "l3"}},
+		{"add existing is deduped", nil, []string{"l1"}, []string{"l1", "l2"}},
+		{"swap", []string{"bug"}, []string{"l3"}, []string{"l2", "l3"}},
+		{"remove all", []string{"bug", "keep"}, nil, []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, mergedLabelIDs(current, tt.removeNames, tt.addIDs))
+		})
+	}
+}
+
 func TestGetIssue_withParent(t *testing.T) {
 	srv := httptest.NewServer(&graphQLHandler{
 		t: t,

--- a/internal/tracker/linear/types.go
+++ b/internal/tracker/linear/types.go
@@ -145,3 +145,37 @@ type projectNode struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 }
+
+// idNameNode holds a label's internal id and display name — the id is what
+// Linear's mutations accept, the name is what users address labels by.
+type idNameNode struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type idNameConnection struct {
+	Nodes []idNameNode `json:"nodes"`
+}
+
+type issueLabelContextData struct {
+	Issue struct {
+		ID   string `json:"id"`
+		Team struct {
+			ID string `json:"id"`
+		} `json:"team"`
+		Labels idNameConnection `json:"labels"`
+	} `json:"issue"`
+}
+
+type teamLabelsData struct {
+	Team struct {
+		Labels idNameConnection `json:"labels"`
+	} `json:"team"`
+}
+
+type issueLabelCreateData struct {
+	IssueLabelCreate struct {
+		Success    bool       `json:"success"`
+		IssueLabel idNameNode `json:"issueLabel"`
+	} `json:"issueLabelCreate"`
+}

--- a/internal/tracker/shortcut/client.go
+++ b/internal/tracker/shortcut/client.go
@@ -195,21 +195,31 @@ func (c *Client) GetIssue(ctx context.Context, key string) (*tracker.Issue, erro
 		return nil, err
 	}
 
+	story, err := c.fetchStory(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	issue, err := c.toTrackerIssue(ctx, *story, "")
+	if err != nil {
+		return nil, err
+	}
+	return &issue, nil
+}
+
+// fetchStory retrieves a single story by numeric ID. Shared by GetIssue and
+// label edits, which must read the current label set before writing.
+func (c *Client) fetchStory(ctx context.Context, id int64) (*scStory, error) {
 	path := fmt.Sprintf("/api/v3/stories/%d", id)
 	resp, err := c.doRequest(ctx, http.MethodGet, path, "", nil, "")
 	if err != nil {
 		return nil, err
 	}
 	var story scStory
-	if err := apiclient.DecodeJSON(resp, &story, "key", key); err != nil {
+	if err := apiclient.DecodeJSON(resp, &story, "storyID", id); err != nil {
 		return nil, err
 	}
-
-	issue, err := c.toTrackerIssue(ctx, story, "")
-	if err != nil {
-		return nil, err
-	}
-	return &issue, nil
+	return &story, nil
 }
 
 // CreateIssue implements tracker.Creator.
@@ -219,6 +229,9 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 	}
 	if issue.Description != "" {
 		body["description"] = issue.Description
+	}
+	if len(issue.Labels) > 0 {
+		body["labels"] = scLabelParams(issue.Labels)
 	}
 	if isValidStoryType(issue.Type) {
 		body["story_type"] = issue.Type
@@ -271,6 +284,7 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 		Type:        story.StoryType,
 		URL:         story.AppURL,
 		ParentKey:   parentStoryKey(story.ParentStoryID),
+		Labels:      labelNames(story.Labels),
 	}, nil
 }
 
@@ -400,12 +414,23 @@ func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOpt
 		return nil, err
 	}
 
-	fields := make(map[string]string)
+	fields := make(map[string]any)
 	if opts.Title != nil {
 		fields["name"] = *opts.Title
 	}
 	if opts.Description != nil {
 		fields["description"] = *opts.Description
+	}
+	// Shortcut's story update replaces the full label set, so the current
+	// labels must be fetched and merged before writing. Labels stay out of
+	// the body entirely when the edit doesn't touch them, keeping
+	// title/description-only edits from clobbering labels.
+	if len(opts.AddLabels) > 0 || len(opts.RemoveLabels) > 0 {
+		merged, mErr := c.mergedStoryLabels(ctx, id, opts)
+		if mErr != nil {
+			return nil, mErr
+		}
+		fields["labels"] = scLabelParams(merged)
 	}
 
 	payload, err := json.Marshal(fields)
@@ -428,6 +453,67 @@ func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOpt
 		return nil, err
 	}
 	return &issue, nil
+}
+
+// mergedStoryLabels reads the story's current labels and applies the
+// requested additions/removals, producing the full-replacement set the
+// Shortcut update endpoint expects.
+func (c *Client) mergedStoryLabels(ctx context.Context, id int64, opts tracker.EditOptions) ([]string, error) {
+	story, err := c.fetchStory(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return mergeLabels(labelNames(story.Labels), opts.AddLabels, opts.RemoveLabels), nil
+}
+
+// mergeLabels applies add/remove requests to an existing label set. Existing
+// order is preserved, additions are appended, duplicates are dropped, and
+// removing an absent label is a no-op so label swaps stay idempotent.
+func mergeLabels(existing, add, remove []string) []string {
+	removed := make(map[string]bool, len(remove))
+	for _, name := range remove {
+		removed[name] = true
+	}
+	seen := make(map[string]bool, len(existing)+len(add))
+	merged := make([]string, 0, len(existing)+len(add))
+	keep := func(name string) {
+		if removed[name] || seen[name] {
+			return
+		}
+		seen[name] = true
+		merged = append(merged, name)
+	}
+	for _, name := range existing {
+		keep(name)
+	}
+	for _, name := range add {
+		keep(name)
+	}
+	return merged
+}
+
+// labelNames flattens Shortcut label objects to their plain names.
+func labelNames(labels []scLabel) []string {
+	if len(labels) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(labels))
+	for _, l := range labels {
+		names = append(names, l.Name)
+	}
+	return names
+}
+
+// scLabelParams renders label names as Shortcut CreateLabelParams objects;
+// labels unknown to the workspace are created by Shortcut on the fly. The
+// result is never nil so an emptied label set marshals as [] and actually
+// clears the story's labels.
+func scLabelParams(names []string) []scLabel {
+	params := make([]scLabel, 0, len(names))
+	for _, name := range names {
+		params = append(params, scLabel{Name: name})
+	}
+	return params
 }
 
 // DeleteIssue implements tracker.Deleter using true deletion (DELETE /api/v3/stories/{id}).
@@ -711,6 +797,7 @@ func (c *Client) toTrackerIssue(ctx context.Context, story scStory, project stri
 		Reporter:    reporter,
 		Description: story.Description,
 		URL:         story.AppURL,
+		Labels:      labelNames(story.Labels),
 	}
 	issue.ParentKey = parentStoryKey(story.ParentStoryID)
 	if story.UpdatedAt != "" {

--- a/internal/tracker/shortcut/client_test.go
+++ b/internal/tracker/shortcut/client_test.go
@@ -1186,3 +1186,156 @@ func TestGetIssue_withParent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "42", issue.ParentKey)
 }
+
+func TestListIssues_labelsMapped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v3/groups":
+			_, _ = fmt.Fprint(w, `[{"id":"grp-uuid-1","name":"Human"}]`)
+		case "/api/v3/groups/grp-uuid-1/stories":
+			_, _ = fmt.Fprint(w, `[
+				{"id":1,"name":"Labelled","story_type":"bug","workflow_state_id":500,"owner_ids":[],"requested_by_id":"","labels":[{"name":"bug"},{"name":"urgent"}]},
+				{"id":2,"name":"Unlabelled","story_type":"feature","workflow_state_id":500,"owner_ids":[],"requested_by_id":""}
+			]`)
+		case "/api/v3/workflows":
+			_, _ = fmt.Fprint(w, `[{"id":1,"name":"Default","states":[{"id":500,"name":"To Do","type":"unstarted"}]}]`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "tok-test")
+	issues, err := client.ListIssues(context.Background(), tracker.ListOptions{Project: "Human"})
+
+	require.NoError(t, err)
+	require.Len(t, issues, 2)
+	assert.Equal(t, []string{"bug", "urgent"}, issues[0].Labels)
+	assert.Empty(t, issues[1].Labels)
+}
+
+func TestEditIssue_labelsMerged(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/stories/123":
+			// Current story state read before the full-replacement label write.
+			_, _ = fmt.Fprint(w, `{"id":123,"name":"Story","workflow_state_id":500,"owner_ids":[],"requested_by_id":"","labels":[{"name":"keep"},{"name":"drop"}]}`)
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v3/stories/123":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &gotBody))
+			_, _ = fmt.Fprint(w, `{"id":123,"name":"Story","workflow_state_id":500,"owner_ids":[],"requested_by_id":"","labels":[{"name":"keep"},{"name":"new"}]}`)
+		case r.URL.Path == "/api/v3/workflows":
+			_, _ = fmt.Fprint(w, `[{"id":1,"name":"Default","states":[{"id":500,"name":"To Do","type":"unstarted"}]}]`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "tok-test")
+	issue, err := client.EditIssue(context.Background(), "123", tracker.EditOptions{
+		// "keep" is a duplicate add and "ghost" an absent removal; both must
+		// be no-ops in the merged set.
+		AddLabels:    []string{"new", "keep"},
+		RemoveLabels: []string{"drop", "ghost"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"keep", "new"}, issue.Labels)
+
+	labels, ok := gotBody["labels"].([]any)
+	require.True(t, ok, "PUT body must carry the merged label set")
+	require.Len(t, labels, 2)
+	assert.Equal(t, map[string]any{"name": "keep"}, labels[0])
+	assert.Equal(t, map[string]any{"name": "new"}, labels[1])
+}
+
+func TestEditIssue_noLabelChangeLeavesLabelsUntouched(t *testing.T) {
+	title := "New title"
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/stories/123":
+			t.Error("title-only edit must not fetch the story for label merging")
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v3/stories/123":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &gotBody))
+			_, _ = fmt.Fprint(w, `{"id":123,"name":"New title","workflow_state_id":500,"owner_ids":[],"requested_by_id":""}`)
+		case r.URL.Path == "/api/v3/workflows":
+			_, _ = fmt.Fprint(w, `[{"id":1,"name":"Default","states":[{"id":500,"name":"To Do","type":"unstarted"}]}]`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "tok-test")
+	_, err := client.EditIssue(context.Background(), "123", tracker.EditOptions{Title: &title})
+
+	require.NoError(t, err)
+	assert.Equal(t, "New title", gotBody["name"])
+	// Omitting labels from the body keeps Shortcut's full-replacement label
+	// semantics from wiping existing labels on unrelated edits.
+	_, hasLabels := gotBody["labels"]
+	assert.False(t, hasLabels)
+}
+
+func TestCreateIssue_withLabels(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v3/workflows":
+			_, _ = fmt.Fprint(w, `[{"id":1,"name":"Default","states":[{"id":500,"name":"To Do","type":"unstarted"}]}]`)
+		case "/api/v3/stories":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &gotBody))
+			w.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprint(w, `{"id":77,"name":"Labelled","story_type":"feature","workflow_state_id":500,"labels":[{"name":"idea"},{"name":"backend"}]}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "tok-test")
+	issue, err := client.CreateIssue(context.Background(), &tracker.Issue{
+		Title:  "Labelled",
+		Labels: []string{"idea", "backend"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"idea", "backend"}, issue.Labels)
+
+	labels, ok := gotBody["labels"].([]any)
+	require.True(t, ok)
+	require.Len(t, labels, 2)
+	assert.Equal(t, map[string]any{"name": "idea"}, labels[0])
+	assert.Equal(t, map[string]any{"name": "backend"}, labels[1])
+}
+
+func Test_mergeLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []string
+		add      []string
+		remove   []string
+		want     []string
+	}{
+		{name: "add and remove", existing: []string{"a", "b"}, add: []string{"c"}, remove: []string{"b"}, want: []string{"a", "c"}},
+		{name: "remove absent is noop", existing: []string{"a"}, remove: []string{"x"}, want: []string{"a"}},
+		{name: "duplicate add deduped", existing: []string{"a"}, add: []string{"a", "b", "b"}, want: []string{"a", "b"}},
+		{name: "remove all yields empty", existing: []string{"a"}, remove: []string{"a"}, want: []string{}},
+		{name: "order stable", existing: []string{"z", "a"}, add: []string{"m"}, want: []string{"z", "a", "m"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, mergeLabels(tt.existing, tt.add, tt.remove))
+		})
+	}
+}

--- a/internal/tracker/shortcut/types.go
+++ b/internal/tracker/shortcut/types.go
@@ -2,19 +2,27 @@ package shortcut
 
 // scStory is the Shortcut API representation of a story.
 type scStory struct {
-	ID              int64    `json:"id"`
-	Name            string   `json:"name"`
-	Description     string   `json:"description"`
-	StoryType       string   `json:"story_type"`
-	WorkflowStateID int64    `json:"workflow_state_id"`
-	AppURL          string   `json:"app_url"`
-	OwnerIDs        []string `json:"owner_ids"`
-	RequestedByID   string   `json:"requested_by_id"`
-	Archived        bool     `json:"archived"`
-	ProjectID       *int64   `json:"project_id"`
-	GroupID         string   `json:"group_id"`        // UUID of the group (team)
-	ParentStoryID   *int64   `json:"parent_story_id"` // set when this story is a subtask
-	UpdatedAt       string   `json:"updated_at"`
+	ID              int64     `json:"id"`
+	Name            string    `json:"name"`
+	Description     string    `json:"description"`
+	StoryType       string    `json:"story_type"`
+	WorkflowStateID int64     `json:"workflow_state_id"`
+	AppURL          string    `json:"app_url"`
+	OwnerIDs        []string  `json:"owner_ids"`
+	RequestedByID   string    `json:"requested_by_id"`
+	Archived        bool      `json:"archived"`
+	ProjectID       *int64    `json:"project_id"`
+	GroupID         string    `json:"group_id"`        // UUID of the group (team)
+	ParentStoryID   *int64    `json:"parent_story_id"` // set when this story is a subtask
+	UpdatedAt       string    `json:"updated_at"`
+	Labels          []scLabel `json:"labels"`
+}
+
+// scLabel is a label attached to a story. The same {"name": ...} shape doubles
+// as Shortcut's CreateLabelParams on writes, where unknown labels are created
+// on the fly.
+type scLabel struct {
+	Name string `json:"name"`
 }
 
 // scSearchRequest is the request body for POST /api/v3/stories/search.

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -211,8 +211,37 @@ func (i Issue) IsBug() bool {
 }
 
 func isBugToken(s string) bool {
+	return hasToken(s, "bug")
+}
+
+// IdeaLabel is the canonical label marking a ticket as a raw idea — the first
+// maturity stage of the evolving-ticket lifecycle. It is namespaced so it
+// cannot collide with a team's existing labels; classification additionally
+// accepts the bare token (see IsIdea) so existing "idea" conventions count.
+const IdeaLabel = "human/idea"
+
+// IsIdea reports whether this issue is a raw idea, normalised across trackers
+// exactly like IsBug: any segment equal to "idea" in Type or in any label,
+// after splitting on '/' and ':'. Covers "idea", "human/idea", "kind/idea",
+// "type:idea"; segment equality keeps "ideation" from matching.
+func (i Issue) IsIdea() bool {
+	if hasToken(i.Type, "idea") {
+		return true
+	}
+	for _, l := range i.Labels {
+		if hasToken(l, "idea") {
+			return true
+		}
+	}
+	return false
+}
+
+// hasToken reports whether any '/'- or ':'-separated segment of s equals
+// token case-insensitively — the shared normalisation for cross-tracker
+// label/type classification.
+func hasToken(s, token string) bool {
 	for _, seg := range strings.FieldsFunc(s, func(r rune) bool { return r == '/' || r == ':' }) {
-		if strings.EqualFold(strings.TrimSpace(seg), "bug") {
+		if strings.EqualFold(strings.TrimSpace(seg), token) {
 			return true
 		}
 	}
@@ -333,9 +362,15 @@ type CurrentUserGetter interface {
 type EditOptions struct {
 	Title       *string
 	Description *string
+	// AddLabels are labels to add to the issue. Providers whose label model
+	// requires pre-existing label entities create them on the fly.
+	AddLabels []string
+	// RemoveLabels are labels to remove; labels the issue does not carry are
+	// ignored rather than treated as an error, so a label swap is idempotent.
+	RemoveLabels []string
 }
 
-// Editor updates an existing issue's title and/or description.
+// Editor updates an existing issue's title, description, and/or labels.
 type Editor interface {
 	EditIssue(ctx context.Context, key string, opts EditOptions) (*Issue, error)
 }

--- a/internal/tracker/tracker_test.go
+++ b/internal/tracker/tracker_test.go
@@ -489,3 +489,102 @@ func TestIssue_IsBug(t *testing.T) {
 		})
 	}
 }
+
+func TestIssue_IsIdea(t *testing.T) {
+	tests := []struct {
+		name string
+		i    Issue
+		want bool
+	}{
+		{"empty issue", Issue{}, false},
+		{"label idea lowercase", Issue{Labels: []string{"idea"}}, true},
+		{"label Idea titlecase", Issue{Labels: []string{"Idea"}}, true},
+		{"label human/idea", Issue{Labels: []string{"human/idea"}}, true},
+		{"canonical IdeaLabel constant", Issue{Labels: []string{IdeaLabel}}, true},
+		{"label kind/idea", Issue{Labels: []string{"kind/idea"}}, true},
+		{"label type:idea", Issue{Labels: []string{"type:idea"}}, true},
+		{"type idea", Issue{Type: "idea"}, true},
+		{"type Idea", Issue{Type: "Idea"}, true},
+		{"type human/idea", Issue{Type: "human/idea"}, true},
+		{"type kind/idea", Issue{Type: "kind/idea"}, true},
+		{"type type:idea", Issue{Type: "type:idea"}, true},
+		{"label ideation is not an idea", Issue{Labels: []string{"ideation"}}, false},
+		// hasToken splits on '/' and ':' only, so "no-idea" stays one segment
+		// ("no-idea" != "idea") — hyphenated non-matches must not classify.
+		{"label no-idea is not an idea", Issue{Labels: []string{"no-idea"}}, false},
+		{"label bugidea is not an idea", Issue{Labels: []string{"bugidea"}}, false},
+		{"type ideation is not an idea", Issue{Type: "ideation"}, false},
+		{"idea among other labels", Issue{Labels: []string{"priority/high", "human/idea"}}, true},
+		{"non-idea labels", Issue{Labels: []string{"bug", "kind/feature"}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.i.IsIdea())
+		})
+	}
+}
+
+// fakeLabelEditor is executable documentation of the EditOptions label
+// contract every provider must honour: labels are a set — AddLabels is
+// idempotent (adding a present label changes nothing), RemoveLabels ignores
+// absent labels (a remove-absent is a no-op, not an error), and one call may
+// combine both to swap labels atomically.
+type fakeLabelEditor struct {
+	labels []string
+}
+
+var _ Editor = (*fakeLabelEditor)(nil)
+
+func (f *fakeLabelEditor) EditIssue(_ context.Context, _ string, opts EditOptions) (*Issue, error) {
+	removed := make(map[string]bool, len(opts.RemoveLabels))
+	for _, l := range opts.RemoveLabels {
+		removed[l] = true
+	}
+
+	seen := make(map[string]bool, len(f.labels)+len(opts.AddLabels))
+	next := make([]string, 0, len(f.labels)+len(opts.AddLabels))
+	for _, l := range f.labels {
+		if removed[l] || seen[l] {
+			continue
+		}
+		seen[l] = true
+		next = append(next, l)
+	}
+	for _, l := range opts.AddLabels {
+		if seen[l] {
+			continue
+		}
+		seen[l] = true
+		next = append(next, l)
+	}
+
+	f.labels = next
+	return &Issue{Labels: next}, nil
+}
+
+func TestEditOptions_labelContract(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial []string
+		opts    EditOptions
+		want    []string
+	}{
+		{"add to empty", nil, EditOptions{AddLabels: []string{IdeaLabel}}, []string{IdeaLabel}},
+		{"add is idempotent", []string{"bug"}, EditOptions{AddLabels: []string{"bug"}}, []string{"bug"}},
+		{"remove absent is a no-op", []string{"bug"}, EditOptions{RemoveLabels: []string{"nope"}}, []string{"bug"}},
+		{"remove present", []string{"bug", "keep"}, EditOptions{RemoveLabels: []string{"bug"}}, []string{"keep"}},
+		{"swap in one call", []string{IdeaLabel, "keep"},
+			EditOptions{AddLabels: []string{"human/ready"}, RemoveLabels: []string{IdeaLabel}},
+			[]string{"keep", "human/ready"}},
+		{"no label opts leaves labels untouched", []string{"bug"}, EditOptions{}, []string{"bug"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ed := &fakeLabelEditor{labels: tt.initial}
+			issue, err := ed.EditIssue(context.Background(), "KEY-1", tt.opts)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, issue.Labels)
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -531,7 +531,7 @@ func TestRunCreateIssue(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := cmdprovider.RunCreateIssue(context.Background(), p, &buf, "KAN", "Task", "New issue", "", "")
+	err := cmdprovider.RunCreateIssue(context.Background(), p, &buf, "KAN", "Task", "New issue", "", "", nil)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "KAN-42")
 	assert.Contains(t, buf.String(), "New issue")
@@ -545,7 +545,7 @@ func TestRunCreateIssue_error(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := cmdprovider.RunCreateIssue(context.Background(), p, &buf, "KAN", "Task", "X", "", "")
+	err := cmdprovider.RunCreateIssue(context.Background(), p, &buf, "KAN", "Task", "X", "", "", nil)
 	assert.EqualError(t, err, "create failed")
 }
 


### PR DESCRIPTION
Phase 1 of the evolving-ticket model (SC-159): labels become first-class everywhere.

- `EditOptions.AddLabels/RemoveLabels` implemented in all 7 providers: gitlab native add/remove params; github dedicated label endpoints (404-remove ignored, avoids PATCH race); jira atomic `update.labels` ops + space rejection; linear GraphQL name→id with `issueLabelCreate` for missing + merged full-replacement; shortcut/azuredevops read-merge-write (label-free edits never touch labels); clickup per-tag endpoints.
- Labels at list time for jira, shortcut (default PM tracker), azuredevops.
- `CreateIssue` sends labels in all providers; CLI gains `--label` (create) and `--add-label`/`--remove-label` (edit).
- `Issue.IsIdea()` + `IdeaLabel` mirror the IsBug classification.

Verified live: Shortcut story created with `human/idea` → visible at list → label removed via edit with content untouched; Linear add/remove round-trip through the name→id path. Full gates green, coverage 81.4%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)