### PR TITLE
fusefs: lift 64 KiB per-line cap on RedactEnv

### DIFF
--- a/internal/fusefs/redact.go
+++ b/internal/fusefs/redact.go
@@ -3,7 +3,6 @@
 package fusefs
 
 import (
-	"bufio"
 	"bytes"
 	"strings"
 )
@@ -51,17 +50,34 @@ var safeValues = map[string]bool{
 // RedactEnv takes the raw content of an env-style KEY=VALUE file and returns
 // a copy with secret values replaced by "***". Comments and blank lines are
 // preserved. Safe keys and safe values are kept as-is.
+//
+// Splitting on '\n' directly (rather than via bufio.Scanner) avoids the 64 KiB
+// per-line cap that would silently drop realistic env values like base64-
+// encoded certificates and long JWT chains — Scanner returned bufio.ErrTooLong
+// on such lines and the caller never saw the truncation.
 func RedactEnv(content []byte) []byte {
 	var buf bytes.Buffer
-	scanner := bufio.NewScanner(bytes.NewReader(content))
+	rest := content
 	first := true
-	for scanner.Scan() {
-		line := scanner.Text()
+	for len(rest) > 0 {
+		var line []byte
+		if idx := bytes.IndexByte(rest, '\n'); idx >= 0 {
+			line = rest[:idx]
+			rest = rest[idx+1:]
+		} else {
+			line = rest
+			rest = nil
+		}
+		// Match bufio.ScanLines: a trailing '\r' from a CRLF terminator is
+		// stripped so classification does not see it as part of the value.
+		if len(line) > 0 && line[len(line)-1] == '\r' {
+			line = line[:len(line)-1]
+		}
 		if !first {
 			buf.WriteByte('\n')
 		}
 		first = false
-		buf.WriteString(redactLine(line))
+		buf.WriteString(redactLine(string(line)))
 	}
 	// Preserve trailing newline if present.
 	if len(content) > 0 && content[len(content)-1] == '\n' {

--- a/internal/fusefs/redact_test.go
+++ b/internal/fusefs/redact_test.go
@@ -196,3 +196,16 @@ func TestRedactEnv_URLWithoutCredentials(t *testing.T) {
 	got := string(RedactEnv([]byte(input)))
 	assert.Equal(t, input, got, "URL without credentials should not be redacted")
 }
+
+// A single line larger than bufio.MaxScanTokenSize (64 KiB) — realistic for a
+// base64-encoded certificate or long JWT chain — must still be redacted and
+// followed by later lines, not silently dropped mid-file.
+func TestRedactEnv_LongLineDoesNotTruncateFollowingLines(t *testing.T) {
+	longValue := make([]byte, 128*1024)
+	for i := range longValue {
+		longValue[i] = 'a'
+	}
+	input := "TLS_CERT=" + string(longValue) + "\nPORT=3000\n"
+	got := string(RedactEnv([]byte(input)))
+	assert.Equal(t, "TLS_CERT=***\nPORT=3000\n", got)
+}


### PR DESCRIPTION
`RedactEnv` scanned the env file with `bufio.NewScanner`, which caps a line at 64 KiB and reports oversized lines only through `Err()`. Since `Err()` was never checked, any line longer than 64 KiB — a base64-encoded cert, a long JWT chain — silently dropped that line and every line after it, and the FUSE overlay served the truncated result as a normal file.

Iterating over the raw byte slice removes the per-line cap entirely. Added a regression test with a 128 KiB value followed by a shorter entry to prove nothing after a long line is lost.

Closes #102