### PR TITLE
[SC-235] [HUM-176] Agent containers trust the proxy CA: generate eagerly, refuse non-PEM mounts

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -826,6 +826,18 @@ func buildProxyServer(addr string, interactive bool, logger zerolog.Logger, emit
 		status = "Interactive proxy mode: unknown domains will prompt for approval\n"
 	}
 
+	// The agent container bind-mounts ~/.human/ca.crt and points
+	// NODE_EXTRA_CA_CERTS at it. Generate the CA up front — even when
+	// intercept is off — so the file always exists as real PEM before any
+	// container starts; otherwise Docker fabricates an empty directory at the
+	// bind source and Node's PEM parse fails on every run.
+	if home, herr := os.UserHomeDir(); herr == nil {
+		humanDir := filepath.Join(home, ".human")
+		if _, _, _, caErr := proxy.LoadOrCreateCA(humanDir); caErr != nil {
+			logger.Warn().Err(caErr).Msg("failed to pre-generate proxy CA")
+		}
+	}
+
 	interceptor, interceptStatus := buildInterceptor(proxyCfg, logger)
 	if interceptStatus != "" {
 		status += interceptStatus

--- a/internal/devcontainer/cacert.go
+++ b/internal/devcontainer/cacert.go
@@ -1,0 +1,29 @@
+package devcontainer
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+)
+
+// IsValidCACertFile reports whether path is a regular, non-empty file whose
+// contents decode as a PEM-encoded X.509 certificate. Docker auto-creates a
+// missing bind source as an empty directory; mounting that (or an empty /
+// non-PEM file) makes Node's NODE_EXTRA_CA_CERTS parse fail, so we refuse to
+// emit a bind for anything that is not a real certificate.
+func IsValidCACertFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Size() == 0 {
+		return false
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- path is the well-known ~/.human/ca.crt
+	if err != nil {
+		return false
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return false
+	}
+	_, err = x509.ParseCertificate(block.Bytes)
+	return err == nil
+}

