### PR TITLE
[SC-220] Bugs pane: right-click "Retry fix" relaunches a failed fix run

### DIFF
--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -226,6 +226,24 @@ function showCardMenu(card, x, y) {
         openExternal(card.url);
     });
     menu.appendChild(openItem);
+    // A dead fix run leaves a bug card failed with no pipeline gesture to try
+    // again — the Fix column only accepts grid and rework drops, and a card
+    // cannot be dropped onto the column it already sits in. Retry is therefore
+    // a menu action. Relaunching runs an agent — same Docker gate as the drops.
+    if (card.bug && card.state === "failed") {
+        const retryItem = document.createElement("button");
+        retryItem.type = "button";
+        retryItem.className = "context-menu-item";
+        retryItem.textContent = "Retry fix";
+        retryItem.disabled = !current.dockerAvailable;
+        if (retryItem.disabled)
+            retryItem.title = "Docker required";
+        retryItem.addEventListener("click", () => {
+            menu.remove();
+            void fixBug(card.key, card.title);
+        });
+        menu.appendChild(retryItem);
+    }
     // Mockups belong to the product conversation: the item appears only in the
     // Product backlog column, toggling create → creating → view as the local
     // mockup set for this ticket comes into existence. Bug tickets never get

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -454,6 +454,24 @@ function showCardMenu(card: Card, x: number, y: number): void {
   });
   menu.appendChild(openItem);
 
+  // A dead fix run leaves a bug card failed with no pipeline gesture to try
+  // again — the Fix column only accepts grid and rework drops, and a card
+  // cannot be dropped onto the column it already sits in. Retry is therefore
+  // a menu action. Relaunching runs an agent — same Docker gate as the drops.
+  if (card.bug && card.state === "failed") {
+    const retryItem = document.createElement("button");
+    retryItem.type = "button";
+    retryItem.className = "context-menu-item";
+    retryItem.textContent = "Retry fix";
+    retryItem.disabled = !current.dockerAvailable;
+    if (retryItem.disabled) retryItem.title = "Docker required";
+    retryItem.addEventListener("click", () => {
+      menu.remove();
+      void fixBug(card.key, card.title);
+    });
+    menu.appendChild(retryItem);
+  }
+
   // Mockups belong to the product conversation: the item appears only in the
   // Product backlog column, toggling create → creating → view as the local
   // mockup set for this ticket comes into existence. Bug tickets never get


### PR DESCRIPTION
## Summary
Implements SC-220. A bug card whose fix run died (error pill) had no way to retry: the Fix column's drop gate only accepts resting-grid bugs and review-rework, and a card can't be dropped onto the column it already occupies — so the natural gesture silently did nothing.

The card's right-click menu now offers **Retry fix** on any failed bug card. It reuses the existing `fixBug` path (optimistic running state → `FixBug` → reconcile); the daemon's `ApplyFix` already accepts a relaunch for any non-running card. Docker-gated like the other agent-launching affordances.

Ticket: SC-220 (UX decision recorded as comment 221)

🤖 Generated with [Claude Code](https://claude.com/claude-code)