### PR TITLE
[SC-189] Deploy pipeline: drop on Deploy merges the work and closes the ticket

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -1275,24 +1275,25 @@ func (l dockerAgentLauncher) Launch(ctx context.Context, name, prompt, workspace
 	return err
 }
 
-// forgePRPublisher implements daemon.PRPublisher: it pushes the recorded branch
-// and opens a pull request on the workspace's forge. It resolves the forge by
-// role/kind from the configured instances rather than by key prefix.
-type forgePRPublisher struct {
+// forgeDeployer implements daemon.Deployer: push + PR, the CI gate, the merge
+// and branch cleanup, all on the workspace's forge. It resolves the forge by
+// role/kind from the configured instances rather than by key prefix, per call,
+// so a config change takes effect without a daemon restart.
+type forgeDeployer struct {
 	resolver *vault.Resolver
 	lookup   config.EnvLookup
 }
 
-func (p forgePRPublisher) PushAndCreatePR(ctx context.Context, req daemon.PRRequest) (string, error) {
-	// Push first: a failed push must surface as pr-failed BEFORE any PR is
+func (p forgeDeployer) PushAndCreatePR(ctx context.Context, req daemon.PRRequest) (daemon.PRResult, error) {
+	// Push first: a failed push must surface as deploy-failed BEFORE any PR is
 	// opened, so we never leave a half-created PR pointing at an unpushed branch.
 	if err := gitrepo.Push(ctx, req.WorkspaceDir, req.Branch); err != nil {
-		return "", err
+		return daemon.PRResult{}, err
 	}
 
 	creator, repo, err := resolveForge(req.WorkspaceDir, p.lookup, p.resolver)
 	if err != nil {
-		return "", err
+		return daemon.PRResult{}, err
 	}
 
 	base := gitrepo.DefaultBranch(ctx, req.WorkspaceDir)
@@ -1304,9 +1305,45 @@ func (p forgePRPublisher) PushAndCreatePR(ctx context.Context, req daemon.PRRequ
 		Body:  req.Body,
 	})
 	if err != nil {
-		return "", errors.WrapWithDetails(err, "creating pull request", "repo", repo, "head", req.Branch)
+		return daemon.PRResult{}, errors.WrapWithDetails(err, "creating pull request", "repo", repo, "head", req.Branch)
 	}
-	return pr.URL, nil
+	return daemon.PRResult{URL: pr.URL, Number: pr.Number}, nil
+}
+
+func (p forgeDeployer) PullRequestChecks(ctx context.Context, workspaceDir string, number int) (forge.ChecksState, error) {
+	creator, repo, err := resolveForge(workspaceDir, p.lookup, p.resolver)
+	if err != nil {
+		return "", err
+	}
+	checker, ok := creator.(forge.ChecksReader)
+	if !ok {
+		return "", errors.WithDetails("forge does not support reading CI checks", "repo", repo)
+	}
+	return checker.PullRequestChecks(ctx, repo, number)
+}
+
+func (p forgeDeployer) MergePullRequest(ctx context.Context, workspaceDir string, number int) error {
+	creator, repo, err := resolveForge(workspaceDir, p.lookup, p.resolver)
+	if err != nil {
+		return err
+	}
+	merger, ok := creator.(forge.Merger)
+	if !ok {
+		return errors.WithDetails("forge does not support merging pull requests", "repo", repo)
+	}
+	return merger.MergePullRequest(ctx, repo, number)
+}
+
+func (p forgeDeployer) DeleteRemoteBranch(ctx context.Context, workspaceDir, branch string) error {
+	creator, repo, err := resolveForge(workspaceDir, p.lookup, p.resolver)
+	if err != nil {
+		return err
+	}
+	deleter, ok := creator.(forge.BranchDeleter)
+	if !ok {
+		return errors.WithDetails("forge does not support deleting branches", "repo", repo)
+	}
+	return deleter.DeleteBranch(ctx, repo, branch)
 }
 
 // resolveForge finds the configured instance that carries a forge capability
@@ -1416,9 +1453,16 @@ func boardTransitionerFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver
 			return err
 		}
 		deps := daemon.BoardTransitionDeps{
-			Commenter:    commenter,
-			Launcher:     dockerAgentLauncher{},
-			Publisher:    forgePRPublisher{resolver: resolver, lookup: lookup},
+			Commenter: commenter,
+			Launcher:  dockerAgentLauncher{},
+			Deployer:  forgeDeployer{resolver: resolver, lookup: lookup},
+			CloseTicket: func(pmKey string) error {
+				transitioner, err := resolvePMTransitioner(entry.Dir, lookup, resolver)
+				if err != nil {
+					return err
+				}
+				return transitioner.TransitionIssue(context.Background(), pmKey, "done")
+			},
 			WorkspaceDir: entry.Dir,
 			ConfigDir:    entry.Dir,
 		}

--- a/internal/daemon/board_markers.go
+++ b/internal/daemon/board_markers.go
@@ -51,6 +51,14 @@ const (
 	PRStartedHeader             = "[human:pr-started]"
 	PRPushedHeader              = "[human:pr-pushed]"
 	PRFailedHeader              = "[human:pr-failed]"
+
+	// Deploy markers supersede the PR markers for the done stage: dropping a
+	// card on Deploy runs push → PR → CI gate → merge → close, so the stage's
+	// lifecycle is "deploying", not "opening a PR". The PR markers stay
+	// recognized so threads written before the deploy pipeline still derive.
+	DeployStartedHeader = "[human:deploy-started]"
+	DeployedHeader      = "[human:deployed]"
+	DeployFailedHeader  = "[human:deploy-failed]"
 )
 
 // PlanCommentHeader marks a comment whose body IS the engineering plan for
