### PR TITLE
[SC-591] Right-click Retry build for failed implementation cards

### DIFF
--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -209,6 +209,24 @@ function showCardMenu(card, x, y) {
         });
         menu.appendChild(retryPlan);
     }
+    // A failed build is otherwise a dead end on the workflow board: the rework
+    // re-drop requires a failed REVIEW verdict and Retry fix is bug-pane-only
+    // (SC-591). Mirrors Retry plan: relaunch runs an agent, same Docker gate;
+    // from="planning" is inert for validation (the daemon re-derives the stage).
+    if (!card.bug && card.stage === "implementation" && card.state === "failed") {
+        const retryBuild = document.createElement("button");
+        retryBuild.type = "button";
+        retryBuild.className = "context-menu-item";
+        retryBuild.textContent = "Retry build";
+        retryBuild.disabled = !current.dockerAvailable;
+        if (retryBuild.disabled)
+            retryBuild.title = "Docker required";
+        retryBuild.addEventListener("click", () => {
+            menu.remove();
+            void transition(card.key, card.title, "planning", "implementation");
+        });
+        menu.appendChild(retryBuild);
+    }
     // Mockups belong to the product conversation: the item appears only in the
     // Product backlog column, toggling create → creating → view as the local
     // mockup set for this ticket comes into existence. Bug tickets never get

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -462,6 +462,24 @@ function showCardMenu(card: Card, x: number, y: number): void {
     menu.appendChild(retryPlan);
   }
 
+  // A failed build is otherwise a dead end on the workflow board: the rework
+  // re-drop requires a failed REVIEW verdict and Retry fix is bug-pane-only
+  // (SC-591). Mirrors Retry plan: relaunch runs an agent, same Docker gate;
+  // from="planning" is inert for validation (the daemon re-derives the stage).
+  if (!card.bug && card.stage === "implementation" && card.state === "failed") {
+    const retryBuild = document.createElement("button");
+    retryBuild.type = "button";
+    retryBuild.className = "context-menu-item";
+    retryBuild.textContent = "Retry build";
+    retryBuild.disabled = !current.dockerAvailable;
+    if (retryBuild.disabled) retryBuild.title = "Docker required";
+    retryBuild.addEventListener("click", () => {
+      menu.remove();
+      void transition(card.key, card.title, "planning", "implementation");
+    });
+    menu.appendChild(retryBuild);
+  }
+
   // Mockups belong to the product conversation: the item appears only in the
   // Product backlog column, toggling create → creating → view as the local
   // mockup set for this ticket comes into existence. Bug tickets never get

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -157,6 +157,16 @@ func (d BoardTransitionDeps) ApplyTransition(ctx context.Context, req BoardTrans
 			"/human-plan "+req.PMKey)
 	}
 
+	// Build retry: the same sanctioned in-place relaunch for a failed
+	// implementation run — without it a failed build is a dead end, since the
+	// rework re-drop requires a failed REVIEW verdict and Retry fix is
+	// bug-pane-only (SC-591). The plan is intact on the ticket; a fresh
+	// executor picks it up.
+	if isBuildRetry(req.To, card) {
+		return d.startAgentStage(ctx, req.PMKey, BoardImplementation, ImplementationStartedHeader,
+			"/human-execute "+dispatchKey(req.PMKey, card))
+	}
+
 	// Forward-only, single-next-stage: the target must be exactly one rank
 	// above the current derived stage.
 	if stageRank[req.To] != stageRank[card.Stage]+1 {
@@ -421,6 +431,15 @@ func isReworkTransition(to BoardStage, card BoardCard) bool {
 func isPlanningRetry(to BoardStage, card BoardCard) bool {
 	return to == BoardPlanning &&
 		card.Stage == BoardPlanning &&
+		card.State == BoardFailed
+}
+
+// isBuildRetry mirrors isPlanningRetry for the implementation stage: failed
+// builds only — running builds are protected by the idempotency guard, and a
+// verification-stage card takes the rework path instead (SC-591).
+func isBuildRetry(to BoardStage, card BoardCard) bool {
+	return to == BoardImplementation &&
+		card.Stage == BoardImplementation &&
 		card.State == BoardFailed
 }
 

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -162,6 +162,39 @@ func TestApplyTransitionRetriesFailedPlanning(t *testing.T) {
 	assert.Equal(t, PlanningStartedHeader, c.added[0])
 }
 
+func TestApplyTransitionRetriesFailedBuild(t *testing.T) {
+	// A failed implementation card was a dead end: Retry fix is bug-pane-only,
+	// Retry plan is planning-only, and every drop rejects it (SC-591). The
+	// "Retry build" gesture targets implementation while the card derives to
+	// implementation/failed — it must relaunch the executor, plan intact.
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:plan-ready]", time.Unix(1, 0)),
+		cmt("[human:implementation-started]", time.Unix(2, 0)),
+		cmt("[human:implementation-failed]\nagent exited without completing the stage", time.Unix(3, 0)),
+	}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardPlanning, To: BoardImplementation})
+	require.NoError(t, err)
+	assert.Equal(t, 1, l.calls)
+	assert.Equal(t, "/human-execute SC-1", l.prompt)
+	assert.Equal(t, "board-SC-1-implementation", l.name)
+	require.Len(t, c.added, 1)
+	assert.Equal(t, ImplementationStartedHeader, c.added[0])
+}
+
+func TestApplyTransitionRunningBuildNotRelaunched(t *testing.T) {
+	// Contract pin: build retry is for FAILED runs only — a running build hits
+	// the idempotency guard and must not spawn a second agent.
+	c := &fakeCommenter{comments: []tracker.Comment{cmt("[human:implementation-started]", time.Unix(1, 0))}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardPlanning, To: BoardImplementation})
+	require.NoError(t, err)
+	assert.Zero(t, l.calls)
+	assert.Empty(t, c.added)
+}
+
 func TestApplyTransitionRunningPlanningNotRelaunched(t *testing.T) {
 	// Contract pin: retry is for FAILED planning only — a running planning
 	// card hits the idempotency guard and must not spawn a second agent.


### PR DESCRIPTION
Ticket 64 exposed the gap: a failed build on the workflow board had no exit — "Retry fix" is bug-pane-only, "Retry plan" is planning-only, the rework re-drop requires a failed *review* verdict, and forward drops reject failed cards.

- `isBuildRetry` in ApplyTransition mirrors SC-355's planning retry exactly: implementation-targeting gesture on an implementation/failed card relaunches `/human-execute` in a fresh container (plan intact on the ticket); running builds keep hitting the idempotency guard (test-pinned).
- Right-click menu gains **Retry build** on non-bug implementation/failed cards, Docker-gated like every launch.

Tests: retry relaunches with the right prompt/agent-name/marker; a running build is never double-launched. `make check` green. Live after daemon rebuild+restart + `make desktop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)