### PR TITLE
[SC-547] Adversarial challenge guards no-fix verdicts

### DIFF
--- a/internal/claude/embed/human-autofix-skill.md
+++ b/internal/claude/embed/human-autofix-skill.md
@@ -34,15 +34,39 @@ It posts a `[human:bug-verdict] <verdict>` comment on the bug ticket — the tic
 
 ## Step 3 — Verdict gate
 
-- **not-a-bug** — the agent has already posted its reasoning. Reclassify or close the ticket: discover statuses with `human <tracker> issue statuses <BUG_KEY>`, then move it with `human <tracker> issue status <BUG_KEY> "<closed-or-wontdo-status>"`. Make **no code changes**. Post the terminal marker `[human:no-fix-needed]` with `verdict: not-a-bug` on `<BUG_KEY>`, then Report and STOP.
-- **undetermined** — the agent has posted an honest status (e.g. could not reproduce). Make **no code changes**. Leave the ticket open for a human. Post the terminal marker `[human:no-fix-needed]` with `verdict: undetermined` on `<BUG_KEY>`, then Report and STOP.
-- **confirmed** — continue.
+- **confirmed** — continue to Step 4.
+- **not-a-bug** or **undetermined** — do NOT act on the verdict yet. A no-fix verdict closes or parks a ticket with no code change — the one outcome that can silently bury a real bug — so it must first survive an adversarial challenge (Step 3a).
+
+### Step 3a — Adversarial challenge (not-a-bug / undetermined only)
+
+Dispatch the skeptic against the verdict:
+
+```
+Task(subagent_type="human-verdict-skeptic", prompt="Challenge the latest bug-verdict on ticket <BUG_KEY>")
+```
+
+Read its `verdict-challenge:` line:
+
+- **UPHELD** — the verdict stands; act on it:
+  - **not-a-bug** — reclassify or close the ticket: discover statuses with `human <tracker> issue statuses <BUG_KEY>`, then move it with `human <tracker> issue status <BUG_KEY> "<closed-or-wontdo-status>"`. Make **no code changes**. Post the terminal marker `[human:no-fix-needed]` with `verdict: not-a-bug` on `<BUG_KEY>`, then Report and STOP.
+  - **undetermined** — make **no code changes**. Leave the ticket open for a human. Post the terminal marker `[human:no-fix-needed]` with `verdict: undetermined` on `<BUG_KEY>`, then Report and STOP.
+- **REFUTED** — the bug is real after all. Post the skeptic's evidence as a comment on `<BUG_KEY>`:
+
+  ```
+  [human:bug-verdict] confirmed
+
+  ## Verdict overturned on adversarial challenge
+  <the skeptic's refutation: reproduction, missing commit, or contradicting output>
+  ```
+
+  Then **continue to Step 4 as a confirmed bug**, using the skeptic's reproduction as the reproduction. Do NOT close anything, do NOT post `[human:no-fix-needed]`. The challenge runs ONCE — a refuted verdict never loops back through triage.
 
 The `[human:no-fix-needed]` marker is **mandatory in board context**: the autofix pipeline runs under the board implementation-stage agent name, whose failure watcher treats any exit with no `[human:ready-for-review]` handoff as a crash and would loop forever re-triaging. This terminal marker signals the clean, resolved stop (ticket 405). Body format:
 
 ```
 [human:no-fix-needed]
 verdict: <not-a-bug | undetermined>
+challenge: upheld
 ```
 
 ## Step 4 — Phase 2: Plan (topology decides where it lives)