@@ -84,6 +92,9 @@ var orderedMarkerSpecs = []markerSpec{
 	{PRStartedHeader, BoardDoneStage, BoardRunning},
 	{PRPushedHeader, BoardDoneStage, BoardDone},
 	{PRFailedHeader, BoardDoneStage, BoardFailed},
+	{DeployStartedHeader, BoardDoneStage, BoardRunning},
+	{DeployedHeader, BoardDoneStage, BoardDone},
+	{DeployFailedHeader, BoardDoneStage, BoardFailed},
 }
 
 // stageRank orders the pipeline stages so derivation can pick the furthest

--- a/internal/daemon/board_state.go
+++ b/internal/daemon/board_state.go
@@ -74,11 +74,29 @@ func DeriveBoardCard(comments []tracker.Comment, statusType tracker.Category, is
 	card := BoardCard{Stage: furthest, State: state, HasPlan: hasPlan}
 	card.EngineeringKey = firstEngineeringKey(comments)
 	card.Branch = latestPrefixedLine(comments, ReadyForReviewHeader, "branch:")
-	card.PRURL = latestPrefixedLine(comments, PRPushedHeader, "pr:")
+	card.PRURL = latestPrefixedLine(comments, DeployedHeader, "pr:")
+	if card.PRURL == "" {
+		// Threads written before the deploy pipeline carry the URL on the old
+		// pr-pushed marker.
+		card.PRURL = latestPrefixedLine(comments, PRPushedHeader, "pr:")
+	}
 	if state == BoardFailed {
-		card.Error = firstLine(latest.Body)
+		card.Error = failureReason(latest.Body)
 	}
 	return card
+}
+
+// failureReason extracts the human-readable reason from a *-failed marker: the
+// first non-empty line after the header. Falls back to the header itself for
+// markers posted without a reason, so a failed card never shows empty.
+func failureReason(body string) string {
+	trimmed := strings.TrimSpace(body)
+	if idx := strings.IndexByte(trimmed, '\n'); idx >= 0 {
+		if reason := firstLine(trimmed[idx+1:]); reason != "" {
+			return reason
+		}
+	}
+	return firstLine(trimmed)
 }
 
 // latestStateInStage resolves the stage's state from its newest marker and

