### PR TITLE
[SC-185] Raise the board issue-fetch cap so tickets never silently vanish

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -1055,8 +1055,12 @@ func listTrackerIssues(reg *daemon.ProjectRegistry, resolver *vault.Resolver) ([
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 			issues, fetchErr := job.inst.Provider.ListIssues(ctx, tracker.ListOptions{
-				Project:    job.project,
-				MaxResults: 20,
+				Project: job.project,
+				// A ticket the board cannot fetch is a ticket silently lost —
+				// the cap must comfortably exceed any real open backlog. The
+				// per-ticket comment scan this once bounded stays cheap: idea
+				// tickets skip it entirely and the rest fan out concurrently.
+				MaxResults: 200,
 				IncludeAll: false,
 			})
 			label := job.project


### PR DESCRIPTION
Fixes SC-185: the board fetch capped at 20 issues per tracker project and silently dropped the rest — on Jira/Linear/GitHub/GitLab-boarded projects, tickets beyond the cap disappear from every column. Raised to 200 with the reasoning in place; the comment-scan cost the old cap bounded is no longer proportional (ideas skip it, the rest run concurrently).

The reported incident itself (empty Ideas column) was a stale daemon — started 3 minutes before #64 merged — documented on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)