### PR TITLE
[SC-514] Preflight doctor + board health LED

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Each module ships a short `README.md` describing what it does for you, in plain 
 **Infrastructure & security**
 
 - [Audit Trail](internal/audit/README.md) — structured, queryable record of every agent action against trackers
-- [Background Daemon](internal/daemon/README.md) — holds credentials, answers commands fast
+- [Background Daemon](internal/daemon/README.md) — holds credentials, answers commands fast, runs the preflight doctor (`human doctor`, board health LED)
 - [Dev Containers](internal/devcontainer/README.md) — reproducible sandbox for agents
 - [HTTPS Proxy](internal/proxy/README.md) — filter outbound agent traffic by domain
 - [Chrome Bridge](internal/chrome/README.md) — drive host Chrome from a container

--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -239,6 +239,12 @@ func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, de
 
 	go runMaintenanceLoop(ctx, logger, confirmStore, statsStore, auditStore)
 
+	doctor := daemon.NewDoctorRunner(buildDoctorChecks(projectRegistry, vaultResolver, doctorPersistence{
+		stats:    statsStore != nil,
+		audit:    auditStore != nil,
+		confirms: confirmDB != nil,
+	}))
+
 	srv := &daemon.Server{
 		Addr:              addr,
 		Token:             token,
@@ -252,6 +258,7 @@ func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, de
 		LiteIssueFetcher:  fetchTrackerIssuesLiteFunc(projectRegistry, vaultResolver),
 		IssueGetter:       daemon.NewCachedIssueGetter(issueGetterFunc(projectRegistry, vaultResolver)),
 		TrackerDiagnoser:  trackerDiagnoserFunc(projectRegistry, vaultResolver),
+		Doctor:            doctor,
 		Projects:          projectRegistry,
 		PendingConfirms:   confirmStore,
 		StatsWriter:       statsWriter,

--- a/cmd/cmddaemon/doctor_checks.go
+++ b/cmd/cmddaemon/doctor_checks.go
@@ -1,0 +1,139 @@
+package cmddaemon
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gethuman-sh/human/internal/daemon"
+	"github.com/gethuman-sh/human/internal/devcontainer"
+	"github.com/gethuman-sh/human/internal/tracker"
+	"github.com/gethuman-sh/human/internal/vault"
+)
+
+// doctorPersistence captures which durable stores opened at startup. The
+// values cannot change while the daemon runs, so the check closes over them.
+type doctorPersistence struct {
+	stats    bool
+	audit    bool
+	confirms bool
+}
+
+// buildDoctorChecks assembles the substrate probes for the preflight doctor.
+// Every check is cheap and side-effect free; failure details name the fix,
+// because they become the board LED tooltip and launch-refusal messages —
+// infrastructure failures must be attributed to infrastructure, never to a
+// ticket (SC-514; regressions 428/478 are the motivating incidents).
+func buildDoctorChecks(reg *daemon.ProjectRegistry, resolver *vault.Resolver, persist doctorPersistence) []daemon.DoctorCheckDef {
+	diagnose := trackerDiagnoserFunc(reg, resolver)
+	return []daemon.DoctorCheckDef{
+		{ID: "trackers", Name: "tracker credentials", Run: func(context.Context) (bool, string) {
+			return checkTrackers(reg, diagnose)
+		}},
+		{ID: "docker", Name: "docker engine", Run: checkDocker},
+		{ID: "ca-cert", Name: "proxy CA certificate", Run: func(context.Context) (bool, string) {
+			return checkCACert(caCertPath())
+		}},
+		{ID: "agent-skills", Name: "agent skills", Run: func(context.Context) (bool, string) {
+			return checkAgentSkills(reg)
+		}},
+		{ID: "persistence", Name: "daemon persistence", Run: func(context.Context) (bool, string) {
+			return checkPersistence(persist)
+		}},
+	}
+}
+
+// caCertPath is the well-known proxy CA location the containers mount
+// (devcontainer/manager.go binds the same path).
+func caCertPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".", ".human", "ca.crt")
+	}
+	return filepath.Join(home, ".human", "ca.crt")
+}
+
+// checkTrackers fails when a configured tracker instance cannot load its
+// credentials — the exact condition that silently drops the instance and
+// leaves the board empty or PM-less (ticket 172's class).
+func checkTrackers(reg *daemon.ProjectRegistry, diagnose func(dir string) []tracker.TrackerStatus) (bool, string) {
+	var broken []string
+	var total int
+	for _, entry := range reg.Entries() {
+		for _, st := range diagnose(entry.Dir) {
+			total++
+			if st.Working || st.VaultRef {
+				continue
+			}
+			broken = append(broken, fmt.Sprintf("%s/%s (set %s)", st.Kind, st.Name, strings.Join(st.Missing, ", ")))
+		}
+	}
+	if len(broken) > 0 {
+		return false, "credentials unresolved for " + strings.Join(broken, "; ")
+	}
+	return true, fmt.Sprintf("%d instance(s) working", total)
+}
+
+// checkDocker mirrors the desktop's dockerAvailable probe: a cheap engine
+// round-trip that fails fast when the socket is absent or the engine stopped.
+func checkDocker(ctx context.Context) (bool, string) {
+	dc, err := devcontainer.NewDockerClient()
+	if err != nil {
+		return false, "docker client unavailable: " + err.Error() + " — start Docker"
+	}
+	if _, err := dc.ImageList(ctx, devcontainer.ImageListOptions{}); err != nil {
+		return false, "docker engine unreachable: " + err.Error() + " — start Docker"
+	}
+	return true, "engine reachable"
+}
+
+// checkCACert catches ticket 428's failure mode: a present-but-unparseable
+// CA silently breaks in-container TLS and hook delivery for every agent. An
+// absent file is fine — the daemon generates it on first proxy use.
+func checkCACert(path string) (bool, string) {
+	if _, err := os.Stat(path); err != nil {
+		return true, "not yet generated"
+	}
+	if !devcontainer.IsValidCACertFile(path) {
+		return false, path + " exists but is not a valid PEM certificate — delete it and restart the daemon to regenerate"
+	}
+	return true, "valid"
+}
+
+// checkAgentSkills catches ticket 478's failure mode: worktree provisioning
+// copies the project's .claude, so a project missing its skills kills every
+// board run at launch with an unknown slash command.
+func checkAgentSkills(reg *daemon.ProjectRegistry) (bool, string) {
+	var missing []string
+	for _, entry := range reg.Entries() {
+		skill := filepath.Join(entry.Dir, ".claude", "skills", "human-autofix", "SKILL.md")
+		if _, err := os.Stat(skill); err != nil {
+			missing = append(missing, entry.Dir)
+		}
+	}
+	if len(missing) > 0 {
+		return false, "no agent skills under " + strings.Join(missing, ", ") + " — run 'human install --agent claude' there"
+	}
+	return true, "skills present"
+}
+
+// checkPersistence reports durable stores that failed to open: the daemon
+// runs, but stats/audit/approvals silently stopped surviving restarts.
+func checkPersistence(p doctorPersistence) (bool, string) {
+	var down []string
+	if !p.stats {
+		down = append(down, "stats")
+	}
+	if !p.audit {
+		down = append(down, "audit")
+	}
+	if !p.confirms {
+		down = append(down, "approvals")
+	}
+	if len(down) > 0 {
+		return false, strings.Join(down, ", ") + " persistence disabled — check ~/.human/*.db permissions and the daemon start log"
+	}
+	return true, "all stores open"
+}

