### PR TITLE
Allowlist owner accounts in the CLA check (Issue #113)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,4 +28,7 @@ jobs:
           path-to-signatures: signatures/cla.json
           path-to-document: https://github.com/gethuman-sh/human/blob/main/CLA.md
           branch: cla-signatures
-          allowlist: dependabot[bot],github-actions[bot]
+          # StephanSchmidt and the humanbot* machine identity are the project
+          # owner's own accounts — the CLA grants rights to the owner, so
+          # asking them to sign it would be circular.
+          allowlist: StephanSchmidt,humanbot*,dependabot[bot],github-actions[bot]


### PR DESCRIPTION
The CLA bot flagged the daemon's own PR #115 because agent commits carry the installation's bot identity, which isn't a signable external contributor. Allowlist the owner account and the `humanbot*` machine identity — the CLA grants rights to the owner, so their own signature would be circular.

Longer-term the bot identity becomes a product-level config (SC-371).

🤖 Generated with [Claude Code](https://claude.com/claude-code)