--- a/internal/devcontainer/cacert_test.go
+++ b/internal/devcontainer/cacert_test.go
@@ -1,0 +1,88 @@
+package devcontainer
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeTestCA generates a real self-signed certificate and writes it as PEM to
+// dir/ca.crt, returning the file path. Tests that assert the CA mount is
+// present need a genuinely PEM-parseable certificate now that the mount is
+// gated on IsValidCACertFile.
+func writeTestCA(t *testing.T, dir string) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "human test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "ca.crt")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(path, pemBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestIsValidCACertFile(t *testing.T) {
+	dir := t.TempDir()
+
+	validPath := writeTestCA(t, dir)
+
+	emptyPath := filepath.Join(dir, "empty.crt")
+	if err := os.WriteFile(emptyPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	nonPEMPath := filepath.Join(dir, "notpem.crt")
+	if err := os.WriteFile(nonPEMPath, []byte("cert-data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dirPath := filepath.Join(dir, "cadir")
+	if err := os.MkdirAll(dirPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"valid PEM", validPath, true},
+		{"directory", dirPath, false},
+		{"empty file", emptyPath, false},
+		{"non-PEM", nonPEMPath, false},
+		{"missing", filepath.Join(dir, "does-not-exist.crt"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsValidCACertFile(tc.path); got != tc.want {
+				t.Errorf("IsValidCACertFile(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/devcontainer/manager.go
+++ b/internal/devcontainer/manager.go
@@ -287,7 +287,7 @@ func (m *Manager) buildCreateOptions(cfg *DevcontainerConfig, projectDir, config
 	targetHome := remoteHome(cfg)
 
 	caCert := filepath.Join(home, ".human", "ca.crt")
-	if _, err := os.Stat(caCert); err == nil {
+	if IsValidCACertFile(caCert) {
 		binds = append(binds, caCert+":"+targetHome+"/.human/ca.crt:ro")
 	}
 

--- a/internal/devcontainer/manager_test.go
+++ b/internal/devcontainer/manager_test.go
@@ -609,15 +609,10 @@ func TestManager_Up_WithMounts(t *testing.T) {
 func TestManager_Up_WithCACert(t *testing.T) {
 	projectDir, mock, docker := setupTestProject(t, `{"image": "ubuntu:22.04", "remoteUser": "vscode"}`)
 
-	// Create CA cert file in the test HOME.
+	// Create a real PEM CA cert in the test HOME; the mount is now gated on
+	// the file being a PEM-parseable certificate.
 	home := os.Getenv("HOME")
-	humanDir := filepath.Join(home, ".human")
-	if err := os.MkdirAll(humanDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(humanDir, "ca.crt"), []byte("cert-data"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestCA(t, filepath.Join(home, ".human"))
 
 	mgr := &Manager{Docker: docker, Logger: testLogger()}
 	_, err := mgr.Up(context.Background(), UpOptions{
@@ -641,6 +636,68 @@ func TestManager_Up_WithCACert(t *testing.T) {
 	}
 	if !foundCACert {
 		t.Errorf("expected CA cert mount in binds: %v", binds)
+	}
+}
+
+func TestManager_Up_CACertIsDirectory_NoMount(t *testing.T) {
+	projectDir, mock, docker := setupTestProject(t, `{"image": "ubuntu:22.04", "remoteUser": "vscode"}`)
+
+	// Reproduce the broken host state: Docker auto-creates the missing bind
+	// source as an empty directory. A directory must never be mounted as the
+	// ca.crt PEM file.
+	home := os.Getenv("HOME")
+	humanDir := filepath.Join(home, ".human")
+	if err := os.MkdirAll(filepath.Join(humanDir, "ca.crt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := &Manager{Docker: docker, Logger: testLogger()}
+	if _, err := mgr.Up(context.Background(), UpOptions{
+		ProjectDir: projectDir,
+		Out:        &bytes.Buffer{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(mock.createCalls) != 1 {
+		t.Fatalf("expected 1 create call, got %d", len(mock.createCalls))
+	}
+	for _, b := range mock.createCalls[0].Binds {
+		if strings.Contains(b, "/.human/ca.crt") {
+			t.Errorf("ca.crt directory must not be mounted, but found bind: %q in %v", b, mock.createCalls[0].Binds)
+		}
+	}
+}
+
+func TestManager_Up_CACertEmpty_NoMount(t *testing.T) {
+	projectDir, mock, docker := setupTestProject(t, `{"image": "ubuntu:22.04", "remoteUser": "vscode"}`)
+
+	home := os.Getenv("HOME")
+	humanDir := filepath.Join(home, ".human")
+	if err := os.MkdirAll(humanDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A zero-byte / non-PEM file would make Node's PEM parse fail; it must not
+	// be mounted either.
+	if err := os.WriteFile(filepath.Join(humanDir, "ca.crt"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := &Manager{Docker: docker, Logger: testLogger()}
+	if _, err := mgr.Up(context.Background(), UpOptions{
+		ProjectDir: projectDir,
+		Out:        &bytes.Buffer{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(mock.createCalls) != 1 {
+		t.Fatalf("expected 1 create call, got %d", len(mock.createCalls))
+	}
+	for _, b := range mock.createCalls[0].Binds {
+		if strings.Contains(b, "/.human/ca.crt") {
+			t.Errorf("empty ca.crt must not be mounted, but found bind: %q in %v", b, mock.createCalls[0].Binds)
+		}
 	}
 }
 

--- a/internal/init/step_devcontainer.go
+++ b/internal/init/step_devcontainer.go
@@ -6,11 +6,13 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/gethuman-sh/human/errors"
 	"github.com/gethuman-sh/human/internal/claude"
 	"github.com/gethuman-sh/human/internal/daemon"
+	"github.com/gethuman-sh/human/internal/devcontainer"
 )
 
 // DevcontainerPrompter abstracts TUI interactions for the devcontainer step.
@@ -80,7 +82,16 @@ func (s *devcontainerStep) Run(w io.Writer, fw claude.FileWriter) ([]string, err
 
 	s.state.SelectedStacks = stacks
 
-	cfg := buildDevcontainerConfig(proxy, intercept, stacks)
+	// Only emit the ca.crt bind mount + NODE_EXTRA_CA_CERTS when a real,
+	// PEM-parseable CA exists on the authoring host. Otherwise Docker
+	// fabricates an empty directory at the bind source and Node's PEM parse
+	// fails inside the container.
+	caPresent := false
+	if home, homeErr := os.UserHomeDir(); homeErr == nil {
+		caPresent = devcontainer.IsValidCACertFile(filepath.Join(home, ".human", "ca.crt"))
+	}
+
+	cfg := buildDevcontainerConfig(proxy, intercept, stacks, caPresent)
 
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
@@ -182,7 +193,7 @@ func checkDevcontainerPrereqs() []string {
 	return hints
 }
 
-func buildDevcontainerConfig(proxy, intercept bool, stacks []StackType) devcontainerConfig {
+func buildDevcontainerConfig(proxy, intercept bool, stacks []StackType, caPresent bool) devcontainerConfig {
 	featureOpts := map[string]interface{}{}
 	if proxy {
 		featureOpts["proxy"] = true
@@ -205,7 +216,6 @@ func buildDevcontainerConfig(proxy, intercept bool, stacks []StackType) devconta
 		Image:        "mcr.microsoft.com/devcontainers/base:ubuntu",
 		RemoteUser:   "vscode",
 		Features:     features,
-		Mounts:       []string{"source=${localEnv:HOME}/.human/ca.crt,target=/home/vscode/.human/ca.crt,type=bind,readonly"},
 		RunArgs:      []string{"--add-host=host.docker.internal:host-gateway"},
 		ForwardPorts: []int{19285, 19286},
 		RemoteEnv: map[string]string{ // #nosec G101 -- not a credential, just env var name referencing localEnv
@@ -217,11 +227,23 @@ func buildDevcontainerConfig(proxy, intercept bool, stacks []StackType) devconta
 		},
 	}
 
+	// Only bind-mount the CA and point NODE_EXTRA_CA_CERTS at it when a real
+	// PEM certificate exists on the authoring host. Emitting the mount for a
+	// missing source makes Docker fabricate an empty directory, and Node's PEM
+	// parse then fails on every run.
+	if caPresent {
+		cfg.Mounts = []string{"source=${localEnv:HOME}/.human/ca.crt,target=/home/vscode/.human/ca.crt,type=bind,readonly"}
+	}
+
 	switch {
 	case proxy && intercept:
 		cfg.CapAdd = []string{"NET_ADMIN"}
-		cfg.RemoteEnv["NODE_EXTRA_CA_CERTS"] = "/home/vscode/.human/ca.crt"
-		cfg.PostStartCommand = "export HUMAN_PROXY_ADDR=$(getent hosts host.docker.internal | awk '{print $1}'):19287 && sudo -E human-proxy-setup && sudo cp /home/vscode/.human/ca.crt /usr/local/share/ca-certificates/human-proxy.crt && sudo update-ca-certificates && human install --agent claude && human chrome-bridge"
+		if caPresent {
+			cfg.RemoteEnv["NODE_EXTRA_CA_CERTS"] = "/home/vscode/.human/ca.crt"
+			cfg.PostStartCommand = "export HUMAN_PROXY_ADDR=$(getent hosts host.docker.internal | awk '{print $1}'):19287 && sudo -E human-proxy-setup && sudo cp /home/vscode/.human/ca.crt /usr/local/share/ca-certificates/human-proxy.crt && sudo update-ca-certificates && human install --agent claude && human chrome-bridge"
+		} else {
+			cfg.PostStartCommand = "export HUMAN_PROXY_ADDR=$(getent hosts host.docker.internal | awk '{print $1}'):19287 && sudo -E human-proxy-setup && human install --agent claude && human chrome-bridge"
+		}
 	case proxy:
 		cfg.CapAdd = []string{"NET_ADMIN"}
 		cfg.PostStartCommand = "export HUMAN_PROXY_ADDR=$(getent hosts host.docker.internal | awk '{print $1}'):19287 && sudo -E human-proxy-setup && human install --agent claude && human chrome-bridge"

--- a/internal/init/wizard_test.go
+++ b/internal/init/wizard_test.go
@@ -2,11 +2,19 @@ package init
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"io"
 
@@ -14,6 +22,34 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// stageTestCA points HOME at a temp dir and writes a real PEM CA to
+// ~/.human/ca.crt. The devcontainer step now emits the ca.crt bind + related
+// env only when a genuine PEM certificate exists on the authoring host, so
+// tests asserting those must stage one.
+func stageTestCA(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "human test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	humanDir := filepath.Join(home, ".human")
+	require.NoError(t, os.MkdirAll(humanDir, 0o755))
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	require.NoError(t, os.WriteFile(filepath.Join(humanDir, "ca.crt"), pemBytes, 0o644))
+}
 
 // mockPrompter implements Prompter for testing.
 type mockPrompter struct {
@@ -653,6 +689,7 @@ func TestDevcontainerStep_Declined(t *testing.T) {
 }
 
 func TestDevcontainerStep_BasicConfig(t *testing.T) {
+	stageTestCA(t)
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
 	t.Cleanup(func() { _ = os.Chdir(origDir) })
@@ -690,6 +727,7 @@ func TestDevcontainerStep_BasicConfig(t *testing.T) {
 }
 
 func TestDevcontainerStep_WithProxy(t *testing.T) {
+	stageTestCA(t)
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
 	t.Cleanup(func() { _ = os.Chdir(origDir) })
@@ -721,6 +759,7 @@ func TestDevcontainerStep_WithProxy(t *testing.T) {
 }
 
 func TestDevcontainerStep_WithProxyAndIntercept(t *testing.T) {
+	stageTestCA(t)
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
 	t.Cleanup(func() { _ = os.Chdir(origDir) })
@@ -745,6 +784,38 @@ func TestDevcontainerStep_WithProxyAndIntercept(t *testing.T) {
 	assert.Contains(t, data, "sudo -E human-proxy-setup")
 	assert.Contains(t, data, "NODE_EXTRA_CA_CERTS")
 	assert.Contains(t, data, "update-ca-certificates")
+	assert.Contains(t, data, "human install --agent claude")
+}
+
+// When no valid CA exists on the authoring host, the generated config must not
+// emit the ca.crt bind mount (Docker would fabricate an empty directory at the
+// source) nor NODE_EXTRA_CA_CERTS (Node's PEM parse would fail).
+func TestDevcontainerStep_NoCA_OmitsMount(t *testing.T) {
+	// HOME points at an empty temp dir: no ~/.human/ca.crt.
+	t.Setenv("HOME", t.TempDir())
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+	require.NoError(t, os.Chdir(tmpDir))
+
+	prompter := &mockPrompter{
+		confirmDevcontainer: true,
+		confirmProxy:        true,
+		confirmIntercept:    true,
+	}
+	step := NewDevcontainerStep(prompter, &WizardState{})
+	fw := newMockFileWriter()
+	var buf bytes.Buffer
+
+	_, err := step.Run(&buf, fw)
+	require.NoError(t, err)
+
+	data := string(fw.files[".devcontainer/devcontainer.json"])
+	assert.NotContains(t, data, "ca.crt,target=/home/vscode/.human/ca.crt,type=bind")
+	assert.NotContains(t, data, "NODE_EXTRA_CA_CERTS")
+	assert.NotContains(t, data, "update-ca-certificates")
+	// The rest of the proxy setup still applies.
+	assert.Contains(t, data, "sudo -E human-proxy-setup")
 	assert.Contains(t, data, "human install --agent claude")
 }
 


### PR DESCRIPTION
## Summary
Fixes SC-235 (Shortcut) / HUM-176 (Linear). Every claude invocation inside an agent container warned `ignoring extra certs from ~/.human/ca.crt, load failed: PEM routines` — Node could not parse the mounted proxy CA, silently dropping the proxy's trust anchor.

Three commits (agent-authored fix, review-passed via the board pipeline; delivered from the host because containerized agents hold no push credentials by design):
- Refuse to bind-mount a non-PEM `ca.crt` in the native manager
- Pre-generate the proxy CA eagerly on daemon start
- Gate the generated `ca.crt` mount on a real CA existing at init time

## Verdict
Confirmed bug (ticket 235 comment 245), fix verified DONE (246), review passed (249).

## Tests
Full suite green: 3439 tests. Lint clean.

Tickets: SC-235, HUM-176

🤖 Generated with [Claude Code](https://claude.com/claude-code)