### PR TITLE
[SC-204] [HUM-175] Clamp bug-card title so it never overflows the card border

### DIFF
--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -189,7 +189,7 @@ function renderCard(card) {
         meta.push(`<a href="${escapeAttr(card.prURL)}" target="_blank">PR</a>`);
     el.innerHTML = `
     <div class="card-key">${escapeHtml(card.key)}</div>
-    <div class="card-title">${escapeHtml(card.title)}</div>
+    <div class="card-title" title="${escapeAttr(card.title)}">${escapeHtml(card.title)}</div>
     <div class="card-meta">${meta.join("")}</div>
     ${card.error ? `<div class="card-error">${escapeHtml(card.error)}</div>` : ""}
   `;

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -579,6 +579,10 @@ body {
      fancy theme's `overflow: hidden` (needed for the sheen) flips their
      automatic min-height to 0 and they squish. The column-body scrolls instead. */
   flex-shrink: 0;
+  /* Contain content so a card in a fixed-height track (the bug grid, style.css
+     .column-body.bug-grid) can never paint its last title line over the rounded
+     bottom border. Matches [data-theme="fancy"] .card, which already clips. */
+  overflow: hidden;
 }
 
 .card[draggable="false"] {
@@ -617,6 +621,18 @@ body {
 .card-title {
   margin-top: 4px;
   line-height: 1.3;
+}
+
+/* In the Bugs pane every card is pinned to one-fifth of the tray height
+   (style.css .column-body.bug-grid grid-auto-rows), so a long title cannot
+   grow the card. Clamp it to the lines that fit above the key/meta rows and
+   end in an ellipsis, keeping the last line off the rounded bottom border
+   (bug 204). Three lines is the most that fits the smallest realistic cell. */
+.column-body.bug-grid .card-title {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
 }
 
 /* An idea captured but still waiting for its ticket number: already a card,

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -6,7 +6,8 @@
   "description": "Workflow-board frontend for the human desktop app (Wails v2).",
   "scripts": {
     "build": "tsc && node scripts/bundle.mjs",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "test": "node --test scripts/*.test.mjs"
   },
   "devDependencies": {
     "typescript": "^7.0.2"

--- a/desktop/frontend/scripts/style.test.mjs
+++ b/desktop/frontend/scripts/style.test.mjs
@@ -1,0 +1,38 @@
+// Regression guard for SC-204 / bug 204: a long bug-card title must be
+// clamped (ellipsis) and the card must contain its overflow so the title
+// never paints over the card's rounded bottom border in the Bugs pane.
+// The frontend is intentionally dependency-free (no DOM test runner), so this
+// asserts the CSS source rules that prevent the overflow rather than rendering.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(resolve(here, "..", "static", "style.css"), "utf8");
+
+// Strip CSS comments so commented-out or explanatory text never matches.
+const stripped = css.replace(/\/\*[\s\S]*?\*\//g, "");
+
+// Extract the body of a `selector { ... }` rule (first match). Returns "" when
+// the selector is absent, so a missing rule fails the containment assertions.
+function ruleBody(selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(escaped + "\\s*\\{([^}]*)\\}");
+  const m = stripped.match(re);
+  return m ? m[1] : "";
+}
+
+test("bug-grid card title is line-clamped with an ellipsis", () => {
+  const body = ruleBody(".column-body.bug-grid .card-title");
+  assert.match(body, /-webkit-line-clamp:\s*\d+/, "title must set -webkit-line-clamp");
+  assert.match(body, /-webkit-box-orient:\s*vertical/, "clamp needs vertical box orient");
+  assert.match(body, /display:\s*-webkit-box/, "clamp needs display:-webkit-box");
+  assert.match(body, /overflow:\s*hidden/, "clamped title must hide its overflow");
+});
+
+test("default-theme .card contains its overflow", () => {
+  const body = ruleBody(".card");
+  assert.match(body, /overflow:\s*hidden/, ".card must clip content so text never crosses the border");
+});

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -412,7 +412,7 @@ function renderCard(card: Card): HTMLElement {
 
   el.innerHTML = `
     <div class="card-key">${escapeHtml(card.key)}</div>
-    <div class="card-title">${escapeHtml(card.title)}</div>
+    <div class="card-title" title="${escapeAttr(card.title)}">${escapeHtml(card.title)}</div>
     <div class="card-meta">${meta.join("")}</div>
     ${card.error ? `<div class="card-error">${escapeHtml(card.error)}</div>` : ""}
   `;

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -579,6 +579,10 @@ body {
      fancy theme's `overflow: hidden` (needed for the sheen) flips their
      automatic min-height to 0 and they squish. The column-body scrolls instead. */
   flex-shrink: 0;
+  /* Contain content so a card in a fixed-height track (the bug grid, style.css
+     .column-body.bug-grid) can never paint its last title line over the rounded
+     bottom border. Matches [data-theme="fancy"] .card, which already clips. */
+  overflow: hidden;
 }
 
 .card[draggable="false"] {
@@ -617,6 +621,18 @@ body {
 .card-title {
   margin-top: 4px;
   line-height: 1.3;
+}
+
+/* In the Bugs pane every card is pinned to one-fifth of the tray height
+   (style.css .column-body.bug-grid grid-auto-rows), so a long title cannot
+   grow the card. Clamp it to the lines that fit above the key/meta rows and
+   end in an ellipsis, keeping the last line off the rounded bottom border
+   (bug 204). Three lines is the most that fits the smallest realistic cell. */
+.column-body.bug-grid .card-title {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
 }
 
 /* An idea captured but still waiting for its ticket number: already a card,


### PR DESCRIPTION
## Summary
Bug-card titles now clamp instead of running over the card border. Fix was built and review-passed ("pass with notes") by the board pipeline on 2026-07-15 during the revoked-credentials incident — the run could not push, and the handoff was lost, so this is the manual delivery of the verified local branch (SC-297 now prevents such cards from presenting as deployable).

Verdict trail on SC-204: [human:bug-verify] DONE, [human:review-complete] verdict: pass with notes.

Tickets: SC-204, HUM-175 (historical Linear key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)