### PR TITLE
[SC-195] Board: closing a ticket removes the card immediately and surfaces failures

### DIFF
--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -704,9 +704,20 @@ async function closeTicket(key) {
         await go().CloseTicket(key);
     }
     catch (err) {
+        // Leave the board untouched so the banner survives — a reconcile here
+        // would overwrite current.error with the (empty) fetch error and the
+        // failure would flash away unseen.
         showError(errMessage(err));
+        return;
     }
-    // The closed ticket is no longer "open", so reconcile drops it from the board.
+    // The daemon confirmed the transition, so the card leaves the board
+    // immediately — the full refetch below takes seconds (per-ticket comment
+    // scan) and waiting for it reads as "close did nothing". Bumping the epoch
+    // invalidates any fetch already in flight, whose pre-close snapshot would
+    // resurrect the card.
+    reconcileEpoch++;
+    current.cards = current.cards.filter((c) => c.key !== key);
+    render();
     await reconcile();
 }
 // createMocks launches mockup generation for one ticket. No confirm dialog —
@@ -868,12 +879,21 @@ async function initialLoad() {
     }
     await reconcile();
 }
+// reconcile fetches can overlap: a board:changed event may land while a
+// post-close refresh is still scanning comments. Only the newest fetch may
+// write `current` — a slower stale response would otherwise overwrite fresh
+// state and resurrect cards that already left the board. closeTicket also
+// bumps the epoch when it mutates `current` directly, for the same reason.
+let reconcileEpoch = 0;
 // reconcile fetches the full board (including derived stages) and renders it. It
 // is the single source of truth after the initial load: board:changed events and
 // post-transition refreshes call it directly.
 async function reconcile() {
+    const epoch = ++reconcileEpoch;
     try {
         const data = await go().Cards();
+        if (epoch !== reconcileEpoch)
+            return;
         current = {
             cards: data.cards || [],
             dockerAvailable: !!data.dockerAvailable,
@@ -881,6 +901,8 @@ async function reconcile() {
         };
     }
     catch (err) {
+        if (epoch !== reconcileEpoch)
+            return;
         current = { cards: [], dockerAvailable: false, error: errMessage(err) };
     }
     boardLoading = false;

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -935,9 +935,20 @@ async function closeTicket(key: string): Promise<void> {
   try {
     await go().CloseTicket(key);
   } catch (err) {
+    // Leave the board untouched so the banner survives — a reconcile here
+    // would overwrite current.error with the (empty) fetch error and the
+    // failure would flash away unseen.
     showError(errMessage(err));
+    return;
   }
-  // The closed ticket is no longer "open", so reconcile drops it from the board.
+  // The daemon confirmed the transition, so the card leaves the board
+  // immediately — the full refetch below takes seconds (per-ticket comment
+  // scan) and waiting for it reads as "close did nothing". Bumping the epoch
+  // invalidates any fetch already in flight, whose pre-close snapshot would
+  // resurrect the card.
+  reconcileEpoch++;
+  current.cards = current.cards.filter((c) => c.key !== key);
+  render();
   await reconcile();
 }
 
@@ -1104,18 +1115,28 @@ async function initialLoad(): Promise<void> {
   await reconcile();
 }
 
+// reconcile fetches can overlap: a board:changed event may land while a
+// post-close refresh is still scanning comments. Only the newest fetch may
+// write `current` — a slower stale response would otherwise overwrite fresh
+// state and resurrect cards that already left the board. closeTicket also
+// bumps the epoch when it mutates `current` directly, for the same reason.
+let reconcileEpoch = 0;
+
 // reconcile fetches the full board (including derived stages) and renders it. It
 // is the single source of truth after the initial load: board:changed events and
 // post-transition refreshes call it directly.
 async function reconcile(): Promise<void> {
+  const epoch = ++reconcileEpoch;
   try {
     const data = await go().Cards();
+    if (epoch !== reconcileEpoch) return;
     current = {
       cards: data.cards || [],
       dockerAvailable: !!data.dockerAvailable,
       error: data.error || "",
     };
   } catch (err) {
+    if (epoch !== reconcileEpoch) return;
     current = { cards: [], dockerAvailable: false, error: errMessage(err) };
   }
   boardLoading = false;

--- a/internal/daemon/board_state.go
+++ b/internal/daemon/board_state.go
@@ -35,20 +35,25 @@ func VerdictFailed(verdict string) bool {
 }
 
 // DeriveBoardCard computes a PM ticket's board placement from its comment
-// thread and tracker status. The rule: the furthest stage carrying ANY marker
-// wins; within that stage the latest marker (by Created) decides
-// running/done/failed. A ticket with no markers sits in Backlog while open and
-// is Hidden once closed/done (those never entered the pipeline). Pure: no I/O.
+// thread and tracker status. A closed/done ticket is always Hidden — closing
+// is how work leaves the board, whatever its pipeline history. For open
+// tickets the rule: the furthest stage carrying ANY marker wins; within that
+// stage the latest marker (by Created) decides running/done/failed. A ticket
+// with no markers sits in Backlog. Pure: no I/O.
 //
 // isIdea (the ticket carries an idea label, tracker.Issue.IsIdea) takes
 // precedence over everything while the ticket is open: an idea sits in the
 // Ideas column even if it somehow carries pipeline markers — deliberately, so
 // the label is the single source of truth until promotion removes it.
 func DeriveBoardCard(comments []tracker.Comment, statusType tracker.Category, isIdea bool) BoardCard {
+	// The lister normally filters closed tickets, but one closed mid-session
+	// (the board's own Close action, or a teammate on the tracker) can still
+	// arrive here via an in-flight fetch — it must never render as open work.
+	if statusType == tracker.CategoryDone || statusType == tracker.CategoryClosed {
+		return BoardCard{Stage: BoardHidden}
+	}
+
 	if isIdea {
-		if statusType == tracker.CategoryDone || statusType == tracker.CategoryClosed {
-			return BoardCard{Stage: BoardHidden}
-		}
 		return BoardCard{Stage: BoardIdeas}
 	}
 
@@ -72,11 +77,7 @@ func DeriveBoardCard(comments []tracker.Comment, statusType tracker.Category, is
 	_, hasPlan := latestPlanComment(comments)
 
 	if !anyMarker {
-		// No pipeline activity: a closed/done PM ticket never entered the
-		// board and is hidden; an open one waits in Backlog.
-		if statusType == tracker.CategoryDone || statusType == tracker.CategoryClosed {
-			return BoardCard{Stage: BoardHidden, HasPlan: hasPlan}
-		}
+		// No pipeline activity yet: the open ticket waits in Backlog.
 		return BoardCard{Stage: BoardBacklog, HasPlan: hasPlan}
 	}
 

--- a/internal/daemon/board_state_test.go
+++ b/internal/daemon/board_state_test.go
@@ -34,6 +34,24 @@ func TestDeriveBoardCard(t *testing.T) {
 		assert.Equal(t, BoardHidden, card.Stage)
 	})
 
+	t.Run("done with markers is hidden", func(t *testing.T) {
+		// A ticket closed mid-pipeline (board Close action, or directly on the
+		// tracker) has left the board — its marker history must not keep it
+		// rendered in a column.
+		comments := []tracker.Comment{
+			cmt("[human:plan-ready]\nengineering: HUM-7", t0),
+			cmt("[human:implementation-started]", t1),
+		}
+		card := DeriveBoardCard(comments, tracker.CategoryDone, false)
+		assert.Equal(t, BoardHidden, card.Stage)
+	})
+
+	t.Run("closed with markers is hidden", func(t *testing.T) {
+		comments := []tracker.Comment{cmt("[human:planning-started]", t0)}
+		card := DeriveBoardCard(comments, tracker.CategoryClosed, false)
+		assert.Equal(t, BoardHidden, card.Stage)
+	})
+
 	t.Run("planning-started is planning running", func(t *testing.T) {
 		card := DeriveBoardCard([]tracker.Comment{cmt("[human:planning-started]", t0)}, tracker.CategoryUnstarted, false)
 		assert.Equal(t, BoardPlanning, card.Stage)


### PR DESCRIPTION
Fixes the "right-click → Close ticket does nothing" bug (Shortcut 195).

## Diagnosis
Every close actually reached the daemon and closed the ticket on the tracker (verified for 174/187/189/192 in the daemon log + tracker). What was broken is the board's feedback loop:

1. The card only left the board after a full refetch — seconds of per-ticket comment scanning — so a confirmed close looked like nothing happened.
2. Reconcile fetches were unsequenced: a slow fetch started before the close could land after the post-close refresh and resurrect the card.
3. A failed close flashed its error banner for milliseconds before the follow-up reconcile wiped it.

## Changes
- **Frontend**: a confirmed close drops the card optimistically and invalidates in-flight fetches; reconcile responses are epoch-guarded (newest fetch wins); a failed close returns early so the banner persists.
- **Backend**: `DeriveBoardCard` now hides done/closed tickets regardless of pipeline markers — a closed ticket can never render as open work, even if a tracker or stale fetch returns it.

Repro harness against the live daemon confirmed close returns in ~340ms and the immediate refetch already excludes the ticket, so the optimistic removal never disagrees with the next reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)