### PR TITLE
[SC-196] Reserve a Bugs spot in the app rail

### DIFF
--- a/desktop/frontend/dist/index.html
+++ b/desktop/frontend/dist/index.html
@@ -19,6 +19,23 @@
             <rect x="3" y="3" width="18" height="18" rx="2"/><path d="M9 3v18"/><path d="M15 3v18"/>
           </svg>
         </button>
+        <!-- Placeholder for the upcoming Bugs view: visible so the rail already
+             shows where bug work will live, disabled until the view exists. -->
+        <button class="rail-item" disabled title="Bugs — coming soon">
+          <svg class="rail-icon" width="22" height="22" viewBox="0 0 512 512" fill="none"
+               stroke="currentColor" stroke-width="40" stroke-linecap="round" stroke-linejoin="round"
+               xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path d="M370,378c28.89,23.52,46,46.07,46,86"/>
+            <path d="M142,378c-28.89,23.52-46,46.06-46,86"/>
+            <path d="M384,208c28.89-23.52,32-56.07,32-96"/>
+            <path d="M128,206c-28.89-23.52-32-54.06-32-94"/>
+            <line x1="464" y1="288.13" x2="384" y2="288.13"/>
+            <line x1="128" y1="288.13" x2="48" y2="288.13"/>
+            <line x1="256" y1="192" x2="256" y2="448"/>
+            <path d="M256,448h0c-70.4,0-128-57.6-128-128V223.93c0-65.07,57.6-96,128-96h0c70.4,0,128,25.6,128,96V320C384,390.4,326.4,448,256,448Z"/>
+            <path d="M179.43,143.52A49.08,49.08,0,0,1,176,127.79,80,80,0,0,1,255.79,48h.42A80,80,0,0,1,336,127.79a41.91,41.91,0,0,1-3.12,14.3"/>
+          </svg>
+        </button>
         <button class="rail-item" data-view="agents" title="Running agents">
           <svg class="rail-icon" width="22" height="22" viewBox="0 0 15 15" fill="none"
                xmlns="http://www.w3.org/2000/svg" aria-hidden="true">

--- a/desktop/frontend/static/index.html
+++ b/desktop/frontend/static/index.html
@@ -19,6 +19,23 @@
             <rect x="3" y="3" width="18" height="18" rx="2"/><path d="M9 3v18"/><path d="M15 3v18"/>
           </svg>
         </button>
+        <!-- Placeholder for the upcoming Bugs view: visible so the rail already
+             shows where bug work will live, disabled until the view exists. -->
+        <button class="rail-item" disabled title="Bugs — coming soon">
+          <svg class="rail-icon" width="22" height="22" viewBox="0 0 512 512" fill="none"
+               stroke="currentColor" stroke-width="40" stroke-linecap="round" stroke-linejoin="round"
+               xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path d="M370,378c28.89,23.52,46,46.07,46,86"/>
+            <path d="M142,378c-28.89,23.52-46,46.06-46,86"/>
+            <path d="M384,208c28.89-23.52,32-56.07,32-96"/>
+            <path d="M128,206c-28.89-23.52-32-54.06-32-94"/>
+            <line x1="464" y1="288.13" x2="384" y2="288.13"/>
+            <line x1="128" y1="288.13" x2="48" y2="288.13"/>
+            <line x1="256" y1="192" x2="256" y2="448"/>
+            <path d="M256,448h0c-70.4,0-128-57.6-128-128V223.93c0-65.07,57.6-96,128-96h0c70.4,0,128,25.6,128,96V320C384,390.4,326.4,448,256,448Z"/>
+            <path d="M179.43,143.52A49.08,49.08,0,0,1,176,127.79,80,80,0,0,1,255.79,48h.42A80,80,0,0,1,336,127.79a41.91,41.91,0,0,1-3.12,14.3"/>
+          </svg>
+        </button>
         <button class="rail-item" data-view="agents" title="Running agents">
           <svg class="rail-icon" width="22" height="22" viewBox="0 0 15 15" fill="none"
                xmlns="http://www.w3.org/2000/svg" aria-hidden="true">


### PR DESCRIPTION
Adds a disabled bug icon to the vertical rail, directly below the board (kanban) icon — a visible placeholder for the future Bugs view (Shortcut 196).

- Inlined like the other rail icons: `currentColor` stroke, 22×22, stroke width matched visually to the neighbors.
- Identifying metadata from the icon source (SVG Repo comment, ionicons `<title>`) removed.
- Button is `disabled` with no `data-view`, so it uses the existing `.rail-item:disabled` styling and the rail click handler ignores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)