--- a/internal/daemon/board_state_test.go
+++ b/internal/daemon/board_state_test.go
@@ -86,7 +86,8 @@ func TestDeriveBoardCard(t *testing.T) {
 		card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
 		assert.Equal(t, BoardImplementation, card.Stage)
 		assert.Equal(t, BoardFailed, card.State)
-		assert.Equal(t, "[human:implementation-failed]", card.Error)
+		// The human-readable reason, not the marker header line.
+		assert.Equal(t, "compile error in foo.go", card.Error)
 	})
 
 	t.Run("full chain ending pr-pushed", func(t *testing.T) {

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/forge"
 	"github.com/gethuman-sh/human/internal/tracker"
 )
 
@@ -16,10 +18,14 @@ type AgentLauncher interface {
 	Launch(ctx context.Context, name, prompt, workspace, configDir string) error
 }
 
-// PRPublisher pushes the recorded branch and opens a pull request. Injected so
-// the Done stage is testable without git/forge access.
-type PRPublisher interface {
-	PushAndCreatePR(ctx context.Context, req PRRequest) (prURL string, err error)
+// Deployer executes the forge side of the deploy pipeline: push + PR, the CI
+// gate, the merge, and branch cleanup. Injected so the Done stage is testable
+// without git/forge access.
+type Deployer interface {
+	PushAndCreatePR(ctx context.Context, req PRRequest) (PRResult, error)
+	PullRequestChecks(ctx context.Context, workspaceDir string, number int) (forge.ChecksState, error)
+	MergePullRequest(ctx context.Context, workspaceDir string, number int) error
+	DeleteRemoteBranch(ctx context.Context, workspaceDir, branch string) error
 }
 
 // PRRequest carries everything needed to push a branch and open its PR.
@@ -29,6 +35,19 @@ type PRRequest struct {
 	Title        string
 	Body         string
 }
+
+// PRResult identifies the created pull request for the pipeline steps that
+// follow creation (checks, merge).
+type PRResult struct {
+	URL    string
+	Number int
+}
+
+// Deploy pacing. Package vars so tests can run the CI gate without real time.
+var (
+	deployCheckInterval = 30 * time.Second
+	deployTimeout       = 45 * time.Minute
+)
 
 // BoardTransitionRequest is the wire request for advancing a card one stage.
 // PMTitle is carried from the card so the Done stage can title the PR without a
@@ -42,9 +61,12 @@ type BoardTransitionRequest struct {
 
 // BoardTransitionDeps wires the transition engine's collaborators.
 type BoardTransitionDeps struct {
-	Commenter    tracker.Commenter
-	Launcher     AgentLauncher
-	Publisher    PRPublisher
+	Commenter tracker.Commenter
+	Launcher  AgentLauncher
+	Deployer  Deployer
+	// CloseTicket closes the PM ticket after a successful deploy so shipped
+	// work leaves the board. nil skips the close (the deploy still succeeds).
+	CloseTicket  func(pmKey string) error
 	WorkspaceDir string
 	ConfigDir    string
 }
@@ -167,33 +189,96 @@ func (d BoardTransitionDeps) startAgentStage(ctx context.Context, pmKey string, 
 	return nil
 }
 
-// runDoneStage pushes the recorded branch and opens a PR. A missing branch or a
-// push/PR failure posts [human:pr-failed] with the error rather than leaving a
-// partial PR; success posts [human:pr-pushed] with the PR URL.
+// startDeploy launches the deploy pipeline in the background. A package var so
+// tests can run the pipeline synchronously.
+var startDeploy = func(d BoardTransitionDeps, req BoardTransitionRequest, card BoardCard) {
+	go d.deploy(context.Background(), req, card)
+}
+
+// runDoneStage kicks off the deploy pipeline: push → PR → CI gate → merge →
+// branch cleanup → close ticket. The CI gate can take many minutes, so the
+// transition request returns as soon as [human:deploy-started] is posted and
+// the pipeline reports the outcome via markers.
 func (d BoardTransitionDeps) runDoneStage(ctx context.Context, req BoardTransitionRequest, card BoardCard) error {
 	if card.Branch == "" {
-		body := PRFailedHeader + "\nno branch recorded on ready-for-review handoff"
+		body := DeployFailedHeader + "\nno branch recorded on ready-for-review handoff"
 		_, _ = d.Commenter.AddComment(ctx, req.PMKey, body)
-		return errors.WithDetails("no branch recorded for Done", "pm", req.PMKey)
+		return errors.WithDetails("no branch recorded for deploy", "pm", req.PMKey)
 	}
-	if _, err := d.Commenter.AddComment(ctx, req.PMKey, PRStartedHeader); err != nil {
-		return errors.WrapWithDetails(err, "posting pr-started marker", "pm", req.PMKey)
+	if _, err := d.Commenter.AddComment(ctx, req.PMKey, DeployStartedHeader); err != nil {
+		return errors.WrapWithDetails(err, "posting deploy-started marker", "pm", req.PMKey)
 	}
-	url, err := d.Publisher.PushAndCreatePR(ctx, PRRequest{
+	startDeploy(d, req, card)
+	return nil
+}
+
+// deploy walks the pipeline to its end. It runs detached from the transition
+// request (whose context dies with the connection), bounded by deployTimeout.
+func (d BoardTransitionDeps) deploy(ctx context.Context, req BoardTransitionRequest, card BoardCard) {
+	ctx, cancel := context.WithTimeout(ctx, deployTimeout)
+	defer cancel()
+
+	res, err := d.Deployer.PushAndCreatePR(ctx, PRRequest{
 		WorkspaceDir: d.WorkspaceDir,
 		Branch:       card.Branch,
 		Title:        req.PMTitle,
 		Body:         doneBody(req.PMKey, card),
 	})
 	if err != nil {
-		body := PRFailedHeader + "\n" + err.Error()
-		_, _ = d.Commenter.AddComment(ctx, req.PMKey, body)
-		return errors.WrapWithDetails(err, "pushing and creating PR", "pm", req.PMKey)
+		d.deployFailed(req.PMKey, "", err.Error())
+		return
 	}
-	if _, err := d.Commenter.AddComment(ctx, req.PMKey, PRPushedHeader+"\npr: "+url); err != nil {
-		return errors.WrapWithDetails(err, "posting pr-pushed marker", "pm", req.PMKey)
+	if err := d.waitForChecks(ctx, res); err != nil {
+		d.deployFailed(req.PMKey, res.URL, err.Error())
+		return
 	}
-	return nil
+	if err := d.Deployer.MergePullRequest(ctx, d.WorkspaceDir, res.Number); err != nil {
+		d.deployFailed(req.PMKey, res.URL, err.Error())
+		return
+	}
+	// Past the merge the work IS shipped: branch cleanup and the ticket close
+	// are best-effort and must never turn the card red.
+	_ = d.Deployer.DeleteRemoteBranch(ctx, d.WorkspaceDir, card.Branch)
+	_, _ = d.Commenter.AddComment(ctx, req.PMKey, DeployedHeader+"\npr: "+res.URL)
+	if d.CloseTicket != nil {
+		_ = d.CloseTicket(req.PMKey)
+	}
+}
+
+// waitForChecks blocks until the PR's CI verdict is conclusive. Passing
+// returns nil; failing and a gate timeout return an error carrying the reason.
+func (d BoardTransitionDeps) waitForChecks(ctx context.Context, res PRResult) error {
+	ticker := time.NewTicker(deployCheckInterval)
+	defer ticker.Stop()
+	for {
+		state, err := d.Deployer.PullRequestChecks(ctx, d.WorkspaceDir, res.Number)
+		if err != nil {
+			return err
+		}
+		switch state {
+		case forge.ChecksPassing:
+			return nil
+		case forge.ChecksFailing:
+			return errors.WithDetails("CI checks failed", "pr", res.URL)
+		}
+		select {
+		case <-ctx.Done():
+			return errors.WithDetails("timed out waiting for CI checks", "pr", res.URL)
+		case <-ticker.C:
+		}
+	}
+}
+
+// deployFailed posts the failure marker on its own context: the pipeline's
+// context may already be cancelled (timeout), and the marker must still land.
+func (d BoardTransitionDeps) deployFailed(pmKey, prURL, reason string) {
+	postCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	body := DeployFailedHeader + "\n" + reason
+	if prURL != "" {
+		body += "\npr: " + prURL
+	}
+	_, _ = d.Commenter.AddComment(postCtx, pmKey, body)
 }
 
 // doneBody builds the PR description with the PM→engineering→branch trail.
@@ -219,7 +304,7 @@ func failedHeaderFor(stage BoardStage) string {
 	case BoardVerification:
 		return ReviewFailedHeader
 	case BoardDoneStage:
-		return PRFailedHeader
+		return DeployFailedHeader
 	default:
 		return ""
 	}

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -3,12 +3,14 @@ package daemon
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gethuman-sh/human/internal/forge"
 	"github.com/gethuman-sh/human/internal/tracker"
 )
 
@@ -48,28 +50,72 @@ func (f *fakeLauncher) Launch(_ context.Context, name, prompt, _, _ string) erro
 	return f.err
 }
 
-// fakePublisher returns a canned URL or error.
-type fakePublisher struct {
-	url  string
-	err  error
-	req  PRRequest
-	call int
+// fakeDeployer scripts the deploy pipeline steps: PR creation, successive
+// checks poll results, merge, and branch deletion.
+type fakeDeployer struct {
+	prErr     error
+	res       PRResult
+	req       PRRequest
+	call      int
+	checks    []forge.ChecksState
+	checksErr error
+	checkCall int
+	mergeErr  error
+	merged    int
+	deleted   []string
 }
 
-func (f *fakePublisher) PushAndCreatePR(_ context.Context, req PRRequest) (string, error) {
+func (f *fakeDeployer) PushAndCreatePR(_ context.Context, req PRRequest) (PRResult, error) {
 	f.call++
 	f.req = req
-	return f.url, f.err
+	if f.prErr != nil {
+		return PRResult{}, f.prErr
+	}
+	return f.res, nil
 }
 
-func newDeps(c *fakeCommenter, l *fakeLauncher, p *fakePublisher) BoardTransitionDeps {
-	return BoardTransitionDeps{Commenter: c, Launcher: l, Publisher: p, WorkspaceDir: "/ws", ConfigDir: "/ws"}
+func (f *fakeDeployer) PullRequestChecks(_ context.Context, _ string, _ int) (forge.ChecksState, error) {
+	if f.checksErr != nil {
+		return "", f.checksErr
+	}
+	i := f.checkCall
+	if i >= len(f.checks) {
+		i = len(f.checks) - 1
+	}
+	f.checkCall++
+	return f.checks[i], nil
+}
+
+func (f *fakeDeployer) MergePullRequest(_ context.Context, _ string, _ int) error {
+	f.merged++
+	return f.mergeErr
+}
+
+func (f *fakeDeployer) DeleteRemoteBranch(_ context.Context, _, branch string) error {
+	f.deleted = append(f.deleted, branch)
+	return nil
+}
+
+func newDeps(c *fakeCommenter, l *fakeLauncher, p *fakeDeployer) BoardTransitionDeps {
+	return BoardTransitionDeps{Commenter: c, Launcher: l, Deployer: p, WorkspaceDir: "/ws", ConfigDir: "/ws"}
+}
+
+// syncDeploy makes the deploy pipeline run inline (and poll without real
+// time) so tests observe its markers deterministically.
+func syncDeploy(t *testing.T) {
+	t.Helper()
+	origStart, origInterval := startDeploy, deployCheckInterval
+	startDeploy = func(d BoardTransitionDeps, req BoardTransitionRequest, card BoardCard) {
+		d.deploy(context.Background(), req, card)
+	}
+	deployCheckInterval = time.Millisecond
+	t.Cleanup(func() { startDeploy, deployCheckInterval = origStart, origInterval })
 }
 
 func TestApplyTransitionBackwardRejected(t *testing.T) {
 	c := &fakeCommenter{comments: []tracker.Comment{cmt("[human:plan-ready]\nengineering: HUM-9", time.Unix(1, 0))}}
 	l := &fakeLauncher{}
-	deps := newDeps(c, l, &fakePublisher{})
+	deps := newDeps(c, l, &fakeDeployer{})
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardPlanning, To: BoardBacklog})
 	require.Error(t, err)
 	assert.Empty(t, c.added)
@@ -79,7 +125,7 @@ func TestApplyTransitionBackwardRejected(t *testing.T) {
 func TestApplyTransitionSkipRejected(t *testing.T) {
 	c := &fakeCommenter{}
 	l := &fakeLauncher{}
-	deps := newDeps(c, l, &fakePublisher{})
+	deps := newDeps(c, l, &fakeDeployer{})
 	// Backlog -> Implementation skips Planning.
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", To: BoardImplementation})
 	require.Error(t, err)
@@ -90,7 +136,7 @@ func TestApplyTransitionGatedBlock(t *testing.T) {
 	// Planning running (not done) must block advancing to Implementation.
 	c := &fakeCommenter{comments: []tracker.Comment{cmt("[human:planning-started]", time.Unix(1, 0))}}
 	l := &fakeLauncher{}
-	deps := newDeps(c, l, &fakePublisher{})
+	deps := newDeps(c, l, &fakeDeployer{})
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardPlanning, To: BoardImplementation})
 	require.Error(t, err)
 	assert.Zero(t, l.calls)
@@ -99,7 +145,7 @@ func TestApplyTransitionGatedBlock(t *testing.T) {
 func TestApplyTransitionBacklogToPlanning(t *testing.T) {
 	c := &fakeCommenter{}
 	l := &fakeLauncher{}
-	deps := newDeps(c, l, &fakePublisher{})
+	deps := newDeps(c, l, &fakeDeployer{})
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", To: BoardPlanning})
 	require.NoError(t, err)
 	assert.Equal(t, 1, l.calls)
@@ -112,7 +158,7 @@ func TestApplyTransitionBacklogToPlanning(t *testing.T) {
 func TestApplyTransitionPlanningToImplementation(t *testing.T) {
 	c := &fakeCommenter{comments: []tracker.Comment{cmt("[human:plan-ready]\nengineering: HUM-9", time.Unix(1, 0))}}
 	l := &fakeLauncher{}
-	deps := newDeps(c, l, &fakePublisher{})
+	deps := newDeps(c, l, &fakeDeployer{})
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardPlanning, To: BoardImplementation})
 	require.NoError(t, err)
 	assert.Equal(t, "/human-execute HUM-9", l.prompt)
@@ -124,7 +170,7 @@ func TestApplyTransitionImplementationToVerification(t *testing.T) {
 		cmt("[human:ready-for-review]\nengineering: HUM-9\nbranch: feat/x", time.Unix(1, 0)),
 	}}
 	l := &fakeLauncher{}
-	deps := newDeps(c, l, &fakePublisher{})
+	deps := newDeps(c, l, &fakeDeployer{})
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardImplementation, To: BoardVerification})
 	require.NoError(t, err)
 	assert.Equal(t, "/human-review HUM-9", l.prompt)
@@ -135,7 +181,7 @@ func TestApplyTransitionIdempotentDuplicate(t *testing.T) {
 	// An open started marker for the target stage makes the drop a no-op.
 	c := &fakeCommenter{comments: []tracker.Comment{cmt("[human:planning-started]", time.Unix(1, 0))}}
 	l := &fakeLauncher{}
-	deps := newDeps(c, l, &fakePublisher{})
+	deps := newDeps(c, l, &fakeDeployer{})
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", To: BoardPlanning})
 	require.NoError(t, err)
 	assert.Zero(t, l.calls)
@@ -144,43 +190,108 @@ func TestApplyTransitionIdempotentDuplicate(t *testing.T) {
 
 func TestApplyTransitionDoneNoBranch(t *testing.T) {
 	c := &fakeCommenter{comments: []tracker.Comment{cmt("[human:review-complete]", time.Unix(1, 0))}}
-	p := &fakePublisher{}
+	p := &fakeDeployer{}
 	deps := newDeps(c, &fakeLauncher{}, p)
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardVerification, To: BoardDoneStage})
 	require.Error(t, err)
 	assert.Zero(t, p.call)
 	require.Len(t, c.added, 1)
-	assert.Contains(t, c.added[0], PRFailedHeader)
+	assert.Contains(t, c.added[0], DeployFailedHeader)
 }
 
-func TestApplyTransitionDoneSuccess(t *testing.T) {
+func TestApplyTransitionDeploySuccess(t *testing.T) {
+	syncDeploy(t)
 	c := &fakeCommenter{comments: []tracker.Comment{
 		cmt("[human:ready-for-review]\nengineering: HUM-9\nbranch: feat/x", time.Unix(1, 0)),
 		cmt("[human:review-complete]", time.Unix(2, 0)),
 	}}
-	p := &fakePublisher{url: "https://example/pr/7"}
+	p := &fakeDeployer{res: PRResult{URL: "https://example/pr/7", Number: 7}, checks: []forge.ChecksState{forge.ChecksPassing}}
 	deps := newDeps(c, &fakeLauncher{}, p)
+	var closed string
+	deps.CloseTicket = func(pmKey string) error { closed = pmKey; return nil }
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", PMTitle: "My feature", From: BoardVerification, To: BoardDoneStage})
 	require.NoError(t, err)
 	assert.Equal(t, 1, p.call)
 	assert.Equal(t, "feat/x", p.req.Branch)
 	assert.Equal(t, "My feature", p.req.Title)
-	assert.Contains(t, c.added, PRStartedHeader)
-	assert.Contains(t, c.added, PRPushedHeader+"\npr: https://example/pr/7")
+	assert.Equal(t, 1, p.merged)
+	assert.Equal(t, []string{"feat/x"}, p.deleted)
+	assert.Equal(t, "SC-1", closed)
+	assert.Contains(t, c.added, DeployStartedHeader)
+	assert.Contains(t, c.added, DeployedHeader+"\npr: https://example/pr/7")
+}
+
+func TestApplyTransitionDeployWaitsForPendingChecks(t *testing.T) {
+	syncDeploy(t)
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:ready-for-review]\nbranch: feat/x", time.Unix(1, 0)),
+		cmt("[human:review-complete]", time.Unix(2, 0)),
+	}}
+	p := &fakeDeployer{res: PRResult{URL: "https://example/pr/8", Number: 8},
+		checks: []forge.ChecksState{forge.ChecksPending, forge.ChecksPending, forge.ChecksPassing}}
+	deps := newDeps(c, &fakeLauncher{}, p)
+	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardVerification, To: BoardDoneStage})
+	require.NoError(t, err)
+	assert.Equal(t, 3, p.checkCall)
+	assert.Equal(t, 1, p.merged)
+}
+
+func TestApplyTransitionDeployChecksFail(t *testing.T) {
+	syncDeploy(t)
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:ready-for-review]\nbranch: feat/x", time.Unix(1, 0)),
+		cmt("[human:review-complete]", time.Unix(2, 0)),
+	}}
+	p := &fakeDeployer{res: PRResult{URL: "https://example/pr/9", Number: 9}, checks: []forge.ChecksState{forge.ChecksFailing}}
+	deps := newDeps(c, &fakeLauncher{}, p)
+	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardVerification, To: BoardDoneStage})
+	require.NoError(t, err) // the transition itself succeeded; the failure is a marker
+	assert.Zero(t, p.merged)
+	var failed string
+	for _, b := range c.added {
+		if strings.HasPrefix(b, DeployFailedHeader) {
+			failed = b
+		}
+	}
+	require.NotEmpty(t, failed)
+	assert.Contains(t, failed, "CI checks failed")
+	assert.Contains(t, failed, "pr: https://example/pr/9")
+}
+
+func TestApplyTransitionDeployMergeFails(t *testing.T) {
+	syncDeploy(t)
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:ready-for-review]\nbranch: feat/x", time.Unix(1, 0)),
+		cmt("[human:review-complete]", time.Unix(2, 0)),
+	}}
+	p := &fakeDeployer{res: PRResult{URL: "https://example/pr/10", Number: 10},
+		checks: []forge.ChecksState{forge.ChecksPassing}, mergeErr: errors.New("merge conflict")}
+	deps := newDeps(c, &fakeLauncher{}, p)
+	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardVerification, To: BoardDoneStage})
+	require.NoError(t, err)
+	assert.Empty(t, p.deleted)
+	var sawFailed bool
+	for _, b := range c.added {
+		if strings.HasPrefix(b, DeployFailedHeader) && strings.Contains(b, "merge conflict") {
+			sawFailed = true
+		}
+	}
+	assert.True(t, sawFailed)
 }
 
 func TestApplyTransitionDonePushFails(t *testing.T) {
+	syncDeploy(t)
 	c := &fakeCommenter{comments: []tracker.Comment{
 		cmt("[human:ready-for-review]\nengineering: HUM-9\nbranch: feat/x", time.Unix(1, 0)),
 		cmt("[human:review-complete]", time.Unix(2, 0)),
 	}}
-	p := &fakePublisher{err: errors.New("push rejected")}
+	p := &fakeDeployer{prErr: errors.New("push rejected")}
 	deps := newDeps(c, &fakeLauncher{}, p)
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardVerification, To: BoardDoneStage})
-	require.Error(t, err)
+	require.NoError(t, err) // async pipeline: the push failure lands as a marker
 	var sawFailed bool
 	for _, b := range c.added {
-		if len(b) >= len(PRFailedHeader) && b[:len(PRFailedHeader)] == PRFailedHeader {
+		if strings.HasPrefix(b, DeployFailedHeader) && strings.Contains(b, "push rejected") {
 			sawFailed = true
 		}
 	}
@@ -190,7 +301,7 @@ func TestApplyTransitionDonePushFails(t *testing.T) {
 func TestStartAgentStageLaunchFails(t *testing.T) {
 	c := &fakeCommenter{}
 	l := &fakeLauncher{err: errors.New("docker down")}
-	deps := newDeps(c, l, &fakePublisher{})
+	deps := newDeps(c, l, &fakeDeployer{})
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", To: BoardPlanning})
 	require.Error(t, err)
 	// started marker posted, then failed marker posted on launch error.
@@ -229,7 +340,7 @@ func (listErrCommenter) ListComments(context.Context, string) ([]tracker.Comment
 }
 
 func TestApplyTransitionListCommentsError(t *testing.T) {
-	deps := newDeps(&fakeCommenter{}, &fakeLauncher{}, &fakePublisher{})
+	deps := newDeps(&fakeCommenter{}, &fakeLauncher{}, &fakeDeployer{})
 	deps.Commenter = listErrCommenter{&fakeCommenter{}}
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", To: BoardPlanning})
 	require.Error(t, err)
@@ -239,7 +350,7 @@ func TestStartAgentStageStartedMarkerError(t *testing.T) {
 	// AddComment failing on the started marker aborts before launch.
 	c := &fakeCommenter{addErr: errors.New("comment api down")}
 	l := &fakeLauncher{}
-	deps := newDeps(c, l, &fakePublisher{})
+	deps := newDeps(c, l, &fakeDeployer{})
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", To: BoardPlanning})
 	require.Error(t, err)
 	assert.Zero(t, l.calls)
@@ -249,7 +360,7 @@ func TestFailedHeaderFor(t *testing.T) {
 	assert.Equal(t, PlanningFailedHeader, failedHeaderFor(BoardPlanning))
 	assert.Equal(t, ImplementationFailedHeader, failedHeaderFor(BoardImplementation))
 	assert.Equal(t, ReviewFailedHeader, failedHeaderFor(BoardVerification))
-	assert.Equal(t, PRFailedHeader, failedHeaderFor(BoardDoneStage))
+	assert.Equal(t, DeployFailedHeader, failedHeaderFor(BoardDoneStage))
 	assert.Equal(t, "", failedHeaderFor(BoardBacklog))
 }
 
@@ -261,7 +372,7 @@ func TestApplyTransitionImplementationWithoutEngineeringKey(t *testing.T) {
 		cmt("[human:plan-ready]", time.Unix(2, 0)),
 	}}
 	l := &fakeLauncher{}
-	deps := newDeps(c, l, &fakePublisher{})
+	deps := newDeps(c, l, &fakeDeployer{})
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardPlanning, To: BoardImplementation})
 	require.NoError(t, err)
 	assert.Equal(t, "/human-execute SC-1", l.prompt)
@@ -272,7 +383,7 @@ func TestApplyTransitionVerificationWithoutEngineeringKey(t *testing.T) {
 		cmt("[human:ready-for-review]\nbranch: feat/x", time.Unix(1, 0)),
 	}}
 	l := &fakeLauncher{}
-	deps := newDeps(c, l, &fakePublisher{})
+	deps := newDeps(c, l, &fakeDeployer{})
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardImplementation, To: BoardVerification})
 	require.NoError(t, err)
 	assert.Equal(t, "/human-review SC-1", l.prompt)
