### PR TITLE
Issue #122 Complete GitHub community standards checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: Bug report
+description: Something in human does not work as expected
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, and what went wrong? Include the exact command and output where possible.
+      placeholder: Running `human list` fails with ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `human --version`
+      placeholder: v0.20.0
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      description: OS and how you installed human (Homebrew, go install, release binary)
+      placeholder: macOS 15, Homebrew
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Setup context
+      description: Relevant setup — which trackers are configured, whether the daemon is running, devcontainer or host. Do NOT paste tokens or secrets.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant log output. Redact anything sensitive.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/gethuman-sh/human/security/advisories/new
+    about: Please report security issues privately, not as public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: Feature request
+description: Suggest an idea or improvement for human
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the situation where human falls short, not the solution yet.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: What would you like to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you use today, or other ways this could be solved.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!-- Thanks for contributing! See CONTRIBUTING.md for details. -->
+
+## What does this PR do?
+
+<!-- Short description of the change and why it is needed. -->
+
+## Related issue
+
+<!-- Open an issue first for anything non-trivial. -->
+
+Closes #
+
+## Checklist
+
+- [ ] `make check` passes locally (tests, lint, coverage)
+- [ ] Commit messages reference the issue (e.g. `Issue #123`) — install the hook with `make hooks`
+- [ ] One focused, logical change
+- [ ] I have signed the [CLA](https://github.com/gethuman-sh/human/blob/main/CLA.md) (the bot will prompt on your first PR)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+stephan@inkmi.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-stephan@inkmi.com.
+stephan@amazingcto.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release of `human` receives security fixes. Please update to
+the newest version before reporting an issue.
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security vulnerabilities.**
+
+Report vulnerabilities privately via GitHub's private vulnerability reporting:
+
+https://github.com/gethuman-sh/human/security/advisories/new
+
+Alternatively, email stephan@inkmi.com.
+
+Please include:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce (a proof of concept helps)
+- The affected version (`human --version`) and platform
+
+You will receive an acknowledgement within a few days. Once the issue is
+confirmed, a fix is prepared and released before any details are published.
+
+## Scope
+
+`human` runs on developer machines and connects to issue trackers, code hosts,
+and knowledge tools with the user's credentials. Of particular interest:
+
+- Credential handling (vault references, token resolution, daemon storage)
+- The daemon's local API surface
+- The proxy allowlist and devcontainer isolation
+- Injection via untrusted ticket, comment, or document content

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ Report vulnerabilities privately via GitHub's private vulnerability reporting:
 
 https://github.com/gethuman-sh/human/security/advisories/new
 
-Alternatively, email stephan@inkmi.com.
+Alternatively, email stephan@amazingcto.com.
 
 Please include:
 


### PR DESCRIPTION
Closes #122

Adds the files missing from the Community Standards checklist (Insights → Community Standards):

- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1
- `SECURITY.md` — points to GitHub private vulnerability reporting (already enabled on the repo) and outlines the areas of interest (credential handling, daemon API, proxy allowlist, prompt injection via tracker content)
- `.github/ISSUE_TEMPLATE/` — bug report + feature request forms, plus a contact link steering security reports to private reporting
- `.github/PULL_REQUEST_TEMPLATE.md` — mirrors CONTRIBUTING.md: issue reference, `make check`, CLA

The remaining checklist item, "Repository admins accept content reports", is a repo setting only an admin can toggle in the web UI (Settings → Moderation options → Reported content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)