### PR TITLE
[SC-159] [HUM-170] [human:plan] marker and plan-on-ticket pipeline dispatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,14 +15,13 @@ Whatever you do, the new state needs to be 'done done'.
 
 # Tickets
 
-There are two kinds of tickets:
+A ticket is **one artifact that evolves in place** through maturity stages (kinds):
 
-- **PM tickets** (Shortcut, project "Stephan Schmidt's Team"): Product requirements, user stories, feature requests. Read these to understand what to build.
-- **Engineering tickets** (Linear, project "HUM"): Implementation plans, technical tasks, bugs. Create these when planning and executing work.
+1. **idea** — a raw thought, captured as a real ticket carrying the `human/idea` label (bare `idea` also classifies). Title-only is fine.
+2. **pm** — promotion: the ideation agent rewrites title/description into product language and removes the idea label. Same key forever; PM ticket descriptions stay product language, no implementation detail.
+3. **planned** — the engineering plan attaches to the ticket as a `[human:plan]` marker comment (full markdown; read it back with `human plan show <KEY>`). Re-planning posts a new plan comment; the latest wins.
 
-Use 'human' to read and write tickets on both trackers.
-
-Maintain traceability from PM ticket → engineering ticket → git commits. Reference the Shortcut ticket in the Linear ticket, and reference the PM ticket (Shortcut) in commit messages.
+**Topology rule:** whether planning ALSO creates a separate engineering ticket depends on the tracker config. In THIS repo's setup — PM tickets on Shortcut (project "Stephan Schmidt's Team", `role: pm`) and engineering tickets on Linear (project "HUM", `role: engineering`) — the trackers are split, so planning creates a Linear engineering ticket whose description is the plan, and traceability runs PM ticket → engineering ticket → git commits (reference the Shortcut ticket in the Linear ticket, and both in commit messages). Teams with a single tracker get no second ticket: the plan comment on the ticket is the plan, and commits reference the one key.
 
 # Review handoff
 
@@ -37,11 +36,11 @@ branch: main
 commits: 2037e40, 64bb370
 ```
 
-- `engineering:` is comma-separated — one PM ticket can spawn multiple engineering tickets.
+- `engineering:` is comma-separated — one PM ticket can spawn multiple engineering tickets. **Single-tracker topology omits this line entirely**: the review target is the PM ticket the comment sits on.
 - `branch:` is the branch the commits live on.
-- `commits:` is the short SHAs attributed to those engineering keys via `git log --grep=<ENG_KEY>`.
+- `commits:` is the short SHAs attributed to the referenced keys via `git log --grep=<KEY>`.
 
-The `human-executor` agent posts this comment automatically as its final step. A reviewer (today: another user runs `/human-pickup-review <PM_KEY>`; future: daemon polling) parses the block, runs `human-reviewer` against each engineering key, and posts a `[human:review-complete]` follow-up comment on the same PM ticket with the verdict.
+The `human-executor` agent posts this comment automatically as its final step. A reviewer (today: another user runs `/human-pickup-review <PM_KEY>`; future: daemon polling) parses the block, runs `human-reviewer` against each engineering key (or against the PM key when the `engineering:` line is absent), and posts a `[human:review-complete]` follow-up comment on the same PM ticket with the verdict.
 
 The TUI marks engineering tickets whose PM ticket carries an unresolved `[human:ready-for-review]` comment with an `(R)` annotation in the tracker view.
 
@@ -130,7 +129,7 @@ When asked to commit, go through changes and create atomar commits that have one
 
 Every commit message **must** contain an issue reference, **unless** the commit touches only documentation (`README.md`, `CLAUDE.md`, `LICENSE`, `CHANGELOG.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, or anything under `docs/`). Any commit that touches code or config — including a mixed docs+code commit — still needs a ref. Accepted formats: `Issue #123`, `Issue HUM-30`, `[SC-57]`, `octocat/repo#42`, `MyProject/42`. A `commit-msg` hook enforces this — activate with `make hooks`.
 
