### PR TITLE
[SC-184] Drop the approval countdown and spell out the shortcut hints

### DIFF
--- a/desktop/frontend/dist/index.html
+++ b/desktop/frontend/dist/index.html
@@ -59,9 +59,9 @@
           <span id="perm-question" class="perm-question"></span>
           <span id="perm-meta" class="perm-meta"></span>
           <button id="perm-deny" class="perm-btn perm-deny" type="button">Deny</button>
-          <span class="perm-kbd" aria-hidden="true">Ctrl⇧N</span>
+          <span class="perm-kbd" aria-hidden="true">Ctrl+Shift+N</span>
           <button id="perm-approve" class="perm-btn perm-approve" type="button">Approve</button>
-          <span class="perm-kbd" aria-hidden="true">Ctrl⇧Y</span>
+          <span class="perm-kbd" aria-hidden="true">Ctrl+Shift+Y</span>
           <button id="perm-more" class="perm-more hidden" type="button"></button>
         </div>
         <div id="perm-queue" class="perm-queue hidden" aria-label="Waiting permission requests"></div>

--- a/desktop/frontend/static/index.html
+++ b/desktop/frontend/static/index.html
@@ -59,9 +59,9 @@
           <span id="perm-question" class="perm-question"></span>
           <span id="perm-meta" class="perm-meta"></span>
           <button id="perm-deny" class="perm-btn perm-deny" type="button">Deny</button>
-          <span class="perm-kbd" aria-hidden="true">Ctrl⇧N</span>
+          <span class="perm-kbd" aria-hidden="true">Ctrl+Shift+N</span>
           <button id="perm-approve" class="perm-btn perm-approve" type="button">Approve</button>
-          <span class="perm-kbd" aria-hidden="true">Ctrl⇧Y</span>
+          <span class="perm-kbd" aria-hidden="true">Ctrl+Shift+Y</span>
           <button id="perm-more" class="perm-more hidden" type="button"></button>
         </div>
         <div id="perm-queue" class="perm-queue hidden" aria-label="Waiting permission requests"></div>

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -33,41 +33,21 @@ var ClientVersion = "dev"
 // RunRemote connects to the daemon at addr, sends the CLI args, and returns
 // the exit code. Stdout and stderr are written to os.Stdout and os.Stderr.
 //
