### PR TITLE
[SC-236] Spare bare idle agents from the zombie sweep

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -1826,6 +1826,11 @@ func (s *dockerAgentSweeper) RunningAgents() ([]daemon.AgentInfo, error) {
 			Name:        m.Name,
 			ContainerID: m.ContainerID,
 			CreatedAt:   m.CreatedAt,
+			// A bare `human agent start NAME` persists an empty Prompt and never
+			// launches claude (agent.Manager.Start only execs claude when a
+			// prompt is present), so an empty Prompt marks an idle-by-design
+			// agent the sweep must not mistake for a crashed one (SC-236).
+			Idle: m.Prompt == "",
 		})
 	}
 	return result, nil

--- a/internal/daemon/agentzombiesweep.go
+++ b/internal/daemon/agentzombiesweep.go
@@ -12,6 +12,13 @@ type AgentInfo struct {
 	Name        string
 	ContainerID string
 	CreatedAt   time.Time
+	// Idle marks an agent started without a prompt (bare `human agent start`),
+	// which by design never launches a claude process. Such an agent is
+	// indistinguishable from a crashed one by process-liveness alone, so the
+	// sweep must not reap it until claude has actually been observed running
+	// for it — otherwise a deliberately idle agent is killed within seconds
+	// of coming up (SC-236).
+	Idle bool
 }
 
 // AgentZombieSweeper checks for orphaned agent containers whose main
@@ -47,6 +54,15 @@ func RunAgentZombieSweep(ctx context.Context, sweeper AgentZombieSweeper, onReap
 
 	logger.Info().Msg("agent zombie sweep started")
 
+	// seenClaude records, per agent name, whether the sweep has ever observed a
+	// live claude process for it. An idle-by-design agent that has never been
+	// seen with claude is spared; once claude is observed, a later absence still
+	// reaps the agent — preserving the crashed-agent contract (SC-236). Kept
+	// in memory across ticks; a daemon restart resets it, which is safe: an idle
+	// agent is spared again by its Idle flag, and a crashed prompt-driven agent
+	// is reaped on the first tick because its Idle flag is false.
+	seenClaude := map[string]bool{}
+
 	ticker := time.NewTicker(zombieSweepInterval)
 	defer ticker.Stop()
 
@@ -55,19 +71,22 @@ func RunAgentZombieSweep(ctx context.Context, sweeper AgentZombieSweeper, onReap
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			sweepZombieAgents(ctx, sweeper, onReaped, logger)
+			sweepZombieAgents(ctx, sweeper, seenClaude, onReaped, logger)
 		}
 	}
 }
 
-func sweepZombieAgents(ctx context.Context, sweeper AgentZombieSweeper, onReaped func(agentName string), logger zerolog.Logger) {
+func sweepZombieAgents(ctx context.Context, sweeper AgentZombieSweeper, seenClaude map[string]bool, onReaped func(agentName string), logger zerolog.Logger) {
 	agents, err := sweeper.RunningAgents()
 	if err != nil {
 		logger.Warn().Err(err).Msg("zombie sweep: failed to list agents")
 		return
 	}
 
+	live := make(map[string]struct{}, len(agents))
 	for _, a := range agents {
+		live[a.Name] = struct{}{}
+
 		if a.ContainerID == "" {
 			continue
 		}
@@ -82,6 +101,16 @@ func sweepZombieAgents(ctx context.Context, sweeper AgentZombieSweeper, onReaped
 			continue
 		}
 		if running {
+			// Record the observation so a later absence still reaps this agent,
+			// even one flagged idle — this is what preserves the crashed-agent
+			// contract for agents that once ran claude (SC-236).
+			seenClaude[a.Name] = true
+			continue
+		}
+
+		// claude is absent. Spare an idle-by-design agent that has never been
+		// observed running claude: it is idle on purpose, not a zombie (SC-236).
+		if a.Idle && !seenClaude[a.Name] {
 			continue
 		}
 
@@ -95,5 +124,13 @@ func sweepZombieAgents(ctx context.Context, sweeper AgentZombieSweeper, onReaped
 			onReaped(a.Name)
 		}
 		cancel()
+	}
+
+	// Drop observations for agents that no longer exist so the map stays bounded
+	// by the live agent set across the sweep goroutine's lifetime.
+	for name := range seenClaude {
+		if _, ok := live[name]; !ok {
+			delete(seenClaude, name)
+		}
 	}
 }

--- a/internal/daemon/agentzombiesweep_test.go
+++ b/internal/daemon/agentzombiesweep_test.go
@@ -52,7 +52,7 @@ func TestSweepZombieAgents_CleansOrphaned(t *testing.T) {
 		processUp: map[string]bool{"c1": false},
 	}
 
-	sweepZombieAgents(context.Background(), s, nil, zerolog.Nop())
+	sweepZombieAgents(context.Background(), s, map[string]bool{}, nil, zerolog.Nop())
 
 	assert.Equal(t, []string{"agent-1"}, s.deleted)
 }
