### PR TITLE
[SC-203] Detail panel fixes: instance resolution, daemon-side caching + markdown, working links

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -232,7 +232,7 @@ func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, de
 		NetworkEvents:     networkStore,
 		IssueFetcher:      fetchTrackerIssuesFunc(projectRegistry, vaultResolver),
 		LiteIssueFetcher:  fetchTrackerIssuesLiteFunc(projectRegistry, vaultResolver),
-		IssueGetter:       issueGetterFunc(projectRegistry, vaultResolver),
+		IssueGetter:       daemon.NewCachedIssueGetter(issueGetterFunc(projectRegistry, vaultResolver)),
 		TrackerDiagnoser:  trackerDiagnoserFunc(projectRegistry, vaultResolver),
 		Projects:          projectRegistry,
 		PendingConfirms:   confirmStore,
@@ -1051,7 +1051,14 @@ func issueGetterFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver) func
 		if err != nil {
 			return nil, err
 		}
-		inst, err := tracker.Resolve(req.Tracker, instances, req.Key)
+		// Resolve by kind+name when the kind is known: a name alone is
+		// ambiguous when different provider sections share one instance name.
+		var inst *tracker.Instance
+		if req.Kind != "" {
+			inst, err = tracker.ResolveByKind(req.Kind, instances, req.Tracker)
+		} else {
+			inst, err = tracker.Resolve(req.Tracker, instances, req.Key)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -18,7 +18,10 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	"github.com/gethuman-sh/human/errors"
 	"github.com/gethuman-sh/human/internal/daemon"
 	"github.com/gethuman-sh/human/internal/ideaspace"
 	"github.com/gethuman-sh/human/internal/tracker"
@@ -74,10 +77,12 @@ type Card struct {
 	// Assignee is the ticket owner shown in the detail panel. Display-only:
 	// the board never assigns; empty renders as "Unassigned" in the frontend.
 	Assignee string `json:"assignee,omitempty"`
-	// Tracker is the instance name the issue was listed from. The detail
-	// panel passes it back to IssueDetail so the daemon resolves the exact
-	// instance — bare numeric keys are ambiguous across tracker kinds.
-	Tracker string `json:"tracker,omitempty"`
+	// Tracker/TrackerKind are the instance name and provider kind the issue
+	// was listed from. The detail panel passes them back to GetIssueDetail so
+	// the daemon resolves the exact instance — bare numeric keys are ambiguous
+	// across kinds, and names can repeat across provider sections.
+	Tracker     string `json:"tracker,omitempty"`
+	TrackerKind string `json:"trackerKind,omitempty"`
 	// IdeaColumn is the idea-space sub-column (0 loosest … 4 most concrete)
 	// for cards in the Ideas stage. Locally persisted preference, never
 	// tracker state; the zero value is the leftmost column, so an idea with
@@ -127,29 +132,40 @@ func (a *App) Cards() (BoardData, error) {
 
 // IssueDetail is the full-ticket payload for the board's detail panel — only
 // the fields the panel renders beyond what the card already carries.
+// DescriptionHTML is rendered and sanitized by the daemon; the frontend may
+// inject it verbatim.
 type IssueDetail struct {
-	Title       string `json:"title"`
-	Assignee    string `json:"assignee,omitempty"`
-	Description string `json:"description,omitempty"`
+	Title           string `json:"title"`
+	Assignee        string `json:"assignee,omitempty"`
+	Description     string `json:"description,omitempty"`
+	DescriptionHTML string `json:"descriptionHTML,omitempty"`
 }
 
 // GetIssueDetail fetches one full ticket from the daemon. The detail panel
 // calls it on open because list fetches on some trackers (e.g. Shortcut)
 // return slim payloads without descriptions, so the card's own description
 // can be empty even for a ticket that has one.
-func (a *App) GetIssueDetail(trackerName, key string) (IssueDetail, error) {
+func (a *App) GetIssueDetail(trackerKind, trackerName, key string) (IssueDetail, error) {
 	info, err := daemon.ReadInfo()
 	if err != nil {
 		return IssueDetail{}, err
 	}
-	issue, err := daemon.GetTrackerIssue(info.Addr, info.Token, trackerName, key)
+	issue, err := daemon.GetTrackerIssue(info.Addr, info.Token, trackerKind, trackerName, key)
 	if err != nil {
-		return IssueDetail{}, err
+		// Wails serializes only err.Error() to the frontend, which for daemon
+		// failures is a generic wrapper; fold the daemon's stderr detail in so
+		// the panel shows the actual cause instead of "daemon command failed".
+		msg := errors.CauseChain(err)
+		if stderr, ok := errors.AllDetails(err)["stderr"].(string); ok && strings.TrimSpace(stderr) != "" {
+			msg += ": " + strings.TrimSpace(stderr)
+		}
+		return IssueDetail{}, fmt.Errorf("%s", msg)
 	}
 	return IssueDetail{
-		Title:       issue.Title,
-		Assignee:    issue.Assignee,
-		Description: issue.Description,
+		Title:           issue.Title,
+		Assignee:        issue.Assignee,
+		Description:     issue.Description,
+		DescriptionHTML: issue.DescriptionHTML,
 	}, nil
 }
 
@@ -257,6 +273,7 @@ func boardFromResults(results []daemon.TrackerIssuesResult, dockerAvailable bool
 			Description:    issue.Description,
 			Assignee:       issue.Assignee,
 			Tracker:        pm.TrackerName,
+			TrackerKind:    pm.TrackerKind,
 			Bug:            issue.IsBug(),
 			IdeaColumn:     ideaCol,
 			MockupSlug:     mock.Slug,

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -13,6 +13,20 @@ import { initPermissions } from "./permissions.js";
 import { initMockupsView, showMockups, setPendingMockupSlug } from "./mockupsview.js";
 import { initSettingsView, showSettings, settingsIndex, saveSetting, setPaletteOpener, setActiveSection, } from "./settingsview.js";
 import { initPalette, openPalette, isPaletteChord } from "./palette.js";
+// openExternal routes a URL to the system browser via the Wails runtime.
+// Anchor clicks with target=_blank are NOT reliably forwarded by the Linux
+// webview (WebKitGTK swallows the new-window request), so every external
+// link must go through BrowserOpenURL; the anchor is only a styling shell.
+function openExternal(url) {
+    if (!url)
+        return;
+    if (window.runtime?.BrowserOpenURL) {
+        window.runtime.BrowserOpenURL(url);
+        return;
+    }
+    // Dev fallback (vite in a real browser): no Wails runtime, plain open works.
+    window.open(url, "_blank");
+}
 // Queue columns: each names a state that is TRUE of every card in it, always.
 // The agent work happens on the transitions (a drag is the launch), so a card
 // being worked stays in its ORIGIN queue with a live badge and only arrives in
@@ -179,6 +193,14 @@ function renderCard(card) {
     <div class="card-meta">${meta.join("")}</div>
     ${card.error ? `<div class="card-error">${escapeHtml(card.error)}</div>` : ""}
   `;
+    // External links must go through the Wails runtime (see openExternal);
+    // the pointerdown filter in beginPointerDrag already exempts anchors.
+    el.querySelectorAll(".card-meta a").forEach((a) => {
+        a.addEventListener("click", (e) => {
+            e.preventDefault();
+            openExternal(a.href);
+        });
+    });
     el.addEventListener("contextmenu", (e) => {
         e.preventDefault();
         showCardMenu(card, e.clientX, e.clientY);
@@ -201,12 +223,7 @@ function showCardMenu(card, x, y) {
     openItem.disabled = !card.url;
     openItem.addEventListener("click", () => {
         menu.remove();
-        // Same anchor pattern as the PR link: the webview routes target=_blank
-        // external URLs to the system browser.
-        const a = document.createElement("a");
-        a.href = card.url;
-        a.target = "_blank";
-        a.click();
+        openExternal(card.url);
     });
     menu.appendChild(openItem);
     // Mockups belong to the product conversation: the item appears only in the
@@ -731,11 +748,11 @@ function beginPointerDrag(el, card) {
             // only reads its dataset, which a detached node still carries.
             if (target && allowed)
                 performDrop(target, info, { x: ev.clientX, y: ev.clientY });
-            // A press that never crossed the drag threshold is a plain click: open
+            // A press that never crossed the drag threshold is a plain click: toggle
             // the ticket detail panel. Links/buttons never get here (pointerdown
             // filters them), and right-clicks go to the contextmenu handler instead.
             else if (wasClick)
-                openTicketDetail(card);
+                toggleTicketDetail(card);
         };
         const onCancel = () => {
             teardown();
@@ -1263,11 +1280,30 @@ function renderIdeationError(msg) {
 // of the clicked card, re-resolved by key after each render() so the full
 // fetch backfills a description the quick titles-only pass left empty.
 let detailCard = null;
+// detailError surfaces a failed per-ticket backfill in the panel. A silent
+// failure is indistinguishable from "the ticket has no description", which
+// is exactly the confusion it must prevent.
+let detailError = null;
+// detailHTML is the daemon-rendered markdown of the open ticket's description.
+// Caching lives in the daemon (stale-while-revalidate on the tracker-issue
+// route), so the panel just shows whatever the last fetch returned.
+let detailHTML = null;
+// toggleTicketDetail is the card-click entry point: a second click on the
+// ticket that is already open closes the panel instead of re-opening it.
+function toggleTicketDetail(card) {
+    if (detailCard && detailCard.key === card.key) {
+        closeTicketDetail();
+        return;
+    }
+    openTicketDetail(card);
+}
 function openTicketDetail(card) {
     // The detail panel and the ideation panel share the fixed right edge; only
     // one may be visible. Closing ideation keeps its session running (AD-4).
     closeIdeation();
     detailCard = card;
+    detailError = null;
+    detailHTML = null;
     renderTicketDetail();
     document.getElementById("detail-panel")?.classList.remove("hidden");
     void fetchTicketDetail(card);
@@ -1278,11 +1314,13 @@ function openTicketDetail(card) {
 // that has one. The snapshot renders first; this fills in what the list missed.
 async function fetchTicketDetail(card) {
     try {
-        const detail = await go().GetIssueDetail(card.tracker ?? "", card.key);
+        const detail = await go().GetIssueDetail(card.trackerKind ?? "", card.tracker ?? "", card.key);
         // A slow fetch for a previously clicked card must never overwrite the
         // currently open one.
         if (!detailCard || detailCard.key !== card.key)
             return;
+        detailError = null;
+        detailHTML = detail.descriptionHTML || null;
         detailCard = {
             ...detailCard,
             title: detail.title || detailCard.title,
@@ -1291,13 +1329,16 @@ async function fetchTicketDetail(card) {
         };
         renderTicketDetail();
     }
-    catch {
-        // The snapshot already renders; a failed backfill just means the panel
-        // shows what the list fetch carried.
+    catch (err) {
+        if (!detailCard || detailCard.key !== card.key)
+            return;
+        detailError = errMessage(err);
+        renderTicketDetail();
     }
 }
 function closeTicketDetail() {
     detailCard = null;
+    detailHTML = null;
     document.getElementById("detail-panel")?.classList.add("hidden");
 }
 // refreshTicketDetail re-renders the open panel from the freshest card with
@@ -1331,18 +1372,40 @@ function renderTicketDetail() {
     const owner = detailCard.assignee
         ? `<span class="detail-owner-name">${escapeHtml(detailCard.assignee)}</span>`
         : "Unassigned";
-    const desc = detailCard.description
-        ? `<div class="detail-description">${escapeHtml(detailCard.description)}</div>`
-        : `<div class="detail-description empty">No description</div>`;
+    // Prefer the daemon-rendered (and sanitized) HTML; fall back to escaped
+    // plain text while it hasn't arrived, so the panel is never empty-handed.
+    let desc;
+    if (detailHTML) {
+        desc = `<div class="detail-description rendered">${detailHTML}</div>`;
+    }
+    else if (detailCard.description) {
+        desc = `<div class="detail-description">${escapeHtml(detailCard.description)}</div>`;
+    }
+    else {
+        desc = `<div class="detail-description empty">No description</div>`;
+    }
     const link = detailCard.url
-        ? `<a class="detail-tracker-link" href="${escapeAttr(detailCard.url)}" target="_blank">Open in tracker</a>`
+        ? `<a class="detail-tracker-link" href="${escapeAttr(detailCard.url)}">Open in tracker</a>`
+        : "";
+    const error = detailError
+        ? `<div class="detail-error">Couldn't load the full ticket: ${escapeHtml(detailError)}</div>`
         : "";
     body.innerHTML = `
     <div class="detail-title">${escapeHtml(detailCard.title)}</div>
     <div class="detail-owner">Owner: ${owner}</div>
+    ${error}
     ${desc}
     ${link}
   `;
+    // Every anchor in the panel — the tracker link and any link inside the
+    // rendered description — must leave via the system browser, never navigate
+    // the webview away from the board.
+    body.querySelectorAll("a").forEach((a) => {
+        a.addEventListener("click", (e) => {
+            e.preventDefault();
+            openExternal(a.classList.contains("detail-tracker-link") ? (detailCard?.url ?? "") : a.href);
+        });
+    });
 }
 async function openIdeation() {
     // Mirror of the exclusivity in openTicketDetail: both panels occupy the

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -1385,7 +1385,7 @@ function renderTicketDetail() {
         desc = `<div class="detail-description empty">No description</div>`;
     }
     const link = detailCard.url
-        ? `<a class="detail-tracker-link" href="${escapeAttr(detailCard.url)}">Open in tracker</a>`
+        ? `<button type="button" class="detail-tracker-btn">Open in tracker</button>`
         : "";
     const error = detailError
         ? `<div class="detail-error">Couldn't load the full ticket: ${escapeHtml(detailError)}</div>`
@@ -1397,13 +1397,14 @@ function renderTicketDetail() {
     ${desc}
     ${link}
   `;
-    // Every anchor in the panel — the tracker link and any link inside the
-    // rendered description — must leave via the system browser, never navigate
-    // the webview away from the board.
+    const url = detailCard.url;
+    body.querySelector(".detail-tracker-btn")?.addEventListener("click", () => openExternal(url));
+    // Links inside the rendered description must leave via the system browser,
+    // never navigate the webview away from the board.
     body.querySelectorAll("a").forEach((a) => {
         a.addEventListener("click", (e) => {
             e.preventDefault();
-            openExternal(a.classList.contains("detail-tracker-link") ? (detailCard?.url ?? "") : a.href);
+            openExternal(a.href);
         });
     });
 }

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -1072,6 +1072,12 @@ body {
 
 /* Escaped plain text; pre-wrap preserves the ticket's line structure without
    a markdown renderer (same approach as the ideation transcript .msg). */
+.detail-error {
+  font-size: 12px;
+  color: var(--failed);
+  margin-bottom: 12px;
+}
+
 .detail-description {
   font-size: 13px;
   line-height: 1.45;
@@ -1081,6 +1087,85 @@ body {
 .detail-description.empty {
   color: var(--muted);
   font-style: italic;
+}
+
+/* Daemon-rendered markdown: real block elements, so pre-wrap (needed only by
+   the plain-text fallback) would double every newline between them. */
+.detail-description.rendered {
+  white-space: normal;
+}
+
+.detail-description.rendered h1,
+.detail-description.rendered h2,
+.detail-description.rendered h3,
+.detail-description.rendered h4 {
+  font-size: 13px;
+  font-weight: 700;
+  margin: 14px 0 6px;
+}
+
+.detail-description.rendered h1 { font-size: 15px; }
+.detail-description.rendered h2 { font-size: 14px; }
+
+.detail-description.rendered p {
+  margin: 0 0 10px;
+}
+
+.detail-description.rendered ul,
+.detail-description.rendered ol {
+  margin: 0 0 10px;
+  padding-left: 20px;
+}
+
+.detail-description.rendered li {
+  margin: 2px 0;
+}
+
+.detail-description.rendered code {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 4px;
+  padding: 1px 4px;
+  font-size: 12px;
+}
+
+.detail-description.rendered pre {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin: 0 0 10px;
+  overflow-x: auto;
+}
+
+.detail-description.rendered pre code {
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.detail-description.rendered blockquote {
+  border-left: 3px solid var(--col-border);
+  margin: 0 0 10px;
+  padding: 2px 0 2px 10px;
+  color: var(--muted);
+}
+
+.detail-description.rendered table {
+  border-collapse: collapse;
+  margin: 0 0 10px;
+  font-size: 12px;
+}
+
+.detail-description.rendered th,
+.detail-description.rendered td {
+  border: 1px solid var(--col-border);
+  padding: 4px 8px;
+  text-align: left;
+}
+
+.detail-description.rendered img {
+  max-width: 100%;
 }
 
 .detail-tracker-link {

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -1168,10 +1168,21 @@ body {
   max-width: 100%;
 }
 
-.detail-tracker-link {
+.detail-tracker-btn {
   display: inline-block;
   margin-top: 12px;
+  background: var(--accent);
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  padding: 8px 14px;
   font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.detail-tracker-btn:hover {
+  filter: brightness(1.1);
 }
 
 /* --- Running agents view --------------------------------------------------

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -42,9 +42,11 @@ interface Card {
   labels?: string[];
   description?: string;
   assignee?: string;
-  // Tracker instance name the issue was listed from; passed back to
-  // GetIssueDetail so the daemon resolves the exact instance.
+  // Tracker instance name + provider kind the issue was listed from; passed
+  // back to GetIssueDetail so the daemon resolves the exact instance (names
+  // can repeat across provider sections, keys across kinds).
   tracker?: string;
+  trackerKind?: string;
   error?: string;
   verdict?: string;
   // Idea-space sub-column (0 loosest … 4 most concrete) for Ideas-stage cards.
@@ -174,11 +176,13 @@ interface IssueDetailData {
   title: string;
   assignee?: string;
   description?: string;
+  // Rendered and sanitized by the daemon — safe to inject verbatim.
+  descriptionHTML?: string;
 }
 
 interface AppBindings {
   Cards(): Promise<BoardData>;
-  GetIssueDetail(trackerName: string, key: string): Promise<IssueDetailData>;
+  GetIssueDetail(trackerKind: string, trackerName: string, key: string): Promise<IssueDetailData>;
   CardsQuick(): Promise<BoardData>;
   Transition(pmKey: string, pmTitle: string, from: string, to: string): Promise<void>;
   FixBug(pmKey: string, pmTitle: string): Promise<void>;
@@ -209,11 +213,28 @@ interface AppBindings {
 declare global {
   interface Window {
     go?: { main?: { App?: AppBindings } };
-    runtime?: { EventsOn(name: string, cb: () => void): void };
+    runtime?: {
+      EventsOn(name: string, cb: () => void): void;
+      BrowserOpenURL?(url: string): void;
+    };
   }
 }
 
 export {};
+
+// openExternal routes a URL to the system browser via the Wails runtime.
+// Anchor clicks with target=_blank are NOT reliably forwarded by the Linux
+// webview (WebKitGTK swallows the new-window request), so every external
+// link must go through BrowserOpenURL; the anchor is only a styling shell.
+function openExternal(url: string): void {
+  if (!url) return;
+  if (window.runtime?.BrowserOpenURL) {
+    window.runtime.BrowserOpenURL(url);
+    return;
+  }
+  // Dev fallback (vite in a real browser): no Wails runtime, plain open works.
+  window.open(url, "_blank");
+}
 
 // Queue columns: each names a state that is TRUE of every card in it, always.
 // The agent work happens on the transitions (a drag is the launch), so a card
@@ -394,6 +415,14 @@ function renderCard(card: Card): HTMLElement {
     <div class="card-meta">${meta.join("")}</div>
     ${card.error ? `<div class="card-error">${escapeHtml(card.error)}</div>` : ""}
   `;
+  // External links must go through the Wails runtime (see openExternal);
+  // the pointerdown filter in beginPointerDrag already exempts anchors.
+  el.querySelectorAll<HTMLAnchorElement>(".card-meta a").forEach((a) => {
+    a.addEventListener("click", (e: MouseEvent) => {
+      e.preventDefault();
+      openExternal(a.href);
+    });
+  });
   el.addEventListener("contextmenu", (e: MouseEvent) => {
     e.preventDefault();
     showCardMenu(card, e.clientX, e.clientY);
@@ -420,12 +449,7 @@ function showCardMenu(card: Card, x: number, y: number): void {
   openItem.disabled = !card.url;
   openItem.addEventListener("click", () => {
     menu.remove();
-    // Same anchor pattern as the PR link: the webview routes target=_blank
-    // external URLs to the system browser.
-    const a = document.createElement("a");
-    a.href = card.url;
-    a.target = "_blank";
-    a.click();
+    openExternal(card.url);
   });
   menu.appendChild(openItem);
 
@@ -958,10 +982,10 @@ function beginPointerDrag(el: HTMLElement, card: Card): void {
       // `target` may have been replaced by the flushed render, but performDrop
       // only reads its dataset, which a detached node still carries.
       if (target && allowed) performDrop(target, info, { x: ev.clientX, y: ev.clientY });
-      // A press that never crossed the drag threshold is a plain click: open
+      // A press that never crossed the drag threshold is a plain click: toggle
       // the ticket detail panel. Links/buttons never get here (pointerdown
       // filters them), and right-clicks go to the contextmenu handler instead.
-      else if (wasClick) openTicketDetail(card);
+      else if (wasClick) toggleTicketDetail(card);
     };
 
     const onCancel = (): void => {
@@ -1515,12 +1539,32 @@ function renderIdeationError(msg: string): void {
 // fetch backfills a description the quick titles-only pass left empty.
 
 let detailCard: Card | null = null;
+// detailError surfaces a failed per-ticket backfill in the panel. A silent
+// failure is indistinguishable from "the ticket has no description", which
+// is exactly the confusion it must prevent.
+let detailError: string | null = null;
+// detailHTML is the daemon-rendered markdown of the open ticket's description.
+// Caching lives in the daemon (stale-while-revalidate on the tracker-issue
+// route), so the panel just shows whatever the last fetch returned.
+let detailHTML: string | null = null;
+
+// toggleTicketDetail is the card-click entry point: a second click on the
+// ticket that is already open closes the panel instead of re-opening it.
+function toggleTicketDetail(card: Card): void {
+  if (detailCard && detailCard.key === card.key) {
+    closeTicketDetail();
+    return;
+  }
+  openTicketDetail(card);
+}
 
 function openTicketDetail(card: Card): void {
   // The detail panel and the ideation panel share the fixed right edge; only
   // one may be visible. Closing ideation keeps its session running (AD-4).
   closeIdeation();
   detailCard = card;
+  detailError = null;
+  detailHTML = null;
   renderTicketDetail();
   document.getElementById("detail-panel")?.classList.remove("hidden");
   void fetchTicketDetail(card);
@@ -1532,10 +1576,12 @@ function openTicketDetail(card: Card): void {
 // that has one. The snapshot renders first; this fills in what the list missed.
 async function fetchTicketDetail(card: Card): Promise<void> {
   try {
-    const detail = await go().GetIssueDetail(card.tracker ?? "", card.key);
+    const detail = await go().GetIssueDetail(card.trackerKind ?? "", card.tracker ?? "", card.key);
     // A slow fetch for a previously clicked card must never overwrite the
     // currently open one.
     if (!detailCard || detailCard.key !== card.key) return;
+    detailError = null;
+    detailHTML = detail.descriptionHTML || null;
     detailCard = {
       ...detailCard,
       title: detail.title || detailCard.title,
@@ -1543,14 +1589,16 @@ async function fetchTicketDetail(card: Card): Promise<void> {
       description: detail.description || detailCard.description,
     };
     renderTicketDetail();
-  } catch {
-    // The snapshot already renders; a failed backfill just means the panel
-    // shows what the list fetch carried.
+  } catch (err) {
+    if (!detailCard || detailCard.key !== card.key) return;
+    detailError = errMessage(err);
+    renderTicketDetail();
   }
 }
 
 function closeTicketDetail(): void {
   detailCard = null;
+  detailHTML = null;
   document.getElementById("detail-panel")?.classList.add("hidden");
 }
 
@@ -1582,18 +1630,38 @@ function renderTicketDetail(): void {
   const owner = detailCard.assignee
     ? `<span class="detail-owner-name">${escapeHtml(detailCard.assignee)}</span>`
     : "Unassigned";
-  const desc = detailCard.description
-    ? `<div class="detail-description">${escapeHtml(detailCard.description)}</div>`
-    : `<div class="detail-description empty">No description</div>`;
+  // Prefer the daemon-rendered (and sanitized) HTML; fall back to escaped
+  // plain text while it hasn't arrived, so the panel is never empty-handed.
+  let desc: string;
+  if (detailHTML) {
+    desc = `<div class="detail-description rendered">${detailHTML}</div>`;
+  } else if (detailCard.description) {
+    desc = `<div class="detail-description">${escapeHtml(detailCard.description)}</div>`;
+  } else {
+    desc = `<div class="detail-description empty">No description</div>`;
+  }
   const link = detailCard.url
-    ? `<a class="detail-tracker-link" href="${escapeAttr(detailCard.url)}" target="_blank">Open in tracker</a>`
+    ? `<a class="detail-tracker-link" href="${escapeAttr(detailCard.url)}">Open in tracker</a>`
+    : "";
+  const error = detailError
+    ? `<div class="detail-error">Couldn't load the full ticket: ${escapeHtml(detailError)}</div>`
     : "";
   body.innerHTML = `
     <div class="detail-title">${escapeHtml(detailCard.title)}</div>
     <div class="detail-owner">Owner: ${owner}</div>
+    ${error}
     ${desc}
     ${link}
   `;
+  // Every anchor in the panel — the tracker link and any link inside the
+  // rendered description — must leave via the system browser, never navigate
+  // the webview away from the board.
+  body.querySelectorAll<HTMLAnchorElement>("a").forEach((a) => {
+    a.addEventListener("click", (e: MouseEvent) => {
+      e.preventDefault();
+      openExternal(a.classList.contains("detail-tracker-link") ? (detailCard?.url ?? "") : a.href);
+    });
+  });
 }
 
 async function openIdeation(): Promise<void> {

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -1641,7 +1641,7 @@ function renderTicketDetail(): void {
     desc = `<div class="detail-description empty">No description</div>`;
   }
   const link = detailCard.url
-    ? `<a class="detail-tracker-link" href="${escapeAttr(detailCard.url)}">Open in tracker</a>`
+    ? `<button type="button" class="detail-tracker-btn">Open in tracker</button>`
     : "";
   const error = detailError
     ? `<div class="detail-error">Couldn't load the full ticket: ${escapeHtml(detailError)}</div>`
@@ -1653,13 +1653,14 @@ function renderTicketDetail(): void {
     ${desc}
     ${link}
   `;
-  // Every anchor in the panel — the tracker link and any link inside the
-  // rendered description — must leave via the system browser, never navigate
-  // the webview away from the board.
+  const url = detailCard.url;
+  body.querySelector<HTMLButtonElement>(".detail-tracker-btn")?.addEventListener("click", () => openExternal(url));
+  // Links inside the rendered description must leave via the system browser,
+  // never navigate the webview away from the board.
   body.querySelectorAll<HTMLAnchorElement>("a").forEach((a) => {
     a.addEventListener("click", (e: MouseEvent) => {
       e.preventDefault();
-      openExternal(a.classList.contains("detail-tracker-link") ? (detailCard?.url ?? "") : a.href);
+      openExternal(a.href);
     });
   });
 }

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -1072,6 +1072,12 @@ body {
 
 /* Escaped plain text; pre-wrap preserves the ticket's line structure without
    a markdown renderer (same approach as the ideation transcript .msg). */
+.detail-error {
+  font-size: 12px;
+  color: var(--failed);
+  margin-bottom: 12px;
+}
+
 .detail-description {
   font-size: 13px;
   line-height: 1.45;
@@ -1081,6 +1087,85 @@ body {
 .detail-description.empty {
   color: var(--muted);
   font-style: italic;
+}
+
+/* Daemon-rendered markdown: real block elements, so pre-wrap (needed only by
+   the plain-text fallback) would double every newline between them. */
+.detail-description.rendered {
+  white-space: normal;
+}
+
+.detail-description.rendered h1,
+.detail-description.rendered h2,
+.detail-description.rendered h3,
+.detail-description.rendered h4 {
+  font-size: 13px;
+  font-weight: 700;
+  margin: 14px 0 6px;
+}
+
+.detail-description.rendered h1 { font-size: 15px; }
+.detail-description.rendered h2 { font-size: 14px; }
+
+.detail-description.rendered p {
+  margin: 0 0 10px;
+}
+
+.detail-description.rendered ul,
+.detail-description.rendered ol {
+  margin: 0 0 10px;
+  padding-left: 20px;
+}
+
+.detail-description.rendered li {
+  margin: 2px 0;
+}
+
+.detail-description.rendered code {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 4px;
+  padding: 1px 4px;
+  font-size: 12px;
+}
+
+.detail-description.rendered pre {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin: 0 0 10px;
+  overflow-x: auto;
+}
+
+.detail-description.rendered pre code {
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.detail-description.rendered blockquote {
+  border-left: 3px solid var(--col-border);
+  margin: 0 0 10px;
+  padding: 2px 0 2px 10px;
+  color: var(--muted);
+}
+
+.detail-description.rendered table {
+  border-collapse: collapse;
+  margin: 0 0 10px;
+  font-size: 12px;
+}
+
+.detail-description.rendered th,
+.detail-description.rendered td {
+  border: 1px solid var(--col-border);
+  padding: 4px 8px;
+  text-align: left;
+}
+
+.detail-description.rendered img {
+  max-width: 100%;
 }
 
 .detail-tracker-link {

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -1168,10 +1168,21 @@ body {
   max-width: 100%;
 }
 
-.detail-tracker-link {
+.detail-tracker-btn {
   display: inline-block;
   margin-top: 12px;
+  background: var(--accent);
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  padding: 8px 14px;
   font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.detail-tracker-btn:hover {
+  filter: brightness(1.1);
 }
 
 /* --- Running agents view --------------------------------------------------

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/google/go-containerregistry v0.21.7
 	github.com/hanwen/go-fuse/v2 v2.10.1
+	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/odvcencio/gotreesitter v0.23.1
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/afero v1.15.0
@@ -135,6 +136,7 @@ require (
 	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.11.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bep/debounce v1.2.1 // indirect
@@ -313,6 +315,7 @@ require (
 	github.com/goreleaser/goreleaser/v2 v2.14.1 // indirect
 	github.com/goreleaser/nfpm/v2 v2.45.0 // indirect
 	github.com/goreleaser/quill v0.0.0-20251224035235-ab943733386f // indirect
+	github.com/gorilla/css v1.0.1 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/gostaticanalysis/analysisutil v0.7.1 // indirect
 	github.com/gostaticanalysis/comment v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -285,6 +285,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
+github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
+github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -799,6 +801,8 @@ github.com/goreleaser/nfpm/v2 v2.45.0 h1:rTqqX/vqvln4x7B2HmPL57gh21iIMqyxzP8goI3
 github.com/goreleaser/nfpm/v2 v2.45.0/go.mod h1:O0h9bB68D39NTnM9rSOJhVCYxQk7sU8i04q2bzczFdk=
 github.com/goreleaser/quill v0.0.0-20251224035235-ab943733386f h1:2HQF/pifDK7XnmVhQi3OecdUcHLOaXIKVKscW8qKzCk=
 github.com/goreleaser/quill v0.0.0-20251224035235-ab943733386f/go.mod h1:Xp6aA14QqdPBg7UHToFag7mrjsV7XaKEpw1t6fDfT6M=
+github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
+github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
@@ -1040,6 +1044,8 @@ github.com/mgechev/revive v1.14.0 h1:CC2Ulb3kV7JFYt+izwORoS3VT/+Plb8BvslI/l1yZsc
 github.com/mgechev/revive v1.14.0/go.mod h1:MvnujelCZBZCaoDv5B3foPo6WWgULSSFxvfxp7GsPfo=
 github.com/mholt/archives v0.1.2 h1:UBSe5NfYKHI1sy+S5dJsEsG9jsKKk8NJA4HCC+xTI4A=
 github.com/mholt/archives v0.1.2/go.mod h1:D7QzTHgw3ctfS6wgOO9dN+MFgdZpbksGCxprUOwZWDs=
+github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
+github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
 github.com/minio/minlz v1.0.0 h1:Kj7aJZ1//LlTP1DM8Jm7lNKvvJS2m74gyyXXn3+uJWQ=
 github.com/minio/minlz v1.0.0/go.mod h1:qT0aEB35q79LLornSzeDH75LBf3aH1MV+jB5w9Wasec=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -314,12 +314,14 @@ func GetTrackerIssuesLite(addr, token string) ([]TrackerIssuesResult, error) {
 	return getTrackerIssues(addr, token, "tracker-issues-lite")
 }
 
-// GetTrackerIssue fetches one full issue by key via the daemon. The board's
-// detail panel uses it because list fetches on some trackers return slim
-// payloads without descriptions. trackerName pins the instance the issue was
-// listed from, avoiding key-format guessing.
-func GetTrackerIssue(addr, token, trackerName, key string) (*tracker.Issue, error) {
-	data, err := json.Marshal(IssueDetailRequest{Tracker: trackerName, Key: key})
+// GetTrackerIssue fetches one full issue by key via the daemon, including the
+// daemon-rendered sanitized HTML of its description. The board's detail panel
+// uses it because list fetches on some trackers return slim payloads without
+// descriptions. trackerKind+trackerName pin the instance the issue was listed
+// from: keys are ambiguous across kinds and names can repeat across provider
+// sections.
+func GetTrackerIssue(addr, token, trackerKind, trackerName, key string) (*IssueDetailResult, error) {
+	data, err := json.Marshal(IssueDetailRequest{Tracker: trackerName, Kind: trackerKind, Key: key})
 	if err != nil {
 		return nil, errors.WrapWithDetails(err, "marshaling issue detail request")
 	}
@@ -327,11 +329,11 @@ func GetTrackerIssue(addr, token, trackerName, key string) (*tracker.Issue, erro
 	if err != nil {
 		return nil, err
 	}
-	var issue tracker.Issue
-	if err := json.Unmarshal(out, &issue); err != nil {
+	var result IssueDetailResult
+	if err := json.Unmarshal(out, &result); err != nil {
 		return nil, errors.WrapWithDetails(err, "invalid tracker issue JSON")
 	}
-	return &issue, nil
+	return &result, nil
 }
 
 func getTrackerIssues(addr, token, command string) ([]TrackerIssuesResult, error) {

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -442,20 +442,23 @@ func TestGetTrackerIssue_Success(t *testing.T) {
 	addr := startMockDaemon(t, func(req Request) Response {
 		require.Len(t, req.Args, 2)
 		assert.Equal(t, "tracker-issue", req.Args[0])
-		// The request must carry the instance name so the daemon resolves the
-		// exact tracker instead of guessing from an ambiguous numeric key.
+		// The request must carry the instance name AND kind so the daemon
+		// resolves the exact tracker: numeric keys are ambiguous across kinds,
+		// and the same name can appear in several provider sections.
 		var detailReq IssueDetailRequest
 		require.NoError(t, json.Unmarshal([]byte(req.Args[1]), &detailReq))
 		assert.Equal(t, "human", detailReq.Tracker)
+		assert.Equal(t, "shortcut", detailReq.Kind)
 		assert.Equal(t, "188", detailReq.Key)
-		return Response{Stdout: `{"key":"188","title":"Building column","assignee":"Stephan","description":"Full body"}` + "\n"}
+		return Response{Stdout: `{"key":"188","title":"Building column","assignee":"Stephan","description":"Full body","description_html":"<p>Full body</p>"}` + "\n"}
 	})
 
-	issue, err := GetTrackerIssue(addr, "tok", "human", "188")
+	issue, err := GetTrackerIssue(addr, "tok", "shortcut", "human", "188")
 	require.NoError(t, err)
 	assert.Equal(t, "188", issue.Key)
 	assert.Equal(t, "Stephan", issue.Assignee)
 	assert.Equal(t, "Full body", issue.Description)
+	assert.Equal(t, "<p>Full body</p>", issue.DescriptionHTML)
 }
 
 func TestGetTrackerIssue_InvalidJSON(t *testing.T) {
@@ -463,7 +466,7 @@ func TestGetTrackerIssue_InvalidJSON(t *testing.T) {
 		return Response{Stdout: "not json\n"}
 	})
 
-	_, err := GetTrackerIssue(addr, "tok", "human", "188")
+	_, err := GetTrackerIssue(addr, "tok", "shortcut", "human", "188")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid tracker issue JSON")
 }

--- a/internal/daemon/issue_detail.go
+++ b/internal/daemon/issue_detail.go
@@ -1,0 +1,92 @@
+package daemon
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+
+	"github.com/microcosm-cc/bluemonday"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// descMarkdown and descPolicy render a ticket's markdown description to
+// sanitized HTML. GFM matches what trackers actually emit (tables, task
+// lists, strikethrough); bluemonday's UGC policy is the allowlist for
+// untrusted remote content — descriptions render inside a webview whose
+// window.go bindings can drive the daemon, so sanitization must happen here
+// on the trusted side, never in the webview itself. Both are safe for
+// concurrent use after construction.
+var (
+	descMarkdown = goldmark.New(goldmark.WithExtensions(extension.GFM))
+	descPolicy   = bluemonday.UGCPolicy()
+)
+
+// RenderDescriptionHTML converts a markdown description to sanitized HTML.
+// It returns "" for blank input and on conversion errors — the client then
+// falls back to showing the raw text, which is always safe to escape.
+func RenderDescriptionHTML(md string) string {
+	if strings.TrimSpace(md) == "" {
+		return ""
+	}
+	var buf bytes.Buffer
+	if err := descMarkdown.Convert([]byte(md), &buf); err != nil {
+		return ""
+	}
+	return descPolicy.Sanitize(buf.String())
+}
+
+// NewCachedIssueGetter wraps an issue getter with a stale-while-revalidate
+// cache: a key seen before returns instantly from cache while a background
+// refresh updates the entry for the next request. The board's detail panel
+// re-requests a ticket on every open, so serving the last known copy first
+// removes the per-open tracker round-trip from the reading experience without
+// the panel ever going more than one open stale. Cache size is bounded by the
+// board itself (a fetch caps at 200 issues per project), so no eviction.
+func NewCachedIssueGetter(inner func(IssueDetailRequest) (*tracker.Issue, error)) func(IssueDetailRequest) (*tracker.Issue, error) {
+	var mu sync.Mutex
+	cache := make(map[string]*tracker.Issue)
+	inflight := make(map[string]bool)
+
+	cacheKey := func(req IssueDetailRequest) string {
+		return req.Kind + "\x00" + req.Tracker + "\x00" + req.Key
+	}
+
+	return func(req IssueDetailRequest) (*tracker.Issue, error) {
+		key := cacheKey(req)
+
+		mu.Lock()
+		if cached, ok := cache[key]; ok {
+			// Single-flight: one refresh per key at a time, so a burst of
+			// opens doesn't stampede the tracker API.
+			if !inflight[key] {
+				inflight[key] = true
+				go func() {
+					fresh, err := inner(req)
+					mu.Lock()
+					if err == nil {
+						// A failed refresh keeps the stale copy: readable
+						// beats gone when the tracker blips.
+						cache[key] = fresh
+					}
+					inflight[key] = false
+					mu.Unlock()
+				}()
+			}
+			mu.Unlock()
+			return cached, nil
+		}
+		mu.Unlock()
+
+		fresh, err := inner(req)
+		if err != nil {
+			return nil, err
+		}
+		mu.Lock()
+		cache[key] = fresh
+		mu.Unlock()
+		return fresh, nil
+	}
+}

--- a/internal/daemon/issue_detail_test.go
+++ b/internal/daemon/issue_detail_test.go
@@ -1,0 +1,146 @@
+package daemon
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// --- RenderDescriptionHTML tests ---
+
+func TestRenderDescriptionHTML_BasicMarkdown(t *testing.T) {
+	html := RenderDescriptionHTML("## Symptom\n\nSome **bold** text\n\n- one\n- two")
+	assert.Contains(t, html, "<h2>Symptom</h2>")
+	assert.Contains(t, html, "<strong>bold</strong>")
+	assert.Contains(t, html, "<li>one</li>")
+}
+
+func TestRenderDescriptionHTML_GFMTable(t *testing.T) {
+	html := RenderDescriptionHTML("| a | b |\n|---|---|\n| 1 | 2 |")
+	assert.Contains(t, html, "<table>")
+	assert.Contains(t, html, "<td>1</td>")
+}
+
+// Descriptions are untrusted remote content rendered in a webview whose
+// bindings can drive the daemon — script/handler survival here would be an
+// XSS straight into board control, so sanitization is the load-bearing part.
+func TestRenderDescriptionHTML_SanitizesUntrustedHTML(t *testing.T) {
+	html := RenderDescriptionHTML("hello <script>alert(1)</script> **world**\n\n<img src=x onerror=alert(1)>")
+	assert.NotContains(t, html, "<script")
+	assert.NotContains(t, html, "onerror")
+	assert.Contains(t, html, "<strong>world</strong>")
+}
+
+func TestRenderDescriptionHTML_Empty(t *testing.T) {
+	assert.Equal(t, "", RenderDescriptionHTML(""))
+	assert.Equal(t, "", RenderDescriptionHTML("  \n\t"))
+}
+
+// --- NewCachedIssueGetter tests ---
+
+func TestCachedIssueGetter_MissFetchesOnce(t *testing.T) {
+	var mu sync.Mutex
+	calls := 0
+	getter := NewCachedIssueGetter(func(req IssueDetailRequest) (*tracker.Issue, error) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		return &tracker.Issue{Key: req.Key, Description: "v1"}, nil
+	})
+
+	issue, err := getter(IssueDetailRequest{Kind: "shortcut", Tracker: "human", Key: "1"})
+	require.NoError(t, err)
+	assert.Equal(t, "v1", issue.Description)
+	mu.Lock()
+	assert.Equal(t, 1, calls)
+	mu.Unlock()
+}
+
+func TestCachedIssueGetter_HitServesStaleThenRevalidates(t *testing.T) {
+	var mu sync.Mutex
+	calls := 0
+	getter := NewCachedIssueGetter(func(req IssueDetailRequest) (*tracker.Issue, error) {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+		return &tracker.Issue{Key: req.Key, Description: fmt.Sprintf("v%d", n)}, nil
+	})
+	req := IssueDetailRequest{Kind: "shortcut", Tracker: "human", Key: "1"}
+
+	first, err := getter(req)
+	require.NoError(t, err)
+	assert.Equal(t, "v1", first.Description)
+
+	// Second call must serve the cached copy instantly (stale is fine) while
+	// a background refresh updates the entry for a later call.
+	second, err := getter(req)
+	require.NoError(t, err)
+	assert.Equal(t, "v1", second.Description)
+
+	assert.Eventually(t, func() bool {
+		issue, gErr := getter(req)
+		return gErr == nil && issue.Description != "v1"
+	}, 2*time.Second, 10*time.Millisecond, "background refresh never landed")
+}
+
+func TestCachedIssueGetter_ErrorIsNotCached(t *testing.T) {
+	var mu sync.Mutex
+	fail := true
+	getter := NewCachedIssueGetter(func(req IssueDetailRequest) (*tracker.Issue, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if fail {
+			return nil, errors.WithDetails("tracker down")
+		}
+		return &tracker.Issue{Key: req.Key, Description: "ok"}, nil
+	})
+	req := IssueDetailRequest{Kind: "shortcut", Tracker: "human", Key: "1"}
+
+	_, err := getter(req)
+	require.Error(t, err)
+
+	mu.Lock()
+	fail = false
+	mu.Unlock()
+	issue, err := getter(req)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", issue.Description)
+}
+
+func TestCachedIssueGetter_FailedRefreshKeepsStaleCopy(t *testing.T) {
+	var mu sync.Mutex
+	fail := false
+	getter := NewCachedIssueGetter(func(req IssueDetailRequest) (*tracker.Issue, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if fail {
+			return nil, errors.WithDetails("tracker blip")
+		}
+		return &tracker.Issue{Key: req.Key, Description: "v1"}, nil
+	})
+	req := IssueDetailRequest{Kind: "shortcut", Tracker: "human", Key: "1"}
+
+	_, err := getter(req)
+	require.NoError(t, err)
+
+	mu.Lock()
+	fail = true
+	mu.Unlock()
+
+	// Every subsequent call keeps returning the stale copy: readable beats
+	// gone while the tracker misbehaves.
+	for range 3 {
+		issue, gErr := getter(req)
+		require.NoError(t, gErr)
+		assert.Equal(t, "v1", issue.Description)
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -26,13 +26,26 @@ type TrackerIssuesResult struct {
 	Err        string               `json:"error,omitempty"`
 }
 
-// IssueDetailRequest asks for one full ticket by key. Tracker is the instance
-// name the issue was listed from (TrackerIssuesResult.TrackerName), so the
-// daemon resolves the exact instance instead of guessing from the key format —
-// bare numeric keys (Shortcut, GitLab, Azure DevOps) are ambiguous across kinds.
+// IssueDetailRequest asks for one full ticket by key. Tracker and Kind are the
+// instance name and provider kind the issue was listed from
+// (TrackerIssuesResult.TrackerName/TrackerKind), so the daemon resolves the
+// exact instance instead of guessing — bare numeric keys are ambiguous across
+// kinds, and a name alone is too: different provider sections may configure
+// the same instance name (e.g. a gitlab and a shortcut both named "human").
 type IssueDetailRequest struct {
 	Tracker string `json:"tracker"`
+	Kind    string `json:"kind,omitempty"`
 	Key     string `json:"key"`
+}
+
+// IssueDetailResult is the tracker-issue route's response: the full issue plus
+// a display-ready HTML rendering of its markdown description. The daemon owns
+// the rendering (goldmark + bluemonday sanitization) so every client renders
+// tracker content identically and none of them ever injects unsanitized HTML
+// into a webview.
+type IssueDetailResult struct {
+	tracker.Issue
+	DescriptionHTML string `json:"description_html,omitempty"`
 }
 
 // Request is sent from the client to the daemon (one JSON line per connection).

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -495,7 +495,13 @@ func (s *Server) handleTrackerIssue(conn net.Conn, args []string) {
 		s.writeError(conn, err.Error(), 1)
 		return
 	}
-	data, err := json.Marshal(issue)
+	result := IssueDetailResult{
+		Issue: *issue,
+		// Rendered here, not in a client: the daemon is the one trusted place
+		// where untrusted tracker markdown becomes sanitized display HTML.
+		DescriptionHTML: RenderDescriptionHTML(issue.Description),
+	}
+	data, err := json.Marshal(result)
 	if err != nil {
 		s.writeError(conn, err.Error(), 1)
 		return

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -1476,19 +1476,23 @@ func TestServer_HandleTrackerIssue_ReturnsIssue(t *testing.T) {
 		}
 	})
 
-	resp := sendRequest(t, addr, Request{Token: token, Args: []string{"tracker-issue", `{"tracker":"human","key":"188"}`}})
+	resp := sendRequest(t, addr, Request{Token: token, Args: []string{"tracker-issue", `{"tracker":"human","kind":"shortcut","key":"188"}`}})
 	assert.Equal(t, 0, resp.ExitCode)
-	// The getter must see the exact instance name and key the client sent —
-	// resolution by name is the whole point of the request carrying a tracker.
+	// The getter must see the exact instance name, kind and key the client
+	// sent — kind+name resolution is the whole point of the request carrying
+	// them (names can repeat across provider sections).
 	assert.Equal(t, "human", gotReq.Tracker)
+	assert.Equal(t, "shortcut", gotReq.Kind)
 	assert.Equal(t, "188", gotReq.Key)
 
-	var issue tracker.Issue
-	err := json.Unmarshal([]byte(strings.TrimSpace(resp.Stdout)), &issue)
+	var result IssueDetailResult
+	err := json.Unmarshal([]byte(strings.TrimSpace(resp.Stdout)), &result)
 	require.NoError(t, err)
-	assert.Equal(t, "188", issue.Key)
-	assert.Equal(t, "Stephan", issue.Assignee)
-	assert.Equal(t, "As a product engineer I want the board to show builds.", issue.Description)
+	assert.Equal(t, "188", result.Key)
+	assert.Equal(t, "Stephan", result.Assignee)
+	assert.Equal(t, "As a product engineer I want the board to show builds.", result.Description)
+	// The daemon renders the markdown itself so clients never have to.
+	assert.Contains(t, result.DescriptionHTML, "<p>As a product engineer")
 }
 
 func TestServer_HandleTrackerIssue_GetterError(t *testing.T) {


### PR DESCRIPTION
Follow-ups to #81 from live testing of the ticket detail slide-out:

**Daemon**
- Fix instance resolution for the `tracker-issue` route: name alone is ambiguous when provider sections share an instance name (gitlab + shortcut both named "human"); requests now carry the kind and resolve via `ResolveByKind`
- Stale-while-revalidate cache on the route (single-flight refresh, stale kept on tracker errors) — reopening a ticket is instant, transparently to clients
- `description_html` on the response: goldmark(GFM) + bluemonday, rendered and sanitized daemon-side (one new dep: bluemonday; goldmark was already in the tree)

**Desktop panel**
- Renders the daemon's HTML with markdown styling; escaped-text fallback until the fetch lands
- Backfill failures shown inline (previously swallowed — masked all of the above)
- Clicking the open card again closes the panel
- All external links (tracker, PR, context menu, in-description) open via `BrowserOpenURL` — the Linux webview silently drops `target=_blank`

Ticket: SC-203

🤖 Generated with [Claude Code](https://claude.com/claude-code)