-// Destructive commands run a grant cycle: the daemon queues a permission
-// request and answers await_confirm; we poll its decision and, once granted,
-// re-submit the same command with the grant's ID — the daemon redeems the
-// grant (one-time) and executes. The queue survives our disconnect, so a
-// timeout defers the operation instead of losing it.
+// Destructive commands run a grant cycle with NO waiting: the daemon queues a
+// permission request and answers await_confirm; we print instructions and
+// return immediately. There is deliberately no countdown — the user approves
+// whenever, and re-running the command redeems the grant (matched by
+// operation, so a fresh process needs no remembered ID). Denials are answered
+// on the re-run with a back-off instruction.
 func RunRemote(addr, token string, args []string, version string) (int, error) {
-	confirmID := newConfirmID()
-	for attempt := 0; ; attempt++ {
-		code, resp, err := runRemoteOnce(addr, token, args, version, confirmID)
-		if err != nil || !resp.AwaitConfirm {
-			return code, err
-		}
-		if attempt > 0 {
-			// The daemon asked again after granting — a mismatched or
-			// already-redeemed grant. Bail out rather than loop.
-			return 1, errors.WithDetails("daemon requested confirmation again after approval", "id", resp.ConfirmID)
-		}
-		// Poll the grant's ID (the daemon may have reattached us to an
-		// earlier request for the same operation).
-		confirmID = resp.ConfirmID
-		switch waitForConfirmDecision(addr, token, resp.ConfirmID, resp.ConfirmPrompt) {
-		case string(ConfirmApproved):
-			continue // re-submit with the granted ID
-		case string(ConfirmDenied):
-			_, _ = fmt.Fprint(os.Stderr, "Operation aborted: the user denied permission. Do not retry; ask the user how to proceed.\n")
-			return 1, nil
-		case confirmWaitTimedOut:
-			_, _ = fmt.Fprintf(os.Stderr, "Permission request %s is still pending; no decision yet. Ask the user to approve it (human TUI or desktop app), then re-run this exact command — once granted it executes without asking again. Check the decision anytime with: human confirm-status %s\n", resp.ConfirmID, resp.ConfirmID)
-			return 1, nil
-		default:
-			// "unknown": swept or never queued — treat as expired.
-			_, _ = fmt.Fprintf(os.Stderr, "Permission request %s expired before it was decided. Re-run this command to request permission again.\n", resp.ConfirmID)
-			return 1, nil
-		}
+	code, resp, err := runRemoteOnce(addr, token, args, version, newConfirmID())
+	if err != nil || !resp.AwaitConfirm {
+		return code, err
 	}
+	_, _ = fmt.Fprintf(os.Stderr,
+		"Permission required: %s (id %s)\nApprove or deny it in the human desktop app or TUI — there is no time limit. Once approved, re-run this exact command to execute it (it will not ask again). Check the decision anytime with: human confirm-status %s\n",
+		resp.ConfirmPrompt, resp.ConfirmID, resp.ConfirmID)
+	return 1, nil
 }
 
 // runRemoteOnce performs a single request/response round-trip. The returned
@@ -147,14 +127,6 @@ func handleOAuthCallback(reader *bufio.Reader) (int, error) {
 	return 0, nil
 }
 
-// confirmPollInterval paces confirm-status polling; confirmWaitTimeout bounds
-// how long the blocking CLI waits before deferring to a later status check.
-// Variables (not consts) so tests can shrink them.
-var (
-	confirmPollInterval = 2 * time.Second
-	confirmWaitTimeout  = 5 * time.Minute
-)
-
 // newConfirmID generates a client-side unique ID for a potentially
 // destructive request. Client-generated so a resubmit with the same ID is
 // idempotent on the daemon and the client knows the key to poll even if the
@@ -167,37 +139,6 @@ func newConfirmID() string {
 		return fmt.Sprintf("c-%d", time.Now().UnixNano())
 	}
 	return "c-" + hex.EncodeToString(buf)
-}
-
-// confirmWaitTimedOut is the pseudo-state waitForConfirmDecision returns when
-// the client-side wait expires while the request is still undecided.
-const confirmWaitTimedOut = "wait-timeout"
-
-// waitForConfirmDecision blocks until the queued permission request is
-// decided and returns the final state (or confirmWaitTimedOut). The blocking
-// is client-side sugar over the daemon's decision queue: on timeout the
-// entry stays pending on the daemon.
-func waitForConfirmDecision(addr, token, id, prompt string) string {
-	_, _ = fmt.Fprintf(os.Stderr, "Waiting for permission: %s (id %s)\n", prompt, id)
-	deadline := time.Now().Add(confirmWaitTimeout)
-	for {
-		st, err := GetConfirmStatus(addr, token, id)
-		if err != nil {
-			// Daemon unreachable mid-wait — report as expired; the entry
-			// (if any) remains decidable on the daemon.
-			return "unknown"
-		}
-		switch st.State {
-		case string(ConfirmPending):
-			// keep polling
-		default:
-			return st.State
-		}
-		if time.Now().After(deadline) {
-			return confirmWaitTimedOut
-		}
-		time.Sleep(confirmPollInterval)
-	}
 }
 
 // GetConfirmStatus fetches the decision state of a queued destructive

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -374,134 +374,41 @@ func TestNewConfirmID_Unique(t *testing.T) {
 	}
 }
 