@@ -289,7 +400,7 @@ func TestDoneBodySingleRef(t *testing.T) {
 func TestApplyTransitionIdeasGuard(t *testing.T) {
 	// Ideas leave their column via ideation's label swap, never via a board
 	// transition — both directions are rejected before any comment fetch.
-	deps := newDeps(&fakeCommenter{}, &fakeLauncher{}, &fakePublisher{})
+	deps := newDeps(&fakeCommenter{}, &fakeLauncher{}, &fakeDeployer{})
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardIdeas, To: BoardBacklog})
 	require.Error(t, err)
 	err = deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardBacklog, To: BoardIdeas})

--- a/internal/forge/README.md
+++ b/internal/forge/README.md
@@ -5,6 +5,9 @@ Lets `human` open pull requests on code-hosting platforms, keeping that work sep
 - Opens a pull request from one branch to another
 - Sets the title and description of a PR
 - Returns the new pull request number and URL
+- Reads a pull request's combined CI verdict (check runs and legacy statuses)
+- Merges a pull request into its base branch
+- Deletes the source branch after a merge
 - Knows which backends can host pull requests
 - Matches your git remote to the right forge
 - Parses HTTPS, SSH, and scp-style remote URLs

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -31,8 +31,39 @@ type Creator interface {
 	CreatePullRequest(ctx context.Context, pr *PullRequest) (*PullRequest, error)
 }
 