-When a change was implemented from an engineering ticket that traces back to a PM ticket, the commit message **must reference both**: the PM ticket and the engineering ticket (e.g. `[SC-79] [HUM-59] Add validation`). This preserves the full PM → engineering → commit trail. The two tickets usually live on different trackers (e.g. Shortcut PM + Linear engineering) — the format is the same regardless of which trackers are used.
+When a change was implemented from an engineering ticket that traces back to a PM ticket (split topology, as in this repo), the commit message **must reference both**: the PM ticket and the engineering ticket (e.g. `[SC-79] [HUM-59] Add validation`). This preserves the full PM → engineering → commit trail; the two tickets usually live on different trackers (e.g. Shortcut PM + Linear engineering) — the format is the same regardless. In single-tracker topology there is one evolving ticket and every commit references that single key (e.g. `[SC-79] Add validation`).
 
 **WATNING** The commit log is public. Make sure to not expose bug fix or security information that could endanger existing installs.
 

--- a/cmd/cmdplan/plan.go
+++ b/cmd/cmdplan/plan.go
@@ -1,0 +1,82 @@
+// Package cmdplan surfaces the [human:plan] comment — the engineering plan a
+// ticket carries in single-tracker topology — as a first-class CLI object, so
+// agents and users read "the plan" without knowing it is stored as a comment.
+package cmdplan
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gethuman-sh/human/cmd/cmdutil"
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// PlanCommentHeader mirrors the daemon's marker constant. Declared here
+// rather than imported so the CLI package does not pull in the daemon.
+const PlanCommentHeader = "[human:plan]"
+
+// BuildPlanCmd creates the top-level "plan" command.
+func BuildPlanCmd(deps cmdutil.Deps) *cobra.Command {
+	planCmd := &cobra.Command{
+		Use:   "plan",
+		Short: "Engineering plan attached to a ticket",
+	}
+	planCmd.AddCommand(buildPlanShowCmd(deps))
+	return planCmd
+}
+
+func buildPlanShowCmd(deps cmdutil.Deps) *cobra.Command {
+	return &cobra.Command{
+		Use:   "show KEY",
+		Short: "Print the ticket's [human:plan] comment (auto-detect tracker)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := cmdutil.ResolveAutoProvider(cmd.Context(), cmd, args[0], true, deps)
+			if err != nil {
+				return err
+			}
+			defer result.Cleanup()
+			return runPlanShow(cmd.Context(), result.Provider, cmd.OutOrStdout(), result.Key)
+		},
+	}
+}
+
+// runPlanShow prints the latest plan comment's body, header stripped. The
+// latest wins so a re-plan supersedes older plans without history edits.
+func runPlanShow(ctx context.Context, p tracker.Provider, out io.Writer, key string) error {
+	comments, err := p.ListComments(ctx, key)
+	if err != nil {
+		return err
+	}
+	body, ok := ExtractPlan(comments)
+	if !ok {
+		return errors.WithDetails("no [human:plan] comment on ticket", "key", key)
+	}
+	_, err = fmt.Fprintln(out, body)
+	return err
+}
+
+// ExtractPlan returns the newest [human:plan] comment body with the header
+// line stripped.
+func ExtractPlan(comments []tracker.Comment) (string, bool) {
+	var body string
+	var haveLatest bool
+	latestIdx := -1
+	for i, c := range comments {
+		trimmed := strings.TrimSpace(c.Body)
+		if !strings.HasPrefix(trimmed, PlanCommentHeader) {
+			continue
+		}
+		if !haveLatest || c.Created.After(comments[latestIdx].Created) {
+			latestIdx = i
+			haveLatest = true
+			body = strings.TrimSpace(strings.TrimPrefix(trimmed, PlanCommentHeader))
+		}
+	}
+	return body, haveLatest
+}

