### PR TITLE
Fix the two flaky tests breaking CI on main

### DIFF
--- a/internal/agent/agentlog_regression_test.go
+++ b/internal/agent/agentlog_regression_test.go
@@ -77,6 +77,9 @@ func TestAgentExecution_PersistsOutputAndTranscript(t *testing.T) {
 		transcript:    "TRANSCRIPT-MARKER",
 	}
 	mgr := &Manager{Docker: docker}
+	// The tee goroutine creates files asynchronously; without this wait it
+	// races the TempDir RemoveAll and cleanup fails with ENOTEMPTY.
+	t.Cleanup(mgr.teeWG.Wait)
 	ctx := context.Background()
 
 	exe, err := mgr.execClaudeDetached(ctx, "container-xyz", "vscode", "", StartOpts{

--- a/internal/agent/agentlog_test.go
+++ b/internal/agent/agentlog_test.go
@@ -39,6 +39,9 @@ func withLogRoot(t *testing.T) string {
 func TestExecClaudeDetached_WritesLaunchRecord(t *testing.T) {
 	withLogRoot(t)
 	mgr := &Manager{Docker: &mockDockerClient{}}
+	// The tee goroutine creates output.log asynchronously; without this wait
+	// it races the TempDir RemoveAll and cleanup fails with ENOTEMPTY.
+	t.Cleanup(mgr.teeWG.Wait)
 	exe, err := mgr.execClaudeDetached(context.Background(), "cid", "vscode", "", StartOpts{
 		Name: "a", Prompt: "P", Model: "opus",
 	})
@@ -82,17 +85,11 @@ func TestTeeExecOutput_DemuxesStdoutAndStderr(t *testing.T) {
 	if exe == nil {
 		t.Fatal("expected non-nil execution")
 	}
-	// Poll for the tee goroutine to flush both frames.
-	var out string
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		data, _ := os.ReadFile(filepath.Join(exe.Dir(), "output.log"))
-		out = string(data)
-		if len(out) > 0 {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
+	// The tee goroutine has flushed and closed the log once the WaitGroup
+	// releases, so a single read observes the complete demuxed output.
+	mgr.teeWG.Wait()
+	data, _ := os.ReadFile(filepath.Join(exe.Dir(), "output.log"))
+	out := string(data)
 	if !contains(out, "OUT") || !contains(out, "ERR") {
 		t.Fatalf("output.log missing demuxed payloads, got %q", out)
 	}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -49,6 +49,11 @@ type StartOpts struct {
 // Manager orchestrates agent lifecycle using devcontainers.
 type Manager struct {
 	Docker devcontainer.DockerClient
+
+	// teeWG tracks detached tee goroutines so tests can wait for the output
+	// log to be fully flushed before their temp dirs are removed; production
+	// callers never wait — the tee outlives the launch by design.
+	teeWG sync.WaitGroup
 }
 
 // Start creates a new container-based agent.
@@ -217,7 +222,11 @@ func (m *Manager) execClaudeDetached(ctx context.Context, containerID, remoteUse
 		// The tee goroutine owns the attach and closes it on stream EOF (the
 		// exec exiting), so launch returns immediately while the detached
 		// stdout/stderr is durably persisted to the host.
-		go teeExecOutput(attach, exe)
+		m.teeWG.Add(1)
+		go func() {
+			defer m.teeWG.Done()
+			teeExecOutput(attach, exe)
+		}()
 	} else {
 		_ = attach.Close()
 	}

--- a/internal/chrome/socket_relay_test.go
+++ b/internal/chrome/socket_relay_test.go
@@ -14,6 +14,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// dialRelay waits for the relay's socket to become dialable. The socket file
+// is born at bind time, a moment before listen(2), so a dial right after the
+// file appears can still hit ECONNREFUSED — retry until the deadline.
+func dialRelay(t *testing.T, dir string) net.Conn {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		matches, _ := filepath.Glob(filepath.Join(dir, "*.sock"))
+		if len(matches) > 0 {
+			conn, err := net.Dial("unix", matches[0])
+			if err == nil {
+				return conn
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("relay socket never became dialable")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func TestSocketRelay_HappyPath(t *testing.T) {
 	dir := shortTempDir(t)
 	relay := NewSocketRelay(dir, zerolog.Nop())
@@ -42,12 +63,7 @@ func TestSocketRelay_HappyPath(t *testing.T) {
 	<-listenReady
 
 	// Simulate Chrome native host connecting.
-	matches, err := filepath.Glob(filepath.Join(dir, "*.sock"))
-	require.NoError(t, err)
-	require.Len(t, matches, 1)
-
-	chromeConn, err := net.Dial("unix", matches[0])
-	require.NoError(t, err)
+	chromeConn := dialRelay(t, dir)
 	defer func() { _ = chromeConn.Close() }()
 
 	// Spawn should dequeue the connection.
@@ -56,7 +72,7 @@ func TestSocketRelay_HappyPath(t *testing.T) {
 	defer func() { _ = wait() }()
 
 	// Chrome → bridge direction.
-	_, err = chromeConn.Write([]byte("from-chrome"))
+	_, err := chromeConn.Write([]byte("from-chrome"))
 	require.NoError(t, err)
 	_ = chromeConn.(*net.UnixConn).CloseWrite()
 
@@ -100,21 +116,8 @@ func TestSocketRelay_ChromeBeforeSpawn(t *testing.T) {
 
 	<-listenReady
 
-	matches, err := filepath.Glob(filepath.Join(dir, "*.sock"))
-	require.NoError(t, err)
-	require.Len(t, matches, 1)
-
-	// Chrome connects first. Retry to avoid race between file creation and listener readiness.
-	var chromeConn net.Conn
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		chromeConn, err = net.Dial("unix", matches[0])
-		if err == nil {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	require.NoError(t, err)
+	// Chrome connects first.
+	chromeConn := dialRelay(t, dir)
 	defer func() { _ = chromeConn.Close() }()
 
 	// Give the relay time to queue the connection.
@@ -152,10 +155,6 @@ func TestSocketRelay_SpawnBlocksUntilChrome(t *testing.T) {
 
 	<-listenReady
 
-	matches, err := filepath.Glob(filepath.Join(dir, "*.sock"))
-	require.NoError(t, err)
-	require.Len(t, matches, 1)
-
 	// Start Spawn in a goroutine — it should block.
 	spawnDone := make(chan struct{})
 	var spawnErr error
@@ -177,8 +176,7 @@ func TestSocketRelay_SpawnBlocksUntilChrome(t *testing.T) {
 	}
 
 	// Now Chrome connects.
-	chromeConn, err := net.Dial("unix", matches[0])
-	require.NoError(t, err)
+	chromeConn := dialRelay(t, dir)
 	_ = chromeConn.Close()
 
 	// Spawn should complete.
@@ -244,8 +242,7 @@ func TestSocketRelay_CleanShutdown(t *testing.T) {
 	require.Len(t, matches, 1)
 
 	// Queue a connection, then cancel.
-	chromeConn, err := net.Dial("unix", matches[0])
-	require.NoError(t, err)
+	chromeConn := dialRelay(t, dir)
 	// Don't close — let shutdown drain it.
 	_ = chromeConn
 


### PR DESCRIPTION
CI on main has been failing intermittently on two flaky tests; this PR fixes both. (The third breakage, the gosec G705 false positive, was fixed on main by #137 while this PR was open — the redundant commit has been rebased away.)

**Flaky `TestExecClaudeDetached_WritesLaunchRecord` (failed on the #133 and #134 main runs)**
The detached tee goroutine creates `output.log` asynchronously and races `t.TempDir` cleanup (`unlinkat … directory not empty`). `Manager` now tracks tee goroutines in a WaitGroup that tests wait on; the demux test's polling loop becomes a deterministic wait.

**Flaky `TestSocketRelay_HappyPath` (failed on the #133 main run)**
The socket file appears at bind time, a moment before `listen(2)`, so a dial right after the readiness glob sees the file can hit `ECONNREFUSED`. One test already retried for exactly this reason — extracted that into a `dialRelay` helper used at every dial site.

`make check` green locally; agent and chrome packages stressed with `-race -count=20`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)