-// Forge aggregates code-forge operations. Today that is only pull-request
-// creation; future operations (list, merge, status) extend this interface.
+// ChecksState summarizes the CI verdict on a pull request head. It collapses
+// each provider's status/check-run vocabulary into the three states a deploy
+// gate needs: still waiting, safe to merge, or must not merge.
+type ChecksState string
+
+const (
+	ChecksPending ChecksState = "pending"
+	ChecksPassing ChecksState = "passing"
+	ChecksFailing ChecksState = "failing"
+)
+
+// ChecksReader reports the combined CI state of a pull request. A repository
+// with no CI configured reports ChecksPassing — the deploy gate only blocks on
+// evidence of failure or of checks still running, never on absence of CI.
+type ChecksReader interface {
+	PullRequestChecks(ctx context.Context, repo string, number int) (ChecksState, error)
+}
+
+// Merger merges a pull request into its base branch.
+type Merger interface {
+	MergePullRequest(ctx context.Context, repo string, number int) error
+}
+
+// BranchDeleter deletes a remote branch, used to clean up a pull request's
+// source branch after merging.
+type BranchDeleter interface {
+	DeleteBranch(ctx context.Context, repo, branch string) error
+}
+
+// Forge aggregates the code-forge operations every provider must support. The
+// deploy-oriented capabilities (ChecksReader, Merger, BranchDeleter) stay
+// separate so a provider can be a Forge without the full deploy pipeline —
+// callers type-assert for them.
 type Forge interface {
 	Creator
 }

