### PR TITLE
[SC-297] A fix without a recorded branch never offers Deploy

### DIFF
--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -92,8 +92,9 @@ function verdictFailed(verdict) {
 }
 // queueOf maps the wire (stage, state) onto the column whose name is true of
 // the card. The whole build-and-review cycle lives in the Code lane —
-// including a review that found problems, because that card is NOT ready to
-// deploy; only a passing review releases it.
+// including a review that found problems, and a review with no recorded
+// branch (nothing to ship), because those cards are NOT ready to deploy;
+// only a passing review of a recorded branch releases one.
 function queueOf(card) {
     switch (card.stage) {
         case "ideas":
@@ -105,7 +106,7 @@ function queueOf(card) {
         case "implementation":
             return "building";
         case "verification":
-            return card.state === "done" && !verdictFailed(card.verdict) ? "deploy" : "building";
+            return card.state === "done" && !verdictFailed(card.verdict) && !!card.branch ? "deploy" : "building";
         case "done":
             return "deploy";
         default:
@@ -157,6 +158,11 @@ function badge(card) {
         return `<span class="badge failed" title="Stage failed">✕</span>`;
     if (card.stage === "verification" && card.state === "done" && verdictFailed(card.verdict)) {
         return `<span class="badge warning" title="${escapeAttr("Review verdict: " + (card.verdict ?? ""))}">⚠ review found problems</span>`;
+    }
+    if (card.stage === "verification" && card.state === "done" && !card.branch) {
+        // A passed review with no recorded branch has nothing to ship — deploying
+        // it can only fail, so it must read as needing a rebuild, never as ready.
+        return `<span class="badge warning" title="Review passed but no branch was recorded on the handoff — drop it on the build stage to rebuild">⚠ no branch recorded</span>`;
     }
     if (card.stage === "done" && card.state === "done") {
         return `<span class="badge done" title="Merged and shipped">deployed</span>`;
@@ -730,14 +736,16 @@ function dropTargetAt(x, y) {
     return el ? el.closest("[data-drop]") : null;
 }
 // isReadyToDeploy reports a card resting in Ready to Deploy on a passed
-// review — the only cards the Deploy zone accepts.
+// review of a recorded branch — the only cards the Deploy zone accepts.
+// Without a branch there is nothing to ship: deploying can only fail, so the
+// card must never be offered (SC-297).
 function isReadyToDeploy(card) {
-    return card.stage === "verification" && card.state === "done" && !verdictFailed(card.verdict);
+    return card.stage === "verification" && card.state === "done" && !verdictFailed(card.verdict) && !!card.branch;
 }
-// isReworkable reports a card pinned in Code by a failing review verdict; a
-// re-drop onto Code rebuilds it against the review findings.
+// isReworkable reports a card pinned in Code by a failing review verdict or a
+// missing branch; a re-drop onto Code (or Fix, for bugs) rebuilds it.
 function isReworkable(card) {
-    return card.stage === "verification" && card.state === "done" && verdictFailed(card.verdict);
+    return card.stage === "verification" && card.state === "done" && (verdictFailed(card.verdict) || !card.branch);
 }
 // dropAllowed reports whether the dragged card may drop on target. Queue
 // targets keep the forward-adjacency + docker-enabled rules, evaluated on the

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -309,8 +309,9 @@ function verdictFailed(verdict?: string): boolean {
 
 // queueOf maps the wire (stage, state) onto the column whose name is true of
 // the card. The whole build-and-review cycle lives in the Code lane —
-// including a review that found problems, because that card is NOT ready to
-// deploy; only a passing review releases it.
+// including a review that found problems, and a review with no recorded
+// branch (nothing to ship), because those cards are NOT ready to deploy;
+// only a passing review of a recorded branch releases one.
 function queueOf(card: Card): string {
   switch (card.stage) {
     case "ideas":
@@ -322,7 +323,7 @@ function queueOf(card: Card): string {
     case "implementation":
       return "building";
     case "verification":
-      return card.state === "done" && !verdictFailed(card.verdict) ? "deploy" : "building";
+      return card.state === "done" && !verdictFailed(card.verdict) && !!card.branch ? "deploy" : "building";
     case "done":
       return "deploy";
     default:
@@ -380,6 +381,11 @@ function badge(card: Card): string {
   if (card.state === "failed") return `<span class="badge failed" title="Stage failed">✕</span>`;
   if (card.stage === "verification" && card.state === "done" && verdictFailed(card.verdict)) {
     return `<span class="badge warning" title="${escapeAttr("Review verdict: " + (card.verdict ?? ""))}">⚠ review found problems</span>`;
+  }
+  if (card.stage === "verification" && card.state === "done" && !card.branch) {
+    // A passed review with no recorded branch has nothing to ship — deploying
+    // it can only fail, so it must read as needing a rebuild, never as ready.
+    return `<span class="badge warning" title="Review passed but no branch was recorded on the handoff — drop it on the build stage to rebuild">⚠ no branch recorded</span>`;
   }
   if (card.stage === "done" && card.state === "done") {
     return `<span class="badge done" title="Merged and shipped">deployed</span>`;
@@ -967,15 +973,17 @@ function dropTargetAt(x: number, y: number): HTMLElement | null {
 }
 
 // isReadyToDeploy reports a card resting in Ready to Deploy on a passed
-// review — the only cards the Deploy zone accepts.
+// review of a recorded branch — the only cards the Deploy zone accepts.
+// Without a branch there is nothing to ship: deploying can only fail, so the
+// card must never be offered (SC-297).
 function isReadyToDeploy(card: Card): boolean {
-  return card.stage === "verification" && card.state === "done" && !verdictFailed(card.verdict);
+  return card.stage === "verification" && card.state === "done" && !verdictFailed(card.verdict) && !!card.branch;
 }
 
-// isReworkable reports a card pinned in Code by a failing review verdict; a
-// re-drop onto Code rebuilds it against the review findings.
+// isReworkable reports a card pinned in Code by a failing review verdict or a
+// missing branch; a re-drop onto Code (or Fix, for bugs) rebuilds it.
 function isReworkable(card: Card): boolean {
-  return card.stage === "verification" && card.state === "done" && verdictFailed(card.verdict);
+  return card.stage === "verification" && card.state === "done" && (verdictFailed(card.verdict) || !card.branch);
 }
 
 // dropAllowed reports whether the dragged card may drop on target. Queue

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -334,12 +334,14 @@ func dispatchKey(pmKey string, card BoardCard) string {
 }
 
 // isReworkTransition reports the one allowed backward move: re-running the
-// build on a card whose review returned a failing verdict.
+// build on a card whose review returned a failing verdict — or whose review
+// passed without a recorded branch, which has nothing to ship and can only be
+// repaired by rebuilding (SC-297).
 func isReworkTransition(to BoardStage, card BoardCard) bool {
 	return to == BoardImplementation &&
 		card.Stage == BoardVerification &&
 		card.State == BoardDone &&
-		VerdictFailed(card.Verdict)
+		(VerdictFailed(card.Verdict) || card.Branch == "")
 }
 
 // doneBody builds the PR description with the PM→engineering→branch trail.

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -413,6 +413,21 @@ func TestApplyTransitionReworkAfterFailedVerdict(t *testing.T) {
 	assert.Contains(t, c.added, ImplementationStartedHeader)
 }
 
+func TestApplyTransitionReworkAllowedWhenNoBranchRecorded(t *testing.T) {
+	// Regression (SC-297): a passed review whose run never recorded a branch
+	// has nothing to ship — the only repair is a rebuild, so the backward move
+	// onto the build stage must be allowed exactly like a failed verdict.
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:review-complete]\nverdict: pass", time.Unix(1, 0)),
+	}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardVerification, To: BoardImplementation})
+	require.NoError(t, err)
+	assert.Equal(t, 1, l.calls)
+	assert.Contains(t, l.prompt, "/human-execute SC-1")
+}
+
 func TestApplyTransitionReworkRejectedWithoutFailedVerdict(t *testing.T) {
 	// Backward to implementation stays forbidden when the review passed.
 	c := &fakeCommenter{comments: []tracker.Comment{


### PR DESCRIPTION
## Summary
A card whose review passed but whose fix run never recorded a branch (no ready-for-review handoff) presented as "fixed ✓" and counted toward Deploy — but deploying it can only fail ("no branch recorded", hit SC-204 on 2026-07-16). Now:

- Board + Bugs pane: the card reads "⚠ no branch recorded" (hover explains the rebuild), sits in the Code/Fix lane, and never enters the Deploy zone or count.
- The sanctioned rework re-drop accepts it (frontend `isReworkable` and daemon `isReworkTransition`), so dropping it back on the build stage rebuilds it.
- The daemon's existing click-time guard stays as backstop.

Regression test: rework transition allowed for a passed review with no recorded branch.

Ticket: SC-297

🤖 Generated with [Claude Code](https://claude.com/claude-code)