### PR TITLE
starter: delete leftover file when an entry violates a size cap

### DIFF
--- a/internal/starter/fetch.go
+++ b/internal/starter/fetch.go
@@ -152,16 +152,23 @@ func writeEntry(tr io.Reader, header *tar.Header, dest string, total *int64) (bo
 	n, err := io.Copy(f, io.LimitReader(tr, maxEntryBytes+1))
 	closeErr := f.Close()
 	if err != nil {
+		_ = os.Remove(dest)
 		return false, humanerrors.WrapWithDetails(err, "writing starter file", "path", dest)
 	}
 	if closeErr != nil {
+		_ = os.Remove(dest)
 		return false, humanerrors.WrapWithDetails(closeErr, "writing starter file", "path", dest)
 	}
+	// A rejected entry must not stay on disk: the outer loop opens with
+	// O_EXCL, so a leftover would jam every subsequent Fetch on the same path
+	// until the user cleaned it up manually.
 	if n > maxEntryBytes {
+		_ = os.Remove(dest)
 		return false, humanerrors.WithDetails("starter file exceeds size limit", "entry", header.Name, "limit", maxEntryBytes)
 	}
 	*total += n
 	if *total > maxTotalBytes {
+		_ = os.Remove(dest)
 		return false, humanerrors.WithDetails("starter archive exceeds size limit", "limit", maxTotalBytes)
 	}
 	return true, nil

--- a/internal/starter/fetch_test.go
+++ b/internal/starter/fetch_test.go
@@ -249,9 +249,16 @@ func TestFetchEntrySizeCap(t *testing.T) {
 	})
 	stubDownload(t, http.StatusOK, archive)
 
-	_, err := Fetch(context.Background(), webGoTemplate(), t.TempDir())
+	dest := t.TempDir()
+	_, err := Fetch(context.Background(), webGoTemplate(), dest)
 	if err == nil || !strings.Contains(err.Error(), "size limit") {
 		t.Fatalf("expected size-limit error, got %v", err)
+	}
+	// A rejected oversized entry must not stay on disk — the outer loop opens
+	// with O_EXCL so a leftover would jam every subsequent Fetch on the same
+	// path.
+	if _, statErr := os.Stat(filepath.Join(dest, "huge.bin")); !os.IsNotExist(statErr) {
+		t.Fatalf("oversized entry left on disk: stat err = %v", statErr)
 	}
 }
 


### PR DESCRIPTION
`writeEntry` opened `dest` with `O_EXCL` and streamed `maxEntryBytes+1` bytes via `io.Copy` before checking the size. When the check tripped, the (over-)written file was left on disk, so any later `Fetch` on the same template hit `EEXIST` on that path and refused to run until the user cleaned it up. Same shape for the archive-wide `maxTotalBytes` branch and the two I/O error branches.

Removed the leftover on every error return from `writeEntry` and extended the size-cap test to assert the file is gone after the failure.

Closes #104