### PR TITLE
[SC-159] [HUM-171] Ideas board column with quick capture and evolve-mode promotion

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -1138,6 +1138,14 @@ func scanReadyForReview(jobs []fetchJob, results []daemon.TrackerIssuesResult) (
 			continue
 		}
 		for _, issue := range results[i].Issues {
+			// Idea tickets are placed by their label alone — no marker scan
+			// needed, so skip the per-issue comment round-trip entirely.
+			if issue.IsIdea() {
+				mu.Lock()
+				cards[issue.Key] = daemon.DeriveBoardCard(nil, issue.StatusType, true)
+				mu.Unlock()
+				continue
+			}
 			wg.Add(1)
 			// Capture StatusType alongside Key so DeriveBoardCard can decide
 			// the empty-Backlog-vs-Hidden case for a marker-less ticket.
@@ -1149,7 +1157,7 @@ func scanReadyForReview(jobs []fetchJob, results []daemon.TrackerIssuesResult) (
 				if err != nil {
 					return
 				}
-				card := daemon.DeriveBoardCard(comments, statusType)
+				card := daemon.DeriveBoardCard(comments, statusType, false)
 				keys, pr := latestReadyKeys(comments)
 				mu.Lock()
 				cards[key] = card
@@ -1520,19 +1528,50 @@ func resolvePMCreator(dir string, lookup config.EnvLookup, resolver *vault.Resol
 	return nil, "", errors.WithDetails("no PM-role tracker configured", "dir", dir)
 }
 
+// resolvePMEditor resolves the PM-role tracker.Editor for evolve-mode idea
+// promotion. Role-based, never key-prefix — mirrors resolvePMCommenter.
+func resolvePMEditor(dir string, lookup config.EnvLookup, resolver *vault.Resolver) (tracker.Editor, error) {
+	instances, err := cmdutil.LoadAllInstancesWithResolver(dir, lookup, resolver)
+	if err != nil {
+		return nil, err
+	}
+	for _, inst := range instances {
+		if inst.InferRole() != "pm" {
+			continue
+		}
+		if ed, ok := inst.Provider.(tracker.Editor); ok {
+			return ed, nil
+		}
+	}
+	return nil, errors.WithDetails("no PM-role tracker with edit support configured", "dir", dir)
+}
+
 // ideationEngine wires the board ideation engine: host claude runner, role-
-// resolved PM creator, and a hook-store poke so the created card reaches the
-// board through the existing subscribe/refetch loop.
+// resolved PM creator/editor, and a hook-store poke so the created card
+// reaches the board through the existing subscribe/refetch loop.
 func ideationEngine(reg *daemon.ProjectRegistry, resolver *vault.Resolver, hookStore *daemon.HookEventStore, logger zerolog.Logger) *daemon.IdeationEngine {
+	firstEntry := func() (daemon.ProjectEntry, error) {
+		entries := reg.Entries()
+		if len(entries) == 0 {
+			return daemon.ProjectEntry{}, errors.WithDetails("no project registered for ideation")
+		}
+		return entries[0], nil
+	}
 	return &daemon.IdeationEngine{
 		Runner: hostClaudeIdeationRunner{reg: reg},
 		ResolveCreator: func() (tracker.Creator, string, error) {
-			entries := reg.Entries()
-			if len(entries) == 0 {
-				return nil, "", errors.WithDetails("no project registered for ideation")
+			entry, err := firstEntry()
+			if err != nil {
+				return nil, "", err
 			}
-			entry := entries[0]
 			return resolvePMCreator(entry.Dir, entry.EnvLookup(), resolver)
+		},
+		ResolveEditor: func() (tracker.Editor, error) {
+			entry, err := firstEntry()
+			if err != nil {
+				return nil, err
+			}
+			return resolvePMEditor(entry.Dir, entry.EnvLookup(), resolver)
 		},
 		Notify: func() {
 			hookStore.Append(hookevents.Event{EventName: "IdeationCreated", Timestamp: time.Now().UTC()})

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -58,6 +58,11 @@ type Card struct {
 	Branch         string `json:"branch,omitempty"`
 	PRURL          string `json:"prURL,omitempty"`
 	Error          string `json:"error,omitempty"`
+	// Labels and Description feed the Ideas→Backlog promotion: labels tell
+	// the evolve session which idea labels to remove, the description seeds
+	// the ideation conversation alongside the title.
+	Labels      []string `json:"labels,omitempty"`
+	Description string   `json:"description,omitempty"`
 }
 
 // BoardData is the full payload the frontend renders: the flat card list plus an
@@ -130,11 +135,17 @@ func boardFromResults(results []daemon.TrackerIssuesResult, dockerAvailable bool
 		if stage == "" {
 			// No derived card (quick fetch, or a marker-less ticket): a
 			// done/closed ticket that never entered the pipeline is hidden;
-			// everything else sits in Backlog.
+			// ideas sit in the Ideas column by their label alone; everything
+			// else sits in Backlog. Mirrors daemon.DeriveBoardCard so the
+			// quick pass and full pass agree.
 			if issue.StatusType == tracker.CategoryDone || issue.StatusType == tracker.CategoryClosed {
 				continue
 			}
-			stage = daemon.BoardBacklog
+			if issue.IsIdea() {
+				stage = daemon.BoardIdeas
+			} else {
+				stage = daemon.BoardBacklog
+			}
 		}
 		if stage == daemon.BoardHidden {
 			// Closed PM ticket that never entered the pipeline — not shown.
@@ -150,6 +161,8 @@ func boardFromResults(results []daemon.TrackerIssuesResult, dockerAvailable bool
 			Branch:         card.Branch,
 			PRURL:          card.PRURL,
 			Error:          card.Error,
+			Labels:         issue.Labels,
+			Description:    issue.Description,
 		})
 	}
 	return data
@@ -247,20 +260,35 @@ type IdeationView struct {
 
 // StartIdeation begins (or re-attaches to) the board ideation session. mode
 // is "chat" or "guided"; empty defaults to "chat" in the daemon engine.
-func (a *App) StartIdeation(seed, mode string, restart bool) (IdeationView, error) {
+// evolveKey (with the card's idea labels) switches the session to evolve
+// mode: the outcome rewrites that ticket in place instead of creating one —
+// the Ideas→Backlog promotion path.
+func (a *App) StartIdeation(seed, mode string, restart bool, evolveKey string, evolveLabels []string) (IdeationView, error) {
 	info, err := daemon.ReadInfo()
 	if err != nil {
 		return IdeationView{}, err
 	}
 	st, err := daemon.IdeationStart(info.Addr, info.Token, daemon.IdeationStartRequest{
-		Seed:    seed,
-		Mode:    daemon.IdeationMode(mode),
-		Restart: restart,
+		Seed:         seed,
+		Mode:         daemon.IdeationMode(mode),
+		Restart:      restart,
+		EvolveKey:    evolveKey,
+		EvolveLabels: evolveLabels,
 	})
 	if err != nil {
 		return IdeationView{}, err
 	}
 	return ideationView(st), nil
+}
+
+// CreateIdea quick-captures a title-only idea ticket — the Ideas column's `+`.
+func (a *App) CreateIdea(title string) error {
+	info, err := daemon.ReadInfo()
+	if err != nil {
+		return err
+	}
+	_, err = daemon.IdeaCreate(info.Addr, info.Token, daemon.IdeaCreateRequest{Title: title})
+	return err
 }
 
 // ReplyIdeation sends the user's answer into the running session.

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -13,8 +13,9 @@ import { initPermissions } from "./permissions.js";
 import { initMockupsView, showMockups } from "./mockupsview.js";
 import { initSettingsView, showSettings, settingsIndex, saveSetting, setPaletteOpener, setActiveSection, } from "./settingsview.js";
 import { initPalette, openPalette, isPaletteChord } from "./palette.js";
-const STAGES = ["backlog", "planning", "implementation", "verification", "done"];
+const STAGES = ["ideas", "backlog", "planning", "implementation", "verification", "done"];
 const STAGE_LABELS = {
+    ideas: "Ideas",
     backlog: "Backlog",
     planning: "Product planning",
     implementation: "Implementation",
@@ -108,6 +109,15 @@ function renderColumn(stage) {
                 `<span class="column-count">${cards.length}</span>`;
         header.querySelector(".add-card").addEventListener("click", () => void openIdeation());
     }
+    else if (stage === "ideas") {
+        // Ideas capture is deliberately dumb: a title becomes a labeled ticket in
+        // one keystroke — the thinking happens later, at promotion.
+        header.innerHTML =
+            `<span>${STAGE_LABELS[stage]}</span>` +
+                `<button class="add-card" title="Capture an idea">+</button>` +
+                `<span class="column-count">${cards.length}</span>`;
+        header.querySelector(".add-card").addEventListener("click", () => showIdeaQuickAdd(col));
+    }
     else {
         header.innerHTML = `<span>${STAGE_LABELS[stage]}</span><span class="column-count">${cards.length}</span>`;
     }
@@ -130,11 +140,56 @@ function renderColumn(stage) {
         markCloseTarget(closeZone);
         body.appendChild(closeZone);
     }
-    else if (stage !== "backlog") {
+    else if (stage === "backlog") {
+        // Backlog accepts drops only from Ideas (adjacency gates the rest): the
+        // drop opens the evolve-mode ideation chat, it never calls Transition.
+        markStageTarget(body, stage);
+    }
+    else if (stage !== "ideas") {
         markStageTarget(body, stage);
     }
     col.appendChild(body);
     return col;
+}
+// showIdeaQuickAdd swaps an inline title input into the Ideas column. Enter
+// creates the idea-labeled ticket via CreateIdea; Escape or blur dismisses.
+function showIdeaQuickAdd(col) {
+    const body = col.querySelector(".column-body");
+    if (!body || body.querySelector(".idea-quick-add"))
+        return;
+    const input = document.createElement("input");
+    input.className = "idea-quick-add";
+    input.type = "text";
+    input.placeholder = "Idea title — Enter to capture";
+    body.prepend(input);
+    input.focus();
+    input.addEventListener("keydown", (e) => {
+        if (e.key === "Escape") {
+            input.remove();
+            return;
+        }
+        if (e.key !== "Enter")
+            return;
+        const title = input.value.trim();
+        if (!title)
+            return;
+        input.disabled = true;
+        void (async () => {
+            try {
+                await go().CreateIdea(title);
+                input.remove();
+                await reconcile();
+            }
+            catch (err) {
+                input.disabled = false;
+                showError(errMessage(err));
+            }
+        })();
+    });
+    input.addEventListener("blur", () => {
+        if (!input.disabled && input.value.trim() === "")
+            input.remove();
+    });
 }
 // --- Pointer-based drag ------------------------------------------------
 //
@@ -286,8 +341,53 @@ function performDrop(target, info, pt) {
         return;
     }
     const to = target.dataset.dropStage || "";
+    if (info.stage === "ideas" && to === "backlog") {
+        // Promotion is a conversation, not a stage transition: the evolve-mode
+        // ideation session rewrites the ticket in place and removes the idea
+        // label; the card moves columns when the board refetches.
+        void promoteIdea(info.key);
+        return;
+    }
     celebrateDrop(pt, { key: info.key, fromStage: info.stage, done: to === "done" });
     void transition(info.key, info.title, info.stage, to);
+}
+// promoteIdea opens the ideation panel in evolve mode, seeded with the idea
+// card's content. An active session must be explicitly replaced — the daemon
+// holds a single ideation session, so a silent restart would discard it.
+async function promoteIdea(key) {
+    const card = current.cards.find((c) => c.key === key);
+    if (!card)
+        return;
+    const active = ideation.state === "thinking" || ideation.state === "awaiting_reply" || ideation.state === "awaiting_approval";
+    if (active) {
+        const ok = await confirmDialog("Replace the active ideation session?", "Promoting this idea abandons the conversation currently in the ideation panel.", "Replace");
+        if (!ok)
+            return;
+    }
+    let seed = card.title;
+    if (card.description)
+        seed += "\n\n" + card.description;
+    const panel = document.getElementById("ideation-panel");
+    if (panel)
+        panel.classList.remove("hidden");
+    ideationOpen = true;
+    // Guided mode by default: a parked idea was parked precisely because it
+    // wasn't thought through — structured questions fit that moment.
+    ideationMode = "guided";
+    ideation = { state: "thinking", messages: [{ role: "user", text: seed }] };
+    renderIdeation();
+    startIdeationPoll();
+    try {
+        ideation = await go().StartIdeation(seed, "guided", true, card.key, card.labels ?? []);
+    }
+    catch (err) {
+        renderIdeationError(errMessage(err));
+        stopIdeationPoll();
+        return;
+    }
+    renderIdeation();
+    if (ideation.state !== "thinking")
+        stopIdeationPoll();
 }
 async function transition(key, title, from, to) {
     const card = current.cards.find((c) => c.key === key);
@@ -718,7 +818,7 @@ async function sendIdeationReply(text) {
     startIdeationPoll();
     try {
         if (isFresh) {
-            ideation = await go().StartIdeation(text, ideationMode ?? "chat", restart);
+            ideation = await go().StartIdeation(text, ideationMode ?? "chat", restart, "", []);
         }
         else {
             ideation = await go().ReplyIdeation(ideation.sessionId, text);

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -174,7 +174,10 @@ body {
 
 .board {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  /* Six columns since the Ideas column landed; min-width keeps each readable
+     and the board scrolls horizontally on narrow windows instead of
+     squishing cards into slivers. */
+  grid-template-columns: repeat(6, minmax(170px, 1fr));
   /* Bound the single row to the board's own height so columns can never grow
      past the space below the header (the old 100vh-based column max-height did,
      which pushed the document 20px taller than the viewport). */
@@ -182,6 +185,22 @@ body {
   gap: 10px;
   padding: 12px;
   height: 100%;
+  overflow-x: auto;
+}
+
+/* Inline quick-add input at the top of the Ideas column. */
+.idea-quick-add {
+  background: var(--card-bg);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  padding: 8px 10px;
+  color: var(--text);
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
+.idea-quick-add:disabled {
+  opacity: 0.5;
 }
 
 .column {

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -39,6 +39,8 @@ interface Card {
   engineeringKey?: string;
   branch?: string;
   prURL?: string;
+  labels?: string[];
+  description?: string;
   error?: string;
 }
 
@@ -161,7 +163,8 @@ interface AppBindings {
   Transition(pmKey: string, pmTitle: string, from: string, to: string): Promise<void>;
   CloseTicket(pmKey: string): Promise<void>;
   DaemonStatus(): Promise<boolean>;
-  StartIdeation(seed: string, mode: string, restart: boolean): Promise<IdeationView>;
+  StartIdeation(seed: string, mode: string, restart: boolean, evolveKey: string, evolveLabels: string[]): Promise<IdeationView>;
+  CreateIdea(title: string): Promise<void>;
   ReplyIdeation(sessionId: string, message: string): Promise<IdeationView>;
   ApproveIdeation(sessionId: string, title: string, description: string): Promise<IdeationView>;
   IdeationStatus(): Promise<IdeationView>;
@@ -189,8 +192,9 @@ declare global {
 
 export {};
 
-const STAGES = ["backlog", "planning", "implementation", "verification", "done"] as const;
+const STAGES = ["ideas", "backlog", "planning", "implementation", "verification", "done"] as const;
 const STAGE_LABELS: Record<string, string> = {
+  ideas: "Ideas",
   backlog: "Backlog",
   planning: "Product planning",
   implementation: "Implementation",
@@ -293,6 +297,14 @@ function renderColumn(stage: string): HTMLElement {
       `<button class="add-card" title="New ticket via ideation">+</button>` +
       `<span class="column-count">${cards.length}</span>`;
     header.querySelector(".add-card")!.addEventListener("click", () => void openIdeation());
+  } else if (stage === "ideas") {
+    // Ideas capture is deliberately dumb: a title becomes a labeled ticket in
+    // one keystroke — the thinking happens later, at promotion.
+    header.innerHTML =
+      `<span>${STAGE_LABELS[stage]}</span>` +
+      `<button class="add-card" title="Capture an idea">+</button>` +
+      `<span class="column-count">${cards.length}</span>`;
+    header.querySelector(".add-card")!.addEventListener("click", () => showIdeaQuickAdd(col));
   } else {
     header.innerHTML = `<span>${STAGE_LABELS[stage]}</span><span class="column-count">${cards.length}</span>`;
   }
@@ -316,12 +328,53 @@ function renderColumn(stage: string): HTMLElement {
     closeZone.textContent = "Close Ticket";
     markCloseTarget(closeZone);
     body.appendChild(closeZone);
-  } else if (stage !== "backlog") {
+  } else if (stage === "backlog") {
+    // Backlog accepts drops only from Ideas (adjacency gates the rest): the
+    // drop opens the evolve-mode ideation chat, it never calls Transition.
+    markStageTarget(body, stage);
+  } else if (stage !== "ideas") {
     markStageTarget(body, stage);
   }
 
   col.appendChild(body);
   return col;
+}
+
+// showIdeaQuickAdd swaps an inline title input into the Ideas column. Enter
+// creates the idea-labeled ticket via CreateIdea; Escape or blur dismisses.
+function showIdeaQuickAdd(col: HTMLElement): void {
+  const body = col.querySelector(".column-body");
+  if (!body || body.querySelector(".idea-quick-add")) return;
+  const input = document.createElement("input");
+  input.className = "idea-quick-add";
+  input.type = "text";
+  input.placeholder = "Idea title — Enter to capture";
+  body.prepend(input);
+  input.focus();
+
+  input.addEventListener("keydown", (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      input.remove();
+      return;
+    }
+    if (e.key !== "Enter") return;
+    const title = input.value.trim();
+    if (!title) return;
+    input.disabled = true;
+    void (async () => {
+      try {
+        await go().CreateIdea(title);
+        input.remove();
+        await reconcile();
+      } catch (err) {
+        input.disabled = false;
+        showError(errMessage(err));
+      }
+    })();
+  });
+  input.addEventListener("blur", () => {
+    if (!input.disabled && input.value.trim() === "") input.remove();
+  });
 }
 
 // --- Pointer-based drag ------------------------------------------------
@@ -484,8 +537,57 @@ function performDrop(
     return;
   }
   const to = target.dataset.dropStage || "";
+  if (info.stage === "ideas" && to === "backlog") {
+    // Promotion is a conversation, not a stage transition: the evolve-mode
+    // ideation session rewrites the ticket in place and removes the idea
+    // label; the card moves columns when the board refetches.
+    void promoteIdea(info.key);
+    return;
+  }
   celebrateDrop(pt, { key: info.key, fromStage: info.stage, done: to === "done" });
   void transition(info.key, info.title, info.stage, to);
+}
+
+// promoteIdea opens the ideation panel in evolve mode, seeded with the idea
+// card's content. An active session must be explicitly replaced — the daemon
+// holds a single ideation session, so a silent restart would discard it.
+async function promoteIdea(key: string): Promise<void> {
+  const card = current.cards.find((c) => c.key === key);
+  if (!card) return;
+
+  const active =
+    ideation.state === "thinking" || ideation.state === "awaiting_reply" || ideation.state === "awaiting_approval";
+  if (active) {
+    const ok = await confirmDialog(
+      "Replace the active ideation session?",
+      "Promoting this idea abandons the conversation currently in the ideation panel.",
+      "Replace",
+    );
+    if (!ok) return;
+  }
+
+  let seed = card.title;
+  if (card.description) seed += "\n\n" + card.description;
+
+  const panel = document.getElementById("ideation-panel");
+  if (panel) panel.classList.remove("hidden");
+  ideationOpen = true;
+  // Guided mode by default: a parked idea was parked precisely because it
+  // wasn't thought through — structured questions fit that moment.
+  ideationMode = "guided";
+  ideation = { state: "thinking", messages: [{ role: "user", text: seed }] };
+  renderIdeation();
+  startIdeationPoll();
+
+  try {
+    ideation = await go().StartIdeation(seed, "guided", true, card.key, card.labels ?? []);
+  } catch (err) {
+    renderIdeationError(errMessage(err));
+    stopIdeationPoll();
+    return;
+  }
+  renderIdeation();
+  if (ideation.state !== "thinking") stopIdeationPoll();
 }
 
 async function transition(key: string, title: string, from: string, to: string): Promise<void> {
@@ -932,7 +1034,7 @@ async function sendIdeationReply(text: string): Promise<void> {
 
   try {
     if (isFresh) {
-      ideation = await go().StartIdeation(text, ideationMode ?? "chat", restart);
+      ideation = await go().StartIdeation(text, ideationMode ?? "chat", restart, "", []);
     } else {
       ideation = await go().ReplyIdeation(ideation.sessionId!, text);
     }

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -174,7 +174,10 @@ body {
 
 .board {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  /* Six columns since the Ideas column landed; min-width keeps each readable
+     and the board scrolls horizontally on narrow windows instead of
+     squishing cards into slivers. */
+  grid-template-columns: repeat(6, minmax(170px, 1fr));
   /* Bound the single row to the board's own height so columns can never grow
      past the space below the header (the old 100vh-based column max-height did,
      which pushed the document 20px taller than the viewport). */
@@ -182,6 +185,22 @@ body {
   gap: 10px;
   padding: 12px;
   height: 100%;
+  overflow-x: auto;
+}
+
+/* Inline quick-add input at the top of the Ideas column. */
+.idea-quick-add {
+  background: var(--card-bg);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  padding: 8px 10px;
+  color: var(--text);
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
+.idea-quick-add:disabled {
+  opacity: 0.5;
 }
 
 .column {

--- a/internal/daemon/board_markers.go
+++ b/internal/daemon/board_markers.go
@@ -9,6 +9,10 @@ import "strings"
 type BoardStage string
 
 const (
+	// BoardIdeas holds idea-labeled tickets (see tracker.Issue.IsIdea) —
+	// membership comes from the label, never from markers, and the only way
+	// out is promotion via ideation (label swap), not a board transition.
+	BoardIdeas          BoardStage = "ideas"
 	BoardBacklog        BoardStage = "backlog"
 	BoardPlanning       BoardStage = "planning"
 	BoardImplementation BoardStage = "implementation"
@@ -85,11 +89,12 @@ var orderedMarkerSpecs = []markerSpec{
 // stageRank orders the pipeline stages so derivation can pick the furthest
 // stage a ticket has reached. Hidden is not ranked (handled separately).
 var stageRank = map[BoardStage]int{
-	BoardBacklog:        0,
-	BoardPlanning:       1,
-	BoardImplementation: 2,
-	BoardVerification:   3,
-	BoardDoneStage:      4,
+	BoardIdeas:          0,
+	BoardBacklog:        1,
+	BoardPlanning:       2,
+	BoardImplementation: 3,
+	BoardVerification:   4,
+	BoardDoneStage:      5,
 }
 
 // ClassifyMarker reports the stage and state a comment body represents and

--- a/internal/daemon/board_state.go
+++ b/internal/daemon/board_state.go
@@ -27,7 +27,19 @@ type BoardCard struct {
 // wins; within that stage the latest marker (by Created) decides
 // running/done/failed. A ticket with no markers sits in Backlog while open and
 // is Hidden once closed/done (those never entered the pipeline). Pure: no I/O.
-func DeriveBoardCard(comments []tracker.Comment, statusType tracker.Category) BoardCard {
+//
+// isIdea (the ticket carries an idea label, tracker.Issue.IsIdea) takes
+// precedence over everything while the ticket is open: an idea sits in the
+// Ideas column even if it somehow carries pipeline markers — deliberately, so
+// the label is the single source of truth until promotion removes it.
+func DeriveBoardCard(comments []tracker.Comment, statusType tracker.Category, isIdea bool) BoardCard {
+	if isIdea {
+		if statusType == tracker.CategoryDone || statusType == tracker.CategoryClosed {
+			return BoardCard{Stage: BoardHidden}
+		}
+		return BoardCard{Stage: BoardIdeas}
+	}
+
 	furthest := BoardBacklog
 	furthestRank := -1
 	var anyMarker bool
@@ -57,20 +69,7 @@ func DeriveBoardCard(comments []tracker.Comment, statusType tracker.Category) Bo
 	}
 
 	// Second pass: within the furthest stage, the latest marker decides state.
-	state := BoardIdle
-	var haveLatest bool
-	var latest tracker.Comment
-	for _, c := range comments {
-		stage, st, ok := ClassifyMarker(c.Body)
-		if !ok || stage != furthest {
-			continue
-		}
-		if !haveLatest || c.Created.After(latest.Created) {
-			latest = c
-			haveLatest = true
-			state = st
-		}
-	}
+	state, latest := latestStateInStage(comments, furthest)
 
 	card := BoardCard{Stage: furthest, State: state, HasPlan: hasPlan}
 	card.EngineeringKey = firstEngineeringKey(comments)
@@ -80,6 +79,26 @@ func DeriveBoardCard(comments []tracker.Comment, statusType tracker.Category) Bo
 		card.Error = firstLine(latest.Body)
 	}
 	return card
+}
+
+// latestStateInStage resolves the stage's state from its newest marker and
+// returns that marker's comment so a failure message can be extracted.
+func latestStateInStage(comments []tracker.Comment, stage BoardStage) (BoardState, tracker.Comment) {
+	state := BoardIdle
+	var haveLatest bool
+	var latest tracker.Comment
+	for _, c := range comments {
+		s, st, ok := ClassifyMarker(c.Body)
+		if !ok || s != stage {
+			continue
+		}
+		if !haveLatest || c.Created.After(latest.Created) {
+			latest = c
+			haveLatest = true
+			state = st
+		}
+	}
+	return state, latest
 }
 
 // latestPlanComment returns the body of the newest [human:plan] comment with

--- a/internal/daemon/board_state_test.go
+++ b/internal/daemon/board_state_test.go
@@ -19,29 +19,29 @@ func TestDeriveBoardCard(t *testing.T) {
 	t2 := time.Unix(3000, 0)
 
 	t.Run("no markers open is backlog", func(t *testing.T) {
-		card := DeriveBoardCard(nil, tracker.CategoryUnstarted)
+		card := DeriveBoardCard(nil, tracker.CategoryUnstarted, false)
 		assert.Equal(t, BoardBacklog, card.Stage)
 		assert.Equal(t, BoardIdle, card.State)
 	})
 
 	t.Run("no markers closed is hidden", func(t *testing.T) {
-		card := DeriveBoardCard(nil, tracker.CategoryClosed)
+		card := DeriveBoardCard(nil, tracker.CategoryClosed, false)
 		assert.Equal(t, BoardHidden, card.Stage)
 	})
 
 	t.Run("no markers done is hidden", func(t *testing.T) {
-		card := DeriveBoardCard(nil, tracker.CategoryDone)
+		card := DeriveBoardCard(nil, tracker.CategoryDone, false)
 		assert.Equal(t, BoardHidden, card.Stage)
 	})
 
 	t.Run("planning-started is planning running", func(t *testing.T) {
-		card := DeriveBoardCard([]tracker.Comment{cmt("[human:planning-started]", t0)}, tracker.CategoryUnstarted)
+		card := DeriveBoardCard([]tracker.Comment{cmt("[human:planning-started]", t0)}, tracker.CategoryUnstarted, false)
 		assert.Equal(t, BoardPlanning, card.Stage)
 		assert.Equal(t, BoardRunning, card.State)
 	})
 
 	t.Run("plan-ready with eng key", func(t *testing.T) {
-		card := DeriveBoardCard([]tracker.Comment{cmt("[human:plan-ready]\nengineering: HUM-7", t0)}, tracker.CategoryUnstarted)
+		card := DeriveBoardCard([]tracker.Comment{cmt("[human:plan-ready]\nengineering: HUM-7", t0)}, tracker.CategoryUnstarted, false)
 		assert.Equal(t, BoardPlanning, card.Stage)
 		assert.Equal(t, BoardDone, card.State)
 		assert.Equal(t, "HUM-7", card.EngineeringKey)
@@ -52,7 +52,7 @@ func TestDeriveBoardCard(t *testing.T) {
 			cmt("[human:plan-ready]\nengineering: HUM-7", t0),
 			cmt("[human:implementation-started]", t1),
 		}
-		card := DeriveBoardCard(comments, tracker.CategoryUnstarted)
+		card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
 		assert.Equal(t, BoardImplementation, card.Stage)
 		assert.Equal(t, BoardRunning, card.State)
 		assert.Equal(t, "HUM-7", card.EngineeringKey)
@@ -63,7 +63,7 @@ func TestDeriveBoardCard(t *testing.T) {
 			cmt("[human:planning-started]", t0),
 			cmt("[human:plan-ready]\nengineering: HUM-9", t1),
 		}
-		card := DeriveBoardCard(comments, tracker.CategoryUnstarted)
+		card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
 		assert.Equal(t, BoardPlanning, card.Stage)
 		assert.Equal(t, BoardDone, card.State)
 	})
@@ -72,7 +72,7 @@ func TestDeriveBoardCard(t *testing.T) {
 		comments := []tracker.Comment{
 			cmt("[human:ready-for-review]\nengineering: HUM-9\nbranch: feat/x\ncommits: abc", t0),
 		}
-		card := DeriveBoardCard(comments, tracker.CategoryUnstarted)
+		card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
 		assert.Equal(t, BoardImplementation, card.Stage)
 		assert.Equal(t, BoardDone, card.State)
 		assert.Equal(t, "feat/x", card.Branch)
@@ -83,7 +83,7 @@ func TestDeriveBoardCard(t *testing.T) {
 		comments := []tracker.Comment{
 			cmt("[human:implementation-failed]\ncompile error in foo.go", t0),
 		}
-		card := DeriveBoardCard(comments, tracker.CategoryUnstarted)
+		card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
 		assert.Equal(t, BoardImplementation, card.Stage)
 		assert.Equal(t, BoardFailed, card.State)
 		assert.Equal(t, "[human:implementation-failed]", card.Error)
@@ -96,7 +96,7 @@ func TestDeriveBoardCard(t *testing.T) {
 			cmt("[human:review-complete]", t2),
 			cmt("[human:pr-pushed]\npr: https://example/pr/1", t2.Add(time.Second)),
 		}
-		card := DeriveBoardCard(comments, tracker.CategoryUnstarted)
+		card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
 		assert.Equal(t, BoardDoneStage, card.Stage)
 		assert.Equal(t, BoardDone, card.State)
 		assert.Equal(t, "https://example/pr/1", card.PRURL)
@@ -110,7 +110,7 @@ func TestDeriveBoardCard_HasPlan(t *testing.T) {
 	t1 := time.Unix(2000, 0)
 
 	t.Run("plan comment sets HasPlan without shifting stage", func(t *testing.T) {
-		card := DeriveBoardCard([]tracker.Comment{cmt("[human:plan]\n\n## Steps\n1. do it", t0)}, tracker.CategoryUnstarted)
+		card := DeriveBoardCard([]tracker.Comment{cmt("[human:plan]\n\n## Steps\n1. do it", t0)}, tracker.CategoryUnstarted, false)
 		assert.True(t, card.HasPlan)
 		// The plan is content, not a stage signal — the card stays in Backlog.
 		assert.Equal(t, BoardBacklog, card.Stage)
@@ -118,7 +118,7 @@ func TestDeriveBoardCard_HasPlan(t *testing.T) {
 
 	t.Run("plan-ready is not a plan comment", func(t *testing.T) {
 		// Prefix isolation: [human:plan-ready] must not read as [human:plan].
-		card := DeriveBoardCard([]tracker.Comment{cmt("[human:plan-ready]\nengineering: HUM-9", t0)}, tracker.CategoryUnstarted)
+		card := DeriveBoardCard([]tracker.Comment{cmt("[human:plan-ready]\nengineering: HUM-9", t0)}, tracker.CategoryUnstarted, false)
 		assert.False(t, card.HasPlan)
 		assert.Equal(t, BoardPlanning, card.Stage)
 	})
@@ -127,9 +127,35 @@ func TestDeriveBoardCard_HasPlan(t *testing.T) {
 		card := DeriveBoardCard([]tracker.Comment{
 			cmt("[human:plan]\nthe plan", t0),
 			cmt("[human:planning-started]", t1),
-		}, tracker.CategoryUnstarted)
+		}, tracker.CategoryUnstarted, false)
 		assert.True(t, card.HasPlan)
 		assert.Equal(t, BoardPlanning, card.Stage)
+	})
+}
+
+func TestDeriveBoardCard_Ideas(t *testing.T) {
+	t0 := time.Unix(1000, 0)
+
+	t.Run("open idea sits in Ideas regardless of markers", func(t *testing.T) {
+		// The label is the single source of truth until promotion removes it —
+		// even pipeline markers cannot pull an idea forward.
+		card := DeriveBoardCard([]tracker.Comment{cmt("[human:planning-started]", t0)}, tracker.CategoryUnstarted, true)
+		assert.Equal(t, BoardIdeas, card.Stage)
+		assert.Equal(t, BoardIdle, card.State)
+	})
+
+	t.Run("closed idea is hidden", func(t *testing.T) {
+		card := DeriveBoardCard(nil, tracker.CategoryClosed, true)
+		assert.Equal(t, BoardHidden, card.Stage)
+	})
+
+	t.Run("done idea is hidden", func(t *testing.T) {
+		card := DeriveBoardCard(nil, tracker.CategoryDone, true)
+		assert.Equal(t, BoardHidden, card.Stage)
+	})
+
+	t.Run("ideas rank below backlog", func(t *testing.T) {
+		assert.Less(t, stageRank[BoardIdeas], stageRank[BoardBacklog])
 	})
 }
 

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -86,11 +86,19 @@ func parseAgentName(name string) (pmKey string, stage BoardStage, ok bool) {
 // forward move is allowed (forward-only, single-step, gated on the prior
 // stage's completion). All errors carry details for the client.
 func (d BoardTransitionDeps) ApplyTransition(ctx context.Context, req BoardTransitionRequest) error {
+	// Ideas never move via board transitions: promotion out of the Ideas
+	// column is a label swap performed by the ideation engine's evolve mode,
+	// which the desktop opens instead of calling this route.
+	if req.From == BoardIdeas || req.To == BoardIdeas {
+		return errors.WithDetails("ideas transitions are handled via ideation",
+			"pm", req.PMKey, "from", string(req.From), "to", string(req.To))
+	}
+
 	comments, err := d.Commenter.ListComments(ctx, req.PMKey)
 	if err != nil {
 		return errors.WrapWithDetails(err, "loading PM comments for transition", "pm", req.PMKey)
 	}
-	card := DeriveBoardCard(comments, tracker.CategoryUnstarted)
+	card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
 
 	// Idempotency: if the target stage already has an open *-started marker, a
 	// duplicate drop (e.g. a quick re-drag before the board refetches) must not

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -285,3 +285,13 @@ func TestDoneBodySingleRef(t *testing.T) {
 	assert.Contains(t, body, "PM ticket: SC-1")
 	assert.NotContains(t, body, "Engineering ticket:")
 }
+
+func TestApplyTransitionIdeasGuard(t *testing.T) {
+	// Ideas leave their column via ideation's label swap, never via a board
+	// transition — both directions are rejected before any comment fetch.
+	deps := newDeps(&fakeCommenter{}, &fakeLauncher{}, &fakePublisher{})
+	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardIdeas, To: BoardBacklog})
+	require.Error(t, err)
+	err = deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardBacklog, To: BoardIdeas})
+	require.Error(t, err)
+}

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -434,6 +434,24 @@ func IdeationApprove(addr, token string, req IdeationApproveRequest) (IdeationSt
 	return ideationCall(addr, token, "ideation-approve", req)
 }
 
+// IdeaCreate quick-captures a title-only, idea-labeled ticket on the PM
+// tracker — the Ideas column's `+` button.
+func IdeaCreate(addr, token string, req IdeaCreateRequest) (IdeaCreateResponse, error) {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return IdeaCreateResponse{}, errors.WrapWithDetails(err, "marshaling idea-create request")
+	}
+	out, err := RunRemoteCapture(addr, token, []string{"idea-create", string(data)})
+	if err != nil {
+		return IdeaCreateResponse{}, err
+	}
+	var resp IdeaCreateResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return IdeaCreateResponse{}, errors.WrapWithDetails(err, "invalid idea-create JSON")
+	}
+	return resp, nil
+}
+
 // GetIdeationStatus fetches the current ideation session snapshot.
 func GetIdeationStatus(addr, token string) (IdeationStatus, error) {
 	out, err := RunRemoteCapture(addr, token, []string{"ideation-status"})

--- a/internal/daemon/ideation.go
+++ b/internal/daemon/ideation.go
@@ -76,10 +76,18 @@ type IdeationStatus struct {
 
 // IdeationStartRequest is the wire request for ideation-start. Seed is the
 // user's initial idea text. Restart abandons an active session first.
+//
+// EvolveKey switches the session's terminal action from creating a ticket to
+// rewriting the existing ticket in place (idea promotion): EditIssue with the
+// refined title/description plus removal of the idea labels. EvolveLabels
+// lists the card's idea-matching labels to remove; when empty the canonical
+// idea labels are removed.
 type IdeationStartRequest struct {
-	Seed    string       `json:"seed"`
-	Mode    IdeationMode `json:"mode,omitempty"` // defaults to IdeationModeChat when empty
-	Restart bool         `json:"restart,omitempty"`
+	Seed         string       `json:"seed"`
+	Mode         IdeationMode `json:"mode,omitempty"` // defaults to IdeationModeChat when empty
+	Restart      bool         `json:"restart,omitempty"`
+	EvolveKey    string       `json:"evolve_key,omitempty"`
+	EvolveLabels []string     `json:"evolve_labels,omitempty"`
 }
 
 // IdeationReplyRequest is the wire request for ideation-reply.
@@ -113,6 +121,10 @@ type IdeationRunner interface {
 // configured project, mirroring the role-based resolution of resolvePMCommenter.
 type PMCreatorResolver func() (creator tracker.Creator, project string, err error)
 
+// PMEditorResolver resolves the PM-role tracker's Editor for evolve-mode
+// promotion (rewriting an existing idea ticket in place).
+type PMEditorResolver func() (tracker.Editor, error)
+
 // ideationSession is the engine's internal mutable state (guarded by engine mu).
 type ideationSession struct {
 	id              string
@@ -126,6 +138,8 @@ type ideationSession struct {
 	createdURL      string
 	errMsg          string
 	repairAttempted bool // one corrective turn allowed per malformed ticket OR question block
+	evolveKey       string
+	evolveLabels    []string
 }
 
 // IdeationEngine owns the single board ideation session. All exported methods
@@ -133,8 +147,9 @@ type ideationSession struct {
 type IdeationEngine struct {
 	Runner         IdeationRunner
 	ResolveCreator PMCreatorResolver
-	Notify         func()        // pokes the subscribe loop after ticket creation; nil ok
-	TurnTimeout    time.Duration // defaults to 5 * time.Minute when zero
+	ResolveEditor  PMEditorResolver // evolve-mode promotion; nil disables it
+	Notify         func()           // pokes the subscribe loop after ticket creation; nil ok
+	TurnTimeout    time.Duration    // defaults to 5 * time.Minute when zero
 	Logger         zerolog.Logger
 
 	mu   sync.Mutex
@@ -200,17 +215,34 @@ func (e *IdeationEngine) Start(req IdeationStartRequest) (IdeationStatus, error)
 		transcript: []IdeationMessage{
 			{Role: "user", Text: req.Seed, Time: now},
 		},
+		evolveKey:    req.EvolveKey,
+		evolveLabels: req.EvolveLabels,
 	}
 	e.sess = sess
 	snap := e.snapshot()
 	e.mu.Unlock()
 
+	// Evolve mode refines an existing idea ticket; the agent must know the
+	// outcome updates that ticket in place rather than creating a new one.
+	seed := req.Seed
+	if req.EvolveKey != "" {
+		seed = evolveSeed(req.EvolveKey, req.Seed)
+	}
 	if mode == IdeationModeGuided {
-		go e.runTurn(sess.id, "", guidedIdeationPrompt(req.Seed))
+		go e.runTurn(sess.id, "", guidedIdeationPrompt(seed))
 	} else {
-		go e.runTurn(sess.id, "", ideationPrompt(req.Seed))
+		go e.runTurn(sess.id, "", ideationPrompt(seed))
 	}
 	return snap, nil
+}
+
+// evolveSeed frames an existing idea ticket's content for the ideation agent:
+// the conversation's outcome rewrites ticket key in place (same key, refined
+// title/description, idea label removed) — creation language would mislead it.
+func evolveSeed(key, seed string) string {
+	return "You are refining an EXISTING captured idea ticket (" + key + ") that will be UPDATED IN PLACE — " +
+		"the refined title and description replace the ticket's current content under the same key; no new ticket is created.\n\n" +
+		"Current idea content:\n" + seed
 }
 
 // Reply feeds the user's answer into the running session.
@@ -384,9 +416,23 @@ func (e *IdeationEngine) applyRepairOrError(sessID, reply, repairPrompt, errMsg 
 	e.mu.Unlock()
 }
 
-// createTicket calls the tracker Creator to materialize the PM ticket. Run
+// createTicket materializes the session's outcome: evolve mode rewrites the
+// existing idea ticket in place, otherwise a new PM ticket is created. Run
 // without holding mu so the network call cannot block Status()/Reply().
 func (e *IdeationEngine) createTicket(sessID, title, description string) {
+	e.mu.Lock()
+	var evolveKey string
+	var evolveLabels []string
+	if e.sess != nil && e.sess.id == sessID {
+		evolveKey = e.sess.evolveKey
+		evolveLabels = e.sess.evolveLabels
+	}
+	e.mu.Unlock()
+	if evolveKey != "" {
+		e.evolveTicket(sessID, evolveKey, title, description, evolveLabels)
+		return
+	}
+
 	if e.ResolveCreator == nil {
 		e.mu.Lock()
 		if e.sess != nil && e.sess.id == sessID {
@@ -433,6 +479,108 @@ func (e *IdeationEngine) createTicket(sessID, title, description string) {
 	if e.Notify != nil {
 		e.Notify()
 	}
+}
+
+// evolveTicket promotes an idea: the refined content replaces the ticket's
+// title/description under the same key and the idea labels come off, moving
+// the card from Ideas into Backlog on the next board derivation.
+func (e *IdeationEngine) evolveTicket(sessID, key, title, description string, removeLabels []string) {
+	fail := func(msg string) {
+		e.mu.Lock()
+		if e.sess != nil && e.sess.id == sessID {
+			e.sess.state = IdeationError
+			e.sess.errMsg = msg
+		}
+		e.mu.Unlock()
+	}
+	if e.ResolveEditor == nil {
+		fail("no PM ticket editor configured")
+		return
+	}
+	editor, err := e.ResolveEditor()
+	if err != nil {
+		fail(err.Error())
+		return
+	}
+	// Only idea-classifying labels come off — the caller passes the card's
+	// full label set and promotion must not strip unrelated labels. Falls
+	// back to the canonical pair (absent-removal is a no-op) so promotion
+	// works even when the client sent nothing.
+	var ideaLabels []string
+	for _, l := range removeLabels {
+		if (tracker.Issue{Labels: []string{l}}).IsIdea() {
+			ideaLabels = append(ideaLabels, l)
+		}
+	}
+	if len(ideaLabels) == 0 {
+		ideaLabels = []string{tracker.IdeaLabel, "idea"}
+	}
+	removeLabels = ideaLabels
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	updated, err := editor.EditIssue(ctx, key, tracker.EditOptions{
+		Title:        &title,
+		Description:  &description,
+		RemoveLabels: removeLabels,
+	})
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.sess == nil || e.sess.id != sessID {
+		return
+	}
+	if err != nil {
+		e.sess.state = IdeationError
+		e.sess.errMsg = errors.WrapWithDetails(err, "promoting idea ticket", "key", key).Error()
+		return
+	}
+	if updated == nil {
+		e.sess.state = IdeationError
+		e.sess.errMsg = "edit returned no issue for " + key
+		return
+	}
+	e.sess.state = IdeationDone
+	e.sess.createdKey = updated.Key
+	e.sess.createdURL = updated.URL
+	e.sess.transcript = append(e.sess.transcript, IdeationMessage{
+		Role: "agent",
+		Text: "Updated ticket " + updated.Key,
+		Time: time.Now(),
+	})
+	if e.Notify != nil {
+		e.Notify()
+	}
+}
+
+// CreateIdea quick-captures a title-only ticket carrying the idea label — the
+// Ideas column's `+` button. No agent involved; the ideation conversation
+// happens later, at promotion time.
+func (e *IdeationEngine) CreateIdea(title string) (key, url string, err error) {
+	if strings.TrimSpace(title) == "" {
+		return "", "", errors.WithDetails("idea title must not be empty")
+	}
+	if e.ResolveCreator == nil {
+		return "", "", errors.WithDetails("no PM ticket creator configured")
+	}
+	creator, project, err := e.ResolveCreator()
+	if err != nil {
+		return "", "", err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	created, err := creator.CreateIssue(ctx, &tracker.Issue{
+		Project: project,
+		Title:   title,
+		Labels:  []string{tracker.IdeaLabel},
+	})
+	if err != nil {
+		return "", "", errors.WrapWithDetails(err, "creating idea ticket", "project", project)
+	}
+	if e.Notify != nil {
+		e.Notify()
+	}
+	return created.Key, created.URL, nil
 }
 
 // ideationTicketMarker is the line the agent emits when confident; the JSON

--- a/internal/daemon/ideation_route.go
+++ b/internal/daemon/ideation_route.go
@@ -98,3 +98,47 @@ func (s *Server) handleIdeationStatus(conn net.Conn) {
 	}
 	s.writeIdeationStatus(conn, s.Ideation.Status())
 }
+
+// IdeaCreateRequest is the idea-create wire payload: a title-only quick
+// capture from the board's Ideas column.
+type IdeaCreateRequest struct {
+	Title string `json:"title"`
+}
+
+// IdeaCreateResponse reports the created idea ticket.
+type IdeaCreateResponse struct {
+	Key string `json:"key"`
+	URL string `json:"url,omitempty"`
+}
+
+// handleIdeaCreate quick-captures an idea-labeled ticket on the PM tracker.
+// One JSON arg, mirroring ideation-start, so free-text titles survive arg
+// splitting.
+func (s *Server) handleIdeaCreate(conn net.Conn, args []string) {
+	if s.Ideation == nil {
+		s.writeError(conn, "ideation not available", 1)
+		return
+	}
+	if len(args) != 1 {
+		s.writeError(conn, "idea-create requires one JSON arg", 1)
+		return
+	}
+	var req IdeaCreateRequest
+	if err := json.Unmarshal([]byte(args[0]), &req); err != nil {
+		s.writeError(conn, "invalid idea-create request: "+err.Error(), 1)
+		return
+	}
+	key, url, err := s.Ideation.CreateIdea(req.Title)
+	if err != nil {
+		s.writeError(conn, err.Error(), 1)
+		return
+	}
+	data, err := json.Marshal(IdeaCreateResponse{Key: key, URL: url})
+	if err != nil {
+		s.writeError(conn, err.Error(), 1)
+		return
+	}
+	resp := Response{Stdout: string(data) + "\n"}
+	enc := json.NewEncoder(conn)
+	_ = enc.Encode(resp)
+}

--- a/internal/daemon/ideation_route_test.go
+++ b/internal/daemon/ideation_route_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/tracker"
 )
 
 func startIdeationServer(t *testing.T, token string, engine *IdeationEngine) string {
@@ -229,4 +231,34 @@ func TestHandleIdeationApproveValid(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(resp.Stdout), &st))
 	assert.Equal(t, IdeationDone, st.State)
 	assert.NotEmpty(t, st.CreatedKey)
+}
+
+func TestServer_ideaCreateRoute(t *testing.T) {
+	creator := newFakeCreator()
+	engine := newTestEngine(&fakeRunner{}, creator, "proj", nil)
+	srv := &Server{Logger: zerolog.Nop(), Ideation: engine}
+
+	resp := captureHandlerResponse(t, func(conn net.Conn) {
+		srv.handleIdeaCreate(conn, []string{`{"title":"Weekly digest email"}`})
+	})
+	require.Equal(t, 0, resp.ExitCode, "stderr: %s", resp.Stderr)
+	var out IdeaCreateResponse
+	require.NoError(t, json.Unmarshal([]byte(resp.Stdout), &out))
+	assert.Equal(t, "SC-999", out.Key)
+
+	captured := creator.capturedIssue()
+	require.NotNil(t, captured)
+	assert.Equal(t, []string{tracker.IdeaLabel}, captured.Labels)
+}
+
+func TestServer_ideaCreateRouteBadInput(t *testing.T) {
+	srv := &Server{Logger: zerolog.Nop(), Ideation: newTestEngine(&fakeRunner{}, newFakeCreator(), "proj", nil)}
+	for name, args := range map[string][]string{
+		"no arg":       {},
+		"invalid json": {"{broken"},
+		"empty title":  {`{"title":"  "}`},
+	} {
+		resp := captureHandlerResponse(t, func(conn net.Conn) { srv.handleIdeaCreate(conn, args) })
+		assert.Equal(t, 1, resp.ExitCode, "case %s", name)
+	}
 }

--- a/internal/daemon/ideation_test.go
+++ b/internal/daemon/ideation_test.go
@@ -585,3 +585,110 @@ func TestIdeationChatMode_Unchanged(t *testing.T) {
 	assert.Equal(t, "SC-999", st.CreatedKey)
 	assert.NotNil(t, creator.capturedIssue())
 }
+
+// fakeEditor is a function-backed tracker.Editor capturing the edit.
+type fakeEditor struct {
+	mu       sync.Mutex
+	key      string
+	opts     tracker.EditOptions
+	returned *tracker.Issue
+	err      error
+}
+
+func (f *fakeEditor) EditIssue(_ context.Context, key string, opts tracker.EditOptions) (*tracker.Issue, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.key = key
+	f.opts = opts
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.returned, nil
+}
+
+func (f *fakeEditor) captured() (string, tracker.EditOptions) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.key, f.opts
+}
+
+func TestIdeationEvolveMode(t *testing.T) {
+	runner := &fakeRunner{turns: []IdeationTurn{{Reply: markerBlock("Refined title", "Refined body"), ResumeID: "cs-1"}}}
+	editor := &fakeEditor{returned: &tracker.Issue{Key: "SC-42", URL: "https://app.shortcut.com/x/story/42"}}
+	creator := newFakeCreator()
+	e := newTestEngine(runner, creator, "proj", nil)
+	e.ResolveEditor = func() (tracker.Editor, error) { return editor, nil }
+
+	_, err := e.Start(IdeationStartRequest{
+		Seed:         "My idea\n\nrough notes",
+		EvolveKey:    "SC-42",
+		EvolveLabels: []string{"human/idea", "urgent"},
+	})
+	require.NoError(t, err)
+	st := waitForState(t, e, IdeationDone)
+
+	// The evolve terminal action edits in place — never creates.
+	assert.Nil(t, creator.capturedIssue())
+	key, opts := editor.captured()
+	assert.Equal(t, "SC-42", key)
+	require.NotNil(t, opts.Title)
+	assert.Equal(t, "Refined title", *opts.Title)
+	require.NotNil(t, opts.Description)
+	assert.Equal(t, "Refined body", *opts.Description)
+	// Only idea-classifying labels come off; "urgent" survives promotion.
+	assert.Equal(t, []string{"human/idea"}, opts.RemoveLabels)
+	assert.Equal(t, "SC-42", st.CreatedKey)
+
+	// The agent was told it is refining in place.
+	call := runner.callAt(0)
+	assert.Contains(t, call.prompt, "UPDATED IN PLACE")
+	assert.Contains(t, call.prompt, "SC-42")
+}
+
+func TestIdeationEvolveNoEditorConfigured(t *testing.T) {
+	runner := &fakeRunner{turns: []IdeationTurn{{Reply: markerBlock("T", "D"), ResumeID: "cs-1"}}}
+	e := newTestEngine(runner, newFakeCreator(), "proj", nil)
+
+	_, err := e.Start(IdeationStartRequest{Seed: "idea", EvolveKey: "SC-1"})
+	require.NoError(t, err)
+	st := waitForState(t, e, IdeationError)
+	assert.Contains(t, st.Error, "no PM ticket editor configured")
+}
+
+func TestIdeationEvolveDefaultLabels(t *testing.T) {
+	runner := &fakeRunner{turns: []IdeationTurn{{Reply: markerBlock("T", "D"), ResumeID: "cs-1"}}}
+	editor := &fakeEditor{returned: &tracker.Issue{Key: "SC-7"}}
+	e := newTestEngine(runner, newFakeCreator(), "proj", nil)
+	e.ResolveEditor = func() (tracker.Editor, error) { return editor, nil }
+
+	_, err := e.Start(IdeationStartRequest{Seed: "idea", EvolveKey: "SC-7"})
+	require.NoError(t, err)
+	waitForState(t, e, IdeationDone)
+
+	// No labels supplied: the canonical pair comes off (absent-removal is a
+	// no-op provider-side, so listing both is safe).
+	_, opts := editor.captured()
+	assert.Equal(t, []string{tracker.IdeaLabel, "idea"}, opts.RemoveLabels)
+}
+
+func TestCreateIdea(t *testing.T) {
+	creator := newFakeCreator()
+	e := newTestEngine(&fakeRunner{}, creator, "proj", nil)
+
+	key, url, err := e.CreateIdea("Weekly digest email")
+	require.NoError(t, err)
+	assert.Equal(t, "SC-999", key)
+	assert.NotEmpty(t, url)
+
+	captured := creator.capturedIssue()
+	require.NotNil(t, captured)
+	assert.Equal(t, "proj", captured.Project)
+	assert.Equal(t, "Weekly digest email", captured.Title)
+	assert.Equal(t, []string{tracker.IdeaLabel}, captured.Labels)
+}
+
+func TestCreateIdeaEmptyTitle(t *testing.T) {
+	e := newTestEngine(&fakeRunner{}, newFakeCreator(), "proj", nil)
+	_, _, err := e.CreateIdea("   ")
+	require.Error(t, err)
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -360,6 +360,7 @@ func (s *Server) routeSimpleCommand(conn net.Conn, args []string, projectDir str
 		"ideation-reply":      func() { s.handleIdeationReply(conn, args[1:]) },
 		"ideation-approve":    func() { s.handleIdeationApprove(conn, args[1:]) },
 		"ideation-status":     func() { s.handleIdeationStatus(conn) },
+		"idea-create":         func() { s.handleIdeaCreate(conn, args[1:]) },
 		"features-generate":   func() { s.handleFeaturesGenerate(conn) },
 		"config-get":          func() { s.handleConfigGet(conn, projectDir) },
 		"config-set":          func() { s.handleConfigSet(conn, args[1:], projectDir) },


### PR DESCRIPTION
Phase 3 of the evolving-ticket model (SC-159): the idea lifecycle lands on the board.

- **Ideas column** (6th, left of Backlog): membership by idea label alone (`Issue.IsIdea`), derived without the per-issue comment scan; closed ideas hidden. Idea-label precedence over stage markers is deliberate and documented.
- **Quick capture**: `+` on the column → inline title input → `idea-create` daemon route → `CreateIssue` with `human/idea`.
- **Promotion**: dragging Ideas→Backlog opens the ideation panel in **evolve mode** (guided by default), seeded with the card; the terminal action is `EditIssue` — same key, refined content, idea labels removed (only idea-classifying labels come off; others survive). Active-session conflicts confirm before `Restart`.
- Board transitions touching Ideas are rejected daemon-side; Backlog becomes a drop target only for the promotion path.
- `StartIdeation` binding gains `evolveKey`/`evolveLabels` (wailsjs regenerated); 6-column CSS with min-widths + horizontal scroll.

Full gates green, coverage ≥80%, desktop app builds on the 3-OS matrix path (`make desktop` local pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)