--- a/cmd/cmddaemon/doctor_checks_test.go
+++ b/cmd/cmddaemon/doctor_checks_test.go
@@ -1,0 +1,38 @@
+package cmddaemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An absent CA is a fresh install (generated on first proxy use) — only a
+// present-but-unparseable file is the ticket-428 failure that must go red.
+func TestCheckCACert(t *testing.T) {
+	ok, detail := checkCACert(filepath.Join(t.TempDir(), "missing.crt"))
+	assert.True(t, ok)
+	assert.Equal(t, "not yet generated", detail)
+
+	bogus := filepath.Join(t.TempDir(), "ca.crt")
+	require.NoError(t, os.WriteFile(bogus, []byte("not a pem"), 0o600))
+	ok, detail = checkCACert(bogus)
+	assert.False(t, ok)
+	assert.Contains(t, detail, "restart the daemon to regenerate")
+}
+
+func TestCheckPersistence(t *testing.T) {
+	ok, _ := checkPersistence(doctorPersistence{stats: true, audit: true, confirms: true})
+	assert.True(t, ok)
+
+	ok, detail := checkPersistence(doctorPersistence{stats: false, audit: true, confirms: true})
+	assert.False(t, ok)
+	assert.Contains(t, detail, "stats")
+	assert.NotContains(t, detail, "audit,")
+
+	ok, detail = checkPersistence(doctorPersistence{stats: true, audit: true, confirms: false})
+	assert.False(t, ok)
+	assert.Contains(t, detail, "approvals")
+}

--- a/cmd/cmddoctor/doctor.go
+++ b/cmd/cmddoctor/doctor.go
@@ -1,0 +1,64 @@
+// Package cmddoctor implements `human doctor`: the preflight health report
+// for the agent pipeline's substrate. Infrastructure failures must be
+// attributed to infrastructure — the doctor names what is broken and how to
+// fix it, before an agent run burns minutes rediscovering it.
+package cmddoctor
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/daemon"
+)
+
+// BuildDoctorCmd creates the doctor command.
+func BuildDoctorCmd() *cobra.Command {
+	var refresh bool
+
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Check the health of the agent pipeline's substrate",
+		Long: "Runs the daemon's preflight checks (tracker credentials, docker, proxy CA,\n" +
+			"agent skills, persistence) and prints each with its fix. The board's status\n" +
+			"LED shows the same result.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out := cmd.OutOrStdout()
+
+			info, err := daemon.ReadInfo()
+			if err != nil || !info.IsReachable() {
+				printCheck(out, false, "daemon", "not reachable — start it with 'human daemon'")
+				return errors.WithDetails("daemon not reachable")
+			}
+			printCheck(out, true, "daemon", "reachable at "+info.Addr)
+
+			data, err := daemon.GetDoctor(info.Addr, info.Token, refresh)
+			if err != nil {
+				return errors.WrapWithDetails(err, "querying daemon doctor")
+			}
+			for _, c := range data.Checks {
+				printCheck(out, c.OK, c.Name, c.Detail)
+			}
+			if !data.Healthy {
+				return errors.WithDetails("substrate unhealthy — agent launches on failing checks are blocked")
+			}
+			_, _ = fmt.Fprintln(out, "\nAll systems go.")
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&refresh, "refresh", false, "force a live check run instead of the cached result")
+	return cmd
+}
+
+func printCheck(out io.Writer, ok bool, name, detail string) {
+	mark := "✓"
+	if !ok {
+		mark = "✗"
+	}
+	if detail != "" {
+		detail = " — " + detail
+	}
+	_, _ = fmt.Fprintf(out, "%s %s%s\n", mark, name, detail)
+}

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -317,6 +317,26 @@ func (a *App) DaemonStatus() bool {
 	return alive
 }
 
