### PR TITLE
Board watcher ignores re-run stage agents: rework/re-fix never chains to review, stuck cards get no failure marker

### DIFF
--- a/internal/daemon/agentcleanup.go
+++ b/internal/daemon/agentcleanup.go
@@ -31,24 +31,25 @@ func RunAgentCleanup(ctx context.Context, store *HookEventStore, cleaner AgentCl
 
 	logger.Info().Msg("agent cleanup listener started")
 
-	cleaned := make(map[string]bool)
+	// Track events by monotonic sequence, not by agent name: board stage agents
+	// reuse the same deterministic name on every rebuild, so a name-keyed
+	// lifetime dedupe leaked the re-run's container and worktree (SC-201).
+	var lastSeq uint64
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ch:
-			for _, evt := range store.RecentEvents() {
+			newEvents, seq := store.EventsSince(lastSeq)
+			lastSeq = seq
+			for _, evt := range newEvents {
 				if evt.AgentName == "" {
 					continue
 				}
 				if evt.EventName != "Stop" && evt.EventName != "SessionEnd" && evt.EventName != "StopFailure" {
 					continue
 				}
-				if cleaned[evt.AgentName] {
-					continue
-				}
-				cleaned[evt.AgentName] = true
 				go func(name string) {
 					// Wait for Claude to fully exit before stopping the container.
 					select {

--- a/internal/daemon/agentcleanup_test.go
+++ b/internal/daemon/agentcleanup_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,6 +27,64 @@ func (m *mockCleaner) DecommissionAgent(name string) (string, error) {
 
 func (m *mockCleaner) StopContainer(_ context.Context, _ string) error {
 	return nil
+}
+
+// countingCleaner is concurrency-safe: the fix makes cleanup fire once per
+// exit, so two exits of the same name run two goroutines that both record.
+type countingCleaner struct {
+	mu    sync.Mutex
+	count map[string]int
+	ch    chan string
+}
+
+func newCountingCleaner() *countingCleaner {
+	return &countingCleaner{count: make(map[string]int), ch: make(chan string, 4)}
+}
+
+func (c *countingCleaner) DeleteAgent(_ context.Context, name string) error {
+	c.mu.Lock()
+	c.count[name]++
+	c.mu.Unlock()
+	c.ch <- name
+	return nil
+}
+
+func (c *countingCleaner) DecommissionAgent(name string) (string, error) { return "container-" + name, nil }
+
+func (c *countingCleaner) StopContainer(_ context.Context, _ string) error { return nil }
+
+// SC-201: the cleanup watcher deduped by name for the daemon's lifetime, so a
+// re-run reusing the same board stage agent name never got its container and
+// worktree cleaned up. Every exit must clean up.
+func TestRunAgentCleanup_ReusedNameSecondExitCleansAgain(t *testing.T) {
+	store := NewHookEventStore()
+	cleaner := newCountingCleaner()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go RunAgentCleanup(ctx, store, cleaner, zerolog.Nop())
+	time.Sleep(50 * time.Millisecond)
+
+	name := "board-201-implementation"
+	store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: name, Timestamp: time.Now()})
+	select {
+	case got := <-cleaner.ch:
+		assert.Equal(t, name, got)
+	case <-time.After(4 * time.Second):
+		t.Fatal("expected first cleanup")
+	}
+
+	store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: name, Timestamp: time.Now()})
+	select {
+	case got := <-cleaner.ch:
+		assert.Equal(t, name, got)
+	case <-time.After(4 * time.Second):
+		t.Fatal("second exit of a reused agent name must be cleaned up again (SC-201)")
+	}
+
+	cleaner.mu.Lock()
+	assert.Equal(t, 2, cleaner.count[name], "reused name must be cleaned once per exit")
+	cleaner.mu.Unlock()
 }
 
 func TestRunAgentCleanup_StopEvent(t *testing.T) {

--- a/internal/daemon/board_failure.go
+++ b/internal/daemon/board_failure.go
@@ -34,24 +34,26 @@ func RunBoardFailureWatch(ctx context.Context, store *HookEventStore, commenterF
 
 	logger.Info().Msg("board failure watcher started")
 
-	handled := make(map[string]bool)
+	// Track events by monotonic sequence, not by agent name: board stage agents
+	// reuse the same deterministic name on every rebuild, so a name-keyed
+	// lifetime dedupe silently dropped every re-run's exit (SC-201). EventsSince
+	// hands us each appended event exactly once and survives ring saturation.
+	var lastSeq uint64
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ch:
-			for _, evt := range store.RecentEvents() {
+			newEvents, seq := store.EventsSince(lastSeq)
+			lastSeq = seq
+			for _, evt := range newEvents {
 				if !strings.HasPrefix(evt.AgentName, "board-") {
 					continue
 				}
 				if evt.EventName != "Stop" && evt.EventName != "SessionEnd" && evt.EventName != "StopFailure" {
 					continue
 				}
-				if handled[evt.AgentName] {
-					continue
-				}
-				handled[evt.AgentName] = true
 				go handleBoardAgentExit(ctx, evt.AgentName, commenterFor, chainReview, logger)
 			}
 		}

--- a/internal/daemon/board_failure_test.go
+++ b/internal/daemon/board_failure_test.go
@@ -63,13 +63,75 @@ func TestRunBoardFailureWatch_PostsFailedOnIncompleteStage(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("expected a failed marker to be posted")
 	}
+}
 
-	// A repeat event for the same agent must not post twice.
+// SC-201: board stage agents reuse the same deterministic name on every
+// rebuild (agentNameFor is deterministic; the rework path, forward
+// Implementation and ApplyFix all re-launch the same name). The watcher must
+// handle EVERY exit of a reused name, not just the first — a name-keyed
+// lifetime dedupe silently dropped second-and-later runs.
+func TestRunBoardFailureWatch_ReusedNameSecondIncompleteExitPostsAgain(t *testing.T) {
+	store := NewHookEventStore()
+	c := &syncCommenter{
+		comments: []tracker.Comment{cmt(PlanningStartedHeader, time.Unix(1, 0))},
+		addCh:    make(chan string, 4),
+	}
+	commenterFor := func() (tracker.Commenter, error) { return c, nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go RunBoardFailureWatch(ctx, store, commenterFor, nil, zerolog.Nop())
+	time.Sleep(50 * time.Millisecond)
+
+	// First exit of the reused name posts a failed marker.
 	store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: "board-SC-1-planning", Timestamp: time.Now()})
 	select {
-	case <-c.addCh:
-		t.Fatal("must not post failed marker twice for the same agent")
-	case <-time.After(300 * time.Millisecond):
+	case body := <-c.addCh:
+		assert.Contains(t, body, PlanningFailedHeader)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected first failed marker")
+	}
+
+	// Second exit of the SAME name (a re-run) must post AGAIN.
+	store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: "board-SC-1-planning", Timestamp: time.Now()})
+	select {
+	case body := <-c.addCh:
+		assert.Contains(t, body, PlanningFailedHeader)
+	case <-time.After(2 * time.Second):
+		t.Fatal("second exit of a reused agent name must post a failed marker again (SC-201)")
+	}
+}
+
+// SC-201: a second cleanly-finished build of the same reused name must chain
+// into review again, not be swallowed by lifetime dedupe.
+func TestRunBoardFailureWatch_ReusedNameSecondCleanBuildChainsAgain(t *testing.T) {
+	store := NewHookEventStore()
+	c := &syncCommenter{
+		comments: []tracker.Comment{cmt("[human:ready-for-review]\nbranch: feat/x", time.Unix(1, 0))},
+	}
+	commenterFor := func() (tracker.Commenter, error) { return c, nil }
+	chained := make(chan string, 2)
+	chain := func(pmKey string) error { chained <- pmKey; return nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go RunBoardFailureWatch(ctx, store, commenterFor, chain, zerolog.Nop())
+	time.Sleep(50 * time.Millisecond)
+
+	store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: "board-SC-1-implementation", Timestamp: time.Now()})
+	select {
+	case pmKey := <-chained:
+		assert.Equal(t, "SC-1", pmKey)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected first build to chain a review")
+	}
+
+	store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: "board-SC-1-implementation", Timestamp: time.Now()})
+	select {
+	case pmKey := <-chained:
+		assert.Equal(t, "SC-1", pmKey)
+	case <-time.After(2 * time.Second):
+		t.Fatal("second clean build of a reused agent name must chain a review again (SC-201)")
 	}
 }
 


### PR DESCRIPTION
PM ticket: 201
Branch: autofix/201