--- a/cmd/cmdplan/plan_test.go
+++ b/cmd/cmdplan/plan_test.go
@@ -1,0 +1,40 @@
+package cmdplan
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+func c(body string, sec int64) tracker.Comment {
+	return tracker.Comment{Body: body, Created: time.Unix(sec, 0)}
+}
+
+func TestExtractPlan(t *testing.T) {
+	t.Run("latest plan wins, header stripped", func(t *testing.T) {
+		body, ok := ExtractPlan([]tracker.Comment{
+			c("[human:plan]\n\n## Old", 1),
+			c("[human:plan]\n\n## New\n```go\nx := 1\n```", 2),
+		})
+		assert.True(t, ok)
+		assert.Equal(t, "## New\n```go\nx := 1\n```", body)
+	})
+
+	t.Run("plan-ready is not a plan", func(t *testing.T) {
+		_, ok := ExtractPlan([]tracker.Comment{c("[human:plan-ready]\nengineering: HUM-9", 1)})
+		assert.False(t, ok)
+	})
+
+	t.Run("quoted header mid-body is not a plan", func(t *testing.T) {
+		_, ok := ExtractPlan([]tracker.Comment{c("see `[human:plan]` for details", 1)})
+		assert.False(t, ok)
+	})
+
+	t.Run("no comments", func(t *testing.T) {
+		_, ok := ExtractPlan(nil)
+		assert.False(t, ok)
+	})
+}

--- a/internal/claude/embed/human-executor-agent.md
+++ b/internal/claude/embed/human-executor-agent.md
@@ -32,11 +32,15 @@ human <TRACKER> issue comment list <TICKET_KEY>
 
 ## Execution process
 
-1. **Fetch ticket** using `human <tracker> issue get <key>` (use `human tracker list` to find the right tracker; or `human get <key>` if only one tracker type is configured). The ticket description IS the implementation plan. If the description does not contain a structured plan (no `## Changes` section), fall back to `.human/bugs/<key>.md` (a bug analysis with a fix plan). If neither source provides a plan, stop and report that a plan must be created first with `/human-plan` or `/human-bug-plan`.
-2. **Parse ticket keys** from the plan header. The plan has two lines:
+1. **Fetch the plan.** The key you were given is either an engineering ticket (split topology) or the PM ticket itself (single-tracker topology, where the plan is attached to the ticket). Resolve in this order:
+   - `human <tracker> issue get <key>`: if the description contains a structured plan (a `## Changes` section), that IS the plan.
+   - Otherwise `human plan show <key>`: prints the ticket's `[human:plan]` comment if present — that is the plan.
+   - Otherwise fall back to `.human/bugs/<key>.md` (a bug analysis with a fix plan).
+   - If no source provides a plan, stop and report that a plan must be created first with `/human-plan` or `/human-bug-plan`.
+2. **Parse ticket keys** from the plan header:
    - `**PM ticket**: <PM_KEY>` — the original PM ticket (e.g. `SC-79`)
-   - `**Engineering ticket**: <ENG_KEY>` — the ticket you are executing (e.g. `HUM-59`)
-   Record both keys. Every commit message must reference **both** so the full PM → engineering → commit trail is preserved. If the PM ticket line is missing, the plan is incomplete — stop and ask the user for the PM ticket key before making commits.
+   - `**Engineering ticket**: <ENG_KEY>` — present only in split topology
+   Record what exists. Commits reference **both** keys when both exist so the PM → engineering → commit trail is preserved; when the plan lives on the PM ticket itself there is only one key and commits reference it alone. If the plan came from a `[human:plan]` comment without header lines, the key you were given IS the PM key. If no PM key can be determined, stop and ask the user before making commits.
 3. **Parse** the plan's changes section into ordered tasks
 4. **Execute** each task sequentially:
    - Read the target file before modifying it