--- a/internal/forge/github/client.go
+++ b/internal/forge/github/client.go
@@ -14,7 +14,12 @@ import (
 	"github.com/gethuman-sh/human/internal/forge"
 )
 
-var _ forge.Forge = (*Client)(nil)
+var (
+	_ forge.Forge         = (*Client)(nil)
+	_ forge.ChecksReader  = (*Client)(nil)
+	_ forge.Merger        = (*Client)(nil)
+	_ forge.BranchDeleter = (*Client)(nil)
+)
 
 // Client is a GitHub REST API client scoped to code-forge (pull request)
 // operations. It is deliberately separate from the issue-tracker client so the
@@ -79,6 +84,136 @@ func (c *Client) CreatePullRequest(ctx context.Context, pr *forge.PullRequest) (
 		Number: result.Number,
 		URL:    result.HTMLURL,
 	}, nil
+}
+
+// PullRequestChecks implements forge.ChecksReader. GitHub reports CI through
+// two parallel systems — check runs (GitHub Actions and modern apps) and
+// commit statuses (legacy integrations) — so both are consulted: any failure
+// in either fails the whole verdict, anything still running keeps it pending,
+// and a repository reporting through neither passes (no CI configured is not a
+// blocker).
+func (c *Client) PullRequestChecks(ctx context.Context, repoName string, number int) (forge.ChecksState, error) {
+	owner, repo, err := splitProject(repoName)
+	if err != nil {
+		return "", err
+	}
+
+	sha, err := c.pullHeadSHA(ctx, owner, repo, number)
+	if err != nil {
+		return "", err
+	}
+
+	runsPath := fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs",
+		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(sha))
+	resp, err := c.api.Do(ctx, http.MethodGet, runsPath, "", nil)
+	if err != nil {
+		return "", err
+	}
+	var runs checkRunsResponse
+	if err := apiclient.DecodeJSON(resp, &runs, "repo", repoName); err != nil {
+		return "", err
+	}
+
+	statusPath := fmt.Sprintf("/repos/%s/%s/commits/%s/status",
+		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(sha))
+	resp, err = c.api.Do(ctx, http.MethodGet, statusPath, "", nil)
+	if err != nil {
+		return "", err
+	}
+	var combined combinedStatusResponse
+	if err := apiclient.DecodeJSON(resp, &combined, "repo", repoName); err != nil {
+		return "", err
+	}
+
+	return combineChecks(runs, combined), nil
+}
+
+// combineChecks folds check runs and the combined commit status into one
+// verdict. Failure anywhere wins over pending, pending wins over passing.
+func combineChecks(runs checkRunsResponse, combined combinedStatusResponse) forge.ChecksState {
+	state := forge.ChecksPassing
+	for _, run := range runs.CheckRuns {
+		switch run.Conclusion {
+		case "failure", "timed_out", "cancelled", "action_required":
+			return forge.ChecksFailing
+		}
+		if run.Status != "completed" {
+			state = forge.ChecksPending
+		}
+	}
+	switch combined.State {
+	case "failure", "error":
+		return forge.ChecksFailing
+	case "pending":
+		// GitHub reports state "pending" with zero statuses when only check
+		// runs exist — that carries no signal, so it must not hold the gate.
+		if combined.TotalCount > 0 {
+			state = forge.ChecksPending
+		}
+	}
+	return state
+}
+
+// pullHeadSHA fetches the head commit of a pull request, the ref both CI
+// reporting systems key their results on.
+func (c *Client) pullHeadSHA(ctx context.Context, owner, repo string, number int) (string, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d", url.PathEscape(owner), url.PathEscape(repo), number)
+	resp, err := c.api.Do(ctx, http.MethodGet, path, "", nil)
+	if err != nil {
+		return "", err
+	}
+	var pull pullGetResponse
+	if err := apiclient.DecodeJSON(resp, &pull, "number", number); err != nil {
+		return "", err
+	}
+	if pull.Head.SHA == "" {
+		return "", errors.WithDetails("pull request has no head SHA", "number", number)
+	}
+	return pull.Head.SHA, nil
+}
+
+// MergePullRequest implements forge.Merger with a merge commit, preserving the
+// branch's individual commits (and their ticket references) on the mainline.
+func (c *Client) MergePullRequest(ctx context.Context, repoName string, number int) error {
+	owner, repo, err := splitProject(repoName)
+	if err != nil {
+		return err
+	}
+	body, err := json.Marshal(mergeRequest{MergeMethod: "merge"})
+	if err != nil {
+		return errors.WrapWithDetails(err, "marshalling merge request", "repo", repoName)
+	}
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", url.PathEscape(owner), url.PathEscape(repo), number)
+	resp, err := c.api.Do(ctx, http.MethodPut, path, "", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	var result mergeResponse
+	if err := apiclient.DecodeJSON(resp, &result, "repo", repoName); err != nil {
+		return err
+	}
+	if !result.Merged {
+		// The forge's reason goes into the message itself: the deploy pipeline
+		// surfaces err.Error() on the board card, where details are invisible.
+		return errors.WithDetails("pull request was not merged: "+result.Message, "repo", repoName, "number", number)
+	}
+	return nil
+}
+
+// DeleteBranch implements forge.BranchDeleter via the git refs API.
+func (c *Client) DeleteBranch(ctx context.Context, repoName, branch string) error {
+	owner, repo, err := splitProject(repoName)
+	if err != nil {
+		return err
+	}
+	path := fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s",
+		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(branch))
+	resp, err := c.api.Do(ctx, http.MethodDelete, path, "", nil)
+	if err != nil {
+		return err
+	}
+	_ = resp.Body.Close()
+	return nil
 }
 
 // splitProject parses an "owner/repo" string. Duplicated from the tracker-side

