### PR TITLE
[SC-203] Ticket detail slide-out on card click

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -232,6 +232,7 @@ func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, de
 		NetworkEvents:     networkStore,
 		IssueFetcher:      fetchTrackerIssuesFunc(projectRegistry, vaultResolver),
 		LiteIssueFetcher:  fetchTrackerIssuesLiteFunc(projectRegistry, vaultResolver),
+		IssueGetter:       issueGetterFunc(projectRegistry, vaultResolver),
 		TrackerDiagnoser:  trackerDiagnoserFunc(projectRegistry, vaultResolver),
 		Projects:          projectRegistry,
 		PendingConfirms:   confirmStore,
@@ -1032,6 +1033,31 @@ func fetchTrackerIssuesLiteFunc(reg *daemon.ProjectRegistry, resolver *vault.Res
 	return func() ([]daemon.TrackerIssuesResult, error) {
 		_, results, err := listTrackerIssues(reg, resolver)
 		return results, err
+	}
+}
+
+// issueGetterFunc builds the daemon's IssueGetter closure: it resolves the
+// tracker instance named in the request and fetches the single full issue.
+// The per-key fetch exists because list endpoints on some trackers (e.g.
+// Shortcut) return slim payloads without descriptions.
+func issueGetterFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver) func(daemon.IssueDetailRequest) (*tracker.Issue, error) {
+	return func(req daemon.IssueDetailRequest) (*tracker.Issue, error) {
+		entries := reg.Entries()
+		if len(entries) == 0 {
+			return nil, errors.WithDetails("no project registered for issue detail")
+		}
+		entry := entries[0]
+		instances, err := cmdutil.LoadAllInstancesWithResolver(entry.Dir, entry.EnvLookup(), resolver)
+		if err != nil {
+			return nil, err
+		}
+		inst, err := tracker.Resolve(req.Tracker, instances, req.Key)
+		if err != nil {
+			return nil, err
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		return inst.Provider.GetIssue(ctx, req.Key)
 	}
 }
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -71,6 +71,13 @@ type Card struct {
 	// the ideation conversation alongside the title.
 	Labels      []string `json:"labels,omitempty"`
 	Description string   `json:"description,omitempty"`
+	// Assignee is the ticket owner shown in the detail panel. Display-only:
+	// the board never assigns; empty renders as "Unassigned" in the frontend.
+	Assignee string `json:"assignee,omitempty"`
+	// Tracker is the instance name the issue was listed from. The detail
+	// panel passes it back to IssueDetail so the daemon resolves the exact
+	// instance — bare numeric keys are ambiguous across tracker kinds.
+	Tracker string `json:"tracker,omitempty"`
 	// IdeaColumn is the idea-space sub-column (0 loosest … 4 most concrete)
 	// for cards in the Ideas stage. Locally persisted preference, never
 	// tracker state; the zero value is the leftmost column, so an idea with
@@ -116,6 +123,34 @@ func (a *App) Cards() (BoardData, error) {
 	data := boardFromResults(results, dockerAvailable(), a.ideas.Assignments(), cardMockups())
 	a.pruneIdeaSpace(data)
 	return data, nil
+}
+
+// IssueDetail is the full-ticket payload for the board's detail panel — only
+// the fields the panel renders beyond what the card already carries.
+type IssueDetail struct {
+	Title       string `json:"title"`
+	Assignee    string `json:"assignee,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// GetIssueDetail fetches one full ticket from the daemon. The detail panel
+// calls it on open because list fetches on some trackers (e.g. Shortcut)
+// return slim payloads without descriptions, so the card's own description
+// can be empty even for a ticket that has one.
+func (a *App) GetIssueDetail(trackerName, key string) (IssueDetail, error) {
+	info, err := daemon.ReadInfo()
+	if err != nil {
+		return IssueDetail{}, err
+	}
+	issue, err := daemon.GetTrackerIssue(info.Addr, info.Token, trackerName, key)
+	if err != nil {
+		return IssueDetail{}, err
+	}
+	return IssueDetail{
+		Title:       issue.Title,
+		Assignee:    issue.Assignee,
+		Description: issue.Description,
+	}, nil
 }
 
 // pruneIdeaSpace drops idea-space placements for tickets that are no longer
@@ -220,6 +255,8 @@ func boardFromResults(results []daemon.TrackerIssuesResult, dockerAvailable bool
 			Verdict:        card.Verdict,
 			Labels:         issue.Labels,
 			Description:    issue.Description,
+			Assignee:       issue.Assignee,
+			Tracker:        pm.TrackerName,
 			Bug:            issue.IsBug(),
 			IdeaColumn:     ideaCol,
 			MockupSlug:     mock.Slug,

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -724,12 +724,18 @@ function beginPointerDrag(el, card) {
         const onUp = (ev) => {
             const target = started ? dropTargetAt(ev.clientX, ev.clientY) : null;
             const allowed = !!target && dropAllowed(target);
+            const wasClick = !started;
             teardown();
             endDrag();
             // `target` may have been replaced by the flushed render, but performDrop
             // only reads its dataset, which a detached node still carries.
             if (target && allowed)
                 performDrop(target, info, { x: ev.clientX, y: ev.clientY });
+            // A press that never crossed the drag threshold is a plain click: open
+            // the ticket detail panel. Links/buttons never get here (pointerdown
+            // filters them), and right-clicks go to the contextmenu handler instead.
+            else if (wasClick)
+                openTicketDetail(card);
         };
         const onCancel = () => {
             teardown();
@@ -994,6 +1000,9 @@ function render() {
     else {
         banner.classList.add("hidden");
     }
+    // The detail panel lives outside #board, so the rebuild above never touches
+    // it — it only needs its card data refreshed from the new board state.
+    refreshTicketDetail();
 }
 function showError(msg) {
     current.error = msg;
@@ -1247,7 +1256,98 @@ function renderIdeationError(msg) {
     ideation = { ...ideation, state: "error", error: msg };
     renderIdeation();
 }
+// --- Ticket detail panel ---------------------------------------------------
+//
+// A plain click on any card (board or Bugs pane) opens a read-only slide-out
+// with the ticket's key, title, owner and description. It renders a snapshot
+// of the clicked card, re-resolved by key after each render() so the full
+// fetch backfills a description the quick titles-only pass left empty.
+let detailCard = null;
+function openTicketDetail(card) {
+    // The detail panel and the ideation panel share the fixed right edge; only
+    // one may be visible. Closing ideation keeps its session running (AD-4).
+    closeIdeation();
+    detailCard = card;
+    renderTicketDetail();
+    document.getElementById("detail-panel")?.classList.remove("hidden");
+    void fetchTicketDetail(card);
+}
+// fetchTicketDetail backfills the panel from a per-ticket fetch: the board's
+// list fetch is slim on some trackers (Shortcut returns stories without
+// descriptions), so the card's own description can be empty even for a ticket
+// that has one. The snapshot renders first; this fills in what the list missed.
+async function fetchTicketDetail(card) {
+    try {
+        const detail = await go().GetIssueDetail(card.tracker ?? "", card.key);
+        // A slow fetch for a previously clicked card must never overwrite the
+        // currently open one.
+        if (!detailCard || detailCard.key !== card.key)
+            return;
+        detailCard = {
+            ...detailCard,
+            title: detail.title || detailCard.title,
+            assignee: detail.assignee || detailCard.assignee,
+            description: detail.description || detailCard.description,
+        };
+        renderTicketDetail();
+    }
+    catch {
+        // The snapshot already renders; a failed backfill just means the panel
+        // shows what the list fetch carried.
+    }
+}
+function closeTicketDetail() {
+    detailCard = null;
+    document.getElementById("detail-panel")?.classList.add("hidden");
+}
+// refreshTicketDetail re-renders the open panel from the freshest card with
+// the same key. A card that left the board (e.g. closed elsewhere) keeps its
+// last snapshot — stale-but-readable beats a panel that vanishes mid-read.
+function refreshTicketDetail() {
+    if (!detailCard)
+        return;
+    const key = detailCard.key;
+    const fresh = current.cards.find((c) => c.key === key);
+    if (fresh) {
+        // Merge, don't replace: the fresh card comes from a slim list fetch whose
+        // empty description/assignee must not wipe what fetchTicketDetail filled in.
+        detailCard = {
+            ...fresh,
+            assignee: fresh.assignee || detailCard.assignee,
+            description: fresh.description || detailCard.description,
+        };
+    }
+    renderTicketDetail();
+}
+function renderTicketDetail() {
+    if (!detailCard)
+        return;
+    const keyEl = document.getElementById("detail-key");
+    if (keyEl)
+        keyEl.textContent = detailCard.key;
+    const body = document.getElementById("detail-body");
+    if (!body)
+        return;
+    const owner = detailCard.assignee
+        ? `<span class="detail-owner-name">${escapeHtml(detailCard.assignee)}</span>`
+        : "Unassigned";
+    const desc = detailCard.description
+        ? `<div class="detail-description">${escapeHtml(detailCard.description)}</div>`
+        : `<div class="detail-description empty">No description</div>`;
+    const link = detailCard.url
+        ? `<a class="detail-tracker-link" href="${escapeAttr(detailCard.url)}" target="_blank">Open in tracker</a>`
+        : "";
+    body.innerHTML = `
+    <div class="detail-title">${escapeHtml(detailCard.title)}</div>
+    <div class="detail-owner">Owner: ${owner}</div>
+    ${desc}
+    ${link}
+  `;
+}
 async function openIdeation() {
+    // Mirror of the exclusivity in openTicketDetail: both panels occupy the
+    // fixed right edge, so opening one always closes the other.
+    closeTicketDetail();
     const panel = document.getElementById("ideation-panel");
     if (panel)
         panel.classList.remove("hidden");
@@ -1981,6 +2081,7 @@ function init() {
         }
     });
     document.getElementById("ideation-close")?.addEventListener("click", () => closeIdeation());
+    document.getElementById("detail-close")?.addEventListener("click", () => closeTicketDetail());
     document.getElementById("ideation-form")?.addEventListener("submit", (e) => {
         e.preventDefault();
         void submitIdeation();

--- a/desktop/frontend/dist/index.html
+++ b/desktop/frontend/dist/index.html
@@ -116,6 +116,13 @@
         <button id="ideation-send" type="submit">Send</button>
       </form>
     </aside>
+    <aside id="detail-panel" class="detail-panel hidden" aria-label="Ticket details">
+      <div class="detail-header">
+        <span id="detail-key" class="detail-key"></span>
+        <button id="detail-close" class="detail-close" title="Close">×</button>
+      </div>
+      <div id="detail-body" class="detail-body"></div>
+    </aside>
     <script type="module" src="/board.js"></script>
   </body>
 </html>

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -1004,6 +1004,91 @@ body {
   cursor: pointer;
 }
 
+/* --- Ticket detail slide-out -----------------------------------------------
+   Same fixed-right pattern as .ideation-panel. The two panels are mutually
+   exclusive (opening one closes the other), so they can share z-index 10
+   without stacking concerns; the card context menu (z-index 40) stays on top. */
+.detail-panel {
+  position: fixed;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 380px;
+  background: var(--col-bg);
+  border-left: 1px solid var(--col-border);
+  display: flex;
+  flex-direction: column;
+  z-index: 10;
+}
+
+.detail-panel.hidden {
+  display: none;
+}
+
+.detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  font-weight: 600;
+  border-bottom: 1px solid var(--col-border);
+}
+
+.detail-close {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
+.detail-close:hover {
+  color: var(--text);
+}
+
+.detail-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.detail-title {
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+.detail-owner {
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 12px;
+}
+
+.detail-owner .detail-owner-name {
+  color: var(--text);
+}
+
+/* Escaped plain text; pre-wrap preserves the ticket's line structure without
+   a markdown renderer (same approach as the ideation transcript .msg). */
+.detail-description {
+  font-size: 13px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.detail-description.empty {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.detail-tracker-link {
+  display: inline-block;
+  margin-top: 12px;
+  font-size: 12px;
+}
+
 /* --- Running agents view --------------------------------------------------
    A full-width main-area view swapped in by the "agents" rail icon. The board
    and this view are mutually exclusive; selectView() toggles `.hidden` on both,

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -41,6 +41,10 @@ interface Card {
   prURL?: string;
   labels?: string[];
   description?: string;
+  assignee?: string;
+  // Tracker instance name the issue was listed from; passed back to
+  // GetIssueDetail so the daemon resolves the exact instance.
+  tracker?: string;
   error?: string;
   verdict?: string;
   // Idea-space sub-column (0 loosest … 4 most concrete) for Ideas-stage cards.
@@ -166,8 +170,15 @@ interface StartProjectResult {
   filesCreated: number;
 }
 
+interface IssueDetailData {
+  title: string;
+  assignee?: string;
+  description?: string;
+}
+
 interface AppBindings {
   Cards(): Promise<BoardData>;
+  GetIssueDetail(trackerName: string, key: string): Promise<IssueDetailData>;
   CardsQuick(): Promise<BoardData>;
   Transition(pmKey: string, pmTitle: string, from: string, to: string): Promise<void>;
   FixBug(pmKey: string, pmTitle: string): Promise<void>;
@@ -941,11 +952,16 @@ function beginPointerDrag(el: HTMLElement, card: Card): void {
     const onUp = (ev: PointerEvent): void => {
       const target = started ? dropTargetAt(ev.clientX, ev.clientY) : null;
       const allowed = !!target && dropAllowed(target);
+      const wasClick = !started;
       teardown();
       endDrag();
       // `target` may have been replaced by the flushed render, but performDrop
       // only reads its dataset, which a detached node still carries.
       if (target && allowed) performDrop(target, info, { x: ev.clientX, y: ev.clientY });
+      // A press that never crossed the drag threshold is a plain click: open
+      // the ticket detail panel. Links/buttons never get here (pointerdown
+      // filters them), and right-clicks go to the contextmenu handler instead.
+      else if (wasClick) openTicketDetail(card);
     };
 
     const onCancel = (): void => {
@@ -1226,6 +1242,9 @@ function render(): void {
   } else {
     banner.classList.add("hidden");
   }
+  // The detail panel lives outside #board, so the rebuild above never touches
+  // it — it only needs its card data refreshed from the new board state.
+  refreshTicketDetail();
 }
 
 function showError(msg: string): void {
@@ -1488,7 +1507,99 @@ function renderIdeationError(msg: string): void {
   renderIdeation();
 }
 
+// --- Ticket detail panel ---------------------------------------------------
+//
+// A plain click on any card (board or Bugs pane) opens a read-only slide-out
+// with the ticket's key, title, owner and description. It renders a snapshot
+// of the clicked card, re-resolved by key after each render() so the full
+// fetch backfills a description the quick titles-only pass left empty.
+
+let detailCard: Card | null = null;
+
+function openTicketDetail(card: Card): void {
+  // The detail panel and the ideation panel share the fixed right edge; only
+  // one may be visible. Closing ideation keeps its session running (AD-4).
+  closeIdeation();
+  detailCard = card;
+  renderTicketDetail();
+  document.getElementById("detail-panel")?.classList.remove("hidden");
+  void fetchTicketDetail(card);
+}
+
+// fetchTicketDetail backfills the panel from a per-ticket fetch: the board's
+// list fetch is slim on some trackers (Shortcut returns stories without
+// descriptions), so the card's own description can be empty even for a ticket
+// that has one. The snapshot renders first; this fills in what the list missed.
+async function fetchTicketDetail(card: Card): Promise<void> {
+  try {
+    const detail = await go().GetIssueDetail(card.tracker ?? "", card.key);
+    // A slow fetch for a previously clicked card must never overwrite the
+    // currently open one.
+    if (!detailCard || detailCard.key !== card.key) return;
+    detailCard = {
+      ...detailCard,
+      title: detail.title || detailCard.title,
+      assignee: detail.assignee || detailCard.assignee,
+      description: detail.description || detailCard.description,
+    };
+    renderTicketDetail();
+  } catch {
+    // The snapshot already renders; a failed backfill just means the panel
+    // shows what the list fetch carried.
+  }
+}
+
+function closeTicketDetail(): void {
+  detailCard = null;
+  document.getElementById("detail-panel")?.classList.add("hidden");
+}
+
+// refreshTicketDetail re-renders the open panel from the freshest card with
+// the same key. A card that left the board (e.g. closed elsewhere) keeps its
+// last snapshot — stale-but-readable beats a panel that vanishes mid-read.
+function refreshTicketDetail(): void {
+  if (!detailCard) return;
+  const key = detailCard.key;
+  const fresh = current.cards.find((c) => c.key === key);
+  if (fresh) {
+    // Merge, don't replace: the fresh card comes from a slim list fetch whose
+    // empty description/assignee must not wipe what fetchTicketDetail filled in.
+    detailCard = {
+      ...fresh,
+      assignee: fresh.assignee || detailCard.assignee,
+      description: fresh.description || detailCard.description,
+    };
+  }
+  renderTicketDetail();
+}
+
+function renderTicketDetail(): void {
+  if (!detailCard) return;
+  const keyEl = document.getElementById("detail-key");
+  if (keyEl) keyEl.textContent = detailCard.key;
+  const body = document.getElementById("detail-body");
+  if (!body) return;
+  const owner = detailCard.assignee
+    ? `<span class="detail-owner-name">${escapeHtml(detailCard.assignee)}</span>`
+    : "Unassigned";
+  const desc = detailCard.description
+    ? `<div class="detail-description">${escapeHtml(detailCard.description)}</div>`
+    : `<div class="detail-description empty">No description</div>`;
+  const link = detailCard.url
+    ? `<a class="detail-tracker-link" href="${escapeAttr(detailCard.url)}" target="_blank">Open in tracker</a>`
+    : "";
+  body.innerHTML = `
+    <div class="detail-title">${escapeHtml(detailCard.title)}</div>
+    <div class="detail-owner">Owner: ${owner}</div>
+    ${desc}
+    ${link}
+  `;
+}
+
 async function openIdeation(): Promise<void> {
+  // Mirror of the exclusivity in openTicketDetail: both panels occupy the
+  // fixed right edge, so opening one always closes the other.
+  closeTicketDetail();
   const panel = document.getElementById("ideation-panel");
   if (panel) panel.classList.remove("hidden");
   ideationOpen = true;
@@ -2244,6 +2355,7 @@ function init(): void {
     }
   });
   document.getElementById("ideation-close")?.addEventListener("click", () => closeIdeation());
+  document.getElementById("detail-close")?.addEventListener("click", () => closeTicketDetail());
   document.getElementById("ideation-form")?.addEventListener("submit", (e: Event) => {
     e.preventDefault();
     void submitIdeation();

--- a/desktop/frontend/static/index.html
+++ b/desktop/frontend/static/index.html
@@ -116,6 +116,13 @@
         <button id="ideation-send" type="submit">Send</button>
       </form>
     </aside>
+    <aside id="detail-panel" class="detail-panel hidden" aria-label="Ticket details">
+      <div class="detail-header">
+        <span id="detail-key" class="detail-key"></span>
+        <button id="detail-close" class="detail-close" title="Close">×</button>
+      </div>
+      <div id="detail-body" class="detail-body"></div>
+    </aside>
     <script type="module" src="/board.js"></script>
   </body>
 </html>

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -1004,6 +1004,91 @@ body {
   cursor: pointer;
 }
 
+/* --- Ticket detail slide-out -----------------------------------------------
+   Same fixed-right pattern as .ideation-panel. The two panels are mutually
+   exclusive (opening one closes the other), so they can share z-index 10
+   without stacking concerns; the card context menu (z-index 40) stays on top. */
+.detail-panel {
+  position: fixed;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 380px;
+  background: var(--col-bg);
+  border-left: 1px solid var(--col-border);
+  display: flex;
+  flex-direction: column;
+  z-index: 10;
+}
+
+.detail-panel.hidden {
+  display: none;
+}
+
+.detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  font-weight: 600;
+  border-bottom: 1px solid var(--col-border);
+}
+
+.detail-close {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
+.detail-close:hover {
+  color: var(--text);
+}
+
+.detail-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.detail-title {
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+.detail-owner {
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 12px;
+}
+
+.detail-owner .detail-owner-name {
+  color: var(--text);
+}
+
+/* Escaped plain text; pre-wrap preserves the ticket's line structure without
+   a markdown renderer (same approach as the ideation transcript .msg). */
+.detail-description {
+  font-size: 13px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.detail-description.empty {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.detail-tracker-link {
+  display: inline-block;
+  margin-top: 12px;
+  font-size: 12px;
+}
+
 /* --- Running agents view --------------------------------------------------
    A full-width main-area view swapped in by the "agents" rail icon. The board
    and this view are mutually exclusive; selectView() toggles `.hidden` on both,

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -314,6 +314,26 @@ func GetTrackerIssuesLite(addr, token string) ([]TrackerIssuesResult, error) {
 	return getTrackerIssues(addr, token, "tracker-issues-lite")
 }
 
+// GetTrackerIssue fetches one full issue by key via the daemon. The board's
+// detail panel uses it because list fetches on some trackers return slim
+// payloads without descriptions. trackerName pins the instance the issue was
+// listed from, avoiding key-format guessing.
+func GetTrackerIssue(addr, token, trackerName, key string) (*tracker.Issue, error) {
+	data, err := json.Marshal(IssueDetailRequest{Tracker: trackerName, Key: key})
+	if err != nil {
+		return nil, errors.WrapWithDetails(err, "marshaling issue detail request")
+	}
+	out, err := RunRemoteCapture(addr, token, []string{"tracker-issue", string(data)})
+	if err != nil {
+		return nil, err
+	}
+	var issue tracker.Issue
+	if err := json.Unmarshal(out, &issue); err != nil {
+		return nil, errors.WrapWithDetails(err, "invalid tracker issue JSON")
+	}
+	return &issue, nil
+}
+
 func getTrackerIssues(addr, token, command string) ([]TrackerIssuesResult, error) {
 	out, err := RunRemoteCapture(addr, token, []string{command})
 	if err != nil {

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -437,3 +437,33 @@ func TestRunRemote_DaemonClosesImmediately(t *testing.T) {
 		"unexpected error: %s", errMsg,
 	)
 }
+
+func TestGetTrackerIssue_Success(t *testing.T) {
+	addr := startMockDaemon(t, func(req Request) Response {
+		require.Len(t, req.Args, 2)
+		assert.Equal(t, "tracker-issue", req.Args[0])
+		// The request must carry the instance name so the daemon resolves the
+		// exact tracker instead of guessing from an ambiguous numeric key.
+		var detailReq IssueDetailRequest
+		require.NoError(t, json.Unmarshal([]byte(req.Args[1]), &detailReq))
+		assert.Equal(t, "human", detailReq.Tracker)
+		assert.Equal(t, "188", detailReq.Key)
+		return Response{Stdout: `{"key":"188","title":"Building column","assignee":"Stephan","description":"Full body"}` + "\n"}
+	})
+
+	issue, err := GetTrackerIssue(addr, "tok", "human", "188")
+	require.NoError(t, err)
+	assert.Equal(t, "188", issue.Key)
+	assert.Equal(t, "Stephan", issue.Assignee)
+	assert.Equal(t, "Full body", issue.Description)
+}
+
+func TestGetTrackerIssue_InvalidJSON(t *testing.T) {
+	addr := startMockDaemon(t, func(_ Request) Response {
+		return Response{Stdout: "not json\n"}
+	})
+
+	_, err := GetTrackerIssue(addr, "tok", "human", "188")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid tracker issue JSON")
+}

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -26,6 +26,15 @@ type TrackerIssuesResult struct {
 	Err        string               `json:"error,omitempty"`
 }
 
+// IssueDetailRequest asks for one full ticket by key. Tracker is the instance
+// name the issue was listed from (TrackerIssuesResult.TrackerName), so the
+// daemon resolves the exact instance instead of guessing from the key format —
+// bare numeric keys (Shortcut, GitLab, Azure DevOps) are ambiguous across kinds.
+type IssueDetailRequest struct {
+	Tracker string `json:"tracker"`
+	Key     string `json:"key"`
+}
+
 // Request is sent from the client to the daemon (one JSON line per connection).
 type Request struct {
 	Version   string            `json:"version"`

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -45,11 +45,16 @@ type Server struct {
 	CmdFactory       func() *cobra.Command
 	Opener           BrowserOpener // used for OAuth relay; defaults to browser.DefaultOpener
 	Logger           zerolog.Logger
-	ConnectedPIDs    *ConnectedTracker                        // tracks client PIDs that have pinged; nil disables tracking
-	HookEvents       *HookEventStore                          // in-memory hook event buffer; nil disables hook event tracking
-	NetworkEvents    *NetworkEventStore                       // in-memory ambient network activity buffer; nil disables
-	IssueFetcher     func() ([]TrackerIssuesResult, error)    // injected; fetches issues from configured trackers
-	LiteIssueFetcher func() ([]TrackerIssuesResult, error)    // injected; fetches issue titles only (skips the per-ticket comment scan) so the board can render titles before stages resolve
+	ConnectedPIDs    *ConnectedTracker                     // tracks client PIDs that have pinged; nil disables tracking
+	HookEvents       *HookEventStore                       // in-memory hook event buffer; nil disables hook event tracking
+	NetworkEvents    *NetworkEventStore                    // in-memory ambient network activity buffer; nil disables
+	IssueFetcher     func() ([]TrackerIssuesResult, error) // injected; fetches issues from configured trackers
+	LiteIssueFetcher func() ([]TrackerIssuesResult, error) // injected; fetches issue titles only (skips the per-ticket comment scan) so the board can render titles before stages resolve
+	// IssueGetter fetches one full issue for the board's detail panel. List
+	// endpoints on some trackers (e.g. Shortcut) return slim payloads without
+	// descriptions, so reading a ticket needs a per-key fetch. nil disables
+	// the tracker-issue route.
+	IssueGetter      func(req IssueDetailRequest) (*tracker.Issue, error)
 	TrackerDiagnoser func(dir string) []tracker.TrackerStatus // injected; diagnoses tracker status with vault resolution
 	Projects         *ProjectRegistry                         // multi-project routing; nil means single-project mode
 	PendingConfirms  *PendingConfirmStore                     // pending destructive operation confirmations; nil disables
@@ -353,6 +358,7 @@ func (s *Server) routeSimpleCommand(conn net.Conn, args []string, projectDir str
 		"tracker-diagnose":    func() { s.handleTrackerDiagnose(conn, projectDir) },
 		"tracker-issues":      func() { s.handleTrackerIssues(conn) },
 		"tracker-issues-lite": func() { s.handleTrackerIssuesLite(conn) },
+		"tracker-issue":       func() { s.handleTrackerIssue(conn, args[1:]) },
 		"pending-confirms":    func() { s.handlePendingConfirms(conn) },
 		"confirm-op":          func() { s.handleConfirmOp(conn, args[1:], clientPID) },
 		"confirm-status":      func() { s.handleConfirmStatus(conn, args[1:]) },
@@ -465,6 +471,38 @@ func (s *Server) handleTrackerIssues(conn net.Conn) {
 // quickly, then reconciles them into their real columns via handleTrackerIssues.
 func (s *Server) handleTrackerIssuesLite(conn net.Conn) {
 	s.writeIssueResults(conn, s.LiteIssueFetcher)
+}
+
+// handleTrackerIssue returns one full issue by key. Read-only: it exists
+// because list fetches on some trackers return slim payloads without
+// descriptions, so the board's detail panel re-fetches the single ticket.
+func (s *Server) handleTrackerIssue(conn net.Conn, args []string) {
+	if s.IssueGetter == nil {
+		s.writeError(conn, "issue detail not available", 1)
+		return
+	}
+	if len(args) != 1 {
+		s.writeError(conn, "tracker-issue requires one JSON arg", 1)
+		return
+	}
+	var req IssueDetailRequest
+	if err := json.Unmarshal([]byte(args[0]), &req); err != nil {
+		s.writeError(conn, "invalid tracker-issue request: "+err.Error(), 1)
+		return
+	}
+	issue, err := s.IssueGetter(req)
+	if err != nil {
+		s.writeError(conn, err.Error(), 1)
+		return
+	}
+	data, err := json.Marshal(issue)
+	if err != nil {
+		s.writeError(conn, err.Error(), 1)
+		return
+	}
+	resp := Response{Stdout: string(data) + "\n"}
+	enc := json.NewEncoder(conn)
+	_ = enc.Encode(resp)
 }
 
 // writeIssueResults runs an injected issue fetcher and streams the JSON result.

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -1448,6 +1448,81 @@ func TestServer_HandleTrackerIssuesLite_RoutesToLiteFetcher(t *testing.T) {
 	assert.Equal(t, "lite", results[0].TrackerName)
 }
 
+// --- handleTrackerIssue tests ---
+
+func TestServer_HandleTrackerIssue_NilGetter(t *testing.T) {
+	token := "test-token"
+	addr, _ := startTestServerCustom(t, token, func(s *Server) {
+		s.IssueGetter = nil
+	})
+
+	resp := sendRequest(t, addr, Request{Token: token, Args: []string{"tracker-issue", `{"tracker":"work","key":"HUM-1"}`}})
+	assert.Equal(t, 1, resp.ExitCode)
+	assert.Contains(t, resp.Stderr, "issue detail not available")
+}
+
+func TestServer_HandleTrackerIssue_ReturnsIssue(t *testing.T) {
+	token := "test-token"
+	var gotReq IssueDetailRequest
+	addr, _ := startTestServerCustom(t, token, func(s *Server) {
+		s.IssueGetter = func(req IssueDetailRequest) (*tracker.Issue, error) {
+			gotReq = req
+			return &tracker.Issue{
+				Key:         "188",
+				Title:       "Building gets its own live column",
+				Assignee:    "Stephan",
+				Description: "As a product engineer I want the board to show builds.",
+			}, nil
+		}
+	})
+
+	resp := sendRequest(t, addr, Request{Token: token, Args: []string{"tracker-issue", `{"tracker":"human","key":"188"}`}})
+	assert.Equal(t, 0, resp.ExitCode)
+	// The getter must see the exact instance name and key the client sent —
+	// resolution by name is the whole point of the request carrying a tracker.
+	assert.Equal(t, "human", gotReq.Tracker)
+	assert.Equal(t, "188", gotReq.Key)
+
+	var issue tracker.Issue
+	err := json.Unmarshal([]byte(strings.TrimSpace(resp.Stdout)), &issue)
+	require.NoError(t, err)
+	assert.Equal(t, "188", issue.Key)
+	assert.Equal(t, "Stephan", issue.Assignee)
+	assert.Equal(t, "As a product engineer I want the board to show builds.", issue.Description)
+}
+
+func TestServer_HandleTrackerIssue_GetterError(t *testing.T) {
+	token := "test-token"
+	addr, _ := startTestServerCustom(t, token, func(s *Server) {
+		s.IssueGetter = func(_ IssueDetailRequest) (*tracker.Issue, error) {
+			return nil, fmt.Errorf("story not found")
+		}
+	})
+
+	resp := sendRequest(t, addr, Request{Token: token, Args: []string{"tracker-issue", `{"tracker":"human","key":"999"}`}})
+	assert.Equal(t, 1, resp.ExitCode)
+	assert.Contains(t, resp.Stderr, "story not found")
+}
+
+func TestServer_HandleTrackerIssue_BadArgs(t *testing.T) {
+	token := "test-token"
+	addr, _ := startTestServerCustom(t, token, func(s *Server) {
+		s.IssueGetter = func(_ IssueDetailRequest) (*tracker.Issue, error) {
+			return &tracker.Issue{}, nil
+		}
+	})
+
+	// Missing JSON arg.
+	resp := sendRequest(t, addr, Request{Token: token, Args: []string{"tracker-issue"}})
+	assert.Equal(t, 1, resp.ExitCode)
+	assert.Contains(t, resp.Stderr, "requires one JSON arg")
+
+	// Malformed JSON arg.
+	resp = sendRequest(t, addr, Request{Token: token, Args: []string{"tracker-issue", "{not json"}})
+	assert.Equal(t, 1, resp.ExitCode)
+	assert.Contains(t, resp.Stderr, "invalid tracker-issue request")
+}
+
 // --- handleToolStats tests ---
 
 func TestServer_HandleToolStats_NilStore(t *testing.T) {


### PR DESCRIPTION
Clicking a card (board or Bugs pane) opens a read-only right-edge slide-out with the ticket's key, title, owner and description, following the ideation panel pattern.

- Plain click opens the panel; drag and right-click behave as before (click is the below-drag-threshold pointerup)
- Detail panel and ideation panel are mutually exclusive on the right edge
- New `tracker-issue` daemon route fetches one full ticket by key + instance name: list endpoints on some trackers (Shortcut) return slim payloads without descriptions, so the panel backfills owner/description per ticket on open
- Board refreshes merge into the open panel instead of wiping backfilled text; a vanished card keeps its last snapshot

Ticket: SC-203

🤖 Generated with [Claude Code](https://claude.com/claude-code)