@@ -55,8 +59,9 @@ human <TRACKER> issue comment list <TICKET_KEY>
    ```
    Build the values:
    - `<current-branch>` from `git rev-parse --abbrev-ref HEAD`.
-   - `<short-shas>` from `git log --grep=<ENG_KEY> --format='%h' HEAD` (comma-separated).
+   - `<short-shas>` from `git log --grep=<KEY> --format='%h' HEAD` (comma-separated), grepping the key(s) the commits reference.
    - If multiple engineering tickets were executed in this run, list them all comma-separated under `engineering:` and union their commit SHAs.
+   - Single-tracker topology (no engineering ticket): OMIT the `engineering:` line entirely — the reviewer works from the PM key the comment sits on.
    Post it with `human <pm-tracker> issue comment add <PM_KEY> "<comment-body>"`. If `human-done` failed, do NOT post the handoff — leave the work in progress and report the failures so the user can fix them and re-run.
 7. **Summarize** what was done: files created, files modified, done verdict, link/key of the PM comment that was posted (or note that it was skipped because done failed).
 
@@ -66,7 +71,7 @@ human <TRACKER> issue comment list <TICKET_KEY>
 - Follow the plan's order. Do not skip steps or reorder without cause.
 - If a plan step is ambiguous, read the surrounding code to resolve the ambiguity rather than guessing.
 - Run tests after completing all changes to catch regressions early.
-- Preserve both ticket keys throughout. Every commit message must reference **both** the PM ticket and the engineering ticket so there is one trail from PM → engineering → commit (e.g. `[SC-79] [HUM-59] Add validation for email field`). The two keys usually live on different trackers (e.g. Shortcut PM + Linear engineering, Jira PM + GitHub engineering) — the format is the same regardless.
+- Preserve the ticket trail throughout. Split topology: every commit references **both** the PM and engineering keys (e.g. `[SC-79] [HUM-59] Add validation for email field`) — the two keys usually live on different trackers, the format is the same regardless. Single-tracker topology: there is one key and every commit references it (e.g. `[SC-79] Add validation for email field`).
 - **Boil the Lake**: When the complete implementation costs minutes more than a partial one, do the complete thing. Handle all edge cases, all error paths, all related tests. Completeness is cheap with AI — do not leave known gaps for follow-up tickets.
 - **User Sovereignty**: Recommend, do not decide. When a plan step has multiple valid approaches or a judgment call, present both sides with trade-offs and let the user choose. Never silently make opinionated choices on the user's behalf.
 

--- a/internal/claude/embed/human-plan-skill.md
+++ b/internal/claude/embed/human-plan-skill.md
@@ -6,7 +6,7 @@ argument-hint: <ticket-key>
 
 # Implementation Plan Pipeline
 
-Create an implementation plan using a 3-phase agent pipeline: draft, verify, finalize. The plan is embedded directly in the engineering ticket description — no plan files are created.
+Create an implementation plan using a 3-phase agent pipeline: draft, verify, finalize. No plan files are created — the plan lands on the tracker: as a separate engineering ticket's description (split topology: distinct PM and engineering trackers) or as a `[human:plan]` comment on the ticket itself (single-tracker topology).
 
 ## Phase 1: Draft Plan
 
@@ -57,9 +57,14 @@ After finalizing the plan, review it yourself end-to-end:
 
 Only proceed to ticket creation once you are confident the plan will work.
 
-## Phase 5: Create ticket
+## Phase 5: Attach the plan (topology decides where)
 
-Then resolve the engineering tracker: run `human tracker list` and pick the tracker with `"role": "engineering"`. Use its `type` as the tracker and its first configured project. If no tracker has role `engineering`, fall back to asking the user via `AskUserQuestion`.
+Run `human tracker list` and check the topology:
+
+- **Split topology** — a tracker with `"role": "engineering"` exists and is a DIFFERENT tracker than the PM ticket's: create a separate engineering ticket there (steps below).
+- **Single-tracker topology** — no engineering-role tracker, or it is the same tracker as the PM ticket: do NOT create a second ticket. The plan lives on the PM ticket itself as a `[human:plan]` comment (Phase 5b).
+
+### Phase 5a: Split topology — create the engineering ticket
 
 Confirm the plan has a `**PM ticket**:` line in its header referencing the original PM ticket key. If it is missing, add it before creating the engineering ticket so the executor can reference both tickets in commits.
 
@@ -76,16 +81,39 @@ After creating the ticket, capture the returned engineering ticket key and updat
 
 Then fetch the ticket back and verify the description matches the updated plan content byte-for-byte. If it does not match, update the ticket until it does.
 
+### Phase 5b: Single-tracker topology — attach the plan as a comment
+
+Post the plan verbatim as a `[human:plan]` marker comment on the PM ticket (the ticket description stays product language; the plan is a stage artifact and lives in the comment stream):
+
+```bash
+human <pm-tracker> issue comment add <PM_KEY> "$(cat <<'PLAN_EOF'
+[human:plan]
+
+<FINAL_PLAN_CONTENT>
+PLAN_EOF
+)"
+```
+
+Verify with `human plan show <PM_KEY>` — it must print the plan back. Re-planning posts a new `[human:plan]` comment; the latest wins, never edit old ones. In this topology the plan header needs no `**Engineering ticket**:` line, and commits reference only the PM key.
+
 ## Phase 6: Post the plan-ready marker on the PM ticket
 
-After the engineering ticket exists, post a structured marker comment on the **PM ticket** so the workflow board can advance the card from Planning into Implementation (the board resolves the Implementation input from this `engineering:` line). The format is fixed so it can be parsed unambiguously across trackers:
+Post a structured marker comment on the **PM ticket** so the workflow board can advance the card from Planning into Implementation. The format is fixed so it can be parsed unambiguously across trackers:
+
+- Split topology (engineering ticket created):
 
 ```
 [human:plan-ready]
 engineering: <ENG_KEY>
 ```
 
-Post it with `human <pm-tracker> issue comment add <PM_KEY> "<comment-body>"`, where `<pm-tracker>` is the PM tracker resolved from `human tracker list` (the one with `"role": "pm"`), `<PM_KEY>` is the original PM ticket key from the plan's `**PM ticket**:` header, and `<ENG_KEY>` is the engineering ticket key just created. This mirrors the `[human:ready-for-review]` handoff that `human-executor` posts after implementation.
+- Single-tracker topology (plan attached as comment) — no `engineering:` line; the board dispatches Implementation on the PM key itself:
+
+```
+[human:plan-ready]
+```
+
+Post it with `human <pm-tracker> issue comment add <PM_KEY> "<comment-body>"`, where `<pm-tracker>` is the PM tracker resolved from `human tracker list` (the one with `"role": "pm"`), and `<PM_KEY>` is the original PM ticket key from the plan's `**PM ticket**:` header. This mirrors the `[human:ready-for-review]` handoff that `human-executor` posts after implementation.
 
 ## After completion
 

--- a/internal/claude/embed/human-planner-agent.md
+++ b/internal/claude/embed/human-planner-agent.md
@@ -40,7 +40,7 @@ human <TRACKER> issues list --project=<PROJECT_KEY>
 4. **Identify** existing patterns, conventions, and related code
 5. **Produce** a structured plan following the output format below
 6. **Verify references** — every file, function, and type referenced in the plan must actually exist. Use Grep/Glob to confirm.
-7. **Return** the plan as your output. Do NOT write any files — no `.human/plans/`, no plan files. The orchestrator will embed the plan in the engineering ticket description.
+7. **Return** the plan as your output. Do NOT write any files — no `.human/plans/`, no plan files. The orchestrator attaches the plan to the tracker: as the engineering ticket's description (split topology) or as a `[human:plan]` comment on the ticket itself (single-tracker topology).
 
 ## Plan output format
 

--- a/internal/daemon/board_markers.go
+++ b/internal/daemon/board_markers.go
@@ -49,6 +49,14 @@ const (
 	PRFailedHeader              = "[human:pr-failed]"
 )
 
+// PlanCommentHeader marks a comment whose body IS the engineering plan for
+// this ticket — the single-tracker alternative to a separate engineering
+// ticket. It is content, not a stage signal, so it must never join
+// orderedMarkerSpecs: the [human:plan-ready] marker still carries the stage
+// transition. (ClassifyMarker's prefix matching stays safe because the
+// closing bracket keeps "[human:plan]" from matching "[human:plan-ready]".)
+const PlanCommentHeader = "[human:plan]"
+
 // markerSpec maps a marker header to the (stage, state) it represents.
 type markerSpec struct {
 	Header string

--- a/internal/daemon/board_state.go
+++ b/internal/daemon/board_state.go
@@ -16,6 +16,10 @@ type BoardCard struct {
 	Branch         string     `json:"branch,omitempty"`
 	PRURL          string     `json:"pr_url,omitempty"`
 	Error          string     `json:"error,omitempty"`
+	// HasPlan reports a [human:plan] comment on the ticket — the plan lives
+	// here instead of on a separate engineering ticket (single-tracker
+	// topology).
+	HasPlan bool `json:"has_plan,omitempty"`
 }
 
 // DeriveBoardCard computes a PM ticket's board placement from its comment
@@ -41,13 +45,15 @@ func DeriveBoardCard(comments []tracker.Comment, statusType tracker.Category) Bo
 		}
 	}
 
+	_, hasPlan := latestPlanComment(comments)
+
 	if !anyMarker {
 		// No pipeline activity: a closed/done PM ticket never entered the
 		// board and is hidden; an open one waits in Backlog.
 		if statusType == tracker.CategoryDone || statusType == tracker.CategoryClosed {
-			return BoardCard{Stage: BoardHidden}
+			return BoardCard{Stage: BoardHidden, HasPlan: hasPlan}
 		}
-		return BoardCard{Stage: BoardBacklog}
+		return BoardCard{Stage: BoardBacklog, HasPlan: hasPlan}
 	}
 
 	// Second pass: within the furthest stage, the latest marker decides state.
@@ -66,7 +72,7 @@ func DeriveBoardCard(comments []tracker.Comment, statusType tracker.Category) Bo
 		}
 	}
 
-	card := BoardCard{Stage: furthest, State: state}
+	card := BoardCard{Stage: furthest, State: state, HasPlan: hasPlan}
 	card.EngineeringKey = firstEngineeringKey(comments)
 	card.Branch = latestPrefixedLine(comments, ReadyForReviewHeader, "branch:")
 	card.PRURL = latestPrefixedLine(comments, PRPushedHeader, "pr:")
@@ -74,6 +80,27 @@ func DeriveBoardCard(comments []tracker.Comment, statusType tracker.Category) Bo
 		card.Error = firstLine(latest.Body)
 	}
 	return card
+}
+
+// latestPlanComment returns the body of the newest [human:plan] comment with
+// the header line stripped. The latest wins so re-planning supersedes older
+// plans without editing comment history.
+func latestPlanComment(comments []tracker.Comment) (string, bool) {
+	var body string
+	var haveLatest bool
+	var latest tracker.Comment
+	for _, c := range comments {
+		trimmed := strings.TrimSpace(c.Body)
+		if !strings.HasPrefix(trimmed, PlanCommentHeader) {
+			continue
+		}
+		if !haveLatest || c.Created.After(latest.Created) {
+			latest = c
+			haveLatest = true
+			body = strings.TrimSpace(strings.TrimPrefix(trimmed, PlanCommentHeader))
+		}
+	}
+	return body, haveLatest
 }
 
 // firstEngineeringKey resolves the engineering ticket key from the comment

--- a/internal/daemon/board_state_test.go
+++ b/internal/daemon/board_state_test.go
@@ -104,3 +104,58 @@ func TestDeriveBoardCard(t *testing.T) {
 		assert.Equal(t, "HUM-9", card.EngineeringKey)
 	})
 }
+
+func TestDeriveBoardCard_HasPlan(t *testing.T) {
+	t0 := time.Unix(1000, 0)
+	t1 := time.Unix(2000, 0)
+
+	t.Run("plan comment sets HasPlan without shifting stage", func(t *testing.T) {
+		card := DeriveBoardCard([]tracker.Comment{cmt("[human:plan]\n\n## Steps\n1. do it", t0)}, tracker.CategoryUnstarted)
+		assert.True(t, card.HasPlan)
+		// The plan is content, not a stage signal — the card stays in Backlog.
+		assert.Equal(t, BoardBacklog, card.Stage)
+	})
+
+	t.Run("plan-ready is not a plan comment", func(t *testing.T) {
+		// Prefix isolation: [human:plan-ready] must not read as [human:plan].
+		card := DeriveBoardCard([]tracker.Comment{cmt("[human:plan-ready]\nengineering: HUM-9", t0)}, tracker.CategoryUnstarted)
+		assert.False(t, card.HasPlan)
+		assert.Equal(t, BoardPlanning, card.Stage)
+	})
+
+	t.Run("plan plus markers keeps both", func(t *testing.T) {
+		card := DeriveBoardCard([]tracker.Comment{
+			cmt("[human:plan]\nthe plan", t0),
+			cmt("[human:planning-started]", t1),
+		}, tracker.CategoryUnstarted)
+		assert.True(t, card.HasPlan)
+		assert.Equal(t, BoardPlanning, card.Stage)
+	})
+}
+
+func TestLatestPlanComment(t *testing.T) {
+	t0 := time.Unix(1000, 0)
+	t1 := time.Unix(2000, 0)
+
+	t.Run("latest plan wins", func(t *testing.T) {
+		body, ok := latestPlanComment([]tracker.Comment{
+			cmt("[human:plan]\nold plan", t0),
+			cmt("[human:plan]\nnew plan", t1),
+		})
+		assert.True(t, ok)
+		assert.Equal(t, "new plan", body)
+	})
+
+	t.Run("header stripped, quoted header mid-body ignored", func(t *testing.T) {
+		body, ok := latestPlanComment([]tracker.Comment{
+			cmt("see `[human:plan]` for details", t0),
+		})
+		assert.False(t, ok)
+		assert.Empty(t, body)
+	})
+
+	t.Run("no comments", func(t *testing.T) {
+		_, ok := latestPlanComment(nil)
+		assert.False(t, ok)
+	})
+}

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -120,17 +120,22 @@ func (d BoardTransitionDeps) ApplyTransition(ctx context.Context, req BoardTrans
 		return d.startAgentStage(ctx, req.PMKey, BoardPlanning, PlanningStartedHeader,
 			"/human-plan "+req.PMKey)
 	case BoardImplementation:
-		if card.EngineeringKey == "" {
-			return errors.WithDetails("no engineering key for implementation", "pm", req.PMKey)
+		// Single-tracker topology has no separate engineering ticket — the
+		// plan lives in a [human:plan] comment on the PM ticket, so the agent
+		// is dispatched on the PM key itself.
+		key := card.EngineeringKey
+		if key == "" {
+			key = req.PMKey
 		}
 		return d.startAgentStage(ctx, req.PMKey, BoardImplementation, ImplementationStartedHeader,
-			"/human-execute "+card.EngineeringKey)
+			"/human-execute "+key)
 	case BoardVerification:
-		if card.EngineeringKey == "" {
-			return errors.WithDetails("no engineering key for verification", "pm", req.PMKey)
+		key := card.EngineeringKey
+		if key == "" {
+			key = req.PMKey
 		}
 		return d.startAgentStage(ctx, req.PMKey, BoardVerification, ReviewStartedHeader,
-			"/human-review "+card.EngineeringKey)
+			"/human-review "+key)
 	case BoardDoneStage:
 		return d.runDoneStage(ctx, req, card)
 	default:

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -253,24 +253,35 @@ func TestFailedHeaderFor(t *testing.T) {
 	assert.Equal(t, "", failedHeaderFor(BoardBacklog))
 }
 
-func TestApplyTransitionMissingEngineeringKey(t *testing.T) {
-	// plan-ready without an engineering: line leaves EngineeringKey empty, so
-	// advancing to Implementation must error before launching.
-	c := &fakeCommenter{comments: []tracker.Comment{cmt("[human:plan-ready]", time.Unix(1, 0))}}
+func TestApplyTransitionImplementationWithoutEngineeringKey(t *testing.T) {
+	// Single-tracker topology: no engineering: line anywhere — the plan is a
+	// [human:plan] comment, so the executor is dispatched on the PM key.
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:plan]\nthe plan", time.Unix(1, 0)),
+		cmt("[human:plan-ready]", time.Unix(2, 0)),
+	}}
 	l := &fakeLauncher{}
 	deps := newDeps(c, l, &fakePublisher{})
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardPlanning, To: BoardImplementation})
-	require.Error(t, err)
-	assert.Zero(t, l.calls)
+	require.NoError(t, err)
+	assert.Equal(t, "/human-execute SC-1", l.prompt)
 }
 
-func TestApplyTransitionVerificationMissingEngineeringKey(t *testing.T) {
-	// An implementation done-marker that carries no engineering: line blocks
-	// the Verification launch.
-	c := &fakeCommenter{comments: []tracker.Comment{cmt("[human:ready-for-review]\nbranch: feat/x", time.Unix(1, 0))}}
+func TestApplyTransitionVerificationWithoutEngineeringKey(t *testing.T) {
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:ready-for-review]\nbranch: feat/x", time.Unix(1, 0)),
+	}}
 	l := &fakeLauncher{}
 	deps := newDeps(c, l, &fakePublisher{})
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardImplementation, To: BoardVerification})
-	require.Error(t, err)
-	assert.Zero(t, l.calls)
+	require.NoError(t, err)
+	assert.Equal(t, "/human-review SC-1", l.prompt)
+}
+
+func TestDoneBodySingleRef(t *testing.T) {
+	// Regression: without an engineering ticket the PR body carries only the
+	// PM line — no empty "Engineering ticket:" placeholder.
+	body := doneBody("SC-1", BoardCard{Branch: "feat/x"})
+	assert.Contains(t, body, "PM ticket: SC-1")
+	assert.NotContains(t, body, "Engineering ticket:")
 }

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gethuman-sh/human/cmd/cmdinit"
 	"github.com/gethuman-sh/human/cmd/cmdnotion"
 	"github.com/gethuman-sh/human/cmd/cmdping"
+	"github.com/gethuman-sh/human/cmd/cmdplan"
 	"github.com/gethuman-sh/human/cmd/cmdprovider"
 	"github.com/gethuman-sh/human/cmd/cmdproxy"
 	"github.com/gethuman-sh/human/cmd/cmdslack"
@@ -207,6 +208,10 @@ Configure trackers and tools in .humanconfig.yaml or pass credentials via flags/
 	autoPRCmd := cmdauto.BuildAutoPRCreateCmd(autoDeps)
 	autoPRCmd.GroupID = "shortcuts"
 	rootCmd.AddCommand(autoPRCmd)
+
+	planCmd := cmdplan.BuildPlanCmd(autoDeps)
+	planCmd.GroupID = "shortcuts"
+	rootCmd.AddCommand(planCmd)
 
 	// --- Provider commands (dynamic registration) ---
 	providers := []string{"jira", "github", "gitlab", "linear", "azuredevops", "shortcut", "clickup"}


### PR DESCRIPTION
Phase 2 of the evolving-ticket model (SC-159): in single-tracker topology the engineering plan lives as a `[human:plan]` comment on the ticket and the whole pipeline runs on one key.

- `PlanCommentHeader` (content marker — deliberately NOT a stage signal), `BoardCard.HasPlan` derived from the existing per-issue comment fetch (zero extra API calls).
- Implementation/Verification stage agents dispatch on the PM key when no `engineering:` key exists (previously a hard error); `doneBody` single-ref regression pinned.
- New `human plan show <KEY>` (auto-detects tracker) prints the latest plan comment.
- `human-plan` skill gains a topology branch: distinct engineering tracker → separate ticket as today; same/absent → plan comment + `[human:plan-ready]` without `engineering:` line. Executor resolves the plan from description OR plan comment; commit refs conditional. CLAUDE.md Tickets/Review-handoff/Commit sections rewritten for the lifecycle + topology rule.

Split topology verified byte-identical by the existing test suite; all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)