### PR TITLE
[SC-200] Issue linking: human link command + triage links bugs to their origin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,9 @@ lint:
 	go tool gocyclo -over 15 .
 
 sec:
-	go tool gosec ./...
+	# .claude/worktrees holds agent worktrees — stale snapshots there must not
+	# be compiled against the live tree (a changed interface fails the scan).
+	go tool gosec -exclude-dir .claude ./...
 	./scripts/govulncheck.sh
 
 secrets:

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,19 @@
-.PHONY: all build install test check-test test-integration coverage coverage-check fuzz lint sec secrets check clean upgrade-deps release hooks unhooks desktop desktop-deps desktop-dev desktop-package
+.PHONY: all build fmt fmt-check install test check-test test-integration coverage coverage-check fuzz lint sec secrets check clean upgrade-deps release hooks unhooks desktop desktop-deps desktop-dev desktop-package
 
 VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
 
+# Formatting is NOT part of `build`: goimports needs full import resolution and
+# costs ~1 minute even on tracked files only (a bare `goimports -w .` also walks
+# node_modules and runs for several minutes). Run `make fmt` to fix imports;
+# `check` runs the non-destructive fmt-check gate so drift can't reach a push.
+# Scoped to git-tracked files to skip vendored and generated trees.
+fmt:
+	go tool goimports -w $$(git ls-files '*.go')
+
+fmt-check:
+	@unformatted=$$(go tool goimports -l $$(git ls-files '*.go')); if [ -n "$$unformatted" ]; then echo "unformatted files (run 'make fmt'):"; echo "$$unformatted"; exit 1; fi
+
 build:
-	go tool goimports -w .
 	go build -ldflags "-X main.version=dev -X main.commit=$$(git rev-parse --short HEAD) -X main.date=$$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o bin/human .
 
 install:
@@ -49,7 +59,7 @@ secrets:
 test-integration: build
 	go run ./cmd/integrationtest
 
-check: check-test lint sec secrets
+check: fmt-check check-test lint sec secrets
 
 # Desktop (Wails) targets. The desktop app is a cgo backend (webkit2gtk on
 # Linux, WebView2 on Windows, Obj-C on macOS) and CANNOT be cross-compiled — it

--- a/cmd/cmdauto/auto.go
+++ b/cmd/cmdauto/auto.go
@@ -3,11 +3,13 @@ package cmdauto
 import (
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/spf13/cobra"
 
 	"github.com/gethuman-sh/human/cmd/cmdprovider"
 	"github.com/gethuman-sh/human/cmd/cmdutil"
+	"github.com/gethuman-sh/human/errors"
 	"github.com/gethuman-sh/human/internal/tracker"
 )
 
@@ -111,6 +113,39 @@ func BuildAutoStatusCmd(deps cmdutil.Deps) *cobra.Command {
 
 			project := tracker.ExtractProject(result.Key)
 			PrintAutoHints(cmd.ErrOrStderr(), result.Kind, result.Key, project, "status")
+			return nil
+		},
+	}
+}
+
+// BuildAutoLinkCmd creates the top-level "link" command that auto-detects the
+// tracker from the first key. Native relations exist only within one tracker,
+// so the second key must be shaped for the same tracker kind — a cross-tracker
+// pair is rejected up front rather than sent to an API that cannot express it.
+func BuildAutoLinkCmd(deps cmdutil.Deps) *cobra.Command {
+	return &cobra.Command{
+		Use:   "link KEY OTHER_KEY",
+		Short: `Link two related issues ("relates to", auto-detect tracker)`,
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := cmdutil.ResolveAutoProvider(cmd.Context(), cmd, args[0], true, deps)
+			if err != nil {
+				return err
+			}
+			defer result.Cleanup()
+
+			if !slices.Contains(tracker.DetectCandidateKinds(args[1]), result.Kind) {
+				return errors.WithDetails(
+					"keys resolve to different trackers; a link needs both issues in the same tracker",
+					"key", args[0], "otherKey", args[1], "tracker", result.Kind)
+			}
+
+			if err := cmdprovider.RunLinkIssues(cmd.Context(), result.Provider, cmd.OutOrStdout(), result.Key, args[1]); err != nil {
+				return err
+			}
+
+			project := tracker.ExtractProject(result.Key)
+			PrintAutoHints(cmd.ErrOrStderr(), result.Kind, result.Key, project, "link")
 			return nil
 		},
 	}