+// Doctor returns the daemon's substrate health checks for the rail LED. An
+// unreachable daemon (or a daemon predating the doctor route) surfaces as an
+// unhealthy result with a single explanatory check rather than an error, so
+// the LED always has something truthful to show.
+func (a *App) Doctor() daemon.DoctorData {
+	info, err := daemon.ReadInfo()
+	if err != nil || !info.IsReachable() {
+		return daemon.DoctorData{Checks: []daemon.DoctorCheck{
+			{ID: "daemon", Name: "daemon", OK: false, Detail: "not reachable — start it with 'human daemon'"},
+		}}
+	}
+	data, err := daemon.GetDoctor(info.Addr, info.Token, false)
+	if err != nil {
+		return daemon.DoctorData{Checks: []daemon.DoctorCheck{
+			{ID: "daemon", Name: "daemon", OK: false, Detail: "doctor unavailable: " + err.Error()},
+		}}
+	}
+	return data
+}
+
 // Transition advances a card one stage by delegating to the daemon's
 // board-transition route. The daemon is authoritative: it re-derives the card
 // from live comments and enforces forward-only/gated rules, so an out-of-date

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -1134,6 +1134,30 @@ async function pollDaemonStatus() {
         daemonReachable = false;
     }
     renderDaemonStatus();
+    void pollDoctor();
+}
+// pollDoctor drives the rail LED: green when every substrate check passes,
+// red otherwise, with the failing checks (and their fixes) in the tooltip.
+// The daemon caches check results, so polling at the daemon-status cadence is
+// cheap and the LED reflects reality within seconds.
+async function pollDoctor() {
+    const led = document.getElementById("doctor-led");
+    if (!led)
+        return;
+    let doctor;
+    try {
+        doctor = await go().Doctor();
+    }
+    catch {
+        doctor = { healthy: false, checks: [{ id: "daemon", name: "daemon", ok: false, detail: "not reachable" }] };
+    }
+    const failing = (doctor.checks ?? []).filter((c) => !c.ok);
+    const healthy = doctor.healthy && failing.length === 0;
+    led.classList.toggle("ok", healthy);
+    led.classList.toggle("fail", !healthy);
+    led.title = healthy
+        ? "All systems go"
+        : failing.map((c) => `${c.name}: ${c.detail || "failing"}`).join("\n") || "System health unknown";
 }
 // initialLoad renders the board progressively on startup: a spinner first, then
 // ticket titles (Backlog) from the fast comment-scan-free fetch, then the full

--- a/desktop/frontend/dist/index.html
+++ b/desktop/frontend/dist/index.html
@@ -11,6 +11,7 @@
   <body>
     <div class="app-shell">
       <nav class="rail" aria-label="Primary">
+        <span class="rail-led" id="doctor-led" role="status" title="Checking system health…"></span>
         <button class="rail-item rail-action" data-action="ideation" title="New ticket — ideation">+</button>
         <button class="rail-item active" data-view="board" title="Board" aria-current="page">
           <svg class="rail-icon" width="22" height="22" viewBox="0 0 24 24" fill="none"

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -70,6 +70,31 @@ body {
   padding: 10px 0;
 }
 
