### PR TITLE
[SC-296] Queue deploys so simultaneous ships stop racing the mainline

### DIFF
--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gethuman-sh/human/errors"
@@ -254,9 +255,21 @@ func (d BoardTransitionDeps) runDoneStage(ctx context.Context, req BoardTransiti
 	return nil
 }
 
+// deployGate queues deploy pipelines: the Deploy button ships every ready fix
+// in one click, and concurrent pipelines race each other onto the mainline —
+// the first merge moves the base branch and the forge rejects the rest
+// ("base branch was modified"), redding cards whose fixes are perfectly fine.
+// One deploy at a time, each waiting for the previous one to land, is the
+// queue the button implies (SC-296).
+var deployGate sync.Mutex
+
 // deploy walks the pipeline to its end. It runs detached from the transition
-// request (whose context dies with the connection), bounded by deployTimeout.
+// request (whose context dies with the connection), bounded by deployTimeout —
+// the clock starts when the deploy leaves the queue, so a queued deploy never
+// pays for its predecessors' CI waits.
 func (d BoardTransitionDeps) deploy(ctx context.Context, req BoardTransitionRequest, card BoardCard) {
+	deployGate.Lock()
+	defer deployGate.Unlock()
 	ctx, cancel := context.WithTimeout(ctx, deployTimeout)
 	defer cancel()
 

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -551,4 +552,56 @@ func TestApplyFixLaunchFailurePostsFailedMarker(t *testing.T) {
 	require.Len(t, c.added, 2)
 	assert.Equal(t, ImplementationStartedHeader, c.added[0])
 	assert.True(t, strings.HasPrefix(c.added[1], ImplementationFailedHeader))
+}
+
+// gateProbeDeployer reports when a pipeline enters the forge and holds it
+// there until released, so a test can observe whether a second pipeline gets
+// in while the first is still deploying.
+type gateProbeDeployer struct {
+	started chan string
+	release chan struct{}
+}
+
+func (f *gateProbeDeployer) PushAndCreatePR(_ context.Context, req PRRequest) (PRResult, error) {
+	f.started <- req.Branch
+	<-f.release
+	return PRResult{Number: 1, URL: "pr"}, nil
+}
+
+func (f *gateProbeDeployer) PullRequestChecks(_ context.Context, _ string, _ int) (forge.ChecksState, error) {
+	return forge.ChecksPassing, nil
+}
+
+func (f *gateProbeDeployer) MergePullRequest(_ context.Context, _ string, _ int) error { return nil }
+
+func (f *gateProbeDeployer) DeleteRemoteBranch(_ context.Context, _, _ string) error { return nil }
+
+func TestDeploysQueueOneAtATime(t *testing.T) {
+	// Regression (SC-296): the Deploy button ships every ready fix at once.
+	// Concurrent pipelines race the mainline — the first merge moves the base
+	// branch and the forge rejects the rest ("base branch was modified") — so
+	// pipelines must queue: the second may not enter the forge while the first
+	// is still deploying.
+	f := &gateProbeDeployer{started: make(chan string, 2), release: make(chan struct{})}
+	deps := BoardTransitionDeps{Commenter: &fakeCommenter{}, Deployer: f, WorkspaceDir: "/ws", ConfigDir: "/ws"}
+
+	var done sync.WaitGroup
+	done.Add(2)
+	for _, branch := range []string{"autofix/one", "autofix/two"} {
+		go func(b string) {
+			defer done.Done()
+			deps.deploy(context.Background(), BoardTransitionRequest{PMKey: "SC-9"}, BoardCard{Branch: b})
+		}(branch)
+	}
+
+	first := <-f.started
+	select {
+	case second := <-f.started:
+		t.Fatalf("deploy of %s entered the forge while %s was still deploying", second, first)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(f.release)
+	assert.NotEqual(t, first, <-f.started, "the queued deploy must run after the first lands")
+	done.Wait()
 }


### PR DESCRIPTION
## Summary
The Deploy button transitions every ready fix at once, and the daemon ran each deploy pipeline as its own detached goroutine — so the first merge moved the base branch and GitHub rejected the rest with 405 "Base branch was modified" (hit SC-254 and SC-263 on 2026-07-16). Deploys now take a gate before entering the forge: one ship at a time, each waiting for the previous one to land. The deploy timeout starts when a deploy leaves the queue, so queued deploys never pay for their predecessors' CI waits.

Regression test proves serialization deterministically (fails on main: the second pipeline enters the forge while the first is still deploying).

Ticket: SC-296

🤖 Generated with [Claude Code](https://claude.com/claude-code)