### PR TITLE
[SC-355] Planning renders in Engineering and a failed plan retries in place

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -247,8 +247,8 @@ func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, de
 		AuditStore:        auditStore,
 		AgentCleaner:      &dockerAgentCleaner{},
 		VaultResolver:     vaultResolver,
-		BoardTransitioner: boardTransitionerFunc(projectRegistry, vaultResolver),
-		BoardFixer:        boardFixerFunc(projectRegistry, vaultResolver),
+		BoardTransitioner: boardTransitionerFunc(projectRegistry, vaultResolver, logger),
+		BoardFixer:        boardFixerFunc(projectRegistry, vaultResolver, logger),
 		BugCreator:        bugCreatorFunc(projectRegistry, vaultResolver),
 		CloseTicketer:     closeTicketerFunc(projectRegistry, vaultResolver),
 		FeaturesGenerator: featuresGeneratorFunc(projectRegistry),
@@ -372,7 +372,7 @@ func runDaemonForeground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string,
 			Timestamp: time.Now().UTC(),
 		})
 	}, logger)
-	boardTransition := boardTransitionerFunc(ds.srv.Projects, ds.vaultResolver)
+	boardTransition := boardTransitionerFunc(ds.srv.Projects, ds.vaultResolver, logger)
 	go daemon.RunBoardFailureWatch(ctx, ds.srv.HookEvents,
 		boardPMCommenterFunc(ds.srv.Projects, ds.vaultResolver),
 		func(pmKey string) error {
@@ -1529,7 +1529,7 @@ func closeTicketerFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver) fu
 // and the forge publisher against the resolved project dir. Shared by the
 // board-transition and board-fix closures so both routes drive the exact same
 // engine.
-func boardTransitionDepsFor(reg *daemon.ProjectRegistry, resolver *vault.Resolver) (daemon.BoardTransitionDeps, error) {
+func boardTransitionDepsFor(reg *daemon.ProjectRegistry, resolver *vault.Resolver, logger zerolog.Logger) (daemon.BoardTransitionDeps, error) {
 	entries := reg.Entries()
 	if len(entries) == 0 {
 		return daemon.BoardTransitionDeps{}, errors.WithDetails("no project registered for board transition")
@@ -1553,15 +1553,16 @@ func boardTransitionDepsFor(reg *daemon.ProjectRegistry, resolver *vault.Resolve
 		},
 		WorkspaceDir: entry.Dir,
 		ConfigDir:    entry.Dir,
+		Logger:       logger,
 	}, nil
 }
 
 // boardTransitionerFunc builds the daemon's BoardTransitioner closure: it
 // resolves the PM commenter by role per request and applies the transition with
 // the Docker launcher and forge publisher against the resolved project dir.
-func boardTransitionerFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver) func(daemon.BoardTransitionRequest) error {
+func boardTransitionerFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver, logger zerolog.Logger) func(daemon.BoardTransitionRequest) error {
 	return func(req daemon.BoardTransitionRequest) error {
-		deps, err := boardTransitionDepsFor(reg, resolver)
+		deps, err := boardTransitionDepsFor(reg, resolver, logger)
 		if err != nil {
 			return err
 		}
@@ -1572,9 +1573,9 @@ func boardTransitionerFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver
 // boardFixerFunc builds the daemon's BoardFixer closure: same collaborators as
 // a board transition, but the entry point is the autonomous bug-fix pipeline
 // (planning gate skipped — autofix triages, plans and fixes in one run).
-func boardFixerFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver) func(daemon.BoardFixRequest) error {
+func boardFixerFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver, logger zerolog.Logger) func(daemon.BoardFixRequest) error {
 	return func(req daemon.BoardFixRequest) error {
-		deps, err := boardTransitionDepsFor(reg, resolver)
+		deps, err := boardTransitionDepsFor(reg, resolver, logger)
 		if err != nil {
 			return err
 		}

--- a/desktop/frontend/dist/board-queue.js
+++ b/desktop/frontend/dist/board-queue.js
@@ -1,0 +1,63 @@
+// Pure column-placement and drop-gate logic for the workflow board, kept free
+// of DOM and Wails bindings so it can be unit-tested directly (the rest of
+// board.ts bootstraps against document/window.go at import time and cannot).
+export const QUEUES = ["ideas", "product", "engineering", "building", "deploy"];
+// Wire stage launched by dropping onto a queue from its predecessor.
+export const QUEUE_TRANSITION_TO = {
+    engineering: "planning",
+    building: "implementation",
+};
+export function verdictFailed(verdict) {
+    return (verdict ?? "").trim().toLowerCase().startsWith("fail");
+}
+// queueOf maps (stage, state) onto the column that is true of the card. Running
+// and failed cards render in their DESTINATION lane, not their origin queue:
+// planning lives in Engineering, implementation/verification in Code — the card
+// stays visibly where the user dropped it while its stage runs.
+export function queueOf(card) {
+    switch (card.stage) {
+        case "ideas":
+            return "ideas";
+        case "backlog":
+            return "product";
+        case "planning":
+            return "engineering";
+        case "implementation":
+            return "building";
+        case "verification":
+            return card.state === "done" && !verdictFailed(card.verdict) && !!card.branch ? "deploy" : "building";
+        case "done":
+            return "deploy";
+        default:
+            return "product";
+    }
+}
+export function isReworkable(card) {
+    return card.stage === "verification" && card.state === "done" && (verdictFailed(card.verdict) || !card.branch);
+}
+// planReady reports a planning card whose plan is complete — the only planning
+// state permitted to advance forward into Code. A running or failed planning
+// card in Engineering must NOT launch implementation on an unplanned ticket.
+export function planReady(card) {
+    return card.stage === "planning" && card.state === "done";
+}
+// forwardDropAllowed is the queue-transition predicate: forward-adjacency, plus
+// the Code rework re-drop, plus the plan-ready gate on advancing OUT of
+// Engineering. DOM/Docker gating stays in board.ts's dropAllowed.
+export function forwardDropAllowed(card, toQueue) {
+    if (toQueue === "building" && isReworkable(card))
+        return true;
+    const from = queueOf(card);
+    if (!isNextQueue(from, toQueue))
+        return false;
+    // Engineering -> Code may only launch implementation once the plan is ready.
+    if (from === "engineering" && toQueue === "building")
+        return planReady(card);
+    return true;
+}
+export function queueIndex(queue) {
+    return QUEUES.indexOf(queue);
+}
+export function isNextQueue(fromQueue, toQueue) {
+    return queueIndex(toQueue) === queueIndex(fromQueue) + 1;
+}

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -13,6 +13,7 @@ import { initPermissions } from "./permissions.js";
 import { initMockupsView, showMockups, setPendingMockupSlug } from "./mockupsview.js";
 import { initSettingsView, showSettings, settingsIndex, saveSetting, setPaletteOpener, setActiveSection, } from "./settingsview.js";
 import { initPalette, openPalette, isPaletteChord } from "./palette.js";
+import { QUEUES, QUEUE_TRANSITION_TO, queueOf, isReworkable, forwardDropAllowed, verdictFailed, } from "./board-queue.js";
 // openExternal routes a URL to the system browser via the Wails runtime.
 // Anchor clicks with target=_blank are NOT reliably forwarded by the Linux
 // webview (WebKitGTK swallows the new-window request), so every external
@@ -41,7 +42,6 @@ function openExternal(url) {
 // terminal drop zone that merges the work into main (after CI passes) and
 // closes the ticket, so shipped work simply leaves the board. ("building"
 // stays the internal queue id so theme hooks don't churn on a label.)
-const QUEUES = ["ideas", "product", "engineering", "building", "deploy"];
 const QUEUE_LABELS = {
     ideas: "Ideas",
     product: "Product backlog",
@@ -63,13 +63,6 @@ function ideaColOf(card) {
     const col = card.ideaColumn ?? 0;
     return Math.min(Math.max(col, 0), IDEA_COL_COUNT - 1);
 }
-// Wire stage launched by dropping onto a queue from its predecessor. Queues
-// missing here (ideas, deploy) accept no queue-transition drop at all — cards
-// reach Ready to Deploy only by passing review.
-const QUEUE_TRANSITION_TO = {
-    engineering: "planning",
-    building: "implementation",
-};
 // The verb shown on a drop target while a drag hovers it — the action lives
 // on the thing being touched, never in the column title.
 const QUEUE_VERB = {
@@ -85,34 +78,6 @@ const RUNNING_LABELS = {
     verification: "reviewing…",
     done: "deploying…",
 };
-// verdictFailed mirrors the daemon's VerdictFailed: only an explicit failing
-// verdict blocks — absence is not failure.
-function verdictFailed(verdict) {
-    return (verdict ?? "").trim().toLowerCase().startsWith("fail");
-}
-// queueOf maps the wire (stage, state) onto the column whose name is true of
-// the card. The whole build-and-review cycle lives in the Code lane —
-// including a review that found problems, and a review with no recorded
-// branch (nothing to ship), because those cards are NOT ready to deploy;
-// only a passing review of a recorded branch releases one.
-function queueOf(card) {
-    switch (card.stage) {
-        case "ideas":
-            return "ideas";
-        case "backlog":
-            return "product";
-        case "planning":
-            return card.state === "done" ? "engineering" : "product";
-        case "implementation":
-            return "building";
-        case "verification":
-            return card.state === "done" && !verdictFailed(card.verdict) && !!card.branch ? "deploy" : "building";
-        case "done":
-            return "deploy";
-        default:
-            return "product";
-    }
-}
 let current = { cards: [], dockerAvailable: true, error: "" };
 let dragging = null;
 // Two-phase load state. boardLoading covers the first fetch before any titles
@@ -131,12 +96,6 @@ function go() {
     if (!app)
         throw new Error("Wails bindings not available");
     return app;
-}
-function queueIndex(queue) {
-    return QUEUES.indexOf(queue);
-}
-function isNextQueue(fromQueue, toQueue) {
-    return queueIndex(toQueue) === queueIndex(fromQueue) + 1;
 }
 // targetEnabled gates agent-launching drops on Docker availability; every
 // queue transition except idea promotion launches a containerized agent.
@@ -249,6 +208,26 @@ function showCardMenu(card, x, y) {
             void fixBug(card.key, card.title);
         });
         menu.appendChild(retryItem);
+    }
+    // A failed planning run leaves the card in Engineering with no pipeline gesture
+    // to try again — it cannot be dropped onto the column it already sits in
+    // (mirrors the Retry-fix rationale above). Relaunch runs an agent: same Docker
+    // gate as the drops. from="backlog" reproduces the original launch semantics;
+    // the daemon re-derives the real stage and ignores from except for ideas, so
+    // the value is inert for validation.
+    if (!card.bug && card.stage === "planning" && card.state === "failed") {
+        const retryPlan = document.createElement("button");
+        retryPlan.type = "button";
+        retryPlan.className = "context-menu-item";
+        retryPlan.textContent = "Retry plan";
+        retryPlan.disabled = !current.dockerAvailable;
+        if (retryPlan.disabled)
+            retryPlan.title = "Docker required";
+        retryPlan.addEventListener("click", () => {
+            menu.remove();
+            void transition(card.key, card.title, "backlog", "planning");
+        });
+        menu.appendChild(retryPlan);
     }
     // Mockups belong to the product conversation: the item appears only in the
     // Product backlog column, toggling create → creating → view as the local
@@ -742,11 +721,6 @@ function dropTargetAt(x, y) {
 function isReadyToDeploy(card) {
     return card.stage === "verification" && card.state === "done" && !verdictFailed(card.verdict) && !!card.branch;
 }
-// isReworkable reports a card pinned in Code by a failing review verdict or a
-// missing branch; a re-drop onto Code (or Fix, for bugs) rebuilds it.
-function isReworkable(card) {
-    return card.stage === "verification" && card.state === "done" && (verdictFailed(card.verdict) || !card.branch);
-}
 // dropAllowed reports whether the dragged card may drop on target. Queue
 // targets keep the forward-adjacency + docker-enabled rules, evaluated on the
 // card's RESTING queue so a running card cannot double-launch; the one
@@ -777,9 +751,9 @@ function dropAllowed(target) {
         return bugAreaOf(card) === "grid" || isReworkable(card);
     }
     const toQueue = target.dataset.dropQueue || "";
-    if (toQueue === "building" && isReworkable(card))
-        return targetEnabled(toQueue);
-    return isNextQueue(queueOf(card), toQueue) && targetEnabled(toQueue);
+    // forwardDropAllowed owns forward-adjacency, the Code rework re-drop, and the
+    // Engineering->Code plan-ready gate; targetEnabled keeps the local Docker gate.
+    return forwardDropAllowed(card, toQueue) && targetEnabled(toQueue);
 }
 // setHoverTarget moves the highlight to a new target (clearing the previous),
 // so exactly one drop zone is lit at a time.

--- a/desktop/frontend/scripts/board-queue.test.mjs
+++ b/desktop/frontend/scripts/board-queue.test.mjs
@@ -1,0 +1,45 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { queueOf, forwardDropAllowed, planReady } from "../build/board-queue.js";
+
+// SC-355 regression: a running or failed planning card must render in the
+// Engineering column where the user dropped it — not snap back to Product.
+test("planning card renders in engineering for every state (SC-355)", () => {
+  assert.equal(queueOf({ stage: "planning", state: "running" }), "engineering");
+  assert.equal(queueOf({ stage: "planning", state: "failed" }), "engineering");
+  assert.equal(queueOf({ stage: "planning", state: "done" }), "engineering");
+});
+
+test("destination-lane placement stays intact for other stages", () => {
+  assert.equal(queueOf({ stage: "backlog", state: "done" }), "product");
+  assert.equal(queueOf({ stage: "implementation", state: "running" }), "building");
+  assert.equal(queueOf({ stage: "verification", state: "running" }), "building");
+  assert.equal(
+    queueOf({ stage: "verification", state: "done", verdict: "pass", branch: "b" }),
+    "deploy",
+  );
+});
+
+// SC-355 affordance: only a plan-ready card may advance Engineering -> Code.
+test("forward gate: engineering -> code requires plan-ready", () => {
+  assert.equal(planReady({ stage: "planning", state: "done" }), true);
+  assert.equal(planReady({ stage: "planning", state: "failed" }), false);
+  assert.equal(forwardDropAllowed({ stage: "planning", state: "done" }, "building"), true);
+  assert.equal(forwardDropAllowed({ stage: "planning", state: "failed" }, "building"), false);
+  assert.equal(forwardDropAllowed({ stage: "planning", state: "running" }, "building"), false);
+});
+
+test("forward gate: rework re-drop onto code still allowed", () => {
+  assert.equal(
+    forwardDropAllowed({ stage: "verification", state: "done", verdict: "fail", branch: "b" }, "building"),
+    true,
+  );
+});
+
+// The Engineering column offers "Retry plan" exactly for a failed planning card,
+// and NEVER offers the forward Code drop for it (guards SC-355 affordance).
+test("failed planning card is retry-eligible but not code-droppable", () => {
+  const failed = { stage: "planning", state: "failed" };
+  assert.equal(planReady(failed), false, "failed plan must not be plan-ready");
+  assert.equal(forwardDropAllowed(failed, "building"), false, "failed plan must not drop into Code");
+});

--- a/desktop/frontend/src/board-queue.ts
+++ b/desktop/frontend/src/board-queue.ts
@@ -1,0 +1,77 @@
+// Pure column-placement and drop-gate logic for the workflow board, kept free
+// of DOM and Wails bindings so it can be unit-tested directly (the rest of
+// board.ts bootstraps against document/window.go at import time and cannot).
+
+// Only the fields the placement/gate logic reads. board.ts's Card satisfies it.
+export interface QueueCard {
+  stage: string;
+  state: string;
+  verdict?: string;
+  branch?: string;
+}
+
+export const QUEUES = ["ideas", "product", "engineering", "building", "deploy"] as const;
+
+// Wire stage launched by dropping onto a queue from its predecessor.
+export const QUEUE_TRANSITION_TO: Record<string, string> = {
+  engineering: "planning",
+  building: "implementation",
+};
+
+export function verdictFailed(verdict?: string): boolean {
+  return (verdict ?? "").trim().toLowerCase().startsWith("fail");
+}
+
+// queueOf maps (stage, state) onto the column that is true of the card. Running
+// and failed cards render in their DESTINATION lane, not their origin queue:
+// planning lives in Engineering, implementation/verification in Code — the card
+// stays visibly where the user dropped it while its stage runs.
+export function queueOf(card: QueueCard): string {
+  switch (card.stage) {
+    case "ideas":
+      return "ideas";
+    case "backlog":
+      return "product";
+    case "planning":
+      return "engineering";
+    case "implementation":
+      return "building";
+    case "verification":
+      return card.state === "done" && !verdictFailed(card.verdict) && !!card.branch ? "deploy" : "building";
+    case "done":
+      return "deploy";
+    default:
+      return "product";
+  }
+}
+
+export function isReworkable(card: QueueCard): boolean {
+  return card.stage === "verification" && card.state === "done" && (verdictFailed(card.verdict) || !card.branch);
+}
+
+// planReady reports a planning card whose plan is complete — the only planning
+// state permitted to advance forward into Code. A running or failed planning
+// card in Engineering must NOT launch implementation on an unplanned ticket.
+export function planReady(card: QueueCard): boolean {
+  return card.stage === "planning" && card.state === "done";
+}
+
+// forwardDropAllowed is the queue-transition predicate: forward-adjacency, plus
+// the Code rework re-drop, plus the plan-ready gate on advancing OUT of
+// Engineering. DOM/Docker gating stays in board.ts's dropAllowed.
+export function forwardDropAllowed(card: QueueCard, toQueue: string): boolean {
+  if (toQueue === "building" && isReworkable(card)) return true;
+  const from = queueOf(card);
+  if (!isNextQueue(from, toQueue)) return false;
+  // Engineering -> Code may only launch implementation once the plan is ready.
+  if (from === "engineering" && toQueue === "building") return planReady(card);
+  return true;
+}
+
+export function queueIndex(queue: string): number {
+  return (QUEUES as readonly string[]).indexOf(queue);
+}
+
+export function isNextQueue(fromQueue: string, toQueue: string): boolean {
+  return queueIndex(toQueue) === queueIndex(fromQueue) + 1;
+}

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -29,6 +29,14 @@ import {
   SettingsData,
 } from "./settingsview.js";
 import { initPalette, openPalette, isPaletteChord } from "./palette.js";
+import {
+  QUEUES,
+  QUEUE_TRANSITION_TO,
+  queueOf,
+  isReworkable,
+  forwardDropAllowed,
+  verdictFailed,
+} from "./board-queue.js";
 
 interface Card {
   key: string;
@@ -251,7 +259,6 @@ function openExternal(url: string): void {
 // terminal drop zone that merges the work into main (after CI passes) and
 // closes the ticket, so shipped work simply leaves the board. ("building"
 // stays the internal queue id so theme hooks don't churn on a label.)
-const QUEUES = ["ideas", "product", "engineering", "building", "deploy"] as const;
 const QUEUE_LABELS: Record<string, string> = {
   ideas: "Ideas",
   product: "Product backlog",
@@ -276,14 +283,6 @@ function ideaColOf(card: Card): number {
   return Math.min(Math.max(col, 0), IDEA_COL_COUNT - 1);
 }
 
-// Wire stage launched by dropping onto a queue from its predecessor. Queues
-// missing here (ideas, deploy) accept no queue-transition drop at all — cards
-// reach Ready to Deploy only by passing review.
-const QUEUE_TRANSITION_TO: Record<string, string> = {
-  engineering: "planning",
-  building: "implementation",
-};
-
 // The verb shown on a drop target while a drag hovers it — the action lives
 // on the thing being touched, never in the column title.
 const QUEUE_VERB: Record<string, string> = {
@@ -300,36 +299,6 @@ const RUNNING_LABELS: Record<string, string> = {
   verification: "reviewing…",
   done: "deploying…",
 };
-
-// verdictFailed mirrors the daemon's VerdictFailed: only an explicit failing
-// verdict blocks — absence is not failure.
-function verdictFailed(verdict?: string): boolean {
-  return (verdict ?? "").trim().toLowerCase().startsWith("fail");
-}
-
-// queueOf maps the wire (stage, state) onto the column whose name is true of
-// the card. The whole build-and-review cycle lives in the Code lane —
-// including a review that found problems, and a review with no recorded
-// branch (nothing to ship), because those cards are NOT ready to deploy;
-// only a passing review of a recorded branch releases one.
-function queueOf(card: Card): string {
-  switch (card.stage) {
-    case "ideas":
-      return "ideas";
-    case "backlog":
-      return "product";
-    case "planning":
-      return card.state === "done" ? "engineering" : "product";
-    case "implementation":
-      return "building";
-    case "verification":
-      return card.state === "done" && !verdictFailed(card.verdict) && !!card.branch ? "deploy" : "building";
-    case "done":
-      return "deploy";
-    default:
-      return "product";
-  }
-}
 
 let current: BoardData = { cards: [], dockerAvailable: true, error: "" };
 let dragging: { key: string; title: string; stage: string } | null = null;
@@ -352,14 +321,6 @@ function go(): AppBindings {
   const app = window.go?.main?.App;
   if (!app) throw new Error("Wails bindings not available");
   return app;
-}
-
-function queueIndex(queue: string): number {
-  return (QUEUES as readonly string[]).indexOf(queue);
-}
-
-function isNextQueue(fromQueue: string, toQueue: string): boolean {
-  return queueIndex(toQueue) === queueIndex(fromQueue) + 1;
 }
 
 // targetEnabled gates agent-launching drops on Docker availability; every
@@ -476,6 +437,26 @@ function showCardMenu(card: Card, x: number, y: number): void {
       void fixBug(card.key, card.title);
     });
     menu.appendChild(retryItem);
+  }
+
+  // A failed planning run leaves the card in Engineering with no pipeline gesture
+  // to try again — it cannot be dropped onto the column it already sits in
+  // (mirrors the Retry-fix rationale above). Relaunch runs an agent: same Docker
+  // gate as the drops. from="backlog" reproduces the original launch semantics;
+  // the daemon re-derives the real stage and ignores from except for ideas, so
+  // the value is inert for validation.
+  if (!card.bug && card.stage === "planning" && card.state === "failed") {
+    const retryPlan = document.createElement("button");
+    retryPlan.type = "button";
+    retryPlan.className = "context-menu-item";
+    retryPlan.textContent = "Retry plan";
+    retryPlan.disabled = !current.dockerAvailable;
+    if (retryPlan.disabled) retryPlan.title = "Docker required";
+    retryPlan.addEventListener("click", () => {
+      menu.remove();
+      void transition(card.key, card.title, "backlog", "planning");
+    });
+    menu.appendChild(retryPlan);
   }
 
   // Mockups belong to the product conversation: the item appears only in the
@@ -980,12 +961,6 @@ function isReadyToDeploy(card: Card): boolean {
   return card.stage === "verification" && card.state === "done" && !verdictFailed(card.verdict) && !!card.branch;
 }
 
-// isReworkable reports a card pinned in Code by a failing review verdict or a
-// missing branch; a re-drop onto Code (or Fix, for bugs) rebuilds it.
-function isReworkable(card: Card): boolean {
-  return card.stage === "verification" && card.state === "done" && (verdictFailed(card.verdict) || !card.branch);
-}
-
 // dropAllowed reports whether the dragged card may drop on target. Queue
 // targets keep the forward-adjacency + docker-enabled rules, evaluated on the
 // card's RESTING queue so a running card cannot double-launch; the one
@@ -1012,8 +987,9 @@ function dropAllowed(target: HTMLElement): boolean {
     return bugAreaOf(card) === "grid" || isReworkable(card);
   }
   const toQueue = target.dataset.dropQueue || "";
-  if (toQueue === "building" && isReworkable(card)) return targetEnabled(toQueue);
-  return isNextQueue(queueOf(card), toQueue) && targetEnabled(toQueue);
+  // forwardDropAllowed owns forward-adjacency, the Code rework re-drop, and the
+  // Engineering->Code plan-ready gate; targetEnabled keeps the local Docker gate.
+  return forwardDropAllowed(card, toQueue) && targetEnabled(toQueue);
 }
 
 // setHoverTarget moves the highlight to a new target (clearing the previous),

--- a/internal/daemon/board_markers.go
+++ b/internal/daemon/board_markers.go
@@ -69,6 +69,14 @@ const (
 // closing bracket keeps "[human:plan]" from matching "[human:plan-ready]".)
 const PlanCommentHeader = "[human:plan]"
 
+// CloseFailedHeader flags a ticket whose work shipped but whose automated
+// post-merge close failed. It is a surfaced operator signal, NOT a stage
+// transition: like PlanCommentHeader it is deliberately kept OUT of
+// orderedMarkerSpecs, so ClassifyMarker never classifies it and the card
+// stays green (deployed) while still carrying a visible "close this manually"
+// flag. Best-effort close means recorded-and-surfaced, never red, never silent.
+const CloseFailedHeader = "[human:close-failed]"
+
 // markerSpec maps a marker header to the (stage, state) it represents.
 type markerSpec struct {
 	Header string

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog"
+
 	"github.com/gethuman-sh/human/errors"
 	"github.com/gethuman-sh/human/internal/forge"
 	"github.com/gethuman-sh/human/internal/tracker"
@@ -70,6 +72,10 @@ type BoardTransitionDeps struct {
 	CloseTicket  func(pmKey string) error
 	WorkspaceDir string
 	ConfigDir    string
+	// Logger records best-effort post-merge failures (e.g. a failed automated
+	// close). The zero value is a safe no-op writer, so an un-wired path stays
+	// valid without a logger.
+	Logger zerolog.Logger
 }
 
 // sanitizeRe drops characters that are invalid in an agent name (alphanumeric,
@@ -299,12 +305,40 @@ func (d BoardTransitionDeps) deploy(ctx context.Context, req BoardTransitionRequ
 		return
 	}
 	// Past the merge the work IS shipped: branch cleanup and the ticket close
-	// are best-effort and must never turn the card red.
+	// are best-effort and must never turn the card red. Best-effort here means
+	// recorded-and-surfaced, not silent: a failed close leaves the card in the
+	// board's Fix column (the frontend only drops a card once the ticket leaves
+	// the tracker's open list), so the operator must see it and close by hand.
 	_ = d.Deployer.DeleteRemoteBranch(ctx, d.WorkspaceDir, card.Branch)
 	_, _ = d.Commenter.AddComment(ctx, req.PMKey, DeployedHeader+"\npr: "+res.URL)
-	if d.CloseTicket != nil {
-		_ = d.CloseTicket(req.PMKey)
+	d.closeTicketBestEffort(req.PMKey)
+}
+
+// closeTicketBestEffort runs the automated post-merge close. It never fails the
+// deploy: on error it retries once (most close failures are transient tracker
+// blips), then — if still failing — logs at warn and posts a [human:close-failed]
+// marker so the shipped-but-open card is flagged for manual close. The marker is
+// deliberately non-stage (see CloseFailedHeader), so the card stays green.
+func (d BoardTransitionDeps) closeTicketBestEffort(pmKey string) {
+	if d.CloseTicket == nil {
+		return
 	}
+	err := d.CloseTicket(pmKey)
+	if err != nil {
+		// One immediate retry recovers transient tracker errors.
+		err = d.CloseTicket(pmKey)
+	}
+	if err == nil {
+		return
+	}
+	d.Logger.Warn().Err(err).Str("pm", pmKey).
+		Msg("automated post-merge ticket close failed; card flagged for manual close")
+
+	postCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	body := CloseFailedHeader + "\ndeployed, but the automated close of " + pmKey +
+		" failed: " + err.Error() + "\nclose this ticket manually to clear the card."
+	_, _ = d.Commenter.AddComment(postCtx, pmKey, body)
 }
 
 // waitForChecks blocks until the PR's CI verdict is conclusive. Passing

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -147,6 +147,16 @@ func (d BoardTransitionDeps) ApplyTransition(ctx context.Context, req BoardTrans
 				" — a review found problems; address the findings in the latest [human:review-complete] comment on the ticket first")
 	}
 
+	// Planning retry: a failed planning run is relaunched in place. The retry
+	// gesture targets planning while the card already derives to planning, so
+	// the single-step rule below would reject it and the gesture would launch
+	// nothing (SC-355). A RUNNING planning card never reaches this path — the
+	// idempotency guard above already returned for it.
+	if isPlanningRetry(req.To, card) {
+		return d.startAgentStage(ctx, req.PMKey, BoardPlanning, PlanningStartedHeader,
+			"/human-plan "+req.PMKey)
+	}
+
 	// Forward-only, single-next-stage: the target must be exactly one rank
 	// above the current derived stage.
 	if stageRank[req.To] != stageRank[card.Stage]+1 {
@@ -168,6 +178,13 @@ func (d BoardTransitionDeps) ApplyTransition(ctx context.Context, req BoardTrans
 			"pm", req.PMKey, "verdict", card.Verdict)
 	}
 
+	return d.launchForwardStage(ctx, req, card)
+}
+
+// launchForwardStage dispatches an already-sanctioned forward transition to
+// its stage launcher. Split from ApplyTransition so the gate chain and the
+// dispatch read (and count) as separate concerns.
+func (d BoardTransitionDeps) launchForwardStage(ctx context.Context, req BoardTransitionRequest, card BoardCard) error {
 	switch req.To {
 	case BoardPlanning:
 		return d.startAgentStage(ctx, req.PMKey, BoardPlanning, PlanningStartedHeader,
@@ -396,6 +413,15 @@ func isReworkTransition(to BoardStage, card BoardCard) bool {
 		card.Stage == BoardVerification &&
 		card.State == BoardDone &&
 		(VerdictFailed(card.Verdict) || card.Branch == "")
+}
+
+// isPlanningRetry reports the second sanctioned non-forward move: relaunching
+// planning on a card whose planning run failed. Failed-state only — a running
+// planning card is protected by ApplyTransition's idempotency guard (SC-355).
+func isPlanningRetry(to BoardStage, card BoardCard) bool {
+	return to == BoardPlanning &&
+		card.Stage == BoardPlanning &&
+		card.State == BoardFailed
 }
 
 // doneBody builds the PR description with the PM→engineering→branch trail.

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -143,6 +143,37 @@ func TestApplyTransitionGatedBlock(t *testing.T) {
 	assert.Zero(t, l.calls)
 }
 
+func TestApplyTransitionRetriesFailedPlanning(t *testing.T) {
+	// The "Retry plan" gesture targets planning while the card already derives
+	// to planning/failed — the forward-only rule alone rejects that, leaving
+	// the gesture dead (SC-355). A failed planning card must relaunch planning.
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:planning-started]", time.Unix(1, 0)),
+		cmt("[human:planning-failed]\nagent exited without completing the stage", time.Unix(2, 0)),
+	}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardBacklog, To: BoardPlanning})
+	require.NoError(t, err)
+	assert.Equal(t, 1, l.calls)
+	assert.Equal(t, "/human-plan SC-1", l.prompt)
+	assert.Equal(t, "board-SC-1-planning", l.name)
+	require.Len(t, c.added, 1)
+	assert.Equal(t, PlanningStartedHeader, c.added[0])
+}
+
+func TestApplyTransitionRunningPlanningNotRelaunched(t *testing.T) {
+	// Contract pin: retry is for FAILED planning only — a running planning
+	// card hits the idempotency guard and must not spawn a second agent.
+	c := &fakeCommenter{comments: []tracker.Comment{cmt("[human:planning-started]", time.Unix(1, 0))}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardBacklog, To: BoardPlanning})
+	require.NoError(t, err)
+	assert.Zero(t, l.calls)
+	assert.Empty(t, c.added)
+}
+
 func TestApplyTransitionBacklogToPlanning(t *testing.T) {
 	c := &fakeCommenter{}
 	l := &fakeLauncher{}

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -222,6 +222,50 @@ func TestApplyTransitionDeploySuccess(t *testing.T) {
 	assert.Contains(t, c.added, DeployedHeader+"\npr: https://example/pr/7")
 }
 
+func TestApplyTransitionDeployCloseFails(t *testing.T) {
+	syncDeploy(t)
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:ready-for-review]\nengineering: HUM-9\nbranch: feat/x", time.Unix(1, 0)),
+		cmt("[human:review-complete]", time.Unix(2, 0)),
+	}}
+	p := &fakeDeployer{res: PRResult{URL: "https://example/pr/11", Number: 11},
+		checks: []forge.ChecksState{forge.ChecksPassing}}
+	deps := newDeps(c, &fakeLauncher{}, p)
+	var closeCalls int
+	deps.CloseTicket = func(pmKey string) error {
+		closeCalls++
+		return errors.New("tracker unavailable")
+	}
+	err := deps.ApplyTransition(context.Background(),
+		BoardTransitionRequest{PMKey: "SC-1", PMTitle: "My feature", From: BoardVerification, To: BoardDoneStage})
+
+	// The deploy itself must succeed — the card never turns red.
+	require.NoError(t, err)
+	assert.Equal(t, 1, p.merged)
+	// The work shipped: the deployed marker is still posted.
+	assert.Contains(t, c.added, DeployedHeader+"\npr: https://example/pr/11")
+	// The close was attempted, retried once, then surfaced.
+	assert.Equal(t, 2, closeCalls)
+	// The failure is surfaced on the ticket, flagged for manual close.
+	var surfaced string
+	for _, b := range c.added {
+		if strings.HasPrefix(b, CloseFailedHeader) {
+			surfaced = b
+		}
+	}
+	require.NotEmpty(t, surfaced, "expected a close-failed marker on the ticket")
+	assert.Contains(t, surfaced, "tracker unavailable")
+	assert.Contains(t, surfaced, "SC-1")
+	// The close-failed marker must NOT drive a stage/state transition (never reds).
+	_, _, ok := ClassifyMarker(surfaced)
+	assert.False(t, ok, "close-failed marker must not be a registered stage marker")
+}
+
+func TestCloseFailedHeaderUnregistered(t *testing.T) {
+	_, _, ok := ClassifyMarker(CloseFailedHeader)
+	assert.False(t, ok, "close-failed marker must never drive a stage/state transition")
+}
+
 func TestApplyTransitionDeployWaitsForPendingChecks(t *testing.T) {
 	syncDeploy(t)
 	c := &fakeCommenter{comments: []tracker.Comment{


### PR DESCRIPTION
Fixes SC-355 in two parts.

**Column placement** (commit 58f7ab9, previously reviewed — criteria 1+2 pass): a planning card (running, failed, or done) renders in the Engineering column where it was dropped, instead of snapping back to Product; the Engineering→Code drop stays gated on plan-ready. Pure predicates extracted to board-queue.ts with unit tests.

**Working retry** (commit 38fa1cf, implements option (a) from the on-ticket review): the daemon's forward-only single-step rule rejected a retry targeting planning from a card already derived to planning — the board's 'Retry plan' gesture launched nothing. A failed planning card now relaunches planning as the second sanctioned non-forward move, mirroring the rework loop; a running planning card stays protected by the idempotency guard. The frontend call was already correct (its 'from' argument is inert) — the fix is daemon-side only, per the review.

Daemon-level tests pin the actual relaunch (TestApplyTransitionRetriesFailedPlanning — red before, green after) and the running-card guard (TestApplyTransitionRunningPlanningNotRelaunched), closing the gap where predicate-only unit tests let a dead button ship green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)