--- a/cmd/cmddaemon/board_scan_test.go
+++ b/cmd/cmddaemon/board_scan_test.go
@@ -32,6 +32,7 @@ func (s *stubProvider) ListComments(context.Context, string) ([]tracker.Comment,
 func (s *stubProvider) AddComment(context.Context, string, string) (*tracker.Comment, error) {
 	return nil, nil
 }
+func (s *stubProvider) LinkIssues(context.Context, string, string) error      { return nil }
 func (s *stubProvider) DeleteIssue(context.Context, string) error             { return nil }
 func (s *stubProvider) TransitionIssue(context.Context, string, string) error { return nil }
 func (s *stubProvider) AssignIssue(context.Context, string, string) error     { return nil }

--- a/cmd/cmdindex/index_test.go
+++ b/cmd/cmdindex/index_test.go
@@ -460,7 +460,8 @@ func (m *mockProvider) ListComments(_ context.Context, _ string) ([]tracker.Comm
 func (m *mockProvider) AddComment(_ context.Context, _, _ string) (*tracker.Comment, error) {
 	return nil, nil
 }
-func (m *mockProvider) DeleteIssue(_ context.Context, _ string) error { return nil }
+func (m *mockProvider) LinkIssues(_ context.Context, _, _ string) error { return nil }
+func (m *mockProvider) DeleteIssue(_ context.Context, _ string) error   { return nil }
 func (m *mockProvider) TransitionIssue(_ context.Context, _, _ string) error {
 	return nil
 }

--- a/cmd/cmdprovider/provider.go
+++ b/cmd/cmdprovider/provider.go
@@ -36,6 +36,7 @@ func BuildProviderCommands(kind string, deps cmdutil.Deps) []*cobra.Command {
 	issueCmd.AddCommand(buildIssueEditCmd(kind, deps))
 	issueCmd.AddCommand(buildIssueDeleteCmd(kind, deps))
 	issueCmd.AddCommand(buildIssueCommentCmd(kind, deps))
+	issueCmd.AddCommand(buildIssueLinkCmd(kind, deps))
 	issueCmd.AddCommand(buildIssueStartCmd(kind, deps))
 	issueCmd.AddCommand(buildIssueStatusesCmd(kind, deps))
 	issueCmd.AddCommand(buildIssueStatusSetCmd(kind, deps))
@@ -248,6 +249,22 @@ func buildIssueCommentCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 
 	commentCmd.AddCommand(addCmd, listCmd)
 	return commentCmd
+}
+
+func buildIssueLinkCmd(kind string, deps cmdutil.Deps) *cobra.Command {
+	return &cobra.Command{
+		Use:   "link KEY OTHER_KEY",
+		Short: `Link two related issues ("relates to"; on GitHub, a cross-reference comment)`,
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p, cleanup, err := cmdutil.ResolveProvider(cmd, kind, deps)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+			return RunLinkIssues(cmd.Context(), p, cmd.OutOrStdout(), args[0], args[1])
+		},
+	}
 }
 
 func buildIssueStartCmd(kind string, deps cmdutil.Deps) *cobra.Command {
@@ -474,6 +491,15 @@ func RunAddComment(ctx context.Context, p tracker.Provider, out io.Writer, key, 
 		return errors.WithDetails("add comment returned no comment", "key", key)
 	}
 	_, _ = fmt.Fprintf(out, "%s\t%s\n", comment.ID, comment.Body)
+	return nil
+}
+
+// RunLinkIssues relates two issues in the same tracker and confirms on out.
+func RunLinkIssues(ctx context.Context, p tracker.Provider, out io.Writer, key, otherKey string) error {
+	if err := p.LinkIssues(ctx, key, otherKey); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(out, "Linked %s to %s (relates to)\n", key, otherKey)
 	return nil
 }
 

--- a/cmd/cmdprovider/provider_test.go
+++ b/cmd/cmdprovider/provider_test.go
@@ -46,6 +46,7 @@ type mockProvider struct {
 	assignFn         func(ctx context.Context, key, userID string) error
 	getCurrentUserFn func(ctx context.Context) (string, error)
 	listStatusesFn   func(ctx context.Context, key string) ([]tracker.Status, error)
+	linkIssuesFn     func(ctx context.Context, key, otherKey string) error
 }
 
 func (m *mockProvider) ListIssues(ctx context.Context, opts tracker.ListOptions) ([]tracker.Issue, error) {
@@ -70,6 +71,13 @@ func (m *mockProvider) DeleteIssue(ctx context.Context, key string) error {
 
 func (m *mockProvider) AddComment(ctx context.Context, key, body string) (*tracker.Comment, error) {
 	return m.addCommentFn(ctx, key, body)
+}
+
+func (m *mockProvider) LinkIssues(ctx context.Context, key, otherKey string) error {
+	if m.linkIssuesFn == nil {
+		return nil
+	}
+	return m.linkIssuesFn(ctx, key, otherKey)
 }
 
 func (m *mockProvider) ListComments(ctx context.Context, key string) ([]tracker.Comment, error) {
@@ -1194,4 +1202,32 @@ func TestCmd_LoadInstancesError(t *testing.T) {
 	err := root.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "config error")
+}
+
+func TestRunLinkIssues_Success(t *testing.T) {
+	p := &mockProvider{
+		linkIssuesFn: func(_ context.Context, key, otherKey string) error {
+			assert.Equal(t, "KAN-1", key)
+			assert.Equal(t, "KAN-2", otherKey)
+			return nil
+		},
+	}
+
+	var buf bytes.Buffer
+	err := RunLinkIssues(context.Background(), p, &buf, "KAN-1", "KAN-2")
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Linked KAN-1 to KAN-2")
+}
+
+func TestRunLinkIssues_Error(t *testing.T) {
+	p := &mockProvider{
+		linkIssuesFn: func(_ context.Context, _, _ string) error {
+			return errors.WithDetails("link failed")
+		},
+	}
+
+	var buf bytes.Buffer
+	err := RunLinkIssues(context.Background(), p, &buf, "KAN-1", "KAN-2")
+	require.Error(t, err)
+	assert.Empty(t, buf.String())
 }

--- a/cmd_auto_test.go
+++ b/cmd_auto_test.go
@@ -467,3 +467,34 @@ func TestAutoGet_loaderError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "config load error")
 }
+
+// --- BuildAutoLinkCmd tests ---
+
+func TestAutoLink_singleKind(t *testing.T) {
+	setAutoLoader(t, newMockInstances("jira"))
+
+	cmd := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"link", "KAN-1", "KAN-2"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Linked KAN-1 to KAN-2")
+}
+
+func TestAutoLink_crossTrackerRejected(t *testing.T) {
+	setAutoLoader(t, newMockInstances("jira"))
+
+	cmd := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	// A GitHub-shaped second key cannot be linked from a Jira-shaped first key.
+	cmd.SetArgs([]string{"link", "KAN-1", "octocat/repo#42"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "same tracker")
+}

--- a/internal/claude/embed/human-bug-triage-agent.md
+++ b/internal/claude/embed/human-bug-triage-agent.md
@@ -18,10 +18,14 @@ human tracker list
 # Quick command (auto-detect tracker — works when only one tracker type is configured)
 human get <TICKET_KEY>
 
+# Link two related issues — "relates to" (auto-detect tracker)
+human link <TICKET_KEY> <OTHER_KEY>
+
 # Provider-specific commands (replace <TRACKER> with jira, github, gitlab, linear, azuredevops, or shortcut)
 human <TRACKER> issue get <TICKET_KEY>
 human <TRACKER> issue comment list <TICKET_KEY>
 human <TRACKER> issue comment add <TICKET_KEY> "comment body"
+human <TRACKER> issue link <TICKET_KEY> <OTHER_KEY>
 ```
 
 ## Tracker resolution
@@ -36,13 +40,18 @@ human <TRACKER> issue comment add <TICKET_KEY> "comment body"
 1. **Understand the report** — fetch the ticket (`human <tracker> issue get <key>`) and its discussion (`human <tracker> issue comment list <key>`). Extract error messages, stack traces, failing inputs, and reproduction steps.
 2. **Reproduce** — try to make the bug happen: run the failing command, write or run a quick check, or exercise the affected code path. Note exactly what you ran and what happened. Reduce it to the **minimal reproduction** — the smallest input/state that still triggers the bug — because the minimal case usually points at the defect directly.
 3. **Investigate to the underlying cause** — use Grep/Glob/Read to trace the code flow from the symptom to the defect, then keep asking "why" until the answer is a decision in the code, not another symptom. Build the **cause chain** explicitly: symptom → proximate cause (the line that misbehaves) → underlying cause (the assumption, missing check, or design decision that made that line wrong). A null deref is a proximate cause; *why* the value can be null there is the root cause. Cite specific files and line numbers at every link.
-4. **Find the regression window** — when feasible, use `git log`/`git blame` on the implicated lines to identify the change that introduced the defect (commit, date, ticket reference). "Broken since <commit> (<date>)" turns a guess into evidence — and "works as designed since day one" is equally strong evidence for not-a-bug.
+4. **Find the regression window** — when feasible, use `git log`/`git blame` on the implicated lines to identify the change that introduced the defect (commit, date, ticket reference). "Broken since <commit> (<date>)" turns a guess into evidence — and "works as designed since day one" is equally strong evidence for not-a-bug. When the introducing commit is found, extract **every ticket reference** from its commit message (formats: `Issue #123`, `Issue HUM-30`, `[SC-57]`, `owner/repo#42`, `Project/42`) — those references identify the ticket whose work introduced the defect.
 5. **Scan for siblings** — grep for the same defect pattern elsewhere (other call sites of the broken function, copies of the flawed idiom). List every additional occurrence in the analysis: fixing one instance of a repeated mistake is how a bug ships twice.
 6. **Reach a verdict** — exactly one of:
    - **confirmed** — the bug is real and you reproduced it (or proved the defect from the code with strong evidence).
    - **not-a-bug** — works as intended, user error, misconfiguration, an external dependency, or already fixed.
    - **undetermined** — you could not reproduce it or cannot decide. Do not guess.
 7. **Record on the tracker** — post a single comment whose **first line** is the machine-readable verdict marker, followed by a plain-language explanation and the evidence (see Output format). Post with `human <tracker> issue comment add <key> "<comment-body>"`. This comment is the ticket's permanent record of *why* the bug happened — whoever reads the ticket later (PM, reviewer, future you) must understand the cause without opening the code.
+8. **Link the bug to the originating ticket** — for a **confirmed** bug whose introducing commit named a ticket, link them: `human <tracker> issue link <BUG_KEY> <ORIGIN_KEY>` (or `human link …` when one tracker type is configured). Guards:
+   - Skip any extracted key equal to the bug key itself or to its PM/engineering counterpart — those are the bug's own trail, not the origin.
+   - When the commit references several tickets, link each distinct key that passes the guards.
+   - A key from a **different tracker** cannot be linked natively — do not call link; record the reference in the Root Cause section instead.
+   - Linking is best-effort: if the command fails (already linked, missing rights), note `(link failed: <reason>)` in the comment and continue — a failed link must never change the verdict or block posting.
 
 ## Principles
 
@@ -71,8 +80,9 @@ include the minimal reproduction>
 ## Root Cause
 <for confirmed: the cause chain — symptom → proximate cause → underlying
 cause — with file:line references at every link, and the regression window
-(introducing commit/date) when found. For not-a-bug: why it is not a defect.
-For undetermined: what is still unknown.>
+when found, as the line:
+`Introduced by <commit> (<date>) — originating ticket <KEY> (linked | link failed: <reason> | different tracker, not linked)`.
+For not-a-bug: why it is not a defect. For undetermined: what is still unknown.>
 
 ## Sibling Occurrences
 <other places the same defect pattern exists, with file:line — or "none found">

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -1697,3 +1697,11 @@ func TestServer_ResolveProjectDir_MultiProject_ErrorIntegration(t *testing.T) {
 	assert.Equal(t, 1, resp.ExitCode)
 	assert.Contains(t, resp.Stderr, "does not match any registered project")
 }
+
+func TestDetectDestructiveIgnoresIssueLink(t *testing.T) {
+	// Linking is additive like commenting: it must never queue behind the
+	// destructive-confirm gate. Pins the deny-list so a refactor to an
+	// allow-list cannot silently start gating it.
+	_, ok := detectDestructive([]string{"jira", "issue", "link", "KAN-1", "KAN-2"})
+	assert.False(t, ok)
+}

--- a/internal/recall/sync_test.go
+++ b/internal/recall/sync_test.go
@@ -36,6 +36,10 @@ func (m *mockProvider) AddComment(_ context.Context, _ string, _ string) (*track
 	return nil, nil
 }
 
+func (m *mockProvider) LinkIssues(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
 func (m *mockProvider) DeleteIssue(_ context.Context, _ string) error {
 	return nil
 }

--- a/internal/tracker/README.md
+++ b/internal/tracker/README.md
@@ -6,6 +6,7 @@
 - Read full issue details by key or pasted URL
 - Create new issues on any configured tracker
 - Read and add comments on an issue
+- Link two related issues ("relates to"; on GitHub, recorded as a cross-reference comment)
 - Move an issue to a new status
 - Assign an issue to a user
 - Edit an issue's title and description

--- a/internal/tracker/audit.go
+++ b/internal/tracker/audit.go
@@ -126,6 +126,13 @@ func (a *AuditProvider) AddComment(ctx context.Context, issueKey string, body st
 	return comment, err
 }
 
+func (a *AuditProvider) LinkIssues(ctx context.Context, key string, otherKey string) error {
+	start := time.Now()
+	err := a.inner.LinkIssues(ctx, key, otherKey)
+	a.log("LinkIssues", key, time.Since(start), err)
+	return err
+}
+
 func (a *AuditProvider) TransitionIssue(ctx context.Context, key string, targetStatus string) error {
 	start := time.Now()
 	err := a.inner.TransitionIssue(ctx, key, targetStatus)

--- a/internal/tracker/audit_test.go
+++ b/internal/tracker/audit_test.go
@@ -28,6 +28,7 @@ type mockProvider struct {
 	getCurrentUserFn  func(ctx context.Context) (string, error)
 	editIssueFn       func(ctx context.Context, key string, opts tracker.EditOptions) (*tracker.Issue, error)
 	listStatusesFn    func(ctx context.Context, key string) ([]tracker.Status, error)
+	linkIssuesFn      func(ctx context.Context, key string, otherKey string) error
 }
 
 func (m *mockProvider) ListIssues(ctx context.Context, opts tracker.ListOptions) ([]tracker.Issue, error) {
@@ -52,6 +53,13 @@ func (m *mockProvider) ListComments(ctx context.Context, issueKey string) ([]tra
 
 func (m *mockProvider) AddComment(ctx context.Context, issueKey string, body string) (*tracker.Comment, error) {
 	return m.addCommentFn(ctx, issueKey, body)
+}
+
+func (m *mockProvider) LinkIssues(ctx context.Context, key string, otherKey string) error {
+	if m.linkIssuesFn == nil {
+		return nil
+	}
+	return m.linkIssuesFn(ctx, key, otherKey)
 }
 
 func (m *mockProvider) TransitionIssue(ctx context.Context, key string, targetStatus string) error {
@@ -401,4 +409,19 @@ func TestNewAuditProvider_InvalidPath(t *testing.T) {
 	inner := &mockProvider{}
 	_, err := tracker.NewAuditProvider(inner, "test", "jira", "/nonexistent/dir/audit.log")
 	require.Error(t, err)
+}
+
+func TestAuditProvider_LinkIssues(t *testing.T) {
+	inner := &mockProvider{
+		linkIssuesFn: func(_ context.Context, _, _ string) error { return nil },
+	}
+	ap, logPath := newAudit(t, inner)
+
+	err := ap.LinkIssues(context.Background(), "KAN-10", "KAN-11")
+	require.NoError(t, err)
+
+	entries := readEntries(t, logPath)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "LinkIssues", entries[0].Operation)
+	assert.Equal(t, "KAN-10", entries[0].Key)
 }

--- a/internal/tracker/azuredevops/client.go
+++ b/internal/tracker/azuredevops/client.go
@@ -451,6 +451,45 @@ func (c *Client) DeleteIssue(ctx context.Context, key string) error {
 	return nil
 }
 
+// relatedRel is the Azure DevOps symmetric "Related" link type. Unlike the
+// hierarchy rels it carries no direction suffix — Related is its own reverse.
+const relatedRel = "System.LinkTypes.Related"
+
+// LinkIssues implements tracker.Linker by patching a Related relation onto
+// the first work item — the same /relations/- json-patch the create-time
+// hierarchy link uses.
+func (c *Client) LinkIssues(ctx context.Context, key string, otherKey string) error {
+	project, id, err := parseIssueKey(key)
+	if err != nil {
+		return err
+	}
+	_, otherID, err := parseIssueKey(otherKey)
+	if err != nil {
+		return err
+	}
+
+	ops := []patchOp{{
+		Op:   "add",
+		Path: "/relations/-",
+		Value: adoRelation{
+			Rel: relatedRel,
+			URL: c.workItemURL(otherID),
+		},
+	}}
+	body, err := json.Marshal(ops)
+	if err != nil {
+		return errors.WrapWithDetails(err, "marshalling link request", "key", key, "otherKey", otherKey)
+	}
+
+	path := fmt.Sprintf("/%s/%s/_apis/wit/workitems/%d", url.PathEscape(c.org), url.PathEscape(project), id)
+	resp, err := c.doRequest(ctx, http.MethodPatch, path, "api-version=7.1", bytes.NewReader(body), "application/json-patch+json")
+	if err != nil {
+		return errors.WrapWithDetails(err, "linking issues", "key", key, "otherKey", otherKey)
+	}
+	_ = resp.Body.Close()
+	return nil
+}
+
 // AddComment implements tracker.Commenter.
 func (c *Client) AddComment(ctx context.Context, issueKey string, body string) (*tracker.Comment, error) {
 	project, id, err := parseIssueKey(issueKey)

--- a/internal/tracker/azuredevops/client_test.go
+++ b/internal/tracker/azuredevops/client_test.go
@@ -967,3 +967,39 @@ func TestCreateIssue_withTags(t *testing.T) {
 	assert.Equal(t, "/fields/System.Tags", gotOps[1].Path)
 	assert.Equal(t, "idea; backend", gotOps[1].Value)
 }
+
+func TestLinkIssues_happy(t *testing.T) {
+	var ops []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/myorg/Proj/_apis/wit/workitems/12", r.URL.Path)
+		assert.Equal(t, "7.1", r.URL.Query().Get("api-version"))
+		assert.Equal(t, "application/json-patch+json", r.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &ops))
+
+		_, _ = fmt.Fprint(w, `{"id":12,"rev":2,"fields":{"System.Title":"t"}}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "myorg", "token")
+	err := client.LinkIssues(context.Background(), "Proj/12", "Proj/34")
+	require.NoError(t, err)
+
+	require.Len(t, ops, 1)
+	assert.Equal(t, "add", ops[0]["op"])
+	assert.Equal(t, "/relations/-", ops[0]["path"])
+	value, ok := ops[0]["value"].(map[string]any)
+	require.True(t, ok)
+	// Related is symmetric: no direction suffix, unlike the hierarchy rels.
+	assert.Equal(t, "System.LinkTypes.Related", value["rel"])
+	assert.Contains(t, value["url"], "/34")
+}
+
+func TestLinkIssues_badKey(t *testing.T) {
+	client := New("http://unused", "myorg", "token")
+	require.Error(t, client.LinkIssues(context.Background(), "12", "Proj/34"))
+	require.Error(t, client.LinkIssues(context.Background(), "Proj/12", "34"))
+}

--- a/internal/tracker/clickup/client.go
+++ b/internal/tracker/clickup/client.go
@@ -181,6 +181,26 @@ func (c *Client) ListComments(ctx context.Context, issueKey string) ([]tracker.C
 	return result, nil
 }
 
+// LinkIssues implements tracker.Linker via ClickUp's task-link endpoint
+// (symmetric, untyped). The custom_task_ids query applies to BOTH ids in the
+// path, so a custom-ID pair resolves in one call; a mixed pair (one custom,
+// one canonical) is rejected early because the flag would misread the
+// canonical id as a custom one.
+func (c *Client) LinkIssues(ctx context.Context, key string, otherKey string) error {
+	if looksLikeCustomID(key) != looksLikeCustomID(otherKey) {
+		return errors.WithDetails("cannot link a custom task ID to a canonical task ID; use the same ID form for both",
+			"key", key, "otherKey", otherKey)
+	}
+
+	path := fmt.Sprintf("/api/v2/task/%s/link/%s", url.PathEscape(key), url.PathEscape(otherKey))
+	resp, err := c.doRequest(ctx, http.MethodPost, path, c.customIDQuery(key), nil, "application/json")
+	if err != nil {
+		return errors.WrapWithDetails(err, "linking issues", "key", key, "otherKey", otherKey)
+	}
+	_ = resp.Body.Close()
+	return nil
+}
+
 // AddComment implements tracker.Commenter.
 func (c *Client) AddComment(ctx context.Context, issueKey string, body string) (*tracker.Comment, error) {
 	payload, err := json.Marshal(map[string]string{"comment_text": body})

--- a/internal/tracker/clickup/client_test.go
+++ b/internal/tracker/clickup/client_test.go
@@ -1334,3 +1334,41 @@ func TestCreateIssue_withTags(t *testing.T) {
 	assert.Equal(t, []string{"idea", "backend"}, issue.Labels)
 	assert.Equal(t, []any{"idea", "backend"}, gotBody["tags"])
 }
+
+func TestLinkIssues_happy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v2/task/abc123/link/def456", r.URL.Path)
+		assert.Empty(t, r.URL.Query().Get("custom_task_ids"))
+
+		_, _ = fmt.Fprint(w, `{"task":{"id":"abc123"}}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "token", "team-9")
+	err := client.LinkIssues(context.Background(), "abc123", "def456")
+	require.NoError(t, err)
+}
+
+func TestLinkIssues_customIDPair(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/task/PROJ-1/link/PROJ-2", r.URL.Path)
+		// One flag covers both path ids — that is why mixed pairs are rejected.
+		assert.Equal(t, "true", r.URL.Query().Get("custom_task_ids"))
+		assert.Equal(t, "team-9", r.URL.Query().Get("team_id"))
+
+		_, _ = fmt.Fprint(w, `{"task":{"id":"PROJ-1"}}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "token", "team-9")
+	err := client.LinkIssues(context.Background(), "PROJ-1", "PROJ-2")
+	require.NoError(t, err)
+}
+
+func TestLinkIssues_mixedIDFormsRejected(t *testing.T) {
+	client := New("http://unused", "token", "team-9")
+	err := client.LinkIssues(context.Background(), "PROJ-1", "def456")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "custom task ID")
+}

--- a/internal/tracker/destructive.go
+++ b/internal/tracker/destructive.go
@@ -171,6 +171,11 @@ func (d *DestructiveProvider) AddComment(ctx context.Context, issueKey string, b
 	return d.inner.AddComment(ctx, issueKey, body)
 }
 
+func (d *DestructiveProvider) LinkIssues(ctx context.Context, key string, otherKey string) error {
+	// Additive like AddComment: linking never needs a destructive confirm.
+	return d.inner.LinkIssues(ctx, key, otherKey)
+}
+
 func (d *DestructiveProvider) AssignIssue(ctx context.Context, key string, userID string) error {
 	// Pair with TransitionIssue logging: RunStartIssue transitions and
 	// assigns in one operation and the audit log should capture both

--- a/internal/tracker/destructive_test.go
+++ b/internal/tracker/destructive_test.go
@@ -286,3 +286,17 @@ func TestNewDestructiveProvider_InvalidPath(t *testing.T) {
 	_, err := tracker.NewDestructiveProvider(inner, "test", "jira", "/nonexistent/dir/destructive.log", nil)
 	require.Error(t, err)
 }
+
+func TestDestructiveProvider_LinkIssuesPassthrough(t *testing.T) {
+	// Additive like AddComment: no confirm, no destructive log entry.
+	inner := &mockProvider{
+		linkIssuesFn: func(_ context.Context, _, _ string) error { return nil },
+	}
+	dp, logPath := newDestructive(t, inner, nil)
+
+	err := dp.LinkIssues(context.Background(), "KAN-5", "KAN-6")
+	require.NoError(t, err)
+
+	entries := readDestructiveEntries(t, logPath)
+	assert.Empty(t, entries)
+}

--- a/internal/tracker/github/client.go
+++ b/internal/tracker/github/client.go
@@ -223,6 +223,23 @@ func (c *Client) addSubIssue(ctx context.Context, parentKey string, childID int)
 	return nil
 }
 
+// LinkIssues implements tracker.Linker. GitHub has no issue-relation API, so
+// the relation is recorded as a cross-reference comment — mentioning the
+// other issue in its full owner/repo#N form, which GitHub renders as a link
+// and mirrors onto the mentioned issue's timeline. That mention IS GitHub's
+// native way of relating issues; the full form keeps it working across repos.
+func (c *Client) LinkIssues(ctx context.Context, key string, otherKey string) error {
+	otherOwner, otherRepo, otherNumber, err := parseIssueKey(otherKey)
+	if err != nil {
+		return err
+	}
+	ref := fmt.Sprintf("%s/%s#%d", otherOwner, otherRepo, otherNumber)
+	if _, err := c.AddComment(ctx, key, "Relates to "+ref); err != nil {
+		return errors.WrapWithDetails(err, "linking issues", "key", key, "otherKey", otherKey)
+	}
+	return nil
+}
+
 // AddComment implements tracker.Commenter.
 func (c *Client) AddComment(ctx context.Context, issueKey string, body string) (*tracker.Comment, error) {
 	owner, repo, number, err := parseIssueKey(issueKey)

--- a/internal/tracker/github/client_test.go
+++ b/internal/tracker/github/client_test.go
@@ -1175,3 +1175,32 @@ func TestCreateIssue_withLabels(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []any{"bug", "urgent"}, gotRaw["labels"])
 }
+
+func TestLinkIssues_postsCrossReferenceComment(t *testing.T) {
+	var gotBody commentRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/repos/octocat/hello-world/issues/7/comments", r.URL.Path)
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"id":1,"body":"x","created_at":"2025-01-15T10:30:00Z","user":{"login":"bot"}}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "ghp_test")
+	err := client.LinkIssues(context.Background(), "octocat/hello-world#7", "octocat/other-repo#42")
+	require.NoError(t, err)
+
+	// The full owner/repo#N form keeps the mention working across repos.
+	assert.Equal(t, "Relates to octocat/other-repo#42", gotBody.Body)
+}
+
+func TestLinkIssues_badOtherKey(t *testing.T) {
+	client := New("http://unused", "ghp_test")
+	err := client.LinkIssues(context.Background(), "octocat/hello-world#7", "not-a-key")
+	require.Error(t, err)
+}

--- a/internal/tracker/gitlab/client.go
+++ b/internal/tracker/gitlab/client.go
@@ -178,6 +178,40 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 	}, nil
 }
 
+// LinkIssues implements tracker.Linker via GitLab's issue-links API. The
+// link_type is omitted, so GitLab records its default symmetric "relates_to"
+// relation. The target project travels as its URL-encoded path — the links
+// endpoint accepts a path or a numeric ID interchangeably.
+func (c *Client) LinkIssues(ctx context.Context, key string, otherKey string) error {
+	project, iid, err := parseIssueKey(key)
+	if err != nil {
+		return err
+	}
+	encodedProject, err := splitProject(project)
+	if err != nil {
+		return err
+	}
+	otherProject, otherIID, err := parseIssueKey(otherKey)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/api/v4/projects/%s/issues/%d/links", encodedProject, iid)
+	// The target project goes in RAW form: url.Values.Encode escapes it once,
+	// which is exactly the single encoding the API expects — pre-escaping via
+	// splitProject here would double-encode the path separator.
+	query := url.Values{
+		"target_project_id": {otherProject},
+		"target_issue_iid":  {strconv.Itoa(otherIID)},
+	}
+	resp, err := c.doRequest(ctx, http.MethodPost, path, query.Encode(), nil)
+	if err != nil {
+		return errors.WrapWithDetails(err, "linking issues", "key", key, "otherKey", otherKey)
+	}
+	_ = resp.Body.Close()
+	return nil
+}
+
 // AddComment implements tracker.Commenter.
 func (c *Client) AddComment(ctx context.Context, issueKey string, body string) (*tracker.Comment, error) {
 	project, iid, err := parseIssueKey(issueKey)

--- a/internal/tracker/gitlab/client_test.go
+++ b/internal/tracker/gitlab/client_test.go
@@ -863,3 +863,40 @@ func TestCreateIssue_withLabels(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "bug,urgent", gotBody.Labels)
 }
+
+func TestLinkIssues_happy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v4/projects/group/proj/issues/5/links", r.URL.Path)
+		q := r.URL.Query()
+		// Single-encoded path: url.Values escaped it once on the wire, the
+		// server sees the raw project path back.
+		assert.Equal(t, "group/other", q.Get("target_project_id"))
+		assert.Equal(t, "7", q.Get("target_issue_iid"))
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"source_issue":{},"target_issue":{},"link_type":"relates_to"}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "token")
+	err := client.LinkIssues(context.Background(), "group/proj#5", "group/other#7")
+	require.NoError(t, err)
+}
+
+func TestLinkIssues_badKeys(t *testing.T) {
+	client := New("http://unused", "token")
+	require.Error(t, client.LinkIssues(context.Background(), "no-hash", "group/other#7"))
+	require.Error(t, client.LinkIssues(context.Background(), "group/proj#5", "no-hash"))
+}
+
+func TestLinkIssues_httpError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict) // already linked
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "token")
+	err := client.LinkIssues(context.Background(), "group/proj#5", "group/other#7")
+	require.Error(t, err)
+}

--- a/internal/tracker/jira/client.go
+++ b/internal/tracker/jira/client.go
@@ -210,6 +210,29 @@ func (c *Client) AddComment(ctx context.Context, issueKey string, body string) (
 	return toTrackerComment(jc)
 }
 
+// LinkIssues implements tracker.Linker via Jira's issue-link API. "Relates"
+// is Jira's stock symmetric link type; instances that renamed it surface the
+// API's own error so the user sees the tracker's vocabulary, not ours.
+func (c *Client) LinkIssues(ctx context.Context, key string, otherKey string) error {
+	payload := map[string]any{
+		"type":         map[string]string{"name": "Relates"},
+		"inwardIssue":  map[string]string{"key": key},
+		"outwardIssue": map[string]string{"key": otherKey},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return errors.WrapWithDetails(err, "marshalling issue link request",
+			"key", key, "otherKey", otherKey)
+	}
+
+	resp, err := c.doRequest(ctx, http.MethodPost, "/rest/api/3/issueLink", "", bytes.NewReader(raw))
+	if err != nil {
+		return errors.WrapWithDetails(err, "linking issues", "key", key, "otherKey", otherKey)
+	}
+	_ = resp.Body.Close()
+	return nil
+}
+
 // ListComments implements tracker.Commenter.
 func (c *Client) ListComments(ctx context.Context, issueKey string) ([]tracker.Comment, error) {
 	path := fmt.Sprintf("/rest/api/3/issue/%s/comment", url.PathEscape(issueKey))

--- a/internal/tracker/jira/client_test.go
+++ b/internal/tracker/jira/client_test.go
@@ -861,3 +861,38 @@ func TestGetIssue_labels(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"backend", "urgent"}, issue.Labels)
 }
+
+func TestLinkIssues_happy(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/rest/api/3/issueLink", r.URL.Path)
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "user@example.com", "token")
+	err := client.LinkIssues(context.Background(), "KAN-1", "KAN-2")
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]any{"name": "Relates"}, gotBody["type"])
+	assert.Equal(t, map[string]any{"key": "KAN-1"}, gotBody["inwardIssue"])
+	assert.Equal(t, map[string]any{"key": "KAN-2"}, gotBody["outwardIssue"])
+}
+
+func TestLinkIssues_httpError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "user@example.com", "token")
+	err := client.LinkIssues(context.Background(), "KAN-1", "KAN-2")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "linking issues")
+}

--- a/internal/tracker/linear/client.go
+++ b/internal/tracker/linear/client.go
@@ -103,6 +103,15 @@ const addCommentMutation = `mutation($issueId: String!, $body: String!) {
 	}
 }`
 
+// issueRelationCreateMutation relates two issues. The type is inlined rather
+// than passed as a variable because IssueRelationType is a GraphQL enum —
+// sending the bare enum token avoids the string-vs-enum serialization trap.
+const issueRelationCreateMutation = `mutation($issueId: String!, $relatedIssueId: String!) {
+	issueRelationCreate(input: { issueId: $issueId, relatedIssueId: $relatedIssueId, type: related }) {
+		success
+	}
+}`
+
 const getTeamStatesQuery = `query($key: String!) {
 	teams(filter: { key: { eq: $key } }) {
 		nodes { id states { nodes { id name type } } }
@@ -323,6 +332,43 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 }
 
 // AddComment implements tracker.Commenter.
+// LinkIssues implements tracker.Linker via Linear's issueRelationCreate
+// mutation with the symmetric "related" relation type.
+func (c *Client) LinkIssues(ctx context.Context, key string, otherKey string) error {
+	issueID, err := c.resolveIssueID(ctx, key)
+	if err != nil {
+		return err
+	}
+	relatedID, err := c.resolveIssueID(ctx, otherKey)
+	if err != nil {
+		return err
+	}
+
+	vars := map[string]any{
+		"issueId":        issueID,
+		"relatedIssueId": relatedID,
+	}
+	data, err := c.doGraphQL(ctx, issueRelationCreateMutation, vars)
+	if err != nil {
+		return errors.WrapWithDetails(err, "linking issues", "key", key, "otherKey", otherKey)
+	}
+
+	var result struct {
+		IssueRelationCreate struct {
+			Success bool `json:"success"`
+		} `json:"issueRelationCreate"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return errors.WrapWithDetails(err, "decoding issue relation response",
+			"key", key, "otherKey", otherKey)
+	}
+	if !result.IssueRelationCreate.Success {
+		return errors.WithDetails("linear rejected the issue relation",
+			"key", key, "otherKey", otherKey)
+	}
+	return nil
+}
+
 func (c *Client) AddComment(ctx context.Context, issueKey string, body string) (*tracker.Comment, error) {
 	issueID, err := c.resolveIssueID(ctx, issueKey)
 	if err != nil {

--- a/internal/tracker/linear/client_test.go
+++ b/internal/tracker/linear/client_test.go
@@ -1935,3 +1935,48 @@ func TestGetIssue_withParent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ENG-1", issue.ParentKey)
 }
+
+func TestLinkIssues_happy(t *testing.T) {
+	srv := httptest.NewServer(&graphQLHandler{
+		t: t,
+		handlers: map[string]func(vars map[string]any) string{
+			"issue(": func(vars map[string]any) string {
+				// Two lookups, one per key — return a distinct id for each.
+				if vars["id"] == "ENG-1" {
+					return `{"data":{"issue":{"id":"uuid-eng-1"}}}`
+				}
+				return `{"data":{"issue":{"id":"uuid-eng-2"}}}`
+			},
+			"issueRelationCreate(": func(vars map[string]any) string {
+				assert.Equal(t, "uuid-eng-1", vars["issueId"])
+				assert.Equal(t, "uuid-eng-2", vars["relatedIssueId"])
+				return `{"data":{"issueRelationCreate":{"success":true}}}`
+			},
+		},
+	})
+	defer srv.Close()
+
+	client := New(srv.URL, "token")
+	err := client.LinkIssues(context.Background(), "ENG-1", "ENG-2")
+	require.NoError(t, err)
+}
+
+func TestLinkIssues_rejected(t *testing.T) {
+	srv := httptest.NewServer(&graphQLHandler{
+		t: t,
+		handlers: map[string]func(vars map[string]any) string{
+			"issue(": func(map[string]any) string {
+				return `{"data":{"issue":{"id":"uuid"}}}`
+			},
+			"issueRelationCreate(": func(map[string]any) string {
+				return `{"data":{"issueRelationCreate":{"success":false}}}`
+			},
+		},
+	})
+	defer srv.Close()
+
+	client := New(srv.URL, "token")
+	err := client.LinkIssues(context.Background(), "ENG-1", "ENG-2")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rejected")
+}

--- a/internal/tracker/policy.go
+++ b/internal/tracker/policy.go
@@ -190,6 +190,13 @@ func (pp *PolicyProvider) AddComment(ctx context.Context, issueKey string, body 
 	return pp.inner.AddComment(ctx, issueKey, body)
 }
 
+func (pp *PolicyProvider) LinkIssues(ctx context.Context, key string, otherKey string) error {
+	if err := pp.checkPolicy("link", ""); err != nil {
+		return err
+	}
+	return pp.inner.LinkIssues(ctx, key, otherKey)
+}
+
 func (pp *PolicyProvider) TransitionIssue(ctx context.Context, key string, targetStatus string) error {
 	if err := pp.checkPolicy("transition", targetStatus); err != nil {
 		return err

--- a/internal/tracker/policy_test.go
+++ b/internal/tracker/policy_test.go
@@ -268,3 +268,19 @@ func TestPolicyProvider_AllWriteMethodsChecked(t *testing.T) {
 	_, err = pp.EditIssue(ctx, "KAN-1", tracker.EditOptions{})
 	assert.Error(t, err)
 }
+
+func TestPolicyProvider_LinkIssues(t *testing.T) {
+	inner := &mockProvider{
+		linkIssuesFn: func(_ context.Context, _, _ string) error { return nil },
+	}
+
+	blocked := tracker.NewPolicyProvider(inner, "test",
+		tracker.NewPolicy(tracker.PolicyConfig{Block: []string{"link"}}), nil)
+	err := blocked.LinkIssues(context.Background(), "KAN-1", "KAN-2")
+	assert.Error(t, err)
+
+	allowed := tracker.NewPolicyProvider(inner, "test",
+		tracker.NewPolicy(tracker.PolicyConfig{}), nil)
+	err = allowed.LinkIssues(context.Background(), "KAN-1", "KAN-2")
+	assert.NoError(t, err)
+}

--- a/internal/tracker/safe.go
+++ b/internal/tracker/safe.go
@@ -46,6 +46,11 @@ func (s *SafeProvider) AddComment(ctx context.Context, issueKey string, body str
 	return s.inner.AddComment(ctx, issueKey, body)
 }
 
+func (s *SafeProvider) LinkIssues(ctx context.Context, key string, otherKey string) error {
+	// Additive like AddComment — safe mode blocks only destructive operations.
+	return s.inner.LinkIssues(ctx, key, otherKey)
+}
+
 func (s *SafeProvider) TransitionIssue(_ context.Context, _ string, _ string) error {
 	return errors.WithDetails("operation blocked by safe mode: %s on %s",
 		"operation", "TransitionIssue",

--- a/internal/tracker/safe_test.go
+++ b/internal/tracker/safe_test.go
@@ -127,3 +127,20 @@ func TestSafeProvider_DeleteIssueErrorIncludesInstanceName(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "my-tracker")
 }
+
+func TestSafeProvider_LinkIssuesForwarded(t *testing.T) {
+	// Linking is additive like commenting — safe mode must not block it.
+	var gotKey, gotOther string
+	inner := &mockProvider{
+		linkIssuesFn: func(_ context.Context, key, otherKey string) error {
+			gotKey, gotOther = key, otherKey
+			return nil
+		},
+	}
+	sp := tracker.NewSafeProvider(inner, "test-instance")
+
+	err := sp.LinkIssues(context.Background(), "KAN-1", "KAN-2")
+	require.NoError(t, err)
+	assert.Equal(t, "KAN-1", gotKey)
+	assert.Equal(t, "KAN-2", gotOther)
+}

--- a/internal/tracker/shortcut/client.go
+++ b/internal/tracker/shortcut/client.go
@@ -533,6 +533,36 @@ func (c *Client) DeleteIssue(ctx context.Context, key string) error {
 }
 
 // AddComment implements tracker.Commenter.
+// LinkIssues implements tracker.Linker via Shortcut's story-link API. The
+// "relates to" verb is Shortcut's symmetric story relation; subject/object
+// order therefore carries no meaning beyond display.
+func (c *Client) LinkIssues(ctx context.Context, key string, otherKey string) error {
+	subjectID, err := parseStoryID(key)
+	if err != nil {
+		return err
+	}
+	objectID, err := parseStoryID(otherKey)
+	if err != nil {
+		return err
+	}
+
+	payload, err := json.Marshal(map[string]any{
+		"verb":       "relates to",
+		"subject_id": subjectID,
+		"object_id":  objectID,
+	})
+	if err != nil {
+		return errors.WrapWithDetails(err, "marshalling story link request", "key", key, "otherKey", otherKey)
+	}
+
+	resp, err := c.doRequest(ctx, http.MethodPost, "/api/v3/story-links", "", bytes.NewReader(payload), "application/json")
+	if err != nil {
+		return errors.WrapWithDetails(err, "linking issues", "key", key, "otherKey", otherKey)
+	}
+	_ = resp.Body.Close()
+	return nil
+}
+
 func (c *Client) AddComment(ctx context.Context, issueKey string, body string) (*tracker.Comment, error) {
 	id, err := parseStoryID(issueKey)
 	if err != nil {

--- a/internal/tracker/shortcut/client_test.go
+++ b/internal/tracker/shortcut/client_test.go
@@ -1339,3 +1339,48 @@ func Test_mergeLabels(t *testing.T) {
 		})
 	}
 }
+
+func TestLinkIssues_happy(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v3/story-links", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"id":9,"verb":"relates to","subject_id":42,"object_id":57}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "token")
+	err := client.LinkIssues(context.Background(), "42", "57")
+	require.NoError(t, err)
+
+	// The exact verb string is the API contract — Shortcut rejects variants.
+	assert.Equal(t, "relates to", gotBody["verb"])
+	assert.Equal(t, float64(42), gotBody["subject_id"])
+	assert.Equal(t, float64(57), gotBody["object_id"])
+}
+
+func TestLinkIssues_badKey(t *testing.T) {
+	client := New("http://unused", "token")
+	err := client.LinkIssues(context.Background(), "not-numeric", "57")
+	require.Error(t, err)
+	err = client.LinkIssues(context.Background(), "42", "not-numeric")
+	require.Error(t, err)
+}
+
+func TestLinkIssues_httpError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "token")
+	err := client.LinkIssues(context.Background(), "42", "57")
+	require.Error(t, err)
+}

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -288,6 +288,7 @@ type Provider interface {
 	CurrentUserGetter
 	Editor
 	StatusLister
+	Linker
 }
 
 // Instance represents a configured tracker backend ready for use.
@@ -335,6 +336,16 @@ type Creator interface {
 type Commenter interface {
 	ListComments(ctx context.Context, issueKey string) ([]Comment, error)
 	AddComment(ctx context.Context, issueKey string, body string) (*Comment, error)
+}
+
+// Linker relates two issues in the same tracker. The relation is the generic,
+// symmetric "relates to" — richer typed relations (blocks, duplicates) are
+// deliberately out of scope so every backend can honour the same call.
+// Backends without a native relation API (GitHub) record the relation as a
+// cross-reference comment on the first issue, which is that ecosystem's
+// convention for relating issues.
+type Linker interface {
+	LinkIssues(ctx context.Context, key string, otherKey string) error
 }
 
 // Deleter deletes (or closes) an issue by key.

--- a/internal/tracker/tracker_test.go
+++ b/internal/tracker/tracker_test.go
@@ -31,6 +31,7 @@ func (stubProvider) GetIssue(context.Context, string) (*Issue, error)           
 func (stubProvider) CreateIssue(context.Context, *Issue) (*Issue, error)            { return nil, nil }
 func (stubProvider) ListComments(context.Context, string) ([]Comment, error)        { return nil, nil }
 func (stubProvider) AddComment(context.Context, string, string) (*Comment, error)   { return nil, nil }
+func (stubProvider) LinkIssues(context.Context, string, string) error               { return nil }
 func (stubProvider) DeleteIssue(context.Context, string) error                      { return nil }
 func (stubProvider) TransitionIssue(context.Context, string, string) error          { return nil }
 func (stubProvider) AssignIssue(context.Context, string, string) error              { return nil }

--- a/main.go
+++ b/main.go
@@ -205,6 +205,10 @@ Configure trackers and tools in .humanconfig.yaml or pass credentials via flags/
 	autoStatusCmd.GroupID = "shortcuts"
 	rootCmd.AddCommand(autoStatusCmd)
 
+	autoLinkCmd := cmdauto.BuildAutoLinkCmd(autoDeps)
+	autoLinkCmd.GroupID = "shortcuts"
+	rootCmd.AddCommand(autoLinkCmd)
+
 	autoPRCmd := cmdauto.BuildAutoPRCreateCmd(autoDeps)
 	autoPRCmd.GroupID = "shortcuts"
 	rootCmd.AddCommand(autoPRCmd)

--- a/main_test.go
+++ b/main_test.go
@@ -185,6 +185,7 @@ type mockProvider struct {
 	getCurrentUserFn  func(ctx context.Context) (string, error)
 	editIssueFn       func(ctx context.Context, key string, opts tracker.EditOptions) (*tracker.Issue, error)
 	listStatusesFn    func(ctx context.Context, key string) ([]tracker.Status, error)
+	linkIssuesFn      func(ctx context.Context, key string, otherKey string) error
 }
 
 func (m *mockProvider) ListIssues(ctx context.Context, opts tracker.ListOptions) ([]tracker.Issue, error) {
@@ -209,6 +210,13 @@ func (m *mockProvider) ListComments(ctx context.Context, issueKey string) ([]tra
 
 func (m *mockProvider) AddComment(ctx context.Context, issueKey string, body string) (*tracker.Comment, error) {
 	return m.addCommentFn(ctx, issueKey, body)
+}
+
+func (m *mockProvider) LinkIssues(ctx context.Context, key string, otherKey string) error {
+	if m.linkIssuesFn == nil {
+		return nil
+	}
+	return m.linkIssuesFn(ctx, key, otherKey)
 }
 
 func (m *mockProvider) TransitionIssue(ctx context.Context, key string, targetStatus string) error {


### PR DESCRIPTION
## Summary
- New tracker operation **`Linker.LinkIssues(key, otherKey)`** — the generic symmetric "relates to", embedded in `Provider` and forwarded through all four decorators (safe/policy/audit/destructive) as an additive op, like commenting.
- Implemented in **all seven providers**: Jira `issueLink` (Relates), Linear `issueRelationCreate` (related), Shortcut story-links ("relates to"), GitLab issue links (relates_to), Azure DevOps `System.LinkTypes.Related`, ClickUp task links (mixed custom/canonical ID pairs rejected early). GitHub has no relation API → cross-reference comment in full `owner/repo#N` form.
- New CLI: `human <tracker> issue link KEY OTHER_KEY` and auto-detecting **`human link KEY OTHER_KEY`**; cross-tracker pairs are an explicit error (no silent comment fallback).
- **Bug triage closes the loop**: when the regression window names the introducing commit, triage extracts its ticket refs and links the bug to each same-tracker origin ticket — guarded against self/trail keys, best-effort (a failed link never changes the verdict), cross-tracker origins recorded in prose. The verdict comment carries `Introduced by <commit> — originating ticket <KEY> (linked)`.
- `make check` hardening: gosec now skips `.claude/` — a stale agent worktree snapshot was being compiled against the live tree, so any interface change failed the scan.

## Tests
- Per-provider httptest suites pinning method, path, and exact payloads (incl. Shortcut's `"relates to"` verb, GitLab single-encoding of the target project, ADO's suffix-less Related rel, ClickUp custom-ID query).
- Decorator tests: safe forwards, policy gates on `"link"`, audit records `LinkIssues`, destructive log stays empty.
- CLI tests: `RunLinkIssues` output/error, root `link` happy path, cross-tracker rejection; daemon `detectDestructive` regression test (link is not gated).
- `make check` green.

Live-tracker verification of the Shortcut payload is pending: run `human link 199 200` once the daemon runs this build.

PM ticket: SC-200

🤖 Generated with [Claude Code](https://claude.com/claude-code)