--- a/internal/claude/embed/human-verdict-skeptic-agent.md
+++ b/internal/claude/embed/human-verdict-skeptic-agent.md
@@ -1,0 +1,70 @@
+---
+name: human-verdict-skeptic
+description: Adversarially challenges a not-a-bug or undetermined triage verdict — attempts to refute it with hard evidence before the ticket is closed without a fix
+tools: Bash, Read, Grep, Glob
+model: inherit
+---
+
+# Human Verdict Skeptic Agent
+
+You are an adversarial reviewer of bug-triage verdicts. A triage agent has
+concluded that a reported bug needs **no fix** (`not-a-bug`, already-fixed, or
+`undetermined`), and acting on that verdict will close or park the ticket with
+no code change — the one pipeline outcome that can silently bury a real bug.
+Your ONLY job is to try to **refute** that verdict. You are not a second
+triage: you attack the specific claims the verdict rests on.
+
+## Input
+
+You are given a bug ticket key. Fetch the ticket and its comments with the
+`human` CLI (`human get <KEY>`, `human <tracker> issue comment list <KEY>`)
+and read the latest `[human:bug-verdict]` comment — that is the verdict under
+challenge, including its reproduction notes, cause chain, and (for
+already-fixed claims) the commits it credits.
+
+## Attack the claims
+
+Work through every load-bearing claim, hardest evidence first:
+
+1. **"Could not reproduce" / "does not happen"** — attempt the reproduction
+   yourself on current HEAD, from the ticket's original symptom description,
+   not the verdict's paraphrase of it. Try the obvious variations the triage
+   may have skipped (daemon vs local, container vs host, empty vs populated
+   state). A successful reproduction is a refutation.
+2. **"Already fixed by commit X"** — verify commit X exists AND is reachable
+   from HEAD (`git merge-base --is-ancestor X HEAD`), and that its diff
+   actually addresses the reported symptom rather than something nearby. A
+   credited commit that is missing, unmerged, or off-topic is a refutation.
+3. **"Behaves correctly: it does Y"** — test that the claimed current
+   behavior actually happens (run the command, the test, the code path). A
+   claim that does not hold under execution is a refutation.
+4. **"By design"** — check the design claim against the repo's own documents
+   (README, CLAUDE.md, the ticket's acceptance criteria). A "design" that
+   contradicts the project's stated intent is a refutation.
+
+## The bar
+
+Refutation requires **hard evidence**: a reproduction you ran, a commit that
+is not there, a command whose output contradicts the verdict. Doubt,
+alternative interpretations, or "the triage could have looked harder" are NOT
+refutations — when uncertain, uphold. A skeptic that refutes on vibes makes
+verdicts flip-flop forever; a skeptic that upholds on vibes is merely
+useless. Be the former's opposite and the latter's better.
+
+Do NOT post any tracker comments and do NOT change any ticket — the calling
+skill acts on your finding. Do NOT use `AskUserQuestion`.
+
+## Output
+
+Return as your final message:
+
+```
+verdict-challenge: <UPHELD | REFUTED>
+
+<UPHELD: one paragraph — which claims you attacked, what you ran, why the
+verdict survives.>
+<REFUTED: the evidence — the exact reproduction steps/commands and their
+output, or the missing/off-topic commit — followed by what the triage got
+wrong. This becomes the reproduction the fix run starts from, so it must be
+complete enough to hand to a fixer.>
+```

--- a/internal/claude/install.go
+++ b/internal/claude/install.go
@@ -151,6 +151,9 @@ var autofixSkillContent []byte
 //go:embed embed/human-bug-triage-agent.md
 var bugTriageAgentContent []byte
 
+//go:embed embed/human-verdict-skeptic-agent.md
+var verdictSkepticAgentContent []byte
+
 //go:embed embed/human-bug-fixer-agent.md
 var bugFixerAgentContent []byte
 
@@ -261,6 +264,7 @@ func Install(w io.Writer, fw FileWriter, personal bool) error {
 		{content: gardeningTriageAgentContent, relPath: filepath.Join("agents", "gardening-triage.md")},
 		{content: autofixSkillContent, relPath: filepath.Join("skills", "human-autofix", "SKILL.md")},
 		{content: bugTriageAgentContent, relPath: filepath.Join("agents", "human-bug-triage.md")},
+		{content: verdictSkepticAgentContent, relPath: filepath.Join("agents", "human-verdict-skeptic.md")},
 		{content: bugFixerAgentContent, relPath: filepath.Join("agents", "human-bug-fixer.md")},
 		{content: bugVerifyAgentContent, relPath: filepath.Join("agents", "human-bug-verify.md")},
 		{content: codenavSkillContent, relPath: filepath.Join("skills", "codenav", "SKILL.md")},

--- a/main.go
+++ b/main.go
@@ -459,7 +459,7 @@ func runHook(stdin io.Reader, stderr io.Writer, deliver hookDeliverer) error {
 
 	eventName := resolveEventName(data, input.EventName)
 	if eventName == "" {
-		_, _ = fmt.Fprintf(stderr,
+		_, _ = fmt.Fprintf(stderr, // #nosec G705 -- CLI terminal output, not web
 			"human hook: no recognizable event-name key in %d-byte payload; dropping (update the known-key set in resolveEventName)\n",
 			len(data))
 		return nil
@@ -468,7 +468,7 @@ func runHook(stdin io.Reader, stderr io.Writer, deliver hookDeliverer) error {
 	agentName := os.Getenv("HUMAN_AGENT_NAME")
 	args := []string{"hook-event", eventName, input.SessionID, input.Cwd, input.NotificationType, input.ToolName, input.ErrorType, agentName}
 	if err := deliver(args); err != nil {
-		_, _ = fmt.Fprintf(stderr, "human hook: failed to deliver %q event to daemon: %v\n", eventName, err)
+		_, _ = fmt.Fprintf(stderr, "human hook: failed to deliver %q event to daemon: %v\n", eventName, err) // #nosec G705 -- CLI terminal output, not web
 	}
 	return nil
 }


### PR DESCRIPTION
A not-a-bug or undetermined triage verdict closes or parks a ticket with no code change — the one pipeline outcome that can silently bury a real bug. Today's batch of no-fix verdicts (176, 372, 512) was all correct, but nothing would have caught a wrong one.

**The guard:**
- New `human-verdict-skeptic` agent whose only job is refutation: re-runs the reproduction from the ticket's original symptom (not the verdict's paraphrase), verifies credited fix commits exist and are reachable from HEAD (`git merge-base --is-ancestor`), executes claimed behavior, and checks "by design" claims against the repo's own documents. The bar for refutation is **hard evidence** — when uncertain it upholds, so verdicts never flip-flop.
- The autofix verdict gate (Step 3a) dispatches it before acting on not-a-bug/undetermined. **Upheld**: close/park exactly as before, concurrence recorded on the `[human:no-fix-needed]` marker (`challenge: upheld`). **Refuted**: the evidence is posted as an overturning `[human:bug-verdict] confirmed` comment and the run continues into the fix from the skeptic's reproduction — nothing gets closed, and the challenge runs once (never loops back through triage).

Also rides along: gosec annotations for PR #135's hook-forwarder stderr prints (terminal output, not web — main's `make sec` was red).

Skill/agent-only change plus installer registration; takes effect after merge + `human install`. `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)