### PR TITLE
Surface underlying cause when agent/devcontainer commands fail (opaque 'starting agent container')

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -13,7 +13,7 @@ func LogError(err error) *zerolog.Event {
 	// tozd's Error() and %+v only expose the outermost wrap message, so the root
 	// cause (e.g. a Docker connection failure) is invisible to users unless we
 	// render the full chain ourselves.
-	return log.Error().Str("error", CauseChain(err)).Fields(goerrors.AllDetails(err))
+	return log.Error().Str("error", CauseChain(err)).Fields(AllDetails(err))
 }
 
 // CauseChain renders the full unwrapped error chain as "outer: inner: root".
@@ -63,8 +63,25 @@ func WrapWithDetails(err error, message string, details ...interface{}) error {
 	)
 }
 
+// AllDetails collects structured details from every level of the error chain,
+// walking past causer wraps that tozd's own AllDetails halts at. First writer
+// wins so an outer wrap's value shadows an inner one on key collision, matching
+// tozd's within-scope merge semantics.
 func AllDetails(err error) map[string]interface{} {
-	return goerrors.AllDetails(err)
+	res := make(map[string]interface{})
+	type detailer interface{ Details() map[string]interface{} }
+	for e := err; e != nil; e = stderrors.Unwrap(e) {
+		d, ok := e.(detailer)
+		if !ok {
+			continue
+		}
+		for key, value := range d.Details() {
+			if _, exists := res[key]; !exists {
+				res[key] = value
+			}
+		}
+	}
+	return res
 }
 
 func isFormatVerb(c byte) bool {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -30,6 +30,29 @@ func TestLogError_EmitsCauseChainAndDetails(t *testing.T) {
 	assert.Contains(t, out, "fix-bug")
 }
 
+func TestLogError_SurfacesWrappedDetails(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Logger
+	log.Logger = zerolog.New(&buf)
+	defer func() { log.Logger = orig }()
+
+	// Mirrors the real production chain: exec failure (hooks.go:135) wrapped as
+	// "hook failed" (hooks.go:73) then "starting agent container" (manager.go:85).
+	err := WrapWithDetails(
+		WrapWithDetails(
+			WithDetails("exec failed", "exit_code", 1, "stderr", "boom"),
+			"hook failed"),
+		"starting agent container")
+
+	LogError(err).Msg("command failed")
+
+	out := buf.String()
+	// Inner diagnostics must ride along through both wraps.
+	assert.Contains(t, out, "exit_code")
+	assert.Contains(t, out, "stderr")
+	assert.Contains(t, out, "boom")
+}
+
 func TestCauseChain(t *testing.T) {
 	t.Run("nil error", func(t *testing.T) {
 		assert.Empty(t, CauseChain(nil))
@@ -55,6 +78,28 @@ func TestCauseChain(t *testing.T) {
 		// fmt.Errorf-style wrapping embeds the cause as a suffix.
 		fmtWrapped := fmt.Errorf("outer: %w", root)
 		assert.Equal(t, "outer: inner", CauseChain(fmtWrapped))
+	})
+}
+
+func TestAllDetails(t *testing.T) {
+	t.Run("walks full chain past causer wraps", func(t *testing.T) {
+		err := WrapWithDetails(WithDetails("inner", "stderr", "boom"), "wrap")
+		assert.Equal(t, "boom", AllDetails(err)["stderr"])
+	})
+
+	t.Run("first writer wins on key collision", func(t *testing.T) {
+		err := WrapWithDetails(WithDetails("inner", "k", "inner"), "outer", "k", "outer")
+		assert.Equal(t, "outer", AllDetails(err)["k"])
+	})
+
+	t.Run("nil error yields empty non-nil map", func(t *testing.T) {
+		got := AllDetails(nil)
+		assert.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("non-detailer node yields empty map without panic", func(t *testing.T) {
+		assert.Empty(t, AllDetails(stderrors.New("plain")))
 	})
 }
 


### PR DESCRIPTION
PM ticket: 177
Branch: autofix/177
