### PR TITLE
update: resolve go install home directory via os.UserHomeDir

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -146,13 +146,18 @@ func InstallHint() string {
 		return "brew upgrade human"
 	}
 
-	// go install places the binary inside $GOPATH/bin or $HOME/go/bin.
+	// go install places the binary inside $GOPATH/bin or <user home>/go/bin.
+	// os.UserHomeDir picks the right variable per platform (HOME on Unix,
+	// USERPROFILE on Windows) so Windows `go install` users still match.
 	gopath := os.Getenv("GOPATH")
 	gobin := os.Getenv("GOBIN")
-	homeGoBin := filepath.Join(os.Getenv("HOME"), "go", "bin")
+	var homeGoBin string
+	if home, err := os.UserHomeDir(); err == nil {
+		homeGoBin = filepath.Join(home, "go", "bin")
+	}
 	if (gopath != "" && strings.HasPrefix(exe, filepath.Join(gopath, "bin"))) ||
 		(gobin != "" && strings.HasPrefix(exe, gobin)) ||
-		strings.HasPrefix(exe, homeGoBin) {
+		(homeGoBin != "" && strings.HasPrefix(exe, homeGoBin)) {
 		return "go install github.com/gethuman-sh/human@latest"
 	}
 


### PR DESCRIPTION
`InstallHint()` compared the executable path against `$HOME/go/bin`, but `os.Getenv("HOME")` is empty on Windows (which exposes the user home as `USERPROFILE`), so Windows users installed via `go install` fell through to the generic releases URL. Switched to `os.UserHomeDir()`, which resolves to the correct variable per platform.

Closes #100