### PR TITLE
[SC-214] Fix column: failed cards say "error" with the reason on hover

### DIFF
--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -423,6 +423,16 @@ function renderBugCard(card) {
         if (running)
             running.innerHTML = `<span class="spinner"></span> fixing…`;
     }
+    if (card.state === "failed") {
+        // The board's bare ✕ is too quiet for this pane: a dead fix run must say
+        // so, with the recorded reason a hover away.
+        const failed = el.querySelector(".badge.failed");
+        if (failed) {
+            failed.textContent = "✕ error";
+            if (card.error)
+                failed.title = card.error;
+        }
+    }
     if (isReadyToDeploy(card)) {
         const meta = el.querySelector(".card-meta");
         if (meta) {

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -656,6 +656,15 @@ function renderBugCard(card: Card): HTMLElement {
     const running = el.querySelector(".badge.running");
     if (running) running.innerHTML = `<span class="spinner"></span> fixing…`;
   }
+  if (card.state === "failed") {
+    // The board's bare ✕ is too quiet for this pane: a dead fix run must say
+    // so, with the recorded reason a hover away.
+    const failed = el.querySelector<HTMLElement>(".badge.failed");
+    if (failed) {
+      failed.textContent = "✕ error";
+      if (card.error) failed.title = card.error;
+    }
+  }
   if (isReadyToDeploy(card)) {
     const meta = el.querySelector(".card-meta");
     if (meta) {


### PR DESCRIPTION
## Summary
Implements SC-214. In the Bugs pane's Fix column, a card whose fix run failed showed only the board's bare ✕ badge — mute about what happened. It now shows an **✕ error** pill in the pane's bug-language (matching `fixing…` and `fixed ✓`), with the failure reason recorded on the ticket as its hover tooltip.

Running (`fixing…`) and review-passed (`fixed ✓`) pills are unchanged.

Ticket: SC-214

🤖 Generated with [Claude Code](https://claude.com/claude-code)