--- a/internal/forge/github/client_test.go
+++ b/internal/forge/github/client_test.go
@@ -63,6 +63,104 @@ func TestCreatePullRequest_invalidRepo(t *testing.T) {
 	assert.Contains(t, err.Error(), "owner/repo")
 }
 
+// checksServer serves the three endpoints PullRequestChecks touches with
+// canned check-run and combined-status payloads.
+func checksServer(t *testing.T, checkRuns, combined string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/octocat/hello-world/pulls/7":
+			_, _ = fmt.Fprint(w, `{"head":{"sha":"abc123"}}`)
+		case "/repos/octocat/hello-world/commits/abc123/check-runs":
+			_, _ = fmt.Fprint(w, checkRuns)
+		case "/repos/octocat/hello-world/commits/abc123/status":
+			_, _ = fmt.Fprint(w, combined)
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestPullRequestChecks_verdicts(t *testing.T) {
+	cases := []struct {
+		name      string
+		checkRuns string
+		combined  string
+		want      forge.ChecksState
+	}{
+		{"all green", `{"check_runs":[{"status":"completed","conclusion":"success"}]}`,
+			`{"state":"success","total_count":1}`, forge.ChecksPassing},
+		{"run failed", `{"check_runs":[{"status":"completed","conclusion":"failure"}]}`,
+			`{"state":"success","total_count":0}`, forge.ChecksFailing},
+		{"run still running", `{"check_runs":[{"status":"in_progress","conclusion":""}]}`,
+			`{"state":"success","total_count":0}`, forge.ChecksPending},
+		{"legacy status failed", `{"check_runs":[]}`,
+			`{"state":"failure","total_count":2}`, forge.ChecksFailing},
+		{"legacy status pending", `{"check_runs":[]}`,
+			`{"state":"pending","total_count":2}`, forge.ChecksPending},
+		// GitHub reports "pending" with zero statuses when only check runs
+		// exist — no signal, must not hold the gate.
+		{"no CI at all", `{"check_runs":[]}`,
+			`{"state":"pending","total_count":0}`, forge.ChecksPassing},
+		{"skipped and neutral pass", `{"check_runs":[{"status":"completed","conclusion":"skipped"},{"status":"completed","conclusion":"neutral"}]}`,
+			`{"state":"pending","total_count":0}`, forge.ChecksPassing},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := checksServer(t, tc.checkRuns, tc.combined)
+			defer srv.Close()
+			client := New(srv.URL, "ghp_test")
+			state, err := client.PullRequestChecks(context.Background(), "octocat/hello-world", 7)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, state)
+		})
+	}
+}
+
+func TestMergePullRequest_happy(t *testing.T) {
+	var gotBody mergeRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/repos/octocat/hello-world/pulls/7/merge", r.URL.Path)
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+		_, _ = fmt.Fprint(w, `{"merged":true,"message":"Pull Request successfully merged"}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "ghp_test")
+	require.NoError(t, client.MergePullRequest(context.Background(), "octocat/hello-world", 7))
+	assert.Equal(t, "merge", gotBody.MergeMethod)
+}
+
+func TestMergePullRequest_notMerged(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, `{"merged":false,"message":"Base branch was modified"}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "ghp_test")
+	err := client.MergePullRequest(context.Background(), "octocat/hello-world", 7)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Base branch was modified")
+}
+
+func TestDeleteBranch_happy(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "ghp_test")
+	require.NoError(t, client.DeleteBranch(context.Background(), "octocat/hello-world", "feat/x"))
+	assert.Equal(t, "/repos/octocat/hello-world/git/refs/heads/feat%2Fx", gotPath)
+}
+
 func TestCreatePullRequest_httpError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnprocessableEntity)

