### PR TITLE
Add CLA signing via CLA Assistant Lite (Issue #113)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,31 @@
+name: cla
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# CLA Assistant Lite: gates every external PR on a signed CLA. Signatures are
+# committed to the dedicated cla-signatures branch so main stays clean and the
+# commit-msg issue-ref convention is not violated by bot commits.
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: signatures/cla.json
+          path-to-document: https://github.com/gethuman-sh/human/blob/main/CLA.md
+          branch: cla-signatures
+          allowlist: dependabot[bot],github-actions[bot]

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,127 @@
+# Individual Contributor License Agreement
+
+**human — Contributor License Agreement ("Agreement"), v1.0**
+
+Adapted from the Apache Software Foundation Individual Contributor License
+Agreement v2.2.
+
+Thank you for your interest in contributing to **human**
+(https://github.com/gethuman-sh/human), a project owned and maintained by
+**SJS Holding GmbH**, Zeppelinstraße 1A, 12529 Schönefeld, Deutschland
+("the Project Owner").
+
+In order to clarify the intellectual property license granted with
+Contributions from any person or entity, the Project Owner must have a
+Contributor License Agreement on file that has been agreed to by each
+Contributor, indicating agreement to the license terms below. This license is
+for your protection as a Contributor as well as the protection of the Project
+Owner and users of the project; it does not change your rights to use your own
+Contributions for any other purpose.
+
+You accept and agree to the following terms and conditions for your present
+and future Contributions submitted to the Project Owner. Except for the
+license granted herein to the Project Owner and recipients of software
+distributed by the Project Owner, You reserve all right, title, and interest
+in and to your Contributions.
+
+## 1. Definitions
+
+"You" (or "Your") shall mean the copyright owner or legal entity authorized by
+the copyright owner that is entering into this Agreement with the Project
+Owner. For legal entities, the entity making a Contribution and all other
+entities that control, are controlled by, or are under common control with
+that entity are considered to be a single Contributor. For the purposes of
+this definition, "control" means (i) the power, direct or indirect, to cause
+the direction or management of such entity, whether by contract or otherwise,
+or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or
+(iii) beneficial ownership of such entity.
+
+"Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally
+submitted by You to the Project Owner for inclusion in, or documentation of,
+any of the products owned or managed by the Project Owner (the "Work"). For
+the purposes of this definition, "submitted" means any form of electronic,
+verbal, or written communication sent to the Project Owner or its
+representatives, including but not limited to communication on electronic
+mailing lists, source code control systems, and issue tracking systems that
+are managed by, or on behalf of, the Project Owner for the purpose of
+discussing and improving the Work, but excluding communication that is
+conspicuously marked or otherwise designated in writing by You as "Not a
+Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Project Owner and to recipients of software distributed by the Project Owner a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense, and distribute Your Contributions and such
+derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Project Owner and to recipients of software distributed by the Project Owner a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made, use,
+offer to sell, sell, import, and otherwise transfer the Work, where such
+license applies only to those patent claims licensable by You that are
+necessarily infringed by Your Contribution(s) alone or by combination of Your
+Contribution(s) with the Work to which such Contribution(s) was submitted. If
+any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Work to which You have contributed, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or Work shall terminate as
+of the date such litigation is filed.
+
+## 4. Authority to Contribute
+
+You represent that You are legally entitled to grant the above license. If
+Your employer(s) has rights to intellectual property that You create that
+includes Your Contributions, You represent that You have received permission
+to make Contributions on behalf of that employer, that Your employer has
+waived such rights for Your Contributions to the Project Owner, or that Your
+employer has executed a separate corporate license agreement with the Project
+Owner.
+
+## 5. Original Creation
+
+You represent that each of Your Contributions is Your original creation (see
+section 7 for submissions on behalf of others). You represent that Your
+Contribution submissions include complete details of any third-party license
+or other restriction (including, but not limited to, related patents and
+trademarks) of which You are personally aware and which are associated with
+any part of Your Contributions.
+
+## 6. No Support Obligation; Disclaimer
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. You may provide support for free, for a
+fee, or not at all. Unless required by applicable law or agreed to in writing,
+You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including, without
+limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7. Third-Party Works
+
+Should You wish to submit work that is not Your original creation, You may
+submit it to the Project Owner separately from any Contribution, identifying
+the complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which You are personally aware, and conspicuously marking the
+work as "Submitted on behalf of a third-party: [named here]".
+
+## 8. Notification of Changed Circumstances
+
+You agree to notify the Project Owner of any facts or circumstances of which
+You become aware that would make these representations inaccurate in any
+respect.
+
+## Signing
+
+This Agreement is signed electronically: by posting the sign-off comment
+requested by the CLA Assistant bot on your pull request, you accept and agree
+to the terms of this Agreement for your present and future Contributions.
+Signatures are recorded in the `cla-signatures` branch of this repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing to human
+
+Thanks for contributing! Pull requests are welcome.
+
+## Contributor License Agreement
+
+Before a pull request can be merged, you must sign our
+[Contributor License Agreement](CLA.md) (adapted from the Apache Individual
+CLA v2.2). You keep the copyright to your contribution; the CLA grants the
+project a broad license to use it.
+
+Signing is fully automated: when you open your first pull request, the CLA
+Assistant bot posts a comment with instructions. Reply with
+
+```
+I have read the CLA Document and I hereby sign the CLA
+```
+
+and the check turns green. You only sign once — the signature covers all your
+future contributions and is recorded in the `cla-signatures` branch.
+
+## Pull requests
+
+- Open an issue first for anything non-trivial so the approach can be agreed on.
+- Reference the issue from the PR description (e.g. `Closes #123`).
+- Run `make check` before pushing — it runs tests, lint, and coverage.
+- Keep PRs focused: one logical change per PR.
+
+## Development
+
+```sh
+make build   # build the human binary
+make test    # run tests
+make lint    # run linters
+make check   # everything CI runs
+make hooks   # install the commit-msg hook (issue-ref enforcement)
+```

--- a/internal/daemon/agentcleanup_test.go
+++ b/internal/daemon/agentcleanup_test.go
@@ -49,7 +49,9 @@ func (c *countingCleaner) DeleteAgent(_ context.Context, name string) error {
 	return nil
 }
 
-func (c *countingCleaner) DecommissionAgent(name string) (string, error) { return "container-" + name, nil }
+func (c *countingCleaner) DecommissionAgent(name string) (string, error) {
+	return "container-" + name, nil
+}
 
 func (c *countingCleaner) StopContainer(_ context.Context, _ string) error { return nil }
 


### PR DESCRIPTION
Gates external PRs on a signed Contributor License Agreement.

- `CLA.md` — adapted from the Apache Individual CLA v2.2; contributor keeps copyright, grants SJS Holding GmbH a perpetual, irrevocable copyright license incl. sublicensing plus a patent grant with defensive termination
- `.github/workflows/cla.yml` — CLA Assistant Lite (contributor-assistant/github-action@v2.6.1); signatures recorded on a dedicated `cla-signatures` branch so `main` stays clean
- `CONTRIBUTING.md` — documents the sign-once comment flow plus basic PR/dev guidelines
- Drive-by: gofmt `internal/daemon/agentcleanup_test.go` (came in unformatted with SC-201 and broke `make check`)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)