### PR TITLE
[SC-216] Persist per-execution agent logs: output, transcript, outcome

### DIFF
--- a/cmd/cmdagent/agent.go
+++ b/cmd/cmdagent/agent.go
@@ -3,7 +3,9 @@
 package cmdagent
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"text/tabwriter"
@@ -45,7 +47,80 @@ The container image is built once (with devcontainer features) and cached.`,
 	cmd.AddCommand(buildStopCmd())
 	cmd.AddCommand(buildListCmd())
 	cmd.AddCommand(buildAttachCmd())
+	cmd.AddCommand(buildLogsCmd())
 	return cmd
+}
+
+// buildLogsCmd exposes the per-execution log store for an agent, mirroring the
+// `human audit` UX. It reads directly from the host store (no daemon
+// forwarding): the same process that runs the container writes the log, and
+// agent logs carry no tracker-mutation constraint that would require the
+// daemon.
+func buildLogsCmd() *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:   "logs NAME",
+		Short: "Show recorded execution logs for an agent (launch, output, transcript, outcome)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			execs, err := agent.ListExecutions(args[0])
+			if err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+			if asJSON {
+				return writeJSON(out, execs)
+			}
+			if len(execs) == 0 {
+				_, _ = fmt.Fprintf(out, "no execution logs for agent %q\n", args[0])
+				return nil
+			}
+			renderExecutions(out, execs)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "emit raw JSON")
+	return cmd
+}
+
+func writeJSON(out io.Writer, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errors.WrapWithDetails(err, "marshaling agent logs JSON")
+	}
+	_, _ = fmt.Fprintln(out, string(data))
+	return nil
+}
+
+// renderExecutions prints a fixed-width table of an agent's runs plus a hint on
+// where to read the raw output and transcript for each run.
+func renderExecutions(out io.Writer, execs []agent.ExecutionSummary) {
+	tw := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "STARTED\tID\tMODEL\tREASON\tDURATION\tDIR")
+	for _, e := range execs {
+		reason, duration := "running", "-"
+		if e.Outcome != nil {
+			reason = e.Outcome.Reason
+			duration = agent.FormatDuration(time.Duration(e.Outcome.DurationMs) * time.Millisecond)
+		}
+		model := e.Launch.Model
+		if model == "" {
+			model = "-"
+		}
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			e.Launch.StartedAt.Format("2006-01-02 15:04:05"),
+			shortID(e.Launch.ID), model, reason, duration, e.Dir)
+	}
+	_ = tw.Flush()
+	_, _ = fmt.Fprintf(out, "\nRead a run with: cat <DIR>/output.log  and browse <DIR>/transcript/\n")
+}
+
+// shortID trims an execution id to a display-friendly prefix.
+func shortID(id string) string {
+	if len(id) > 12 {
+		return id[:12]
+	}
+	return id
 }
 
 func newManager(cmd *cobra.Command) (*agent.Manager, func(), error) {

--- a/cmd/cmdagent/agent_test.go
+++ b/cmd/cmdagent/agent_test.go
@@ -1,14 +1,19 @@
 package cmdagent
 
 import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestBuildAgentCmd_hasSubcommands(t *testing.T) {
 	cmd := BuildAgentCmd()
 
-	want := []string{"start", "stop", "list", "attach"}
+	want := []string{"start", "stop", "list", "attach", "logs"}
 	subs := cmd.Commands()
 
 	found := make(map[string]bool)
@@ -53,5 +58,68 @@ func TestBuildAgentCmd_listNoArgs(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when list gets extra args, got nil")
+	}
+}
+
+func TestAgentLogsCmd_NoLogs(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var out bytes.Buffer
+	cmd := BuildAgentCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"logs", "missing"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("logs on unknown agent must not error: %v", err)
+	}
+	if !strings.Contains(out.String(), "no execution logs") {
+		t.Errorf("expected no-logs message, got %q", out.String())
+	}
+}
+
+func TestAgentLogsCmd_RendersRuns(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Seed one finished run on disk exactly as the store lays it out.
+	dir := filepath.Join(home, ".human", "agent-logs", "a1", "abcdef1234567890")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	launch := map[string]any{
+		"id": "abcdef1234567890", "agent": "a1", "prompt": "p",
+		"argv": []string{"claude", "-p", "p"}, "model": "opus",
+		"container_id": "cid", "started_at": time.Now().Format(time.RFC3339Nano),
+	}
+	writeTestJSON(t, filepath.Join(dir, "launch.json"), launch)
+	outcome := map[string]any{
+		"reason": "completed", "exit_code": 0, "duration_ms": 65000,
+		"ended_at": time.Now().Format(time.RFC3339Nano),
+	}
+	writeTestJSON(t, filepath.Join(dir, "outcome.json"), outcome)
+
+	var out bytes.Buffer
+	cmd := BuildAgentCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"logs", "a1"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("logs: %v", err)
+	}
+	for _, want := range []string{"abcdef123456", "opus", "completed", dir} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("table missing %q in output:\n%s", want, out.String())
+		}
+	}
+}
+
+func writeTestJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -111,8 +111,8 @@ type daemonState struct {
 }
 
 // runMaintenanceLoop periodically cleans up stale pending confirmations and
-// prunes the stats and audit stores past their retention windows. It runs until
-// ctx is cancelled.
+// prunes the stats, audit, and agent-execution-log stores past their retention
+// windows. It runs until ctx is cancelled.
 func runMaintenanceLoop(ctx context.Context, logger zerolog.Logger, confirmStore *daemon.PendingConfirmStore, statsStore *stats.StatsStore, auditStore *audit.Store) {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
@@ -131,6 +131,9 @@ func runMaintenanceLoop(ctx context.Context, logger zerolog.Logger, confirmStore
 				if _, pruneErr := auditStore.Prune(ctx); pruneErr != nil {
 					logger.Warn().Err(pruneErr).Msg("periodic audit prune failed")
 				}
+			}
+			if _, pruneErr := agent.PruneExecutions(); pruneErr != nil {
+				logger.Warn().Err(pruneErr).Msg("periodic agent execution log prune failed")
 			}
 		}
 	}
@@ -196,7 +199,9 @@ func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, de
 	vaultResolver := buildVaultResolver(projectRegistry, logger)
 
 	connTracker := daemon.NewConnectedTracker()
-	hookStore := daemon.NewHookEventStore()
+	// Persist hook events to the host so they survive the in-memory ring's
+	// eviction and daemon restarts, keyed to the emitting agent's execution log.
+	hookStore := daemon.NewHookEventStore().WithPersistence(agent.HookEventSink)
 	networkStore := daemon.NewNetworkEventStore()
 	confirmStore := daemon.NewPendingConfirmStore()
 
@@ -1304,6 +1309,18 @@ func (c *dockerAgentCleaner) DecommissionAgent(name string) (string, error) {
 		return "", err
 	}
 	containerID := meta.ContainerID
+	// The async decommission path force-removes the container by id via
+	// StopContainer *after* this function has deleted the meta, bypassing
+	// stopLocked's copy-out. Copy the transcript out and record the outcome here
+	// while the meta (and thus container id + agent name) still exists (SC-216).
+	if containerID != "" {
+		if docker, dErr := devcontainer.NewDockerClient(); dErr == nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			agent.PreserveExecutionArtifacts(ctx, docker, meta, "reaped")
+			cancel()
+			_ = docker.Close()
+		}
+	}
 	_ = agent.DeleteMeta(name)
 	_ = devcontainer.DeleteMeta(name)
 	return containerID, nil

--- a/internal/agent/README.md
+++ b/internal/agent/README.md
@@ -10,3 +10,5 @@
 - List all agents with status and running time
 - Attach to a live agent to watch it work
 - Stop or delete an agent and its container
+- Keep a per-run execution log on the host — the launch (prompt, argv, model), the agent's full output stream, the Claude session transcript (copied out before the container is removed), and the outcome — so even a crashed or reaped run stays analyzable
+- Review past runs with `human agent logs <name>` (`--json` for raw records)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -40,6 +40,10 @@ type Meta struct {
 	ConfigDir     string    `json:"config_dir,omitempty"`
 	ImageName     string    `json:"image_name,omitempty"`
 	RemoteUser    string    `json:"remote_user,omitempty"`
+	// ExecutionID ties this agent to its current run's execution-log dir so
+	// removal paths can copy the transcript out of the exact run before the
+	// container is destroyed.
+	ExecutionID string `json:"execution_id,omitempty"`
 }
 
 // ContainerName returns the Docker container name for an agent.

--- a/internal/agent/agentlog.go
+++ b/internal/agent/agentlog.go
@@ -1,0 +1,325 @@
+package agent
+
+// Host-side per-execution log store. A container-based agent run that dies —
+// failed, or reaped by the zombie sweep — must stay analyzable afterwards: the
+// detached stdout, the Claude session transcript, and the outcome all vanish
+// with the container unless they are teed and copied out to the host first.
+// This store is the durable record every remove path writes into, keyed by
+// agent name and listed newest-first, mirroring the audit trail's UX.
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/claude/hookevents"
+	"github.com/gethuman-sh/human/internal/devcontainer"
+)
+
+// execRetentionDays is the rolling window for execution-log retention. Matches
+// audit.RetentionDays: these are accountability records that must outlive the
+// short-lived trend graphs.
+const execRetentionDays = 90
+
+// execIDBytes is the number of random bytes hex-encoded into an execution id.
+// 16 bytes yields a 32-char hex string with ample uniqueness. Mirrors the
+// crypto/rand pattern in internal/audit/event.go so no UUID dependency is
+// pulled into the dependency-light agent package.
+const execIDBytes = 16
+
+// agentLogsDirOverride lets tests redirect the log root. Empty = default.
+var agentLogsDirOverride string
+
+// ExecutionLogsDir returns ~/.human/agent-logs (falls back to ./.human/agent-logs
+// when the home directory is unknown), sitting beside the agents metadata dir.
+func ExecutionLogsDir() string {
+	if agentLogsDirOverride != "" {
+		return agentLogsDirOverride
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".", ".human", "agent-logs")
+	}
+	return filepath.Join(home, ".human", "agent-logs")
+}
+
+// newExecID returns a cryptographically random 32-char hex execution id.
+func newExecID() string {
+	b := make([]byte, execIDBytes)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand failure is effectively fatal for the process; fall back to
+		// a timestamp-derived id so the run still gets a distinct directory.
+		return hex.EncodeToString([]byte(time.Now().UTC().Format(time.RFC3339Nano)))
+	}
+	return hex.EncodeToString(b)
+}
+
+// LaunchRecord is written before detach: the exact launch of a claude run.
+type LaunchRecord struct {
+	ID          string    `json:"id"`
+	Agent       string    `json:"agent"`
+	Prompt      string    `json:"prompt"`
+	Argv        []string  `json:"argv"`
+	Model       string    `json:"model,omitempty"`
+	ContainerID string    `json:"container_id"`
+	StartedAt   time.Time `json:"started_at"`
+}
+
+// OutcomeRecord is written on completion/reap: why and when a run ended.
+type OutcomeRecord struct {
+	Reason     string    `json:"reason"` // "completed" | "failed" | "reaped"
+	ExitCode   int       `json:"exit_code"`
+	DurationMs int64     `json:"duration_ms"`
+	Result     string    `json:"result,omitempty"`
+	EndedAt    time.Time `json:"ended_at"`
+}
+
+// Execution is the on-disk root for one run: <logsDir>/<agent>/<id>/.
+type Execution struct {
+	dir    string
+	Launch LaunchRecord
+}
+
+// executionDir returns the run directory for an agent/id pair.
+func executionDir(agentName, id string) string {
+	return filepath.Join(ExecutionLogsDir(), agentName, id)
+}
+
+// NewExecution creates the run directory and writes launch.json. The agent name
+// is validated at Start, so a plain join is safe; guard defensively anyway.
+func NewExecution(lr LaunchRecord) (*Execution, error) {
+	if !isValidName(lr.Agent) {
+		return nil, errors.WithDetails("invalid agent name for execution log", "name", lr.Agent)
+	}
+	dir := executionDir(lr.Agent, lr.ID)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, errors.WrapWithDetails(err, "creating execution log directory", "dir", dir)
+	}
+	e := &Execution{dir: dir, Launch: lr}
+	if err := writeJSONFile(filepath.Join(dir, "launch.json"), lr); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+// Dir returns the on-disk root for this execution.
+func (e *Execution) Dir() string { return e.dir }
+
+// OutputWriter returns an append writer to <dir>/output.log (0600), created on
+// first call. The detached exec's demuxed stdout/stderr is teed here.
+func (e *Execution) OutputWriter() (io.WriteCloser, error) {
+	path := filepath.Join(e.dir, "output.log")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600) // #nosec G304 -- path derived from validated agent name + hex id
+	if err != nil {
+		return nil, errors.WrapWithDetails(err, "opening execution output log", "path", path)
+	}
+	return f, nil
+}
+
+// TranscriptDir returns <dir>/transcript, the copy-out target for the Claude
+// session transcript. Created lazily by the copy-out.
+func (e *Execution) TranscriptDir() string {
+	return filepath.Join(e.dir, "transcript")
+}
+
+// RecordOutcome writes outcome.json.
+func (e *Execution) RecordOutcome(o OutcomeRecord) error {
+	return writeJSONFile(filepath.Join(e.dir, "outcome.json"), o)
+}
+
+// ExecutionSummary is one run as surfaced to `human agent logs`.
+type ExecutionSummary struct {
+	Launch  LaunchRecord   `json:"launch"`
+	Outcome *OutcomeRecord `json:"outcome,omitempty"`
+	Dir     string         `json:"dir"`
+}
+
+// ListExecutions returns all executions for an agent, newest-first by
+// StartedAt, attaching outcome.json when present.
+func ListExecutions(agentName string) ([]ExecutionSummary, error) {
+	root := filepath.Join(ExecutionLogsDir(), agentName)
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errors.WrapWithDetails(err, "listing execution logs", "dir", root)
+	}
+	var out []ExecutionSummary
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(root, e.Name())
+		var lr LaunchRecord
+		if err := readJSONFile(filepath.Join(dir, "launch.json"), &lr); err != nil {
+			continue // skip incomplete/corrupt runs
+		}
+		sum := ExecutionSummary{Launch: lr, Dir: dir}
+		var oc OutcomeRecord
+		if err := readJSONFile(filepath.Join(dir, "outcome.json"), &oc); err == nil {
+			sum.Outcome = &oc
+		}
+		out = append(out, sum)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Launch.StartedAt.After(out[j].Launch.StartedAt)
+	})
+	return out, nil
+}
+
+// LatestExecution returns the newest execution for an agent, so a remove path
+// with no execution id on the meta can still find the current run's dir.
+func LatestExecution(agentName string) (*Execution, error) {
+	execs, err := ListExecutions(agentName)
+	if err != nil {
+		return nil, err
+	}
+	if len(execs) == 0 {
+		return nil, errors.WithDetails("no executions for agent", "name", agentName)
+	}
+	return &Execution{dir: execs[0].Dir, Launch: execs[0].Launch}, nil
+}
+
+// lookupExecution resolves the execution dir for a meta: prefer the exact id
+// recorded at launch, else fall back to the agent's latest run. Returns nil
+// when nothing is found — callers treat a missing execution as non-fatal.
+func lookupExecution(meta Meta) *Execution {
+	if meta.ExecutionID != "" {
+		dir := executionDir(meta.Name, meta.ExecutionID)
+		var lr LaunchRecord
+		if err := readJSONFile(filepath.Join(dir, "launch.json"), &lr); err == nil {
+			return &Execution{dir: dir, Launch: lr}
+		}
+	}
+	exe, err := LatestExecution(meta.Name)
+	if err != nil {
+		return nil
+	}
+	return exe
+}
+
+// PreserveExecutionArtifacts copies the run's transcript out of the container
+// and records the outcome — the last chance to capture both before a
+// force-remove destroys them. Best-effort by contract: teardown must proceed
+// whether or not anything could be preserved, so failures are swallowed. Every
+// remove path (Manager stop/delete and the daemon's async decommission bypass)
+// funnels through this one preservation step.
+func PreserveExecutionArtifacts(ctx context.Context, docker devcontainer.DockerClient, meta Meta, reason string) {
+	exe := lookupExecution(meta)
+	if exe == nil {
+		return
+	}
+	_ = CopyTranscript(ctx, docker, meta.ContainerID, meta.RemoteUser, exe.TranscriptDir())
+	_ = exe.RecordOutcome(OutcomeRecord{
+		Reason: reason, EndedAt: time.Now(),
+		DurationMs: time.Since(meta.CreatedAt).Milliseconds(),
+	})
+}
+
+// stopReason classifies why a run is ending at the remove choke point. The
+// zombie sweep marks reaped agents with StatusFailed; a plain stop is a
+// completion.
+func stopReason(meta Meta) string {
+	if meta.Status == StatusFailed {
+		return "reaped"
+	}
+	return "completed"
+}
+
+// PruneExecutions deletes execution dirs whose launch is older than
+// execRetentionDays. Mirrors audit.Prune. Returns the number of runs removed.
+func PruneExecutions() (int, error) {
+	root := ExecutionLogsDir()
+	agents, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, errors.WrapWithDetails(err, "listing execution log root", "dir", root)
+	}
+	cutoff := time.Now().Add(-execRetentionDays * 24 * time.Hour)
+	removed := 0
+	for _, a := range agents {
+		if !a.IsDir() {
+			continue
+		}
+		agentRoot := filepath.Join(root, a.Name())
+		runs, err := os.ReadDir(agentRoot)
+		if err != nil {
+			continue
+		}
+		for _, r := range runs {
+			if !r.IsDir() {
+				continue
+			}
+			dir := filepath.Join(agentRoot, r.Name())
+			var lr LaunchRecord
+			if err := readJSONFile(filepath.Join(dir, "launch.json"), &lr); err != nil {
+				continue
+			}
+			if lr.StartedAt.Before(cutoff) {
+				if err := os.RemoveAll(dir); err == nil {
+					removed++
+				}
+			}
+		}
+	}
+	return removed, nil
+}
+
+// HookEventSink appends a hook event as one JSON line to the agent's latest
+// execution dir (<logsDir>/<agent>/<latest-id>/hooks.jsonl). It is best-effort
+// and never surfaces an error into the daemon's hot path: a hook event tied to
+// an agent must survive the in-memory ring's eviction and daemon restarts. A
+// missing agent name (non-agent session) or no known execution is a no-op.
+func HookEventSink(evt hookevents.Event) {
+	if evt.AgentName == "" || !isValidName(evt.AgentName) {
+		return
+	}
+	exe, err := LatestExecution(evt.AgentName)
+	if err != nil {
+		return
+	}
+	line, err := json.Marshal(evt)
+	if err != nil {
+		return
+	}
+	path := filepath.Join(exe.Dir(), "hooks.jsonl")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600) // #nosec G304 -- path derived from validated agent name + hex id
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	_, _ = f.Write(append(line, '\n'))
+}
+
+// writeJSONFile writes v as indented JSON with 0600 permissions, matching
+// WriteMeta.
+func writeJSONFile(path string, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errors.WrapWithDetails(err, "marshaling execution log record", "path", path)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return errors.WrapWithDetails(err, "writing execution log record", "path", path)
+	}
+	return nil
+}
+
+// readJSONFile decodes the JSON file at path into v.
+func readJSONFile(path string, v any) error {
+	data, err := os.ReadFile(path) // #nosec G304 -- path derived from validated agent name + hex id
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, v)
+}

--- a/internal/agent/agentlog_regression_test.go
+++ b/internal/agent/agentlog_regression_test.go
@@ -1,0 +1,179 @@
+package agent
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gethuman-sh/human/internal/devcontainer"
+)
+
+// stdoutFrame wraps payload in a Docker stdcopy multiplexed stdout frame:
+// an 8-byte header (stream=1, then a big-endian uint32 length) followed by the
+// payload. This is the exact wire format the detached exec attach emits.
+func stdoutFrame(payload string) []byte {
+	h := make([]byte, 8)
+	h[0] = 1 // stdout stream
+	binary.BigEndian.PutUint32(h[4:], uint32(len(payload)))
+	return append(h, []byte(payload)...)
+}
+
+// tarWithTranscript builds a tar archive carrying one transcript file so the
+// mock CopyFromContainer can stand in for a real container copy-out.
+func tarWithTranscript(name, contents string) io.ReadCloser {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	hdr := &tar.Header{Name: name, Mode: 0o600, Size: int64(len(contents))}
+	_ = tw.WriteHeader(hdr)
+	_, _ = tw.Write([]byte(contents))
+	_ = tw.Close()
+	return io.NopCloser(&buf)
+}
+
+// regMockDocker extends the base mock with a real stdout frame on ExecAttach
+// and a real tar archive on CopyFromContainer, so the tee and copy-out paths
+// have known bytes to persist.
+type regMockDocker struct {
+	mockDockerClient
+	stdoutPayload string
+	transcript    string
+}
+
+func (m *regMockDocker) ExecAttach(_ context.Context, _ string) (devcontainer.ExecAttachResponse, error) {
+	return devcontainer.ExecAttachResponse{
+		Reader: bytes.NewReader(stdoutFrame(m.stdoutPayload)),
+		Conn:   io.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func (m *regMockDocker) CopyFromContainer(_ context.Context, _, _ string) (io.ReadCloser, error) {
+	return tarWithTranscript("projects/proj/session.jsonl", m.transcript), nil
+}
+
+// TestAgentExecution_PersistsOutputAndTranscript is the regression test
+// mandated by triage: start an agent through a fake Docker whose exec Reader
+// emits known bytes, force-remove the container, then assert the persisted
+// execution log contains those stdout bytes and a copied transcript. On the
+// pre-fix code the detached output is discarded and the transcript destroyed,
+// so this fails; after the fix both are durable on the host.
+func TestAgentExecution_PersistsOutputAndTranscript(t *testing.T) {
+	tmp := t.TempDir()
+	agentLogsDirOverride = tmp
+	t.Cleanup(func() { agentLogsDirOverride = "" })
+
+	// Redirect the agents meta dir (AgentsDir reads $HOME) into the temp tree
+	// so stopLocked can read the meta we write below without touching real home.
+	t.Setenv("HOME", tmp)
+
+	docker := &regMockDocker{
+		stdoutPayload: "AGENT-STDOUT-MARKER",
+		transcript:    "TRANSCRIPT-MARKER",
+	}
+	mgr := &Manager{Docker: docker}
+	ctx := context.Background()
+
+	exe, err := mgr.execClaudeDetached(ctx, "container-xyz", "vscode", StartOpts{
+		Name: "reg", Prompt: "do it", Model: "opus",
+	})
+	if err != nil {
+		t.Fatalf("execClaudeDetached: %v", err)
+	}
+	if exe == nil {
+		t.Fatal("expected non-nil execution")
+	}
+
+	// Persist the meta so stopLocked can find the container and execution id.
+	meta := Meta{
+		Name: "reg", ContainerID: "container-xyz", RemoteUser: "vscode",
+		Status: StatusRunning, CreatedAt: time.Now(), ExecutionID: exe.Launch.ID,
+	}
+	if err := WriteMeta(meta); err != nil {
+		t.Fatalf("write meta: %v", err)
+	}
+
+	// Wait for the tee goroutine to flush the stdout frame to output.log.
+	waitForOutput(t, filepath.Join(tmp, "reg"))
+
+	if err := mgr.Stop(ctx, "reg"); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+
+	execs, err := ListExecutions("reg")
+	if err != nil {
+		t.Fatalf("list executions: %v", err)
+	}
+	if len(execs) == 0 {
+		t.Fatal("expected at least one execution log")
+	}
+	dir := execs[0].Dir
+
+	out, err := os.ReadFile(filepath.Join(dir, "output.log"))
+	if err != nil {
+		t.Fatalf("read output.log: %v", err)
+	}
+	if !strings.Contains(string(out), "AGENT-STDOUT-MARKER") {
+		t.Fatalf("output.log missing stdout marker, got %q", string(out))
+	}
+
+	transcript := readTree(t, filepath.Join(dir, "transcript"))
+	if !strings.Contains(transcript, "TRANSCRIPT-MARKER") {
+		t.Fatalf("transcript missing marker, got %q", transcript)
+	}
+
+	if execs[0].Launch.Prompt != "do it" {
+		t.Fatalf("launch prompt = %q, want %q", execs[0].Launch.Prompt, "do it")
+	}
+	if execs[0].Launch.Model != "opus" {
+		t.Fatalf("launch model = %q, want opus", execs[0].Launch.Model)
+	}
+	if !containsArg(execs[0].Launch.Argv, "-p") {
+		t.Fatalf("launch argv missing -p: %v", execs[0].Launch.Argv)
+	}
+}
+
+// waitForOutput polls up to 2s for output.log to appear under some execution
+// dir beneath agentDir, so the async tee has time to flush.
+func waitForOutput(t *testing.T, agentDir string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		entries, _ := os.ReadDir(agentDir)
+		for _, e := range entries {
+			p := filepath.Join(agentDir, e.Name(), "output.log")
+			if data, err := os.ReadFile(p); err == nil && len(data) > 0 {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func readTree(t *testing.T, root string) string {
+	t.Helper()
+	var sb strings.Builder
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		data, _ := os.ReadFile(path)
+		sb.Write(data)
+		return nil
+	})
+	return sb.String()
+}
+
+func containsArg(argv []string, want string) bool {
+	for _, a := range argv {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/agentlog_test.go
+++ b/internal/agent/agentlog_test.go
@@ -1,0 +1,214 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gethuman-sh/human/internal/claude/hookevents"
+	"github.com/gethuman-sh/human/internal/devcontainer"
+)
+
+// stderrFrame wraps payload in a Docker stdcopy multiplexed stderr frame.
+func stderrFrame(payload string) []byte {
+	h := make([]byte, 8)
+	h[0] = 2 // stderr stream
+	binary.BigEndian.PutUint32(h[4:], uint32(len(payload)))
+	return append(h, []byte(payload)...)
+}
+
+func bytesReader(b []byte) io.Reader { return bytes.NewReader(b) }
+func nopCloser() io.Closer           { return io.NopCloser(strings.NewReader("")) }
+func contains(s, sub string) bool    { return strings.Contains(s, sub) }
+
+func withLogRoot(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	agentLogsDirOverride = tmp
+	t.Cleanup(func() { agentLogsDirOverride = "" })
+	return tmp
+}
+
+func TestExecClaudeDetached_WritesLaunchRecord(t *testing.T) {
+	withLogRoot(t)
+	mgr := &Manager{Docker: &mockDockerClient{}}
+	exe, err := mgr.execClaudeDetached(context.Background(), "cid", "vscode", StartOpts{
+		Name: "a", Prompt: "P", Model: "opus",
+	})
+	if err != nil {
+		t.Fatalf("execClaudeDetached: %v", err)
+	}
+	if exe == nil {
+		t.Fatal("expected non-nil execution")
+	}
+	if !containsArg(exe.Launch.Argv, "-p") || !containsArg(exe.Launch.Argv, "P") {
+		t.Fatalf("argv missing -p/P: %v", exe.Launch.Argv)
+	}
+	if !containsArg(exe.Launch.Argv, "--model") || !containsArg(exe.Launch.Argv, "opus") {
+		t.Fatalf("argv missing --model/opus: %v", exe.Launch.Argv)
+	}
+	if exe.Launch.ContainerID != "cid" {
+		t.Fatalf("container_id = %q, want cid", exe.Launch.ContainerID)
+	}
+}
+
+// teeMock emits a stdout and a stderr frame so the tee demux can be observed.
+type teeMock struct {
+	mockDockerClient
+}
+
+func (m *teeMock) ExecAttach(_ context.Context, _ string) (devcontainer.ExecAttachResponse, error) {
+	frames := append(stdoutFrame("OUT"), stderrFrame("ERR")...)
+	return devcontainer.ExecAttachResponse{
+		Reader: bytesReader(frames),
+		Conn:   nopCloser(),
+	}, nil
+}
+
+func TestTeeExecOutput_DemuxesStdoutAndStderr(t *testing.T) {
+	withLogRoot(t)
+	mgr := &Manager{Docker: &teeMock{}}
+	exe, err := mgr.execClaudeDetached(context.Background(), "cid", "vscode", StartOpts{Name: "tee", Prompt: "p"})
+	if err != nil {
+		t.Fatalf("execClaudeDetached: %v", err)
+	}
+	if exe == nil {
+		t.Fatal("expected non-nil execution")
+	}
+	// Poll for the tee goroutine to flush both frames.
+	var out string
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		data, _ := os.ReadFile(filepath.Join(exe.Dir(), "output.log"))
+		out = string(data)
+		if len(out) > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !contains(out, "OUT") || !contains(out, "ERR") {
+		t.Fatalf("output.log missing demuxed payloads, got %q", out)
+	}
+}
+
+func TestListExecutions_NewestFirst(t *testing.T) {
+	withLogRoot(t)
+	old, err := NewExecution(LaunchRecord{ID: "old", Agent: "a", StartedAt: time.Now().Add(-time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := old.RecordOutcome(OutcomeRecord{Reason: "completed", EndedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewExecution(LaunchRecord{ID: "new", Agent: "a", StartedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	execs, err := ListExecutions("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(execs) != 2 {
+		t.Fatalf("want 2 executions, got %d", len(execs))
+	}
+	if execs[0].Launch.ID != "new" {
+		t.Fatalf("newest-first violated: %q", execs[0].Launch.ID)
+	}
+	if execs[0].Outcome != nil {
+		t.Fatal("newest run has no outcome yet; want nil")
+	}
+	if execs[1].Outcome == nil || execs[1].Outcome.Reason != "completed" {
+		t.Fatalf("old run outcome not attached: %+v", execs[1].Outcome)
+	}
+}
+
+func TestListExecutions_MissingAgentIsEmpty(t *testing.T) {
+	withLogRoot(t)
+	execs, err := ListExecutions("nope")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(execs) != 0 {
+		t.Fatalf("want empty, got %d", len(execs))
+	}
+}
+
+func TestPruneExecutions_DropsOld(t *testing.T) {
+	withLogRoot(t)
+	if _, err := NewExecution(LaunchRecord{ID: "stale", Agent: "a", StartedAt: time.Now().Add(-100 * 24 * time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewExecution(LaunchRecord{ID: "fresh", Agent: "a", StartedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := PruneExecutions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 1 {
+		t.Fatalf("want 1 pruned, got %d", removed)
+	}
+	execs, _ := ListExecutions("a")
+	if len(execs) != 1 || execs[0].Launch.ID != "fresh" {
+		t.Fatalf("expected only fresh to remain: %+v", execs)
+	}
+}
+
+func TestStopReason(t *testing.T) {
+	if stopReason(Meta{Status: StatusFailed}) != "reaped" {
+		t.Fatal("failed status should map to reaped")
+	}
+	if stopReason(Meta{Status: StatusRunning}) != "completed" {
+		t.Fatal("running/stop should map to completed")
+	}
+}
+
+func TestLookupExecution_PrefersIDThenLatest(t *testing.T) {
+	withLogRoot(t)
+	if _, err := NewExecution(LaunchRecord{ID: "id1", Agent: "a", StartedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	exe := lookupExecution(Meta{Name: "a", ExecutionID: "id1"})
+	if exe == nil || exe.Launch.ID != "id1" {
+		t.Fatalf("lookup by id failed: %+v", exe)
+	}
+	// No id -> falls back to latest.
+	exe = lookupExecution(Meta{Name: "a"})
+	if exe == nil {
+		t.Fatal("expected latest fallback")
+	}
+	// Unknown agent -> nil.
+	if lookupExecution(Meta{Name: "missing"}) != nil {
+		t.Fatal("unknown agent should yield nil")
+	}
+}
+
+func TestHookEventSink_AppendsJSONL(t *testing.T) {
+	withLogRoot(t)
+	if _, err := NewExecution(LaunchRecord{ID: "run1", Agent: "a", StartedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	HookEventSink(hookevents.Event{EventName: "Stop", AgentName: "a", Timestamp: time.Now()})
+	HookEventSink(hookevents.Event{EventName: "Notification", AgentName: "a", Timestamp: time.Now()})
+
+	exe, err := LatestExecution("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(exe.Dir(), "hooks.jsonl"))
+	if err != nil {
+		t.Fatalf("hooks.jsonl not written: %v", err)
+	}
+	lines := strings.Count(string(data), "\n")
+	if lines != 2 {
+		t.Fatalf("want 2 json lines, got %d: %q", lines, string(data))
+	}
+
+	// Empty agent name is a no-op (no panic, nothing written).
+	HookEventSink(hookevents.Event{EventName: "Stop", Timestamp: time.Now()})
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -85,14 +85,25 @@ func (m *Manager) Start(ctx context.Context, opts StartOpts) (Meta, error) {
 		return Meta{}, errors.WrapWithDetails(err, "starting agent container", "name", opts.Name)
 	}
 
+	var executionID string
 	if !opts.Interactive && opts.Prompt != "" {
-		if err := m.execClaudeDetached(ctx, dcMeta.ContainerID, dcMeta.RemoteUser, opts); err != nil {
+		exe, err := m.execClaudeDetached(ctx, dcMeta.ContainerID, dcMeta.RemoteUser, opts)
+		if err != nil {
 			// The agent process never started; don't leave a container tracked
 			// as a running agent. Best-effort teardown, then surface the error.
+			if exe != nil {
+				_ = exe.RecordOutcome(OutcomeRecord{
+					Reason: "failed", EndedAt: time.Now(),
+					DurationMs: time.Since(exe.Launch.StartedAt).Milliseconds(),
+				})
+			}
 			timeout := 10
 			_ = m.Docker.ContainerStop(ctx, dcMeta.ContainerID, &timeout)
 			_ = m.Docker.ContainerRemove(ctx, dcMeta.ContainerID, devcontainer.ContainerRemoveOptions{Force: true})
 			return Meta{}, errors.WrapWithDetails(err, "launching agent process", "name", opts.Name)
+		}
+		if exe != nil {
+			executionID = exe.Launch.ID
 		}
 	}
 
@@ -101,7 +112,7 @@ func (m *Manager) Start(ctx context.Context, opts StartOpts) (Meta, error) {
 		Cwd: workspace, Prompt: opts.Prompt,
 		Status: StatusRunning, CreatedAt: time.Now(), SkipPerms: opts.SkipPerms,
 		Model: opts.Model, ConfigDir: configDir, ImageName: dcMeta.ImageName,
-		RemoteUser: dcMeta.RemoteUser,
+		RemoteUser: dcMeta.RemoteUser, ExecutionID: executionID,
 	}
 	if err := WriteMeta(meta); err != nil {
 		return Meta{}, err
@@ -150,7 +161,7 @@ func (m *Manager) startDevcontainer(ctx context.Context, containerName, configDi
 // (no intermediate shell), so multi-word prompts and shell metacharacters can
 // neither be word-split nor injected. Errors are returned so a failed launch is
 // not silently reported as a running agent.
-func (m *Manager) execClaudeDetached(ctx context.Context, containerID, remoteUser string, opts StartOpts) error {
+func (m *Manager) execClaudeDetached(ctx context.Context, containerID, remoteUser string, opts StartOpts) (*Execution, error) {
 	claudeArgs := m.BuildClaudeArgs(opts)
 	claudeArgs = append(claudeArgs, "-p", opts.Prompt)
 	cmd := append([]string{"claude"}, claudeArgs...)
@@ -159,16 +170,47 @@ func (m *Manager) execClaudeDetached(ctx context.Context, containerID, remoteUse
 		Env: []string{"HUMAN_AGENT_NAME=" + opts.Name},
 	})
 	if err != nil {
-		return errors.WrapWithDetails(err, "creating agent exec")
+		return nil, errors.WrapWithDetails(err, "creating agent exec")
 	}
+
+	// Record the exact launch before detaching. A log-store failure must not
+	// block launching the agent — degrade to no tee rather than failing Start.
+	exe, logErr := NewExecution(LaunchRecord{
+		ID: newExecID(), Agent: opts.Name, Prompt: opts.Prompt,
+		Argv: cmd, Model: opts.Model, ContainerID: containerID, StartedAt: time.Now(),
+	})
+
 	// ExecAttach starts the exec; closing the hijacked stream detaches without
 	// stopping the process, which keeps running in the container.
 	attach, err := m.Docker.ExecAttach(ctx, execID)
 	if err != nil {
-		return errors.WrapWithDetails(err, "starting agent exec")
+		return exe, errors.WrapWithDetails(err, "starting agent exec")
 	}
-	_ = attach.Close()
-	return nil
+
+	if logErr == nil && exe != nil {
+		// The tee goroutine owns the attach and closes it on stream EOF (the
+		// exec exiting), so launch returns immediately while the detached
+		// stdout/stderr is durably persisted to the host.
+		go teeExecOutput(attach, exe)
+	} else {
+		_ = attach.Close()
+	}
+	return exe, nil
+}
+
+// teeExecOutput demuxes the detached agent's multiplexed stdout/stderr into the
+// execution's host output log until the stream ends (the exec exits), then
+// closes the attach. This is the durability path the detached launch never had:
+// without it the output is unrecoverable once the container is gone.
+func teeExecOutput(attach devcontainer.ExecAttachResponse, exe *Execution) {
+	defer func() { _ = attach.Close() }()
+	w, err := exe.OutputWriter()
+	if err != nil {
+		return
+	}
+	defer func() { _ = w.Close() }()
+	// stdout and stderr both go to the one host log; StdCopy demuxes the frames.
+	_, _ = devcontainer.StdCopy(w, w, attach.Reader)
 }
 
 // agentLocks serialises lifecycle operations per agent name. Stop/Delete can be
@@ -207,6 +249,10 @@ func (m *Manager) stopLocked(ctx context.Context, name string) error {
 	}
 
 	if meta.ContainerID != "" {
+		// Persist the transcript and outcome before the container (and its
+		// ~/.claude/projects transcript) are destroyed — the whole point of
+		// SC-216.
+		PreserveExecutionArtifacts(ctx, m.Docker, meta, stopReason(meta))
 		timeout := 10
 		_ = m.Docker.ContainerStop(ctx, meta.ContainerID, &timeout)
 		_ = m.Docker.ContainerRemove(ctx, meta.ContainerID, devcontainer.ContainerRemoveOptions{Force: true})

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -71,6 +71,9 @@ func (m *mockDockerClient) ContainerCommit(_ context.Context, _ string, _ string
 func (m *mockDockerClient) CopyToContainer(_ context.Context, _, _ string, _ io.Reader) error {
 	return nil
 }
+func (m *mockDockerClient) CopyFromContainer(_ context.Context, _, _ string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("")), nil
+}
 func (m *mockDockerClient) ExecCreate(_ context.Context, _ string, _ []string, _ devcontainer.ExecOptions) (string, error) {
 	return "exec-1", nil
 }

--- a/internal/agent/transcript.go
+++ b/internal/agent/transcript.go
@@ -1,0 +1,97 @@
+package agent
+
+import (
+	"archive/tar"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/devcontainer"
+)
+
+// containerTranscriptPath is the in-container Claude session transcript root.
+// The remote user's home is at /home/<user>; an empty or root user falls back
+// to /root.
+func containerTranscriptPath(remoteUser string) string {
+	if remoteUser == "" || remoteUser == "root" {
+		return "/root/.claude/projects"
+	}
+	return "/home/" + remoteUser + "/.claude/projects"
+}
+
+// CopyTranscript streams ~/.claude/projects from the container as a tar archive
+// and extracts it into destDir. It is best-effort: a missing path or copy error
+// is returned wrapped, but callers treat copy-out as non-fatal — the container
+// removal must still proceed. Extraction is hardened against path traversal:
+// entries that would escape destDir are skipped.
+func CopyTranscript(ctx context.Context, docker devcontainer.DockerClient, containerID, remoteUser, destDir string) error {
+	srcPath := containerTranscriptPath(remoteUser)
+	rc, err := docker.CopyFromContainer(ctx, containerID, srcPath)
+	if err != nil {
+		return errors.WrapWithDetails(err, "copying transcript from container", "container", containerID, "src", srcPath)
+	}
+	defer func() { _ = rc.Close() }()
+
+	if err := os.MkdirAll(destDir, 0o700); err != nil {
+		return errors.WrapWithDetails(err, "creating transcript directory", "dir", destDir)
+	}
+
+	tr := tar.NewReader(rc)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return errors.WrapWithDetails(err, "reading transcript archive")
+		}
+		if err := extractTarEntry(tr, hdr, destDir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// extractTarEntry writes one tar entry under destDir, rejecting any name that
+// would escape destDir (path traversal).
+func extractTarEntry(tr *tar.Reader, hdr *tar.Header, destDir string) error {
+	clean := filepath.Clean(hdr.Name)
+	target := filepath.Join(destDir, clean)
+	// The joined target must remain within destDir; anything else is a traversal
+	// attempt and is skipped rather than trusted.
+	if target != destDir && !strings.HasPrefix(target, destDir+string(os.PathSeparator)) {
+		return nil
+	}
+
+	switch hdr.Typeflag {
+	case tar.TypeDir:
+		if err := os.MkdirAll(target, 0o700); err != nil {
+			return errors.WrapWithDetails(err, "creating transcript subdir", "dir", target)
+		}
+	case tar.TypeReg:
+		if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+			return errors.WrapWithDetails(err, "creating transcript parent", "dir", filepath.Dir(target))
+		}
+		f, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600) // #nosec G304 -- target validated to stay within destDir above
+		if err != nil {
+			return errors.WrapWithDetails(err, "creating transcript file", "path", target)
+		}
+		// Bound the copy so a hostile archive cannot fill the disk via one entry.
+		if _, err := io.Copy(f, io.LimitReader(tr, maxTranscriptFileBytes)); err != nil {
+			_ = f.Close()
+			return errors.WrapWithDetails(err, "writing transcript file", "path", target)
+		}
+		if err := f.Close(); err != nil {
+			return errors.WrapWithDetails(err, "closing transcript file", "path", target)
+		}
+	}
+	return nil
+}
+
+// maxTranscriptFileBytes caps a single extracted transcript file so a malformed
+// or hostile archive cannot exhaust host disk through one giant entry. Claude
+// session transcripts are JSONL and stay well under this.
+const maxTranscriptFileBytes = 64 << 20 // 64 MiB

--- a/internal/agent/transcript_test.go
+++ b/internal/agent/transcript_test.go
@@ -1,0 +1,199 @@
+package agent
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gethuman-sh/human/internal/devcontainer"
+)
+
+// tarArchive builds a tar archive from name->contents entries.
+func tarArchive(entries map[string]string) io.ReadCloser {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for name, contents := range entries {
+		_ = tw.WriteHeader(&tar.Header{Name: name, Mode: 0o600, Size: int64(len(contents)), Typeflag: tar.TypeReg})
+		_, _ = tw.Write([]byte(contents))
+	}
+	_ = tw.Close()
+	return io.NopCloser(&buf)
+}
+
+type copyMock struct {
+	mockDockerClient
+	archive func() io.ReadCloser
+
+	mu    sync.Mutex
+	calls []string // ordered record of "copy"/"remove"
+}
+
+func (m *copyMock) CopyFromContainer(_ context.Context, _, _ string) (io.ReadCloser, error) {
+	m.mu.Lock()
+	m.calls = append(m.calls, "copy")
+	m.mu.Unlock()
+	return m.archive(), nil
+}
+
+func (m *copyMock) ContainerRemove(_ context.Context, _ string, _ devcontainer.ContainerRemoveOptions) error {
+	m.mu.Lock()
+	m.calls = append(m.calls, "remove")
+	m.mu.Unlock()
+	return nil
+}
+
+func TestContainerTranscriptPath(t *testing.T) {
+	if got := containerTranscriptPath("vscode"); got != "/home/vscode/.claude/projects" {
+		t.Fatalf("got %q", got)
+	}
+	if got := containerTranscriptPath(""); got != "/root/.claude/projects" {
+		t.Fatalf("empty user got %q", got)
+	}
+	if got := containerTranscriptPath("root"); got != "/root/.claude/projects" {
+		t.Fatalf("root got %q", got)
+	}
+}
+
+func TestCopyTranscript_ExtractsTar(t *testing.T) {
+	dest := t.TempDir()
+	docker := &copyMock{archive: func() io.ReadCloser {
+		return tarArchive(map[string]string{"projects/p/s.jsonl": "SESSION-DATA"})
+	}}
+	if err := CopyTranscript(context.Background(), docker, "cid", "vscode", dest); err != nil {
+		t.Fatalf("CopyTranscript: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dest, "projects", "p", "s.jsonl"))
+	if err != nil {
+		t.Fatalf("read extracted: %v", err)
+	}
+	if string(data) != "SESSION-DATA" {
+		t.Fatalf("contents = %q", string(data))
+	}
+}
+
+func TestCopyTranscript_RejectsTraversal(t *testing.T) {
+	dest := t.TempDir()
+	docker := &copyMock{archive: func() io.ReadCloser {
+		return tarArchive(map[string]string{"../escape.txt": "EVIL"})
+	}}
+	if err := CopyTranscript(context.Background(), docker, "cid", "vscode", dest); err != nil {
+		t.Fatalf("CopyTranscript should skip traversal, not error: %v", err)
+	}
+	// The escaping entry must not be written outside dest.
+	if _, err := os.Stat(filepath.Join(filepath.Dir(dest), "escape.txt")); err == nil {
+		t.Fatal("traversal entry escaped destDir")
+	}
+}
+
+func TestStopLocked_CopiesTranscriptBeforeRemove(t *testing.T) {
+	tmp := withLogRoot(t)
+	t.Setenv("HOME", tmp)
+
+	exe, err := NewExecution(LaunchRecord{ID: "e1", Agent: "s1", StartedAt: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta := Meta{
+		Name: "s1", ContainerID: "cid", RemoteUser: "vscode",
+		Status: StatusRunning, CreatedAt: time.Now(), ExecutionID: exe.Launch.ID,
+	}
+	if err := WriteMeta(meta); err != nil {
+		t.Fatal(err)
+	}
+	docker := &copyMock{archive: func() io.ReadCloser {
+		return tarArchive(map[string]string{"projects/p/s.jsonl": "X"})
+	}}
+	mgr := &Manager{Docker: docker}
+	if err := mgr.Stop(context.Background(), "s1"); err != nil {
+		t.Fatal(err)
+	}
+	if len(docker.calls) < 2 || docker.calls[0] != "copy" || docker.calls[1] != "remove" {
+		t.Fatalf("copy must precede remove, got %v", docker.calls)
+	}
+	var oc OutcomeRecord
+	if err := readJSONFile(filepath.Join(exe.Dir(), "outcome.json"), &oc); err != nil {
+		t.Fatalf("outcome not written: %v", err)
+	}
+	if oc.Reason != "completed" {
+		t.Fatalf("reason = %q, want completed", oc.Reason)
+	}
+}
+
+func TestPreserveExecutionArtifacts_CopiesTranscriptAndOutcome(t *testing.T) {
+	withLogRoot(t)
+
+	exe, err := NewExecution(LaunchRecord{ID: "e9", Agent: "d1", StartedAt: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta := Meta{
+		Name: "d1", ContainerID: "cid", RemoteUser: "vscode",
+		CreatedAt: time.Now(), ExecutionID: exe.Launch.ID,
+	}
+	docker := &copyMock{archive: func() io.ReadCloser {
+		return tarArchive(map[string]string{"projects/p/s.jsonl": "DECOM-DATA"})
+	}}
+	PreserveExecutionArtifacts(context.Background(), docker, meta, "reaped")
+
+	data, err := os.ReadFile(filepath.Join(exe.TranscriptDir(), "projects", "p", "s.jsonl"))
+	if err != nil {
+		t.Fatalf("transcript not copied: %v", err)
+	}
+	if string(data) != "DECOM-DATA" {
+		t.Fatalf("contents = %q", string(data))
+	}
+	var oc OutcomeRecord
+	if err := readJSONFile(filepath.Join(exe.Dir(), "outcome.json"), &oc); err != nil {
+		t.Fatalf("outcome not written: %v", err)
+	}
+	if oc.Reason != "reaped" {
+		t.Fatalf("reason = %q, want reaped", oc.Reason)
+	}
+}
+
+func TestPreserveExecutionArtifacts_NoExecutionIsNoop(t *testing.T) {
+	withLogRoot(t)
+
+	docker := &copyMock{archive: func() io.ReadCloser { return tarArchive(nil) }}
+	// No execution dir exists for this agent; preservation must be a silent no-op.
+	PreserveExecutionArtifacts(context.Background(), docker, Meta{Name: "ghost", ContainerID: "cid"}, "reaped")
+	if len(docker.calls) != 0 {
+		t.Fatalf("expected no docker calls, got %v", docker.calls)
+	}
+}
+
+func TestStopLocked_ReapedReason(t *testing.T) {
+	tmp := withLogRoot(t)
+	t.Setenv("HOME", tmp)
+
+	exe, err := NewExecution(LaunchRecord{ID: "e2", Agent: "s2", StartedAt: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A reaped agent is marked StatusFailed before teardown.
+	meta := Meta{
+		Name: "s2", ContainerID: "cid", RemoteUser: "vscode",
+		Status: StatusFailed, CreatedAt: time.Now(), ExecutionID: exe.Launch.ID,
+	}
+	if err := WriteMeta(meta); err != nil {
+		t.Fatal(err)
+	}
+	docker := &copyMock{archive: func() io.ReadCloser { return tarArchive(nil) }}
+	mgr := &Manager{Docker: docker}
+	if err := mgr.Stop(context.Background(), "s2"); err != nil {
+		t.Fatal(err)
+	}
+	var oc OutcomeRecord
+	if err := readJSONFile(filepath.Join(exe.Dir(), "outcome.json"), &oc); err != nil {
+		t.Fatalf("outcome not written: %v", err)
+	}
+	if oc.Reason != "reaped" {
+		t.Fatalf("reason = %q, want reaped", oc.Reason)
+	}
+}

--- a/internal/daemon/hookstore.go
+++ b/internal/daemon/hookstore.go
@@ -28,6 +28,11 @@ type HookEventStore struct {
 	eventSeqs   []uint64 // monotonic id per event, index-aligned with events
 	appended    uint64   // total events ever appended (last assigned sequence)
 	subscribers []chan struct{}
+	// persist is an optional durable sink invoked for every appended event.
+	// The in-memory ring evicts under load and is empty after a restart, so a
+	// hook event tied to a since-reaped agent run is otherwise lost; the sink
+	// writes it to the host so the trail survives. nil = memory-only.
+	persist func(hookevents.Event)
 }
 
 // NewHookEventStore creates an empty store.
@@ -36,6 +41,16 @@ func NewHookEventStore() *HookEventStore {
 		events:    make([]hookevents.Event, 0, maxHookEvents),
 		eventSeqs: make([]uint64, 0, maxHookEvents),
 	}
+}
+
+// WithPersistence sets a durable sink invoked for every appended event and
+// returns the store for chaining. Wire this only on the daemon's production
+// store; tests keep the default memory-only behaviour.
+func (s *HookEventStore) WithPersistence(sink func(hookevents.Event)) *HookEventStore {
+	s.mu.Lock()
+	s.persist = sink
+	s.mu.Unlock()
+	return s
 }
 
 // Append adds a hook event. Before appending, events for the same
@@ -74,7 +89,13 @@ func (s *HookEventStore) Append(evt hookevents.Event) {
 	}
 	subs := make([]chan struct{}, len(s.subscribers))
 	copy(subs, s.subscribers)
+	persist := s.persist
 	s.mu.Unlock()
+
+	// Persist outside the mutex so slow disk I/O never holds up other appends.
+	if persist != nil {
+		persist(evt)
+	}
 
 	for _, ch := range subs {
 		select {

--- a/internal/daemon/hookstore_test.go
+++ b/internal/daemon/hookstore_test.go
@@ -288,3 +288,21 @@ func TestHookEventStore_UnsubscribeRaceAppend(t *testing.T) {
 		close(done)
 	}
 }
+
+func TestHookEventStore_Persists(t *testing.T) {
+	var mu sync.Mutex
+	var got []hookevents.Event
+	store := NewHookEventStore().WithPersistence(func(e hookevents.Event) {
+		mu.Lock()
+		got = append(got, e)
+		mu.Unlock()
+	})
+
+	evt := hookevents.Event{EventName: "Stop", SessionID: "s1", AgentName: "a1", Timestamp: time.Now()}
+	store.Append(evt)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, got, 1)
+	assert.Equal(t, "a1", got[0].AgentName)
+}

--- a/internal/devcontainer/docker.go
+++ b/internal/devcontainer/docker.go
@@ -30,6 +30,9 @@ type DockerClient interface {
 
 	// File transfer
 	CopyToContainer(ctx context.Context, containerID, dstPath string, content io.Reader) error
+	// CopyFromContainer streams srcPath from the container as a tar archive.
+	// The caller closes the returned reader.
+	CopyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, error)
 
 	// Exec for lifecycle hooks and user commands.
 	ExecCreate(ctx context.Context, containerID string, cmd []string, opts ExecOptions) (string, error)

--- a/internal/devcontainer/docker_engine.go
+++ b/internal/devcontainer/docker_engine.go
@@ -217,6 +217,16 @@ func (e *engineClient) CopyToContainer(ctx context.Context, containerID, dstPath
 	return e.cli.CopyToContainer(ctx, containerID, dstPath, content, container.CopyToContainerOptions{})
 }
 
+func (e *engineClient) CopyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, error) {
+	// The SDK returns the archive reader plus a PathStat; only the archive is
+	// needed for transcript copy-out.
+	rc, _, err := e.cli.CopyFromContainer(ctx, containerID, srcPath)
+	if err != nil {
+		return nil, err
+	}
+	return rc, nil
+}
+
 func (e *engineClient) ExecCreate(ctx context.Context, containerID string, cmd []string, opts ExecOptions) (string, error) {
 	resp, err := e.cli.ContainerExecCreate(ctx, containerID, container.ExecOptions{
 		User:         opts.User,

--- a/internal/devcontainer/hooks_test.go
+++ b/internal/devcontainer/hooks_test.go
@@ -160,6 +160,10 @@ func (m *mockDockerClient) CopyToContainer(_ context.Context, _, _ string, _ io.
 	return nil
 }
 
+func (m *mockDockerClient) CopyFromContainer(_ context.Context, _, _ string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("")), nil
+}
+
 func (m *mockDockerClient) Close() error { return nil }
 
 func testLogger() zerolog.Logger {


### PR DESCRIPTION
Fixes SC-216: agent executions left no analyzable trace — the detached exec's stdout/stderr was discarded at launch, the Claude session transcript was destroyed with the container, and hook events lived only in a memory ring.

Every agent run now writes a durable record under ~/.human/agent-logs/<agent>/<run-id>/:

- launch.json — prompt, full claude argv, model, container id, started-at
- output.log — the demuxed stdout/stderr stream, teed by a goroutine that owns the exec attach
- transcript/ — ~/.claude/projects copied out of the container before every force-remove (manager stop/delete and the daemon's async decommission bypass funnel through one preservation step)
- hooks.jsonl — hook events persisted via an optional durable sink on the hook event store
- outcome.json — reason (completed/failed/reaped), duration, ended-at

Query with the new `human agent logs <name>` (`--json` supported), mirroring the audit-trail UX. Retention: 90 days, pruned in the daemon maintenance loop.

Regression test proves red-before/green-after: with the tee and copy-out seams disabled, a run through a fake Docker leaves no output.log and no transcript; with them in place both survive a force-remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)