@@ -65,7 +65,7 @@ func TestSweepZombieAgents_SkipsHealthy(t *testing.T) {
 		processUp: map[string]bool{"c1": true},
 	}
 
-	sweepZombieAgents(context.Background(), s, nil, zerolog.Nop())
+	sweepZombieAgents(context.Background(), s, map[string]bool{}, nil, zerolog.Nop())
 
 	assert.Empty(t, s.deleted)
 }
@@ -78,7 +78,7 @@ func TestSweepZombieAgents_SkipsGracePeriod(t *testing.T) {
 		processUp: map[string]bool{"c1": false},
 	}
 
-	sweepZombieAgents(context.Background(), s, nil, zerolog.Nop())
+	sweepZombieAgents(context.Background(), s, map[string]bool{}, nil, zerolog.Nop())
 
 	assert.Empty(t, s.deleted)
 }
@@ -91,7 +91,7 @@ func TestSweepZombieAgents_SkipsEmptyContainerID(t *testing.T) {
 		processUp: map[string]bool{},
 	}
 
-	sweepZombieAgents(context.Background(), s, nil, zerolog.Nop())
+	sweepZombieAgents(context.Background(), s, map[string]bool{}, nil, zerolog.Nop())
 
 	assert.Empty(t, s.deleted)
 }
@@ -106,7 +106,7 @@ func TestSweepZombieAgents_MixedAgents(t *testing.T) {
 		processUp: map[string]bool{"c1": true, "c2": false, "c3": false},
 	}
 
-	sweepZombieAgents(context.Background(), s, nil, zerolog.Nop())
+	sweepZombieAgents(context.Background(), s, map[string]bool{}, nil, zerolog.Nop())
 
 	assert.Equal(t, []string{"zombie"}, s.deleted)
 }
