### PR TITLE
[SC-230] Guard ApplyFix against a running fix agent masked by a stale deploy-failed marker

### DIFF
--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -198,11 +198,18 @@ func (d BoardTransitionDeps) ApplyFix(ctx context.Context, req BoardFixRequest) 
 	if err != nil {
 		return errors.WrapWithDetails(err, "loading PM comments for fix", "pm", req.PMKey)
 	}
-	// Idempotency: a re-drop while any stage agent (fix, review, deploy) is
-	// still running must not launch a second one — same intent as
-	// ApplyTransition's duplicate-drop guard, widened to the whole card
-	// because a bug fix chains straight into its review.
-	if card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false); card.State == BoardRunning {
+	// Idempotency: a re-drop or a Retry click while the fix agent — or the
+	// review it chains into — is still running must not launch a second one.
+	// This is stage-scoped (implementation, then the verification it chains
+	// into) rather than a whole-card check on purpose: DeriveBoardCard reports
+	// the FURTHEST stage's state, so a stale [human:deploy-failed] marker pins
+	// the card to done/failed and structurally hides a running re-fix from a
+	// whole-card guard (SC-230). latestStageState mirrors ApplyTransition's
+	// duplicate-drop guard and is immune to that masking.
+	if _, state := latestStageState(comments, BoardImplementation); state == BoardRunning {
+		return nil
+	}
+	if _, state := latestStageState(comments, BoardVerification); state == BoardRunning {
 		return nil
 	}
 	// The --board marker is the mechanical gate that keeps a board run from

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -544,6 +544,24 @@ func TestApplyFixIdempotentWhileReviewRunning(t *testing.T) {
 	assert.Zero(t, l.calls)
 }
 
+func TestApplyFixIdempotentWithStaleDeployFailure(t *testing.T) {
+	// Regression (SC-230): a stale [human:deploy-failed] (older) pins
+	// DeriveBoardCard to the done stage's failed state, masking a live
+	// [human:implementation-started] (newer). The duplicate-launch guard must
+	// scan the implementation stage itself, so a Retry click while the fix
+	// agent runs is a no-op: zero launches, zero marker spam.
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:deploy-failed]\nno forge configured", time.Unix(1, 0)),
+		cmt("[human:implementation-started]", time.Unix(2, 0)),
+	}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+	err := deps.ApplyFix(context.Background(), BoardFixRequest{PMKey: "SC-9"})
+	require.NoError(t, err)
+	assert.Zero(t, l.calls)
+	assert.Empty(t, c.added)
+}
+
 func TestApplyFixRelaunchAfterFailedReview(t *testing.T) {
 	// A bug pinned by a failing review verdict may be re-dropped onto Fix.
 	c := &fakeCommenter{comments: []tracker.Comment{


### PR DESCRIPTION
Fixes SC-230: clicking Retry fix while a fix agent was already running relaunched the pipeline every time — duplicate container launches failing with 'agent already running', start/fail marker spam on the ticket, and the red 'daemon command failed' banner.

Root cause: ApplyFix's duplicate-launch guard checked the whole derived card state, and a stale [human:deploy-failed] marker pins the derived state to the done stage (furthest-stage-wins), permanently masking a running re-fix at the implementation stage.

The guard now checks the implementation AND verification stages' own state (a fix chains straight into its review, so an implementation-only check would reopen the gap during the review window) and quietly ignores the extra click.

Regression test TestApplyFixIdempotentWithStaleDeployFailure: with a stale deploy-failed marker plus a live implementation-started marker, pre-fix a duplicate launch fired; post-fix zero launches, zero marker spam.

Review passed on-ticket ([human:review-complete] verdict: pass, comment 328). The desktop card-state counterpart is deliberately deferred per the plan's Architecture Decision 3 (daemon-guard-only; residual is cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)