### PR TITLE
[SC-478] [SC-482] Make worktree-isolated agents launchable: provision .claude assets, bind parent .git

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -84,7 +84,7 @@ func (m *Manager) Start(ctx context.Context, opts StartOpts) (Meta, error) {
 		return Meta{}, err
 	}
 
-	dcMeta, err := m.startDevcontainer(ctx, containerName, configDir, workspace, opts.Rebuild)
+	dcMeta, err := m.startDevcontainer(ctx, containerName, configDir, workspace, worktreeGitDir(projectDir, worktree), opts.Rebuild)
 	if err != nil {
 		removeWorktreeOnFailure()
 		// A failure here is most often an unreachable Docker engine. Surface an
@@ -133,6 +133,17 @@ func (m *Manager) Start(ctx context.Context, opts StartOpts) (Meta, error) {
 	return meta, nil
 }
 
+// worktreeGitDir names the parent repo's .git for a worktree workspace — a
+// worktree's .git FILE points there by absolute host path, so the container
+// must bind it alongside (ticket 482). Shared-checkout runs (no worktree)
+// carry their .git inside the source mount and need nothing extra.
+func worktreeGitDir(projectDir, worktree string) string {
+	if worktree == "" {
+		return ""
+	}
+	return filepath.Join(projectDir, ".git")
+}
+
 func resolveDirectories(opts StartOpts) (workspace, configDir string) {
 	workspace = opts.Workspace
 	if workspace == "" {
@@ -154,7 +165,7 @@ func resolveDirectories(opts StartOpts) (workspace, configDir string) {
 	return
 }
 
-func (m *Manager) startDevcontainer(ctx context.Context, containerName, configDir, workspace string, rebuild bool) (*devcontainer.Meta, error) {
+func (m *Manager) startDevcontainer(ctx context.Context, containerName, configDir, workspace, gitDir string, rebuild bool) (*devcontainer.Meta, error) {
 	// Ensure daemon is running and reachable from containers (0.0.0.0).
 	daemonInfo := m.ensureDaemonForContainers(configDir)
 
@@ -163,6 +174,7 @@ func (m *Manager) startDevcontainer(ctx context.Context, containerName, configDi
 		ProjectDir:    configDir,
 		ContainerName: containerName,
 		SourceDir:     workspace,
+		GitDir:        gitDir,
 		Rebuild:       rebuild,
 		DaemonInfo:    daemonInfo,
 		Out:           os.Stderr,

--- a/internal/agent/worktree.go
+++ b/internal/agent/worktree.go
@@ -59,5 +59,93 @@ func (m *Manager) mountSourceForRun(ctx context.Context, projectDir, agentName s
 	if err := gitrepo.WorktreeAdd(ctx, projectDir, worktreePath, base); err != nil {
 		return "", err
 	}
+	if err := provisionAgentAssets(projectDir, worktreePath); err != nil {
+		// A half-provisioned workspace would launch an agent that dies later
+		// with a misleading "exited without completing the stage" — fail the
+		// launch loudly instead, and don't leave the fresh worktree behind.
+		_ = gitrepo.WorktreeRemove(ctx, projectDir, worktreePath)
+		return "", errors.WrapWithDetails(err, "provisioning agent worktree", "worktree", worktreePath)
+	}
 	return worktreePath, nil
+}
+
+// agentAssetDirs and agentAssetFiles are the project-level Claude assets an
+// agent needs inside its isolated worktree. .claude/ is git-ignored, so a
+// fresh worktree carries none of it — without the skills the agent's slash
+// command (/human-autofix, /human-plan, …) is unknown and the run dies at
+// startup (ticket 478). Allow-listed rather than copied wholesale so session
+// state (.claude/worktrees, .claude/codenav, …) never leaks into a run.
+var agentAssetDirs = []string{"skills", "commands", "agents"}
+var agentAssetFiles = []string{"settings.json", "settings.local.json"}
+
+// provisionAgentAssets copies the project's .claude agent assets into the
+// worktree. A project without .claude (or without an individual asset) is
+// fine — agents then run bare, exactly as they would in the shared checkout.
+func provisionAgentAssets(projectDir, worktreePath string) error {
+	srcRoot := filepath.Join(projectDir, ".claude")
+	if _, err := os.Stat(srcRoot); err != nil {
+		return nil
+	}
+	dstRoot := filepath.Join(worktreePath, ".claude")
+	for _, dir := range agentAssetDirs {
+		src := filepath.Join(srcRoot, dir)
+		if _, err := os.Stat(src); err != nil {
+			continue
+		}
+		if err := copyTree(src, filepath.Join(dstRoot, dir)); err != nil {
+			return err
+		}
+	}
+	for _, file := range agentAssetFiles {
+		src := filepath.Join(srcRoot, file)
+		if _, err := os.Stat(src); err != nil {
+			continue
+		}
+		if err := copyFile(src, filepath.Join(dstRoot, file)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// copyTree copies a directory recursively: regular files with their mode
+// preserved (skills may carry executable helpers), directories created as
+// needed. Irregular entries (sockets, device nodes) are skipped; symlinks are
+// followed via os.Open so a linked skill file still arrives as content.
+func copyTree(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return errors.WrapWithDetails(err, "walking agent assets", "path", path)
+		}
+		rel, relErr := filepath.Rel(src, path)
+		if relErr != nil {
+			return errors.WrapWithDetails(relErr, "resolving asset path", "path", path)
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o750)
+		}
+		if !d.Type().IsRegular() && d.Type()&os.ModeSymlink == 0 {
+			return nil
+		}
+		return copyFile(path, target)
+	})
+}
+
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src) // #nosec G304 -- paths derive from the project's own .claude dir
+	if err != nil {
+		return errors.WrapWithDetails(err, "reading agent asset", "src", src)
+	}
+	info, err := os.Stat(src)
+	if err != nil {
+		return errors.WrapWithDetails(err, "stat agent asset", "src", src)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
+		return errors.WrapWithDetails(err, "creating asset dir", "dir", filepath.Dir(dst))
+	}
+	if err := os.WriteFile(dst, data, info.Mode().Perm()); err != nil {
+		return errors.WrapWithDetails(err, "writing agent asset", "dst", dst)
+	}
+	return nil
 }

--- a/internal/agent/worktree_test.go
+++ b/internal/agent/worktree_test.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -81,6 +83,111 @@ func TestMountSourceForRun_AddErrorPropagates(t *testing.T) {
 	}
 	if got != "" {
 		t.Fatalf("mount source = %q, want empty on error", got)
+	}
+}
+
+// Regression for SC-478: .claude/ is git-ignored, so a fresh worktree carries
+// no skills/commands/agents — the agent's slash-command launch (/human-autofix)
+// is then an unknown command and every board run dies at startup. The worktree
+// must be provisioned with the project's Claude assets; session state
+// (worktrees/, codenav/, …) must NOT leak in.
+func TestMountSourceForRun_ProvisionsClaudeAssets(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stubGit(t, true)
+	// The real WorktreeAdd materializes the worktree dir; the stub must too so
+	// provisioning has a destination.
+	gitrepo.WorktreeAdd = func(_ context.Context, _, worktreePath, _ string) error {
+		return os.MkdirAll(worktreePath, 0o750)
+	}
+
+	proj := t.TempDir()
+	write := func(rel, content string) {
+		t.Helper()
+		p := filepath.Join(proj, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(".claude/skills/human-autofix/SKILL.md", "autofix skill")
+	write(".claude/commands/human-plan.md", "plan command")
+	write(".claude/agents/human-bug-fixer.md", "bug fixer agent")
+	write(".claude/settings.local.json", "{}")
+	write(".claude/worktrees/leak.txt", "session state")
+	write(".claude/codenav/index.db", "db")
+
+	m := &Manager{}
+	wt, err := m.mountSourceForRun(context.Background(), proj, "agent-a")
+	if err != nil {
+		t.Fatalf("mountSourceForRun: %v", err)
+	}
+
+	for _, rel := range []string{
+		".claude/skills/human-autofix/SKILL.md",
+		".claude/commands/human-plan.md",
+		".claude/agents/human-bug-fixer.md",
+		".claude/settings.local.json",
+	} {
+		if _, err := os.Stat(filepath.Join(wt, rel)); err != nil {
+			t.Errorf("worktree missing agent asset %s: %v", rel, err)
+		}
+	}
+	for _, rel := range []string{".claude/worktrees", ".claude/codenav"} {
+		if _, err := os.Stat(filepath.Join(wt, rel)); err == nil {
+			t.Errorf("session state %s must not leak into the worktree", rel)
+		}
+	}
+}
+
+// A project without a .claude dir (non-board, plain repo) provisions nothing
+// and must not fail the launch.
+func TestMountSourceForRun_NoClaudeDirIsFine(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stubGit(t, true)
+	gitrepo.WorktreeAdd = func(_ context.Context, _, worktreePath, _ string) error {
+		return os.MkdirAll(worktreePath, 0o750)
+	}
+
+	m := &Manager{}
+	wt, err := m.mountSourceForRun(context.Background(), t.TempDir(), "agent-a")
+	if err != nil {
+		t.Fatalf("mountSourceForRun: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(wt, ".claude")); err == nil {
+		t.Fatal("no source .claude, yet one appeared in the worktree")
+	}
+}
+
+// A provisioning failure must fail the launch loudly AND remove the fresh
+// worktree — never hand back a half-provisioned workspace whose agent would
+// die later with a misleading "exited without completing the stage".
+func TestMountSourceForRun_ProvisionFailureCleansUp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stubGit(t, true)
+	removed := stubWorktreeRemove(t)
+	// Materialize the worktree path as a FILE: provisioning cannot create
+	// .claude inside it and must error.
+	gitrepo.WorktreeAdd = func(_ context.Context, _, worktreePath, _ string) error {
+		return os.WriteFile(worktreePath, []byte("not a dir"), 0o600)
+	}
+
+	proj := t.TempDir()
+	skill := filepath.Join(proj, ".claude", "skills", "s", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skill), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(skill, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &Manager{}
+	if _, err := m.mountSourceForRun(context.Background(), proj, "agent-a"); err == nil {
+		t.Fatal("expected provisioning failure to fail the launch")
+	}
+	if len(*removed) != 1 {
+		t.Fatalf("WorktreeRemove calls = %d, want 1 (failed provision must not leave the worktree behind)", len(*removed))
 	}
 }
 

--- a/internal/devcontainer/manager.go
+++ b/internal/devcontainer/manager.go
@@ -30,6 +30,13 @@ type UpOptions struct {
 	Out           io.Writer
 	ContainerName string // override container name (default: derived from project dir)
 	SourceDir     string // override mount source (default: same as ProjectDir)
+	// GitDir is the parent repo's .git directory to bind at its host-identical
+	// path when SourceDir is a git worktree: a worktree's .git FILE references
+	// the parent by absolute host path, so without this bind every in-container
+	// git command fails with "not a git repository" (ticket 482). Empty for
+	// shared-checkout and non-git workspaces, whose .git travels with the
+	// source mount itself.
+	GitDir string
 }
 
 // Up creates and starts a devcontainer. If the container already exists and is
@@ -111,7 +118,7 @@ func (m *Manager) createFresh(ctx context.Context, cfg *DevcontainerConfig, proj
 	}
 	// Docker bind mounts require absolute paths.
 	sourceDir, _ = filepath.Abs(sourceDir)
-	createOpts := m.buildCreateOptions(cfg, sourceDir, projectDir, containerName, imageName, workspaceDir, hash, opts.DaemonInfo)
+	createOpts := m.buildCreateOptions(cfg, sourceDir, projectDir, containerName, imageName, workspaceDir, hash, opts.DaemonInfo, opts.GitDir)
 	ParseRunArgs(cfg.RunArgs, &createOpts, m.Logger)
 
 	_, _ = fmt.Fprintf(out, "Creating container %s...\n", containerName)
@@ -258,7 +265,7 @@ func (m *Manager) handleExisting(ctx context.Context, existing ContainerSummary,
 
 // buildCreateOptions creates ContainerCreateOptions from the devcontainer config.
 // configDir is the directory containing .devcontainer/devcontainer.json (may differ from projectDir).
-func (m *Manager) buildCreateOptions(cfg *DevcontainerConfig, projectDir, configDir, containerName, imageName, workspaceDir, hash string, daemonInfo *daemon.DaemonInfo) ContainerCreateOptions {
+func (m *Manager) buildCreateOptions(cfg *DevcontainerConfig, projectDir, configDir, containerName, imageName, workspaceDir, hash string, daemonInfo *daemon.DaemonInfo, gitDir string) ContainerCreateOptions {
 	env := make([]string, 0)
 	for k, v := range cfg.ContainerEnv {
 		env = append(env, k+"="+v)
@@ -280,6 +287,13 @@ func (m *Manager) buildCreateOptions(cfg *DevcontainerConfig, projectDir, config
 
 	binds := []string{
 		projectDir + ":" + workspaceDir,
+	}
+
+	// A worktree workspace resolves git through the parent repo's .git, which
+	// lives outside the mount — bind it at its host-identical path so the
+	// worktree's absolute gitdir pointer works in-container (ticket 482).
+	if gitDir != "" {
+		binds = append(binds, gitDir+":"+gitDir)
 	}
 
 	// Mount CA cert if it exists.

--- a/internal/devcontainer/manager_test.go
+++ b/internal/devcontainer/manager_test.go
@@ -606,6 +606,57 @@ func TestManager_Up_WithMounts(t *testing.T) {
 	}
 }
 
+// Regression for SC-482: a worktree workspace's .git is a FILE pointing at the
+// parent repo's .git by absolute host path. Binding only the worktree leaves
+// every in-container git command dying with "not a git repository" — the
+// parent .git must be bound at its host-identical path alongside.
+func TestManager_Up_WorktreeGitDirBind(t *testing.T) {
+	projectDir, mock, docker := setupTestProject(t, `{"image": "ubuntu:22.04"}`)
+	gitDir := filepath.Join(projectDir, ".git")
+
+	mgr := &Manager{Docker: docker, Logger: testLogger()}
+	_, err := mgr.Up(context.Background(), UpOptions{
+		ProjectDir: projectDir,
+		SourceDir:  t.TempDir(), // stands in for the private worktree
+		GitDir:     gitDir,
+		Out:        &bytes.Buffer{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(mock.createCalls) != 1 {
+		t.Fatalf("expected 1 create call, got %d", len(mock.createCalls))
+	}
+	want := gitDir + ":" + gitDir
+	for _, b := range mock.createCalls[0].Binds {
+		if b == want {
+			return
+		}
+	}
+	t.Errorf("missing parent-repo git bind %q in binds: %v", want, mock.createCalls[0].Binds)
+}
+
+// Without a GitDir (shared-checkout mount, non-git workspace) no extra bind
+// appears — the workspace's own .git directory travels with the source mount.
+func TestManager_Up_NoGitDirNoExtraBind(t *testing.T) {
+	projectDir, mock, docker := setupTestProject(t, `{"image": "ubuntu:22.04"}`)
+
+	mgr := &Manager{Docker: docker, Logger: testLogger()}
+	_, err := mgr.Up(context.Background(), UpOptions{
+		ProjectDir: projectDir,
+		Out:        &bytes.Buffer{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range mock.createCalls[0].Binds {
+		if strings.Contains(b, ".git:") {
+			t.Errorf("unexpected .git bind %q without GitDir", b)
+		}
+	}
+}
+
 func TestManager_Up_WithCACert(t *testing.T) {
 	projectDir, mock, docker := setupTestProject(t, `{"image": "ubuntu:22.04", "remoteUser": "vscode"}`)
 


### PR DESCRIPTION
Fixes the two SC-411 worktree-isolation regressions that currently kill every board agent run at launch:

- **SC-478 — Agent worktrees lose project skills.** A fresh git worktree carries only tracked files and `.claude/` is git-ignored, so agents launched without their skills and died on `Unknown command: /human-autofix`. The worktree is now provisioned with the project's allow-listed Claude assets (`skills/`, `commands/`, `agents/`, settings) after creation; session state (`worktrees/`, `codenav/`) never leaks in. A provisioning failure fails the launch loudly and removes the fresh worktree.
- **SC-482 — Git dead inside agent worktrees.** A worktree's `.git` is a file referencing the parent repo by absolute host path, which wasn't mounted — every in-container git command failed with `not a git repository` (reproduced in a container; masked so far by SC-478 killing runs earlier). The parent `.git` is now bound at its host-identical path whenever the workspace is a worktree.

Regression tests: `TestMountSourceForRun_ProvisionsClaudeAssets`, `_NoClaudeDirIsFine`, `_ProvisionFailureCleansUp` (agent), `TestManager_Up_WorktreeGitDirBind`, `_NoGitDirNoExtraBind` (devcontainer). `make check` green.

After merge the daemon needs a rebuild + restart to pick this up; then the stuck Fix-column tickets (172, 178, 430) can re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)