-// confirmStatusSequence answers each confirm-status request with the next
-// status in the sequence, sticking on the last one.
-func confirmStatusSequence(t *testing.T, statuses []ConfirmStatus) string {
-	t.Helper()
+// TestRunRemote_AwaitConfirmReturnsImmediately pins the no-waiting contract:
+// an await_confirm answer produces exactly one request (no confirm-status
+// polling, no re-submit) and exit code 1 with instructions — the user
+// approves on their own time and re-runs.
+func TestRunRemote_AwaitConfirmReturnsImmediately(t *testing.T) {
 	var mu sync.Mutex
-	call := 0
-	return startMockDaemon(t, func(req Request) Response {
-		require.GreaterOrEqual(t, len(req.Args), 2)
-		assert.Equal(t, "confirm-status", req.Args[0])
-		mu.Lock()
-		st := statuses[call]
-		if call < len(statuses)-1 {
-			call++
-		}
-		mu.Unlock()
-		data, _ := json.Marshal(st)
-		return Response{Stdout: string(data) + "\n"}
-	})
-}
-
-func TestWaitForConfirmDecision_Denied(t *testing.T) {
-	addr := confirmStatusSequence(t, []ConfirmStatus{
-		{ID: "c-1", State: string(ConfirmDenied)},
-	})
-	state := waitForConfirmDecision(addr, "tok", "c-1", "Delete KAN-1?")
-	assert.Equal(t, string(ConfirmDenied), state)
-}
-
-func TestWaitForConfirmDecision_PendingThenApproved(t *testing.T) {
-	orig := confirmPollInterval
-	confirmPollInterval = 5 * time.Millisecond
-	t.Cleanup(func() { confirmPollInterval = orig })
-
-	addr := confirmStatusSequence(t, []ConfirmStatus{
-		{ID: "c-2", State: string(ConfirmPending)},
-		{ID: "c-2", State: string(ConfirmPending)},
-		{ID: "c-2", State: string(ConfirmApproved)},
-	})
-	state := waitForConfirmDecision(addr, "tok", "c-2", "Delete KAN-1?")
-	assert.Equal(t, string(ConfirmApproved), state)
-}
-
-func TestWaitForConfirmDecision_UnknownIsExpired(t *testing.T) {
-	addr := confirmStatusSequence(t, []ConfirmStatus{
-		{ID: "c-3", State: "unknown"},
-	})
-	state := waitForConfirmDecision(addr, "tok", "c-3", "Delete KAN-1?")
-	assert.Equal(t, "unknown", state)
-}
-
-func TestWaitForConfirmDecision_TimeoutLeavesPending(t *testing.T) {
-	origInterval, origTimeout := confirmPollInterval, confirmWaitTimeout
-	confirmPollInterval = 5 * time.Millisecond
-	confirmWaitTimeout = 20 * time.Millisecond
-	t.Cleanup(func() {
-		confirmPollInterval = origInterval
-		confirmWaitTimeout = origTimeout
-	})
-
-	addr := confirmStatusSequence(t, []ConfirmStatus{
-		{ID: "c-4", State: string(ConfirmPending)},
-	})
-	state := waitForConfirmDecision(addr, "tok", "c-4", "Delete KAN-1?")
-	assert.Equal(t, confirmWaitTimedOut, state, "client gives up but the entry stays pending on the daemon")
-}
-
-// TestRunRemote_GrantCycle drives the full client-side grant cycle against a
-// mock daemon: submit → await_confirm → poll approved → re-submit with the
-// grant ID → the daemon executes and returns the result.
-func TestRunRemote_GrantCycle(t *testing.T) {
-	orig := confirmPollInterval
-	confirmPollInterval = 5 * time.Millisecond
-	t.Cleanup(func() { confirmPollInterval = orig })
-
-	var mu sync.Mutex
-	grantID := ""
-	resubmitSeen := false
-
+	requests := 0
 	addr := startMockDaemon(t, func(req Request) Response {
 		mu.Lock()
 		defer mu.Unlock()
-		if len(req.Args) > 0 && req.Args[0] == "confirm-status" {
-			st := ConfirmStatus{ID: req.Args[1], State: string(ConfirmApproved)}
-			data, _ := json.Marshal(st)
-			return Response{Stdout: string(data) + "\n"}
-		}
-		if grantID == "" {
-			// First submit: queue the permission request.
-			grantID = req.ConfirmID
-			return Response{AwaitConfirm: true, ConfirmID: grantID, ConfirmPrompt: "Delete KAN-1?"}
-		}
-		// Re-submit must carry the granted ID so the daemon can redeem it.
-		if req.ConfirmID == grantID {
-			resubmitSeen = true
-			return Response{Stdout: "deleted KAN-1\n", ExitCode: 0}
-		}
-		return Response{Stderr: "unexpected confirm id\n", ExitCode: 1}
-	})
-
-	code, err := RunRemote(addr, "tok", []string{"jira", "issue", "delete", "KAN-1"}, "dev")
-	require.NoError(t, err)
-	assert.Equal(t, 0, code)
-	mu.Lock()
-	defer mu.Unlock()
-	assert.True(t, resubmitSeen, "client must re-submit the command after the grant")
-}
-
-func TestRunRemote_DeniedAborts(t *testing.T) {
-	var mu sync.Mutex
-	submitted := false
-	addr := startMockDaemon(t, func(req Request) Response {
-		mu.Lock()
-		defer mu.Unlock()
-		if len(req.Args) > 0 && req.Args[0] == "confirm-status" {
-			st := ConfirmStatus{ID: req.Args[1], State: string(ConfirmDenied)}
-			data, _ := json.Marshal(st)
-			return Response{Stdout: string(data) + "\n"}
-		}
-		submitted = true
+		requests++
+		require.NotEqual(t, "confirm-status", req.Args[0], "no-wait client must not poll")
 		return Response{AwaitConfirm: true, ConfirmID: req.ConfirmID, ConfirmPrompt: "Delete KAN-1?"}
 	})
 
+	start := time.Now()
 	code, err := RunRemote(addr, "tok", []string{"jira", "issue", "delete", "KAN-1"}, "dev")
 	require.NoError(t, err)
 	assert.Equal(t, 1, code)
+	assert.Less(t, time.Since(start), time.Second, "there is no countdown")
 	mu.Lock()
 	defer mu.Unlock()
-	assert.True(t, submitted)
+	assert.Equal(t, 1, requests, "queue once, return immediately")
+}
+
+func TestGetConfirmStatus_Success(t *testing.T) {
+	addr := startMockDaemon(t, func(req Request) Response {
+		require.GreaterOrEqual(t, len(req.Args), 2)
+		assert.Equal(t, "confirm-status", req.Args[0])
+		data, _ := json.Marshal(ConfirmStatus{ID: req.Args[1], State: string(ConfirmApproved)})
+		return Response{Stdout: string(data) + "\n"}
+	})
+	st, err := GetConfirmStatus(addr, "tok", "c-9")
+	require.NoError(t, err)
+	assert.Equal(t, string(ConfirmApproved), st.State)
 }
 
 func TestRunRemote_DaemonClosesImmediately(t *testing.T) {


### PR DESCRIPTION
Fixes SC-184 (single-ref commit — dogfooding the new format):

- `RunRemote` no longer runs the 5-minute poll loop after `await_confirm`: it prints clear instructions (approve in app, re-run to execute, `human confirm-status <id>` anytime) and returns. The grant model already makes this safe: approvals redeem operation-level on any re-run (HUM-167), denials answer retries with the back-off message, entries live 24h.
- Removed `waitForConfirmDecision`/`confirmPollInterval`/`confirmWaitTimeout` and their tests; new test pins queue-once-return-immediately (no polling, sub-second).
- Permission strip hints now read **Ctrl+Shift+Y / Ctrl+Shift+N** instead of `Ctrl⇧Y`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)