### PR TITLE
[SC-623] Safety-net board poll for external tracker edits

### DIFF
--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -83,6 +83,11 @@ let stagesLoading = false;
 // Matches the daemon subscribe-retry backoff (desktop/main.go backoff(), 2s)
 // rounded up slightly so the poll never races the retry loop.
 const DAEMON_POLL_MS = 3000;
+// Safety net for edits made directly in the tracker's web UI: those produce no
+// daemon event, so without a slow re-fetch they stay invisible until an
+// unrelated event fires. Event-driven refresh remains the primary path; this
+// only bounds the staleness window.
+const BOARD_SAFETY_POLL_MS = 90000;
 let daemonReachable = false;
 function go() {
     const app = window.go?.main?.App;
@@ -2352,6 +2357,12 @@ function init() {
     void initialLoad();
     void pollDaemonStatus();
     setInterval(() => void pollDaemonStatus(), DAEMON_POLL_MS);
+    setInterval(() => {
+        // Only when the daemon is reachable: a dead daemon already shows its
+        // banner, and polling into it would just churn the error state.
+        if (daemonReachable)
+            void reconcile();
+    }, BOARD_SAFETY_POLL_MS);
     wireRail();
     initFancy();
     initPermissions(() => go(), applyPermissionDecision);

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -331,6 +331,12 @@ let stagesLoading = false;
 // rounded up slightly so the poll never races the retry loop.
 const DAEMON_POLL_MS = 3000;
 
+// Safety net for edits made directly in the tracker's web UI: those produce no
+// daemon event, so without a slow re-fetch they stay invisible until an
+// unrelated event fires. Event-driven refresh remains the primary path; this
+// only bounds the staleness window.
+const BOARD_SAFETY_POLL_MS = 90_000;
+
 let daemonReachable = false;
 
 function go(): AppBindings {
@@ -2657,6 +2663,11 @@ function init(): void {
   void initialLoad();
   void pollDaemonStatus();
   setInterval(() => void pollDaemonStatus(), DAEMON_POLL_MS);
+  setInterval(() => {
+    // Only when the daemon is reachable: a dead daemon already shows its
+    // banner, and polling into it would just churn the error state.
+    if (daemonReachable) void reconcile();
+  }, BOARD_SAFETY_POLL_MS);
 
   wireRail();
   initFancy();

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -50,7 +50,9 @@ func main() {
 // startup stores the lifecycle context and starts the daemon subscription
 // bridge. It mirrors the TUI exactly: subscribe once, and on every daemon change
 // event emit a "board:changed" event to the frontend, which re-calls Cards().
-// There is intentionally no independent polling loop.
+// There is intentionally no Go-side polling loop; the frontend keeps a slow
+// safety-net re-fetch (board.ts BOARD_SAFETY_POLL_MS) solely so tracker edits
+// made outside human — which produce no daemon event — still surface.
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
 	go a.subscribe(ctx)


### PR DESCRIPTION
The workflow board refreshes only on daemon events (agent lifecycle, changes made through human itself). Edits made directly in the tracker's web UI produce no event, so cards went stale until an unrelated event fired or the app restarted (SC-623).

This adds a 90-second safety-net `reconcile()` in the frontend — event-driven refresh remains the primary path, the poll only bounds the staleness window and pauses while the daemon is unreachable. The Go-side "no polling loop" comment in `desktop/main.go` is updated to reflect where the safety net lives.

- Frontend tests: 16/16 pass
- `make check`: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)