@@ -114,6 +114,91 @@ func TestSweepZombieAgents_MixedAgents(t *testing.T) {
 func TestRunAgentZombieSweep_NilSweeper(t *testing.T) {
 	// Should return immediately without panic.
 	RunAgentZombieSweep(context.Background(), nil, nil, zerolog.Nop())
+}
+
+// SC-236: a deliberately idle agent (bare `human agent start NAME`, empty
+// Prompt, so claude is never launched) must survive the sweep. It is
+// indistinguishable from a crashed agent by process-liveness alone, so the
+// sweep spares agents flagged idle that have never been observed running claude.
+func TestSweepZombieAgents_SparesIdleNeverHadClaude(t *testing.T) {
+	s := &mockSweeper{
+		agents: []AgentInfo{
+			{Name: "debug", ContainerID: "c1", CreatedAt: time.Now().Add(-2 * time.Minute), Idle: true},
+		},
+		processUp: map[string]bool{"c1": false},
+	}
+	seen := map[string]bool{}
+
+	sweepZombieAgents(context.Background(), s, seen, nil, zerolog.Nop())
+
+	assert.Empty(t, s.deleted)
+}
+
+// SC-236 contract preservation: an agent that HAD claude and then lost it is a
+// true zombie and must still be reaped — even if flagged idle — because the
+// sweep observed claude running for it on a prior tick.
+func TestSweepZombieAgents_ReapsAgentThatHadClaudeThenDied(t *testing.T) {
+	s := &mockSweeper{
+		agents: []AgentInfo{
+			{Name: "crashed", ContainerID: "c1", CreatedAt: time.Now().Add(-2 * time.Minute), Idle: true},
+		},
+		processUp: map[string]bool{"c1": false},
+	}
+	// Prior observation: claude was seen running for this agent.
+	seen := map[string]bool{"crashed": true}
+
+	sweepZombieAgents(context.Background(), s, seen, nil, zerolog.Nop())
+
+	assert.Equal(t, []string{"crashed"}, s.deleted)
+}
+
+// A prompt-driven (non-idle) agent whose claude is absent is reaped on the very
+// first tick — no prior observation required, preserving pre-SC-236 behavior.
+func TestSweepZombieAgents_ReapsNonIdleWithoutClaude(t *testing.T) {
+	s := &mockSweeper{
+		agents: []AgentInfo{
+			{Name: "prompt-agent", ContainerID: "c1", CreatedAt: time.Now().Add(-2 * time.Minute), Idle: false},
+		},
+		processUp: map[string]bool{"c1": false},
+	}
+	seen := map[string]bool{}
+
+	sweepZombieAgents(context.Background(), s, seen, nil, zerolog.Nop())
+
+	assert.Equal(t, []string{"prompt-agent"}, s.deleted)
+}
+
+// An idle agent that IS currently running claude records the observation, so a
+// later absence reaps it. Verifies seenClaude is populated on a live-claude tick.
+func TestSweepZombieAgents_RecordsClaudeObservation(t *testing.T) {
+	s := &mockSweeper{
+		agents: []AgentInfo{
+			{Name: "idle-then-ran", ContainerID: "c1", CreatedAt: time.Now().Add(-2 * time.Minute), Idle: true},
+		},
+		processUp: map[string]bool{"c1": true},
+	}
+	seen := map[string]bool{}
+
+	sweepZombieAgents(context.Background(), s, seen, nil, zerolog.Nop())
+
+	assert.Empty(t, s.deleted)
+	assert.True(t, seen["idle-then-ran"], "claude observation must be recorded")
+}
+
+// The seenClaude map must not leak entries for agents that no longer exist.
+func TestSweepZombieAgents_PrunesStaleObservations(t *testing.T) {
+	s := &mockSweeper{
+		agents: []AgentInfo{
+			{Name: "still-here", ContainerID: "c1", CreatedAt: time.Now().Add(-2 * time.Minute), Idle: true},
+		},
+		processUp: map[string]bool{"c1": true},
+	}
+	seen := map[string]bool{"gone": true, "still-here": true}
+
+	sweepZombieAgents(context.Background(), s, seen, nil, zerolog.Nop())
+
+	_, staleKept := seen["gone"]
+	assert.False(t, staleKept, "observation for a vanished agent must be pruned")
 }
 
 // SC-206: a reaped board agent died without firing hook events, so the sweep
@@ -130,7 +215,7 @@ func TestSweepZombieAgents_NotifiesOnReap(t *testing.T) {
 	var reaped []string
 	onReaped := func(name string) { reaped = append(reaped, name) }
 
-	sweepZombieAgents(context.Background(), s, onReaped, zerolog.Nop())
+	sweepZombieAgents(context.Background(), s, map[string]bool{}, onReaped, zerolog.Nop())
 
 	assert.Equal(t, []string{"board-204-implementation"}, s.deleted)
 	assert.Equal(t, []string{"board-204-implementation"}, reaped)
@@ -149,7 +234,7 @@ func TestSweepZombieAgents_NoNotifyWhenDeleteFails(t *testing.T) {
 	var reaped []string
 	onReaped := func(name string) { reaped = append(reaped, name) }
 
-	sweepZombieAgents(context.Background(), s, onReaped, zerolog.Nop())
+	sweepZombieAgents(context.Background(), s, map[string]bool{}, onReaped, zerolog.Nop())
 
 	assert.Empty(t, reaped)
 }
@@ -163,7 +248,7 @@ func TestSweepZombieAgents_NilOnReaped(t *testing.T) {
 		processUp: map[string]bool{"c1": false},
 	}
 
-	sweepZombieAgents(context.Background(), s, nil, zerolog.Nop())
+	sweepZombieAgents(context.Background(), s, map[string]bool{}, nil, zerolog.Nop())
 
 	assert.Equal(t, []string{"board-204-implementation"}, s.deleted)
 }


### PR DESCRIPTION
## Summary
The zombie sweep killed any agent container without a live claude process within seconds — including bare containers started for interactive use (e.g. `human agent start auth --interactive`), which legitimately idle with no claude running. The sweep now spares containers that never ran a board stage.

Board-run fix delivered manually: the board agent completed fix + verify + review (verdict: pass, see `[human:review-complete]` on SC-236) but could not push from its credential-less container — the same failure mode SC-252 fixes.

Ticket: SC-236

🤖 Generated with [Claude Code](https://claude.com/claude-code)