+/* The doctor LED: the substrate's health as one dot at the very top of the
+   rail. Neutral while unknown, green when every preflight check passes, red
+   when any fails or the daemon is unreachable — the tooltip carries the
+   failing checks and their fixes. */
+.rail-led {
+  width: 10px;
+  height: 10px;
+  flex: none;
+  border-radius: 50%;
+  margin: 2px 0 4px;
+  background: var(--muted);
+  cursor: help;
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.rail-led.ok {
+  background: var(--done);
+  box-shadow: 0 0 6px var(--done);
+}
+
+.rail-led.fail {
+  background: var(--failed);
+  box-shadow: 0 0 6px var(--failed);
+}
+
 /* Discord-style icon tiles: dark rounded squares that morph toward the accent
    squircle on hover/active. The centred flex keeps glyph and svg icons aligned. */
 .rail-item {

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -194,8 +194,22 @@ interface IssueDetailData {
   fixSummaryHTML?: string;
 }
 
+interface DoctorCheck {
+  id: string;
+  name: string;
+  ok: boolean;
+  detail?: string;
+}
+
+interface DoctorData {
+  healthy: boolean;
+  checkedAt?: string;
+  checks: DoctorCheck[];
+}
+
 interface AppBindings {
   Cards(): Promise<BoardData>;
+  Doctor(): Promise<DoctorData>;
   GetIssueDetail(trackerKind: string, trackerName: string, key: string): Promise<IssueDetailData>;
   CardsQuick(): Promise<BoardData>;
   Transition(pmKey: string, pmTitle: string, from: string, to: string): Promise<void>;
@@ -1393,6 +1407,29 @@ async function pollDaemonStatus(): Promise<void> {
     daemonReachable = false;
   }
   renderDaemonStatus();
+  void pollDoctor();
+}
+
+// pollDoctor drives the rail LED: green when every substrate check passes,
+// red otherwise, with the failing checks (and their fixes) in the tooltip.
+// The daemon caches check results, so polling at the daemon-status cadence is
+// cheap and the LED reflects reality within seconds.
+async function pollDoctor(): Promise<void> {
+  const led = document.getElementById("doctor-led");
+  if (!led) return;
+  let doctor: DoctorData;
+  try {
+    doctor = await go().Doctor();
+  } catch {
+    doctor = { healthy: false, checks: [{ id: "daemon", name: "daemon", ok: false, detail: "not reachable" }] };
+  }
+  const failing = (doctor.checks ?? []).filter((c) => !c.ok);
+  const healthy = doctor.healthy && failing.length === 0;
+  led.classList.toggle("ok", healthy);
+  led.classList.toggle("fail", !healthy);
+  led.title = healthy
+    ? "All systems go"
+    : failing.map((c) => `${c.name}: ${c.detail || "failing"}`).join("\n") || "System health unknown";
 }
 
 // initialLoad renders the board progressively on startup: a spinner first, then

--- a/desktop/frontend/static/index.html
+++ b/desktop/frontend/static/index.html
@@ -11,6 +11,7 @@
   <body>
     <div class="app-shell">
       <nav class="rail" aria-label="Primary">
+        <span class="rail-led" id="doctor-led" role="status" title="Checking system health…"></span>
         <button class="rail-item rail-action" data-action="ideation" title="New ticket — ideation">+</button>
         <button class="rail-item active" data-view="board" title="Board" aria-current="page">
           <svg class="rail-icon" width="22" height="22" viewBox="0 0 24 24" fill="none"

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -70,6 +70,31 @@ body {
   padding: 10px 0;
 }
 
+/* The doctor LED: the substrate's health as one dot at the very top of the
+   rail. Neutral while unknown, green when every preflight check passes, red
+   when any fails or the daemon is unreachable — the tooltip carries the
+   failing checks and their fixes. */
+.rail-led {
+  width: 10px;
+  height: 10px;
+  flex: none;
+  border-radius: 50%;
+  margin: 2px 0 4px;
+  background: var(--muted);
+  cursor: help;
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.rail-led.ok {
+  background: var(--done);
+  box-shadow: 0 0 6px var(--done);
+}
+
+.rail-led.fail {
+  background: var(--failed);
+  box-shadow: 0 0 6px var(--failed);
+}
+
 /* Discord-style icon tiles: dark rounded squares that morph toward the accent
    squircle on hover/active. The centred flex keeps glyph and svg icons aligned. */
 .rail-item {

--- a/internal/daemon/README.md
+++ b/internal/daemon/README.md
@@ -9,6 +9,7 @@ A long-running background service that holds your tracker credentials once and a
 - Completes browser OAuth sign-in flows automatically
 - Surfaces ready-for-review handoffs to the TUI
 - Queues destructive operations as permission requests; an approval is a one-time grant the client redeems by re-submitting the command, and decisions stay queryable by ID for 24 hours — persisted in `~/.human/confirms.db`, so prompts and unredeemed grants survive daemon restarts
+- Runs the preflight doctor: cached substrate health checks (tracker credentials, docker, proxy CA, agent skills, persistence) behind a `doctor` route; agent launches are refused with the failing check's diagnosis, `human doctor` prints the report, and the board's rail LED shows it live
 - Rejects clients older than the wire protocol it speaks with a clear "upgrade the human CLI" error, before any side effects
 - Records tool activity for later statistics
 - Derives each PM ticket's workflow-board placement and applies drag-to-trigger pipeline transitions for the desktop board

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -504,6 +504,24 @@ func GetPendingConfirms(addr, token string) ([]PendingConfirm, error) {
 	return results, nil
 }
 
+// GetDoctor fetches the daemon's substrate health checks. refresh forces a
+// live run instead of the poller cache.
+func GetDoctor(addr, token string, refresh bool) (DoctorData, error) {
+	args := []string{"doctor"}
+	if refresh {
+		args = append(args, "refresh")
+	}
+	out, err := RunRemoteCapture(addr, token, args)
+	if err != nil {
+		return DoctorData{}, err
+	}
+	var data DoctorData
+	if err := json.Unmarshal(out, &data); err != nil {
+		return DoctorData{}, errors.WrapWithDetails(err, "invalid doctor JSON")
+	}
+	return data, nil
+}
+
 // GetToolStats fetches pre-aggregated tool call statistics from the daemon.
 func GetToolStats(addr, token string) (*stats.ToolStats, error) {
 	out, err := RunRemoteCapture(addr, token, []string{"tool-stats"})

--- a/internal/daemon/doctor.go
+++ b/internal/daemon/doctor.go
@@ -1,0 +1,117 @@
+package daemon
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// defaultCheckTimeout bounds a single doctor check so one wedged probe (a
+// hung docker socket, a stalled tracker call) can never hang the runner or
+// the UIs polling it.
+const defaultCheckTimeout = 5 * time.Second
+
+// DoctorCheckDef is one substrate probe: cheap, side-effect free, and honest
+// about what is broken. Run returns ok plus a detail line — for failures the
+// detail must name the fix, not just the symptom, because it becomes the LED
+// tooltip and the launch-refusal message.
+type DoctorCheckDef struct {
+	ID      string
+	Name    string
+	Timeout time.Duration // zero means defaultCheckTimeout
+	Run     func(ctx context.Context) (ok bool, detail string)
+}
+
+// DoctorCheck is the wire form of one check result.
+type DoctorCheck struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	OK     bool   `json:"ok"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// DoctorData is the wire form of a doctor run: the substrate's health as one
+// bool for the LED plus the per-check detail for tooltips and `human doctor`.
+type DoctorData struct {
+	Healthy   bool          `json:"healthy"`
+	CheckedAt string        `json:"checkedAt"`
+	Checks    []DoctorCheck `json:"checks"`
+}
+
+// DoctorRunner runs the check suite and caches the results, so the desktop
+// LED can poll every few seconds while the (potentially slower) probes run at
+// most once per staleness window. Refresh is lazy — no background goroutine to
+// manage; the first stale read pays for the run.
+type DoctorRunner struct {
+	checks []DoctorCheckDef
+
+	mu        sync.Mutex
+	last      DoctorData
+	lastRunAt time.Time
+}
+
+// NewDoctorRunner creates a runner over the given checks. Check order is
+// presentation order.
+func NewDoctorRunner(checks []DoctorCheckDef) *DoctorRunner {
+	return &DoctorRunner{checks: checks}
+}
+
+// Results returns the check results, re-running the suite when the cache is
+// older than maxAge (zero forces a live run). A nil runner reports healthy
+// with no checks — the feature is disabled, and a disabled doctor must never
+// block work.
+func (d *DoctorRunner) Results(ctx context.Context, maxAge time.Duration) DoctorData {
+	if d == nil {
+		return DoctorData{Healthy: true}
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if maxAge > 0 && !d.lastRunAt.IsZero() && time.Since(d.lastRunAt) < maxAge {
+		return d.last
+	}
+	d.last = d.run(ctx)
+	d.lastRunAt = time.Now()
+	return d.last
+}
+
+// run executes every check with its own timeout; callers hold d.mu. The suite
+// is small and each probe bounded, so sequential execution keeps results
+// deterministic without meaningful latency cost.
+func (d *DoctorRunner) run(ctx context.Context) DoctorData {
+	data := DoctorData{Healthy: true, CheckedAt: time.Now().UTC().Format(time.RFC3339)}
+	for _, def := range d.checks {
+		timeout := def.Timeout
+		if timeout == 0 {
+			timeout = defaultCheckTimeout
+		}
+		checkCtx, cancel := context.WithTimeout(ctx, timeout)
+		ok, detail := def.Run(checkCtx)
+		cancel()
+		if !ok {
+			data.Healthy = false
+		}
+		data.Checks = append(data.Checks, DoctorCheck{ID: def.ID, Name: def.Name, OK: ok, Detail: detail})
+	}
+	return data
+}
+
+// Blockers returns the failing subset of the given launch-critical check IDs,
+// from a briefly-cached run: an agent launch on a substrate the doctor knows
+// is broken would burn minutes to rediscover the same failure, so the launch
+// path refuses with the check's own message instead.
+func (d *DoctorRunner) Blockers(ctx context.Context, criticalIDs []string) []DoctorCheck {
+	if d == nil {
+		return nil
+	}
+	critical := make(map[string]bool, len(criticalIDs))
+	for _, id := range criticalIDs {
+		critical[id] = true
+	}
+	var out []DoctorCheck
+	for _, c := range d.Results(ctx, 30*time.Second).Checks {
+		if !c.OK && critical[c.ID] {
+			out = append(out, c)
+		}
+	}
+	return out
+}

--- a/internal/daemon/doctor_test.go
+++ b/internal/daemon/doctor_test.go
@@ -1,0 +1,221 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func doctorWithChecks(checks ...DoctorCheckDef) *DoctorRunner {
+	return NewDoctorRunner(checks)
+}
+
+func passing(id string) DoctorCheckDef {
+	return DoctorCheckDef{
+		ID:   id,
+		Name: id,
+		Run:  func(context.Context) (bool, string) { return true, "fine" },
+	}
+}
+
+func failing(id, detail string) DoctorCheckDef {
+	return DoctorCheckDef{
+		ID:   id,
+		Name: id,
+		Run:  func(context.Context) (bool, string) { return false, detail },
+	}
+}
+
+func TestDoctorRunner_AggregatesHealth(t *testing.T) {
+	d := doctorWithChecks(passing("a"), failing("b", "broken thing"))
+
+	res := d.Results(context.Background(), 0)
+	require.Len(t, res.Checks, 2)
+	assert.False(t, res.Healthy)
+	assert.Equal(t, "a", res.Checks[0].ID)
+	assert.True(t, res.Checks[0].OK)
+	assert.False(t, res.Checks[1].OK)
+	assert.Equal(t, "broken thing", res.Checks[1].Detail)
+	assert.NotEmpty(t, res.CheckedAt)
+
+	allGreen := doctorWithChecks(passing("a"), passing("b"))
+	assert.True(t, allGreen.Results(context.Background(), 0).Healthy)
+}
+
+// The LED polls every few seconds; checks must not re-run on every poll.
+func TestDoctorRunner_CachesWithinMaxAge(t *testing.T) {
+	var runs atomic.Int32
+	d := doctorWithChecks(DoctorCheckDef{
+		ID: "counted", Name: "counted",
+		Run: func(context.Context) (bool, string) {
+			runs.Add(1)
+			return true, ""
+		},
+	})
+
+	for range 5 {
+		d.Results(context.Background(), time.Minute)
+	}
+	assert.Equal(t, int32(1), runs.Load(), "fresh results must be served from cache")
+
+	// maxAge zero forces a live run regardless of cache freshness.
+	d.Results(context.Background(), 0)
+	assert.Equal(t, int32(2), runs.Load())
+}
+
+// A wedged check must not hang the runner: each check gets a bounded slice
+// of time and reports failure when it exceeds it.
+func TestDoctorRunner_CheckTimeoutFails(t *testing.T) {
+	slow := DoctorCheckDef{
+		ID: "slow", Name: "slow", Timeout: 30 * time.Millisecond,
+		Run: func(ctx context.Context) (bool, string) {
+			<-ctx.Done()
+			return false, "context expired"
+		},
+	}
+	d := doctorWithChecks(slow)
+
+	start := time.Now()
+	res := d.Results(context.Background(), 0)
+	require.Less(t, time.Since(start), 5*time.Second)
+	assert.False(t, res.Healthy)
+	assert.False(t, res.Checks[0].OK)
+}
+
+// Blockers filters the failing subset of launch-critical checks so board
+// launches can be refused with the real reason.
+func TestDoctorRunner_Blockers(t *testing.T) {
+	d := doctorWithChecks(
+		passing("docker"),
+		failing("agent-skills", "no /human-autofix in /proj/.claude"),
+		failing("ca-cert", "PEM parse failed"),
+	)
+
+	blockers := d.Blockers(context.Background(), []string{"docker", "agent-skills"})
+	require.Len(t, blockers, 1)
+	assert.Equal(t, "agent-skills", blockers[0].ID)
+	assert.Equal(t, "no /human-autofix in /proj/.claude", blockers[0].Detail)
+
+	healthy := doctorWithChecks(passing("docker"))
+	assert.Empty(t, healthy.Blockers(context.Background(), []string{"docker"}))
+}
+
+// A nil runner is a disabled feature, mirroring the Server's other nil-guards.
+func TestDoctorRunner_NilSafe(t *testing.T) {
+	var d *DoctorRunner
+	res := d.Results(context.Background(), 0)
+	assert.True(t, res.Healthy, "a disabled doctor must not block anything")
+	assert.Empty(t, res.Checks)
+	assert.Empty(t, d.Blockers(context.Background(), []string{"docker"}))
+}
+
+// startDoctorTestServer mirrors startTestServerWithOpts but lets the test
+// configure the doctor and board hooks the gating rides on.
+func startDoctorTestServer(t *testing.T, configure func(*Server)) (addr string) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	srv := &Server{Addr: "127.0.0.1:0", Token: "tok", CmdFactory: echoCmd, Logger: zerolog.Nop()}
+	configure(srv)
+
+	ln, err := net.Listen("tcp", srv.Addr)
+	require.NoError(t, err)
+	addr = ln.Addr().String()
+	_ = ln.Close()
+	srv.Addr = addr
+
+	go func() { _ = srv.ListenAndServe(ctx) }()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, dialErr := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if dialErr == nil {
+			_ = conn.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Cleanup(cancel)
+	return addr
+}
+
+func TestServer_DoctorRoute(t *testing.T) {
+	addr := startDoctorTestServer(t, func(s *Server) {
+		s.Doctor = doctorWithChecks(passing("docker"), failing("ca-cert", "PEM parse failed"))
+	})
+
+	resp := sendRequest(t, addr, Request{Token: "tok", Args: []string{"doctor"}})
+	require.Equal(t, 0, resp.ExitCode, resp.Stderr)
+
+	var data DoctorData
+	require.NoError(t, json.Unmarshal([]byte(resp.Stdout), &data))
+	assert.False(t, data.Healthy)
+	require.Len(t, data.Checks, 2)
+	assert.Equal(t, "ca-cert", data.Checks[1].ID)
+	assert.Equal(t, "PEM parse failed", data.Checks[1].Detail)
+}
+
+// A disabled doctor reports healthy: the route must never invent problems.
+func TestServer_DoctorRouteNilRunner(t *testing.T) {
+	addr := startDoctorTestServer(t, func(*Server) {})
+
+	resp := sendRequest(t, addr, Request{Token: "tok", Args: []string{"doctor"}})
+	require.Equal(t, 0, resp.ExitCode, resp.Stderr)
+
+	var data DoctorData
+	require.NoError(t, json.Unmarshal([]byte(resp.Stdout), &data))
+	assert.True(t, data.Healthy)
+}
+
+// A board fix launch on a substrate the doctor knows is broken is refused
+// with the check's own diagnosis — the agent never launches to rediscover it.
+func TestServer_BoardFixBlockedByDoctor(t *testing.T) {
+	var launched bool
+	addr := startDoctorTestServer(t, func(s *Server) {
+		s.Doctor = doctorWithChecks(failing("agent-skills", "no /human-autofix under /proj/.claude — run human install"))
+		s.BoardFixer = func(BoardFixRequest) error { launched = true; return nil }
+	})
+
+	resp := sendRequest(t, addr, Request{Token: "tok", Args: []string{"board-fix", `{"pm_key":"1","pm_title":"t"}`}})
+	require.NotEqual(t, 0, resp.ExitCode)
+	assert.Contains(t, resp.Stderr, "launch blocked")
+	assert.Contains(t, resp.Stderr, "run human install")
+	assert.False(t, launched, "the fixer must not launch on a blocked substrate")
+}
+
+func TestServer_BoardFixProceedsWhenHealthy(t *testing.T) {
+	var launched bool
+	addr := startDoctorTestServer(t, func(s *Server) {
+		s.Doctor = doctorWithChecks(passing("docker"), passing("agent-skills"))
+		s.BoardFixer = func(BoardFixRequest) error { launched = true; return nil }
+	})
+
+	resp := sendRequest(t, addr, Request{Token: "tok", Args: []string{"board-fix", `{"pm_key":"1","pm_title":"t"}`}})
+	require.Equal(t, 0, resp.ExitCode, resp.Stderr)
+	assert.True(t, launched)
+}
+
+// Deploy (the done stage) merges and closes without an agent — a red docker
+// LED must not stop shipping already-reviewed work.
+func TestServer_DeployTransitionNotGated(t *testing.T) {
+	var applied bool
+	addr := startDoctorTestServer(t, func(s *Server) {
+		s.Doctor = doctorWithChecks(failing("docker", "engine unreachable"))
+		s.BoardTransitioner = func(BoardTransitionRequest) error { applied = true; return nil }
+	})
+
+	resp := sendRequest(t, addr, Request{Token: "tok", Args: []string{"board-transition", `{"pm_key":"1","pm_title":"t","from":"verification","to":"done"}`}})
+	require.Equal(t, 0, resp.ExitCode, resp.Stderr)
+	assert.True(t, applied, "deploy launches no agent and must not be doctor-gated")
+
+	// The same failing docker check DOES gate an agent-launching transition.
+	resp = sendRequest(t, addr, Request{Token: "tok", Args: []string{"board-transition", `{"pm_key":"1","pm_title":"t","from":"backlog","to":"planning"}`}})
+	require.NotEqual(t, 0, resp.ExitCode)
+	assert.Contains(t, resp.Stderr, "engine unreachable")
+}

--- a/internal/daemon/pending_confirm_db_test.go
+++ b/internal/daemon/pending_confirm_db_test.go
@@ -292,7 +292,7 @@ func (f *failingPersistence) Delete(id string) error {
 	f.deletes = append(f.deletes, id)
 	return nil
 }
-func (f *failingPersistence) DeleteOlderThan(time.Time) error      { return f.err("prune") }
+func (f *failingPersistence) DeleteOlderThan(time.Time) error         { return f.err("prune") }
 func (f *failingPersistence) LoadAll() ([]PendingConfirmation, error) { return nil, f.err("load") }
 
 type errTestPersistence string

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 
+	"github.com/gethuman-sh/human/errors"
 	"github.com/gethuman-sh/human/internal/audit"
 	"github.com/gethuman-sh/human/internal/browser"
 	"github.com/gethuman-sh/human/internal/claude/hookevents"
@@ -57,6 +58,7 @@ type Server struct {
 	// disables the tracker-issue route.
 	IssueGetter      func(req IssueDetailRequest) (*IssueDetailFetch, error)
 	TrackerDiagnoser func(dir string) []tracker.TrackerStatus // injected; diagnoses tracker status with vault resolution
+	Doctor           *DoctorRunner                            // substrate health checks; nil disables (doctor route reports healthy, launches never block)
 	Projects         *ProjectRegistry                         // multi-project routing; nil means single-project mode
 	PendingConfirms  *PendingConfirmStore                     // pending destructive operation confirmations; nil disables
 	StatsWriter      *stats.Writer                            // async SQLite writer for tool event persistence; nil disables
@@ -364,6 +366,7 @@ func (s *Server) routeSimpleCommand(conn net.Conn, args []string, projectDir str
 		"tracker-issues-lite": func() { s.handleTrackerIssuesLite(conn) },
 		"tracker-issue":       func() { s.handleTrackerIssue(conn, args[1:]) },
 		"pending-confirms":    func() { s.handlePendingConfirms(conn) },
+		"doctor":              func() { s.handleDoctor(conn, args[1:]) },
 		"confirm-op":          func() { s.handleConfirmOp(conn, args[1:], clientPID) },
 		"confirm-status":      func() { s.handleConfirmStatus(conn, args[1:]) },
 		"tool-stats":          func() { s.handleToolStats(conn) },
@@ -562,6 +565,14 @@ func (s *Server) handleBoardTransition(conn net.Conn, args []string) {
 		s.writeError(conn, "invalid board-transition request: "+err.Error(), 1)
 		return
 	}
+	// The done stage merges and closes without launching an agent, so only
+	// agent-launching targets are gated on substrate health.
+	if req.To != BoardDoneStage {
+		if err := s.launchBlockedByDoctor(); err != nil {
+			s.writeError(conn, err.Error(), 1)
+			return
+		}
+	}
 	if err := s.BoardTransitioner(req); err != nil {
 		s.writeError(conn, err.Error(), 1)
 		return
@@ -588,6 +599,10 @@ func (s *Server) handleBoardFix(conn net.Conn, args []string) {
 	var req BoardFixRequest
 	if err := json.Unmarshal([]byte(args[0]), &req); err != nil {
 		s.writeError(conn, "invalid board-fix request: "+err.Error(), 1)
+		return
+	}
+	if err := s.launchBlockedByDoctor(); err != nil {
+		s.writeError(conn, err.Error(), 1)
 		return
 	}
 	if err := s.BoardFixer(req); err != nil {
@@ -1124,6 +1139,44 @@ func confirmAuditArgs(pc PendingConfirmation) []string {
 		verb = pc.Operation
 	}
 	return []string{pc.Tracker, "issue", verb, pc.Key}
+}
+
+// doctorCacheAge is how stale a doctor result may be when served to pollers
+// (the desktop LED asks every few seconds; probes should run far less often).
+const doctorCacheAge = 2 * time.Minute
+
+// launchCriticalChecks are the doctor checks a board agent launch cannot
+// survive without: launching anyway would burn a full agent run to rediscover
+// a failure the doctor already knows, and the card would blame the ticket.
+var launchCriticalChecks = []string{"docker", "agent-skills"}
+
+// handleDoctor returns the substrate health checks as JSON. "refresh" as an
+// argument forces a live run instead of the poller cache.
+func (s *Server) handleDoctor(conn net.Conn, args []string) {
+	maxAge := doctorCacheAge
+	if len(args) > 0 && args[0] == "refresh" {
+		maxAge = 0
+	}
+	data, err := json.Marshal(s.Doctor.Results(context.Background(), maxAge))
+	if err != nil {
+		s.writeError(conn, err.Error(), 1)
+		return
+	}
+	resp := Response{Stdout: string(data) + "\n"}
+	enc := json.NewEncoder(conn)
+	_ = enc.Encode(resp)
+}
+
+// launchBlockedByDoctor refuses an agent launch when a launch-critical check
+// is failing, naming the check's own diagnosis. Infrastructure failures must
+// be attributed to infrastructure, never to the ticket.
+func (s *Server) launchBlockedByDoctor() error {
+	blockers := s.Doctor.Blockers(context.Background(), launchCriticalChecks)
+	if len(blockers) == 0 {
+		return nil
+	}
+	b := blockers[0]
+	return errors.WithDetails("launch blocked by failing "+b.Name+" check: "+b.Detail, "check", b.ID)
 }
 
 // handlePendingConfirms returns the current pending confirmations as JSON.

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gethuman-sh/human/cmd/cmdclickup"
 	"github.com/gethuman-sh/human/cmd/cmdcodenav"
 	"github.com/gethuman-sh/human/cmd/cmddaemon"
+	"github.com/gethuman-sh/human/cmd/cmddoctor"
 	"github.com/gethuman-sh/human/cmd/cmdfigma"
 	"github.com/gethuman-sh/human/cmd/cmdindex"
 	"github.com/gethuman-sh/human/cmd/cmdinit"
@@ -313,6 +314,10 @@ Configure trackers and tools in .humanconfig.yaml or pass credentials via flags/
 	pingCmd.GroupID = "utility"
 	rootCmd.AddCommand(pingCmd)
 
+	doctorCmd := cmddoctor.BuildDoctorCmd()
+	doctorCmd.GroupID = "utility"
+	rootCmd.AddCommand(doctorCmd)
+
 	proxyCmd := cmdproxy.BuildProxyCmd()
 	proxyCmd.GroupID = "utility"
 	rootCmd.AddCommand(proxyCmd)
@@ -450,6 +455,7 @@ var localSubcommands = map[string]bool{
 	"codenav":       true,
 	"agent-context": true,
 	"tui":           true,
+	"doctor":        true,
 	"ping":          true,
 	"proxy":         true,
 	"hook":          true,


### PR DESCRIPTION
The 1.0 "preflight doctor" pillar: infrastructure failures get attributed to infrastructure, never to a ticket.

- **DoctorRunner** (internal/daemon): injected substrate probes with per-check timeouts, cached for pollers, lazy refresh; nil = disabled and never blocks.
- **Check catalog** (cmd/cmddaemon): tracker credentials resolve, docker engine reachable, proxy CA parses (ticket 428's failure), project agent skills present (ticket 478's), durable stores open — each failure detail names the fix.
- **Launch gating**: board-fix and agent-launching transitions are refused with the failing check's diagnosis when docker/agent-skills are red; the done-stage deploy launches no agent and is never gated.
- **`human doctor`**: prints the checks with fixes, `--refresh` forces a live run, nonzero exit when unhealthy; runs locally instead of being forwarded wholesale.
- **Rail LED**: a dot at the top-left of the board's rail — green when all checks pass, red when any fails or the daemon is unreachable, failing checks + fixes in the tooltip. Polls the daemon's cached results at the existing status cadence.

Also repairs main's fmt gate (PR #132's test file landed unformatted) and adds the approvals store to the persistence probe now that SC-512 is merged.

Tests: runner unit tests (caching, timeout, blockers, nil-safety), server route + gating tests (blocked fix never launches, deploy never gated), check helper tests. `make check` green.

Takes effect after daemon rebuild + restart; the LED needs a `make desktop` rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)