--- a/internal/forge/github/types.go
+++ b/internal/forge/github/types.go
@@ -12,3 +12,30 @@ type pullCreateResponse struct {
 	Title   string `json:"title"`
 	HTMLURL string `json:"html_url"`
 }
+
+type pullGetResponse struct {
+	Head struct {
+		SHA string `json:"sha"`
+	} `json:"head"`
+}
+
+type checkRunsResponse struct {
+	CheckRuns []struct {
+		Status     string `json:"status"`
+		Conclusion string `json:"conclusion"`
+	} `json:"check_runs"`
+}
+
+type combinedStatusResponse struct {
+	State      string `json:"state"`
+	TotalCount int    `json:"total_count"`
+}
+
+type mergeRequest struct {
+	MergeMethod string `json:"merge_method"`
+}
+
+type mergeResponse struct {
+	Merged  bool   `json:"merged"`
+	Message string `json:"message"`
+}


### PR DESCRIPTION
## What

Part 1 of SC-189 ("The board ships"). The done stage becomes a real deploy pipeline:

**push → open PR → wait for CI green → merge → delete branch → close ticket**

- `internal/forge/`: new capability interfaces — `ChecksReader` (collapses GitHub check runs + legacy commit statuses into pending/passing/failing; a repo with no CI passes), `Merger`, `BranchDeleter` — kept separate from `Forge` so providers can support PR creation without the deploy pipeline. GitHub implementations included.
- `internal/daemon/`: `runDoneStage` posts `[human:deploy-started]` and returns immediately; the pipeline runs detached (45 min ceiling, 30 s poll) and reports via `[human:deployed]` / `[human:deploy-failed]` markers. Old `[human:pr-*]` markers stay recognized so existing threads derive unchanged.
- Merge, then best-effort: branch deletion and ticket close never turn a shipped card red.
- Failed cards now show the human-readable reason ("CI checks failed", "merge conflict") instead of the marker header line.

Part 2 (auto-review chaining + the new five-column board UI with the Deploy drop zone) follows in a separate PR.

## Ticket

SC-189

🤖 Generated with [Claude Code](https://claude.com/claude-code)