### PR TITLE
[SC-624] [SC-625] Hand-sort board columns and hide tickets

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/boardprefs"
 	"github.com/gethuman-sh/human/internal/daemon"
 	"github.com/gethuman-sh/human/internal/ideaspace"
 	"github.com/gethuman-sh/human/internal/tracker"
@@ -45,12 +46,18 @@ type App struct {
 	// I/O rather than a daemon route: this is UI preference state that must
 	// never touch the ticket, in line with the credential-only rationale above.
 	ideas *ideaspace.Store
+	// prefs holds the board view preferences (per-column card order, hidden
+	// tickets) — the same local-only rationale as ideas.
+	prefs *boardprefs.Store
 }
 
 // NewApp constructs the backend. Wails injects the lifecycle context via
 // startup, so there is nothing to wire here.
 func NewApp() *App {
-	return &App{ideas: ideaspace.NewStore(ideaspace.DefaultPath())}
+	return &App{
+		ideas: ideaspace.NewStore(ideaspace.DefaultPath()),
+		prefs: boardprefs.NewStore(boardprefs.DefaultPath()),
+	}
 }
 
 // Card is the flat, frontend-facing shape of one board ticket: a PM issue joined
@@ -92,6 +99,10 @@ type Card struct {
 	// tracker.Issue.IsBug). Bug cards render in the Bugs pane instead of the
 	// workflow board's columns.
 	Bug bool `json:"bug,omitempty"`
+	// Hidden marks a ticket the user parked off the board (right-click →
+	// Hide). Locally persisted view preference, never tracker state; the
+	// frontend filters hidden cards out unless the user reveals them.
+	Hidden bool `json:"hidden,omitempty"`
 	// Options carries the card's open decision block: a stage ended in a fork
 	// and a human must pick a direction. OptionsContext is the one-line why.
 	Options        []daemon.BoardOption `json:"options,omitempty"`
@@ -112,6 +123,10 @@ type BoardData struct {
 	Cards           []Card `json:"cards"`
 	Error           string `json:"error,omitempty"`
 	DockerAvailable bool   `json:"dockerAvailable"`
+	// ColumnOrder is the hand-sorted ticket order per queue column (top
+	// first). The frontend sorts each column by it; cards absent from their
+	// queue's list render after it in fetch order.
+	ColumnOrder map[string][]string `json:"columnOrder,omitempty"`
 }
 
 // Cards fetches the current board state from the daemon and flattens the single
@@ -129,8 +144,9 @@ func (a *App) Cards() (BoardData, error) {
 	if err != nil {
 		return BoardData{}, daemonCause(err)
 	}
-	data := boardFromResults(results, dockerAvailable(), a.ideas.Assignments(), cardMockups())
+	data := boardFromResults(results, dockerAvailable(), a.ideas.Assignments(), cardMockups(), a.prefs.Snapshot())
 	a.pruneIdeaSpace(data)
+	a.pruneBoardPrefs(data)
 	return data, nil
 }
 
@@ -214,6 +230,33 @@ func (a *App) SetIdeaColumn(pmKey string, col int) error {
 	return a.ideas.Set(pmKey, col)
 }
 
+// SetColumnOrder persists the hand-sorted card order for one queue column.
+// Purely local UI state — never a tracker write or a board transition.
+func (a *App) SetColumnOrder(queue string, keys []string) error {
+	return a.prefs.SetOrder(queue, keys)
+}
+
+// SetCardHidden parks a ticket off the board (or restores it). Purely local
+// UI state — the ticket on the tracker is untouched.
+func (a *App) SetCardHidden(pmKey string, hidden bool) error {
+	return a.prefs.SetHidden(pmKey, hidden)
+}
+
+// pruneBoardPrefs drops order slots and hidden flags for tickets that are no
+// longer on the board. Same contract as pruneIdeaSpace: only a fully
+// successful full fetch may prune, and a prune failure is ignored — a stale
+// entry is harmless.
+func (a *App) pruneBoardPrefs(data BoardData) {
+	if data.Error != "" {
+		return
+	}
+	keys := make(map[string]struct{}, len(data.Cards))
+	for _, card := range data.Cards {
+		keys[card.Key] = struct{}{}
+	}
+	_ = a.prefs.PruneExcept(keys)
+}
+
 // CardsQuick fetches issue titles only — skipping the per-ticket comment scan
 // that derives board stages — and places every open PM issue in the Backlog. It
 // returns far faster than Cards(), so the board can render titles immediately;
@@ -230,7 +273,7 @@ func (a *App) CardsQuick() (BoardData, error) {
 	if err != nil {
 		return BoardData{}, daemonCause(err)
 	}
-	return boardFromResults(results, true, a.ideas.Assignments(), cardMockups()), nil
+	return boardFromResults(results, true, a.ideas.Assignments(), cardMockups(), a.prefs.Snapshot()), nil
 }
 
 // boardFromResults flattens the single PM-role result into the frontend card
@@ -239,8 +282,8 @@ func (a *App) CardsQuick() (BoardData, error) {
 // Backlog). A PM issue with no derived card is hidden when its status is
 // done/closed and placed in Backlog otherwise, mirroring daemon.DeriveBoardCard's
 // marker-less decision so the quick pass and full pass agree on what to show.
-func boardFromResults(results []daemon.TrackerIssuesResult, dockerAvailable bool, ideaCols map[string]int, mocks map[string]cardMockupInfo) BoardData {
-	data := BoardData{DockerAvailable: dockerAvailable}
+func boardFromResults(results []daemon.TrackerIssuesResult, dockerAvailable bool, ideaCols map[string]int, mocks map[string]cardMockupInfo, prefs boardprefs.Prefs) BoardData {
+	data := BoardData{DockerAvailable: dockerAvailable, ColumnOrder: prefs.Columns}
 	pm, ok := firstPMResult(results)
 	if !ok {
 		// No PM-role tracker configured yet: render five empty columns rather
@@ -279,6 +322,7 @@ func boardFromResults(results []daemon.TrackerIssuesResult, dockerAvailable bool
 			ideaCol = ideaCols[issue.Key]
 		}
 		mock := mocks[issue.Key]
+		_, hidden := prefs.Hidden[issue.Key]
 		data.Cards = append(data.Cards, Card{
 			Key:            issue.Key,
 			Title:          issue.Title,
@@ -296,6 +340,7 @@ func boardFromResults(results []daemon.TrackerIssuesResult, dockerAvailable bool
 			Tracker:        pm.TrackerName,
 			TrackerKind:    pm.TrackerKind,
 			Bug:            issue.IsBug(),
+			Hidden:         hidden,
 			IdeaColumn:     ideaCol,
 			Options:        card.Options,
 			OptionsContext: card.OptionsContext,

--- a/desktop/frontend/dist/board-queue.js
+++ b/desktop/frontend/dist/board-queue.js
@@ -122,6 +122,32 @@ export function forwardDropAllowed(card, toQueue) {
         return planReady(card);
     return true;
 }
+// sortByHandOrder sorts cards by a saved hand-sorted key list: listed cards
+// first in list order, unlisted cards after in their existing (fetch) order.
+// In place, relying on Array.prototype.sort's stability for the tail.
+export function sortByHandOrder(cards, order) {
+    if (!order || order.length === 0)
+        return cards;
+    const pos = new Map(order.map((k, i) => [k, i]));
+    return cards.sort((a, b) => (pos.get(a.key) ?? Number.MAX_SAFE_INTEGER) - (pos.get(b.key) ?? Number.MAX_SAFE_INTEGER));
+}
+// insertKeyAt rebuilds a column's hand-sorted key list after a same-column
+// drop: the dragged key lands before the first resting card whose vertical
+// midpoint is below the drop point, or last when the drop was below them all.
+export function insertKeyAt(restingKeys, midpoints, dragged, dropY) {
+    const keys = [];
+    let inserted = false;
+    restingKeys.forEach((k, i) => {
+        if (!inserted && dropY < midpoints[i]) {
+            keys.push(dragged);
+            inserted = true;
+        }
+        keys.push(k);
+    });
+    if (!inserted)
+        keys.push(dragged);
+    return keys;
+}
 export function queueIndex(queue) {
     return QUEUES.indexOf(queue);
 }

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -13,7 +13,7 @@ import { initPermissions } from "./permissions.js";
 import { initMockupsView, showMockups, setPendingMockupSlug } from "./mockupsview.js";
 import { initSettingsView, showSettings, settingsIndex, saveSetting, setPaletteOpener, setActiveSection, } from "./settingsview.js";
 import { initPalette, openPalette, isPaletteChord } from "./palette.js";
-import { QUEUES, QUEUE_TRANSITION_TO, queueOf, isReworkable, forwardDropAllowed, verdictFailed, badgeInfo, } from "./board-queue.js";
+import { QUEUES, QUEUE_TRANSITION_TO, queueOf, isReworkable, forwardDropAllowed, verdictFailed, badgeInfo, sortByHandOrder, insertKeyAt, } from "./board-queue.js";
 import { buildDetailSections, buildOptionsSection } from "./board-detail.js";
 // openExternal routes a URL to the system browser via the Wails runtime.
 // Anchor clicks with target=_blank are NOT reliably forwarded by the Linux
@@ -73,6 +73,12 @@ const QUEUE_VERB = {
 };
 let current = { cards: [], dockerAvailable: true, error: "" };
 let dragging = null;
+// showHidden reveals user-hidden cards (marked with an "H" pill) instead of
+// filtering them out. Session-local so the board always starts clean.
+let showHidden = false;
+function cardVisible(card) {
+    return !card.hidden || showHidden;
+}
 // Two-phase load state. boardLoading covers the first fetch before any titles
 // exist (the board shows a centered spinner). stagesLoading covers the window
 // after titles render but before the comment scan resolves each card's real
@@ -137,9 +143,15 @@ function renderCard(card) {
         meta.push(`<span>${escapeHtml(card.engineeringKey)}</span>`);
     if (card.prURL)
         meta.push(`<a href="${escapeAttr(card.prURL)}" target="_blank">PR</a>`);
+    // The H pill marks a hidden card while it is revealed via the header's
+    // Unhide toggle — without it, revealed and normal cards would be
+    // indistinguishable and re-hiding would feel like cards vanishing at random.
+    const hiddenPill = card.hidden
+        ? `<span class="hidden-pill" title="Hidden ticket — shown via Unhide">H</span>`
+        : "";
     el.innerHTML = `
     <div class="card-key">${escapeHtml(card.key)}</div>
-    <div class="card-title" title="${escapeAttr(card.title)}">${escapeHtml(card.title)}</div>
+    <div class="card-title" title="${escapeAttr(card.title)}">${hiddenPill}${escapeHtml(card.title)}</div>
     <div class="card-meta">${meta.join("")}</div>
     ${card.error ? `<div class="card-error">${escapeHtml(card.error)}</div>` : ""}
   `;
@@ -266,6 +278,17 @@ function showCardMenu(card, x, y) {
         }
         menu.appendChild(mockItem);
     }
+    // Hiding is view hygiene, not ticket lifecycle: parked noise disappears
+    // from the board while the ticket on the tracker stays untouched.
+    const hideItem = document.createElement("button");
+    hideItem.type = "button";
+    hideItem.className = "context-menu-item";
+    hideItem.textContent = card.hidden ? "Unhide ticket" : "Hide ticket";
+    hideItem.addEventListener("click", () => {
+        menu.remove();
+        toggleCardHidden(card);
+    });
+    menu.appendChild(hideItem);
     const closeItem = document.createElement("button");
     closeItem.type = "button";
     closeItem.className = "context-menu-item danger";
@@ -304,8 +327,10 @@ function renderColumn(queue) {
     const col = document.createElement("section");
     col.className = "column";
     col.dataset.stage = queue;
-    // Bug tickets live in the Bugs pane, never in the workflow columns.
-    const cards = current.cards.filter((c) => queueOf(c) === queue && !c.bug);
+    // Bug tickets live in the Bugs pane, never in the workflow columns; hidden
+    // tickets only render while revealed. The saved hand order sorts what's left.
+    const cards = current.cards.filter((c) => queueOf(c) === queue && !c.bug && cardVisible(c));
+    sortByHandOrder(cards, current.columnOrder?.[queue]);
     const header = document.createElement("div");
     header.className = "column-header";
     if (queue === "product") {
@@ -323,12 +348,11 @@ function renderColumn(queue) {
     body.className = "column-body";
     for (const card of cards)
         body.appendChild(renderCard(card));
-    if (queue === "product" || QUEUE_TRANSITION_TO[queue] !== undefined) {
-        // Drop targets are the queues a drag can act on: product (idea promotion)
-        // and the transition-launching queues. Ready to Deploy is deliberately
-        // NOT a target — cards arrive there only by passing review.
-        markQueueTarget(body, queue);
-    }
+    // Every column is at least a same-column sort target; product additionally
+    // accepts idea promotion and the transition queues launch stages. Dropping
+    // INTO Ready to Deploy stays impossible (dropAllowed gates it) — cards
+    // arrive there only by passing review, but sorting within it is fine.
+    markQueueTarget(body, queue);
     col.appendChild(body);
     return col;
 }
@@ -343,7 +367,7 @@ function renderIdeaSpace() {
     // (fancy tint, clear sweep) anchored to the space as a whole.
     space.className = "idea-space";
     space.dataset.stage = "ideas";
-    const ideas = current.cards.filter((c) => queueOf(c) === "ideas" && !c.bug);
+    const ideas = current.cards.filter((c) => queueOf(c) === "ideas" && !c.bug && cardVisible(c));
     const grid = document.createElement("div");
     grid.className = "idea-space-grid";
     const subcols = [];
@@ -466,7 +490,7 @@ function renderBugs() {
         return;
     const scrollByStage = captureColumnScroll(host);
     host.innerHTML = "";
-    const bugs = current.cards.filter((c) => c.bug);
+    const bugs = current.cards.filter((c) => c.bug && cardVisible(c));
     const gridBugs = bugs.filter((c) => bugAreaOf(c) === "grid");
     const fixBugs = bugs.filter((c) => bugAreaOf(c) !== "grid");
     const ready = bugs.filter(isReadyToDeploy);
@@ -763,6 +787,14 @@ function dropAllowed(target) {
         return bugAreaOf(card) === "grid" || isReworkable(card);
     }
     const toQueue = target.dataset.dropQueue || "";
+    // A drop back into the card's own column is a local reorder — it launches
+    // nothing, so neither the Docker gate nor forward-adjacency applies.
+    if (!card.bug && toQueue === queueOf(card))
+        return true;
+    // Ready to Deploy is never a transition target — cards earn their way in by
+    // passing review; only the same-column sort above may drop here.
+    if (toQueue === "deploy")
+        return false;
     // forwardDropAllowed owns forward-adjacency, the Code rework re-drop, and the
     // Engineering->Code plan-ready gate; targetEnabled keeps the local Docker gate.
     return forwardDropAllowed(card, toQueue) && targetEnabled(toQueue);
@@ -779,6 +811,19 @@ function setHoverTarget(target) {
     const ok = dropAllowed(target);
     target.classList.toggle("drop-ok", ok);
     target.classList.toggle("drop-reject", !ok);
+    // The overlay verb must state what the drop DOES: a same-column drop sorts,
+    // it never launches, so the transition verb would lie ("Build it" on a card
+    // already in Code). Recomputed on every hover since the same body serves both.
+    const drag = dragging;
+    if (ok && target.dataset.drop === "queue" && drag) {
+        const card = current.cards.find((c) => c.key === drag.key);
+        const sorting = !!card && target.dataset.dropQueue === queueOf(card);
+        const verb = sorting ? "Sort here" : QUEUE_VERB[target.dataset.dropQueue || ""];
+        if (verb)
+            target.dataset.verb = verb;
+        else
+            delete target.dataset.verb;
+    }
 }
 function makeDragGhost(card) {
     const ghost = document.createElement("div");
@@ -910,6 +955,13 @@ function performDrop(target, info, pt) {
         return;
     }
     const toQueue = target.dataset.dropQueue || "";
+    const dropped = current.cards.find((c) => c.key === info.key);
+    if (dropped && !dropped.bug && toQueue === queueOf(dropped)) {
+        // A drop into the card's own column sorts it — mirrors the idea-space
+        // local reorder, never a transition.
+        reorderWithinQueue(toQueue, info.key, pt.y);
+        return;
+    }
     if (toQueue === "product" && info.stage === "ideas") {
         // Promotion is a conversation, not a stage transition: the evolve-mode
         // ideation session rewrites the ticket in place and removes the idea
@@ -922,6 +974,38 @@ function performDrop(target, info, pt) {
         return;
     celebrateDrop(pt, { key: info.key, fromStage: info.stage, done: false });
     void transition(info.key, info.title, info.stage, to);
+}
+// reorderWithinQueue persists a same-column drop as the queue's new hand
+// order, read from the live DOM so the dragged card lands exactly where the
+// pointer released among the cards the user was looking at. Optimistic like
+// SetIdeaColumn: render from the new order immediately, snap back via
+// reconcile only if the write fails. Hidden cards are absent from the DOM and
+// so from the saved list — they simply re-append after it when revealed.
+function reorderWithinQueue(queue, key, dropY) {
+    const body = document.querySelector(`.column[data-stage="${queue}"] .column-body`);
+    if (!body)
+        return;
+    const resting = [];
+    const midpoints = [];
+    for (const el of Array.from(body.querySelectorAll(".card"))) {
+        const k = el.dataset.key || "";
+        if (!k || k === key)
+            continue;
+        const r = el.getBoundingClientRect();
+        resting.push(k);
+        midpoints.push(r.top + r.height / 2);
+    }
+    const keys = insertKeyAt(resting, midpoints, key, dropY);
+    if (!current.columnOrder)
+        current.columnOrder = {};
+    current.columnOrder[queue] = keys;
+    render();
+    void go()
+        .SetColumnOrder(queue, keys)
+        .catch((err) => {
+        showError(errMessage(err));
+        void reconcile();
+    });
 }
 // promoteIdea opens the ideation panel in evolve mode, seeded with the idea
 // card's content. An active session must be explicitly replaced — the daemon
@@ -1135,10 +1219,55 @@ function render() {
     // The detail panel lives outside #board, so the rebuild above never touches
     // it — it only needs its card data refreshed from the new board state.
     refreshTicketDetail();
+    updateHideToggle();
 }
 function showError(msg) {
     current.error = msg;
     render();
+}
+// toggleCardHidden parks a ticket off the board or restores it. Optimistic
+// like SetIdeaColumn: flip and render immediately, snap back via reconcile
+// only if the write fails.
+function toggleCardHidden(card) {
+    card.hidden = !card.hidden;
+    render();
+    void go()
+        .SetCardHidden(card.key, !!card.hidden)
+        .catch((err) => {
+        showError(errMessage(err));
+        void reconcile();
+    });
+}
+// updateHideToggle keeps the header's Unhide/Hide button in sync: present only
+// while hidden tickets exist (labeled with the count), toggling whether they
+// render with their H pill or stay filtered out. When the last hidden ticket
+// is unhidden the reveal state resets, so the button never sticks around dead.
+function updateHideToggle() {
+    const header = document.getElementById("app-header");
+    if (!header)
+        return;
+    let btn = document.getElementById("hide-toggle");
+    const hiddenCount = current.cards.filter((c) => c.hidden).length;
+    if (hiddenCount === 0) {
+        showHidden = false;
+        btn?.remove();
+        return;
+    }
+    if (!btn) {
+        btn = document.createElement("button");
+        btn.id = "hide-toggle";
+        btn.type = "button";
+        btn.className = "hide-toggle";
+        btn.addEventListener("click", () => {
+            showHidden = !showHidden;
+            render();
+        });
+        header.appendChild(btn);
+    }
+    btn.textContent = showHidden ? `Hide hidden (${hiddenCount})` : `Unhide (${hiddenCount})`;
+    btn.title = showHidden
+        ? "Conceal the revealed hidden tickets again"
+        : "Reveal hidden tickets (marked with an H pill)";
 }
 function renderDaemonStatus() {
     // Mirrors the TUI's bottom status line ("● Daemon running"/"stopped").

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -832,6 +832,36 @@ body {
   color: var(--muted);
 }
 
+/* Header toggle revealing/concealing user-hidden tickets. Appears only while
+   hidden tickets exist (updateHideToggle), so it never sits dead in the
+   header. justify-content: space-between on .app-header pushes it right. */
+.hide-toggle {
+  font: 12px ui-monospace, "SF Mono", Menlo, monospace;
+  color: var(--text);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 6px;
+  padding: 3px 10px;
+  cursor: pointer;
+}
+
+.hide-toggle:hover {
+  border-color: var(--accent);
+}
+
+/* Marks a hidden card while it is revealed via Unhide — without it, revealed
+   and normal cards would be indistinguishable. */
+.hidden-pill {
+  display: inline-block;
+  margin-right: 6px;
+  padding: 0 6px;
+  border: 1px solid var(--card-border);
+  border-radius: 999px;
+  font: 10px/1.6 ui-monospace, "SF Mono", Menlo, monospace;
+  color: var(--muted);
+  vertical-align: 1px;
+}
+
 /* Bottom status bar, mirroring the TUI's "● Daemon running" status line. Sits
    below the board as a fixed-height footer in the app-main flex column. */
 .statusbar {

--- a/desktop/frontend/scripts/board-queue.test.mjs
+++ b/desktop/frontend/scripts/board-queue.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { queueOf, forwardDropAllowed, planReady, badgeInfo } from "../build/board-queue.js";
+import { queueOf, forwardDropAllowed, planReady, badgeInfo, sortByHandOrder, insertKeyAt } from "../build/board-queue.js";
 
 // SC-355 regression: a running or failed planning card must render in the
 // Engineering column where the user dropped it — not snap back to Product.
@@ -90,4 +90,31 @@ test("open options render a decision-needed badge over the review warning", () =
   assert.match(info.text, /decision needed/);
   // Without options the same card falls back to the review warning.
   assert.equal(badgeInfo({ ...card, options: [] }).cls, "warning");
+});
+
+// SC-624: columns render in the user's hand-sorted order; cards without a
+// saved slot keep fetch order after the sorted ones.
+test("sortByHandOrder: listed keys first in saved order, rest stable after", () => {
+  const cards = [{ key: "A" }, { key: "B" }, { key: "C" }, { key: "D" }];
+  sortByHandOrder(cards, ["C", "A"]);
+  assert.deepEqual(cards.map((c) => c.key), ["C", "A", "B", "D"]);
+});
+
+test("sortByHandOrder: no saved order leaves fetch order untouched", () => {
+  const cards = [{ key: "B" }, { key: "A" }];
+  sortByHandOrder(cards, undefined);
+  assert.deepEqual(cards.map((c) => c.key), ["B", "A"]);
+  sortByHandOrder(cards, []);
+  assert.deepEqual(cards.map((c) => c.key), ["B", "A"]);
+});
+
+// SC-624: a same-column drop inserts the dragged key at the pointer position.
+test("insertKeyAt places dragged key by drop midpoint", () => {
+  // Cards A(mid 100), B(mid 200), C(mid 300).
+  const resting = ["A", "B", "C"];
+  const mids = [100, 200, 300];
+  assert.deepEqual(insertKeyAt(resting, mids, "X", 50), ["X", "A", "B", "C"]);
+  assert.deepEqual(insertKeyAt(resting, mids, "X", 150), ["A", "X", "B", "C"]);
+  assert.deepEqual(insertKeyAt(resting, mids, "X", 999), ["A", "B", "C", "X"]);
+  assert.deepEqual(insertKeyAt([], [], "X", 10), ["X"]);
 });

--- a/desktop/frontend/src/board-queue.ts
+++ b/desktop/frontend/src/board-queue.ts
@@ -148,6 +148,34 @@ export function forwardDropAllowed(card: QueueCard, toQueue: string): boolean {
   return true;
 }
 
+// sortByHandOrder sorts cards by a saved hand-sorted key list: listed cards
+// first in list order, unlisted cards after in their existing (fetch) order.
+// In place, relying on Array.prototype.sort's stability for the tail.
+export function sortByHandOrder<T extends { key: string }>(cards: T[], order: string[] | undefined): T[] {
+  if (!order || order.length === 0) return cards;
+  const pos = new Map(order.map((k, i) => [k, i]));
+  return cards.sort(
+    (a, b) => (pos.get(a.key) ?? Number.MAX_SAFE_INTEGER) - (pos.get(b.key) ?? Number.MAX_SAFE_INTEGER),
+  );
+}
+
+// insertKeyAt rebuilds a column's hand-sorted key list after a same-column
+// drop: the dragged key lands before the first resting card whose vertical
+// midpoint is below the drop point, or last when the drop was below them all.
+export function insertKeyAt(restingKeys: string[], midpoints: number[], dragged: string, dropY: number): string[] {
+  const keys: string[] = [];
+  let inserted = false;
+  restingKeys.forEach((k, i) => {
+    if (!inserted && dropY < midpoints[i]) {
+      keys.push(dragged);
+      inserted = true;
+    }
+    keys.push(k);
+  });
+  if (!inserted) keys.push(dragged);
+  return keys;
+}
+
 export function queueIndex(queue: string): number {
   return (QUEUES as readonly string[]).indexOf(queue);
 }

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -37,6 +37,8 @@ import {
   forwardDropAllowed,
   verdictFailed,
   badgeInfo,
+  sortByHandOrder,
+  insertKeyAt,
 } from "./board-queue.js";
 import { buildDetailSections, buildOptionsSection } from "./board-detail.js";
 
@@ -65,6 +67,9 @@ interface Card {
   // Defect ticket (bug label or bug issue type): rendered in the Bugs pane
   // instead of the workflow board's columns.
   bug?: boolean;
+  // Ticket the user parked off the board (right-click → Hide). Local view
+  // preference; filtered out unless revealed via the header's Unhide toggle.
+  hidden?: boolean;
   mockupSlug?: string;
   mockupState?: string; // "ready" | "creating"
   // The card's open decision block: a stage ended in a fork and a human must
@@ -77,6 +82,9 @@ interface BoardData {
   cards: Card[];
   dockerAvailable: boolean;
   error?: string;
+  // Hand-sorted ticket order per queue column (top first); cards absent from
+  // their queue's list render after it in fetch order.
+  columnOrder?: Record<string, string[]>;
 }
 
 interface IdeationMsg {
@@ -221,6 +229,8 @@ interface AppBindings {
   ChooseOption(pmKey: string, optionID: string): Promise<void>;
   CloseTicket(pmKey: string): Promise<void>;
   SetIdeaColumn(pmKey: string, col: number): Promise<void>;
+  SetColumnOrder(queue: string, keys: string[]): Promise<void>;
+  SetCardHidden(pmKey: string, hidden: boolean): Promise<void>;
   DaemonStatus(): Promise<boolean>;
   StartIdeation(seed: string, mode: string, restart: boolean, evolveKey: string, evolveLabels: string[]): Promise<IdeationView>;
   CreateIdea(title: string): Promise<void>;
@@ -319,6 +329,14 @@ const QUEUE_VERB: Record<string, string> = {
 let current: BoardData = { cards: [], dockerAvailable: true, error: "" };
 let dragging: { key: string; title: string; stage: string } | null = null;
 
+// showHidden reveals user-hidden cards (marked with an "H" pill) instead of
+// filtering them out. Session-local so the board always starts clean.
+let showHidden = false;
+
+function cardVisible(card: Card): boolean {
+  return !card.hidden || showHidden;
+}
+
 // Two-phase load state. boardLoading covers the first fetch before any titles
 // exist (the board shows a centered spinner). stagesLoading covers the window
 // after titles render but before the comment scan resolves each card's real
@@ -386,9 +404,15 @@ function renderCard(card: Card): HTMLElement {
   if (card.engineeringKey) meta.push(`<span>${escapeHtml(card.engineeringKey)}</span>`);
   if (card.prURL) meta.push(`<a href="${escapeAttr(card.prURL)}" target="_blank">PR</a>`);
 
+  // The H pill marks a hidden card while it is revealed via the header's
+  // Unhide toggle — without it, revealed and normal cards would be
+  // indistinguishable and re-hiding would feel like cards vanishing at random.
+  const hiddenPill = card.hidden
+    ? `<span class="hidden-pill" title="Hidden ticket — shown via Unhide">H</span>`
+    : "";
   el.innerHTML = `
     <div class="card-key">${escapeHtml(card.key)}</div>
-    <div class="card-title" title="${escapeAttr(card.title)}">${escapeHtml(card.title)}</div>
+    <div class="card-title" title="${escapeAttr(card.title)}">${hiddenPill}${escapeHtml(card.title)}</div>
     <div class="card-meta">${meta.join("")}</div>
     ${card.error ? `<div class="card-error">${escapeHtml(card.error)}</div>` : ""}
   `;
@@ -518,6 +542,18 @@ function showCardMenu(card: Card, x: number, y: number): void {
     menu.appendChild(mockItem);
   }
 
+  // Hiding is view hygiene, not ticket lifecycle: parked noise disappears
+  // from the board while the ticket on the tracker stays untouched.
+  const hideItem = document.createElement("button");
+  hideItem.type = "button";
+  hideItem.className = "context-menu-item";
+  hideItem.textContent = card.hidden ? "Unhide ticket" : "Hide ticket";
+  hideItem.addEventListener("click", () => {
+    menu.remove();
+    toggleCardHidden(card);
+  });
+  menu.appendChild(hideItem);
+
   const closeItem = document.createElement("button");
   closeItem.type = "button";
   closeItem.className = "context-menu-item danger";
@@ -556,8 +592,10 @@ function renderColumn(queue: string): HTMLElement {
   col.className = "column";
   col.dataset.stage = queue;
 
-  // Bug tickets live in the Bugs pane, never in the workflow columns.
-  const cards = current.cards.filter((c) => queueOf(c) === queue && !c.bug);
+  // Bug tickets live in the Bugs pane, never in the workflow columns; hidden
+  // tickets only render while revealed. The saved hand order sorts what's left.
+  const cards = current.cards.filter((c) => queueOf(c) === queue && !c.bug && cardVisible(c));
+  sortByHandOrder(cards, current.columnOrder?.[queue]);
 
   const header = document.createElement("div");
   header.className = "column-header";
@@ -576,12 +614,11 @@ function renderColumn(queue: string): HTMLElement {
   body.className = "column-body";
   for (const card of cards) body.appendChild(renderCard(card));
 
-  if (queue === "product" || QUEUE_TRANSITION_TO[queue] !== undefined) {
-    // Drop targets are the queues a drag can act on: product (idea promotion)
-    // and the transition-launching queues. Ready to Deploy is deliberately
-    // NOT a target — cards arrive there only by passing review.
-    markQueueTarget(body, queue);
-  }
+  // Every column is at least a same-column sort target; product additionally
+  // accepts idea promotion and the transition queues launch stages. Dropping
+  // INTO Ready to Deploy stays impossible (dropAllowed gates it) — cards
+  // arrive there only by passing review, but sorting within it is fine.
+  markQueueTarget(body, queue);
 
   col.appendChild(body);
   return col;
@@ -599,7 +636,7 @@ function renderIdeaSpace(): HTMLElement {
   space.className = "idea-space";
   space.dataset.stage = "ideas";
 
-  const ideas = current.cards.filter((c) => queueOf(c) === "ideas" && !c.bug);
+  const ideas = current.cards.filter((c) => queueOf(c) === "ideas" && !c.bug && cardVisible(c));
 
   const grid = document.createElement("div");
   grid.className = "idea-space-grid";
@@ -726,7 +763,7 @@ function renderBugs(): void {
   const scrollByStage = captureColumnScroll(host);
   host.innerHTML = "";
 
-  const bugs = current.cards.filter((c) => c.bug);
+  const bugs = current.cards.filter((c) => c.bug && cardVisible(c));
   const gridBugs = bugs.filter((c) => bugAreaOf(c) === "grid");
   const fixBugs = bugs.filter((c) => bugAreaOf(c) !== "grid");
   const ready = bugs.filter(isReadyToDeploy);
@@ -1023,6 +1060,12 @@ function dropAllowed(target: HTMLElement): boolean {
     return bugAreaOf(card) === "grid" || isReworkable(card);
   }
   const toQueue = target.dataset.dropQueue || "";
+  // A drop back into the card's own column is a local reorder — it launches
+  // nothing, so neither the Docker gate nor forward-adjacency applies.
+  if (!card.bug && toQueue === queueOf(card)) return true;
+  // Ready to Deploy is never a transition target — cards earn their way in by
+  // passing review; only the same-column sort above may drop here.
+  if (toQueue === "deploy") return false;
   // forwardDropAllowed owns forward-adjacency, the Code rework re-drop, and the
   // Engineering->Code plan-ready gate; targetEnabled keeps the local Docker gate.
   return forwardDropAllowed(card, toQueue) && targetEnabled(toQueue);
@@ -1039,6 +1082,17 @@ function setHoverTarget(target: HTMLElement | null): void {
   const ok = dropAllowed(target);
   target.classList.toggle("drop-ok", ok);
   target.classList.toggle("drop-reject", !ok);
+  // The overlay verb must state what the drop DOES: a same-column drop sorts,
+  // it never launches, so the transition verb would lie ("Build it" on a card
+  // already in Code). Recomputed on every hover since the same body serves both.
+  const drag = dragging;
+  if (ok && target.dataset.drop === "queue" && drag) {
+    const card = current.cards.find((c) => c.key === drag.key);
+    const sorting = !!card && target.dataset.dropQueue === queueOf(card);
+    const verb = sorting ? "Sort here" : QUEUE_VERB[target.dataset.dropQueue || ""];
+    if (verb) target.dataset.verb = verb;
+    else delete target.dataset.verb;
+  }
 }
 
 function makeDragGhost(card: { key: string; title: string }): HTMLElement {
@@ -1177,6 +1231,13 @@ function performDrop(
     return;
   }
   const toQueue = target.dataset.dropQueue || "";
+  const dropped = current.cards.find((c) => c.key === info.key);
+  if (dropped && !dropped.bug && toQueue === queueOf(dropped)) {
+    // A drop into the card's own column sorts it — mirrors the idea-space
+    // local reorder, never a transition.
+    reorderWithinQueue(toQueue, info.key, pt.y);
+    return;
+  }
   if (toQueue === "product" && info.stage === "ideas") {
     // Promotion is a conversation, not a stage transition: the evolve-mode
     // ideation session rewrites the ticket in place and removes the idea
@@ -1188,6 +1249,36 @@ function performDrop(
   if (!to) return;
   celebrateDrop(pt, { key: info.key, fromStage: info.stage, done: false });
   void transition(info.key, info.title, info.stage, to);
+}
+
+// reorderWithinQueue persists a same-column drop as the queue's new hand
+// order, read from the live DOM so the dragged card lands exactly where the
+// pointer released among the cards the user was looking at. Optimistic like
+// SetIdeaColumn: render from the new order immediately, snap back via
+// reconcile only if the write fails. Hidden cards are absent from the DOM and
+// so from the saved list — they simply re-append after it when revealed.
+function reorderWithinQueue(queue: string, key: string, dropY: number): void {
+  const body = document.querySelector<HTMLElement>(`.column[data-stage="${queue}"] .column-body`);
+  if (!body) return;
+  const resting: string[] = [];
+  const midpoints: number[] = [];
+  for (const el of Array.from(body.querySelectorAll<HTMLElement>(".card"))) {
+    const k = el.dataset.key || "";
+    if (!k || k === key) continue;
+    const r = el.getBoundingClientRect();
+    resting.push(k);
+    midpoints.push(r.top + r.height / 2);
+  }
+  const keys = insertKeyAt(resting, midpoints, key, dropY);
+  if (!current.columnOrder) current.columnOrder = {};
+  current.columnOrder[queue] = keys;
+  render();
+  void go()
+    .SetColumnOrder(queue, keys)
+    .catch((err) => {
+      showError(errMessage(err));
+      void reconcile();
+    });
 }
 
 // promoteIdea opens the ideation panel in evolve mode, seeded with the idea
@@ -1412,11 +1503,57 @@ function render(): void {
   // The detail panel lives outside #board, so the rebuild above never touches
   // it — it only needs its card data refreshed from the new board state.
   refreshTicketDetail();
+  updateHideToggle();
 }
 
 function showError(msg: string): void {
   current.error = msg;
   render();
+}
+
+// toggleCardHidden parks a ticket off the board or restores it. Optimistic
+// like SetIdeaColumn: flip and render immediately, snap back via reconcile
+// only if the write fails.
+function toggleCardHidden(card: Card): void {
+  card.hidden = !card.hidden;
+  render();
+  void go()
+    .SetCardHidden(card.key, !!card.hidden)
+    .catch((err) => {
+      showError(errMessage(err));
+      void reconcile();
+    });
+}
+
+// updateHideToggle keeps the header's Unhide/Hide button in sync: present only
+// while hidden tickets exist (labeled with the count), toggling whether they
+// render with their H pill or stay filtered out. When the last hidden ticket
+// is unhidden the reveal state resets, so the button never sticks around dead.
+function updateHideToggle(): void {
+  const header = document.getElementById("app-header");
+  if (!header) return;
+  let btn = document.getElementById("hide-toggle") as HTMLButtonElement | null;
+  const hiddenCount = current.cards.filter((c) => c.hidden).length;
+  if (hiddenCount === 0) {
+    showHidden = false;
+    btn?.remove();
+    return;
+  }
+  if (!btn) {
+    btn = document.createElement("button");
+    btn.id = "hide-toggle";
+    btn.type = "button";
+    btn.className = "hide-toggle";
+    btn.addEventListener("click", () => {
+      showHidden = !showHidden;
+      render();
+    });
+    header.appendChild(btn);
+  }
+  btn.textContent = showHidden ? `Hide hidden (${hiddenCount})` : `Unhide (${hiddenCount})`;
+  btn.title = showHidden
+    ? "Conceal the revealed hidden tickets again"
+    : "Reveal hidden tickets (marked with an H pill)";
 }
 
 function renderDaemonStatus(): void {

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -832,6 +832,36 @@ body {
   color: var(--muted);
 }
 
+/* Header toggle revealing/concealing user-hidden tickets. Appears only while
+   hidden tickets exist (updateHideToggle), so it never sits dead in the
+   header. justify-content: space-between on .app-header pushes it right. */
+.hide-toggle {
+  font: 12px ui-monospace, "SF Mono", Menlo, monospace;
+  color: var(--text);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 6px;
+  padding: 3px 10px;
+  cursor: pointer;
+}
+
+.hide-toggle:hover {
+  border-color: var(--accent);
+}
+
+/* Marks a hidden card while it is revealed via Unhide — without it, revealed
+   and normal cards would be indistinguishable. */
+.hidden-pill {
+  display: inline-block;
+  margin-right: 6px;
+  padding: 0 6px;
+  border: 1px solid var(--card-border);
+  border-radius: 999px;
+  font: 10px/1.6 ui-monospace, "SF Mono", Menlo, monospace;
+  color: var(--muted);
+  vertical-align: 1px;
+}
+
 /* Bottom status bar, mirroring the TUI's "● Daemon running" status line. Sits
    below the board as a fixed-height footer in the app-main flex column. */
 .statusbar {

--- a/internal/boardprefs/store.go
+++ b/internal/boardprefs/store.go
@@ -1,0 +1,193 @@
+// Package boardprefs persists the workflow board's per-user view preferences:
+// the hand-sorted vertical order of cards within each queue column and the set
+// of tickets the user hid from the board. Like the idea-space placement, this
+// is pure local UI preference — deliberately a file on the user's machine and
+// never a label, comment, or status on the ticket, so arranging or parking
+// cards leaves no trace on the tracker and needs no tracker credentials.
+package boardprefs
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/gethuman-sh/human/errors"
+)
+
+// fileFormat is the on-disk shape. Version exists so a later change (e.g.
+// scoping preferences per tracker) can migrate instead of misreading.
+type fileFormat struct {
+	Version int                 `json:"version"`
+	Columns map[string][]string `json:"columns"`
+	Hidden  []string            `json:"hidden"`
+}
+
+const currentVersion = 1
+
+// Prefs is one consistent snapshot of both preference kinds, taken under a
+// single lock so a caller never sees an order from before a hide.
+type Prefs struct {
+	// Columns maps a queue id to its hand-sorted ticket keys, top first.
+	// Cards absent from the list render after it in fetch order.
+	Columns map[string][]string
+	// Hidden holds the ticket keys the user parked off the board.
+	Hidden map[string]struct{}
+}
+
+// Store reads and writes the preference file.
+type Store struct {
+	// mu serializes read-modify-write cycles; Wails binding calls can run
+	// concurrently and a lost update would silently drop a preference.
+	mu   sync.Mutex
+	path string
+}
+
+// DefaultPath returns the preference file location, matching the ~/.human
+// convention (falling back to ./.human when no home is available).
+func DefaultPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".", ".human", "boardprefs.json")
+	}
+	return filepath.Join(home, ".human", "boardprefs.json")
+}
+
+// NewStore creates a store persisting to path.
+func NewStore(path string) *Store {
+	return &Store{path: path}
+}
+
+// Snapshot returns the saved preferences. A missing, corrupt, or
+// future-versioned file yields empty preferences — no saved order simply
+// means fetch order, and nothing hidden.
+func (s *Store) Snapshot() Prefs {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return prefsOf(s.read())
+}
+
+// SetOrder replaces the hand-sorted key list for one queue.
+func (s *Store) SetOrder(queue string, keys []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	f := s.read()
+	if f.Columns == nil {
+		f.Columns = map[string][]string{}
+	}
+	f.Columns[queue] = keys
+	return s.write(f)
+}
+
+// SetHidden parks or restores one ticket.
+func (s *Store) SetHidden(key string, hidden bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	f := s.read()
+	kept := make([]string, 0, len(f.Hidden)+1)
+	for _, k := range f.Hidden {
+		if k != key {
+			kept = append(kept, k)
+		}
+	}
+	if hidden {
+		kept = append(kept, key)
+	}
+	f.Hidden = kept
+	return s.write(f)
+}
+
+// PruneExcept drops preferences for tickets not in keys — closed or vanished
+// tickets no longer need an order slot or a hidden flag. A missing file is a
+// no-op so pruning never creates state.
+func (s *Store) PruneExcept(keys map[string]struct{}) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, err := os.Stat(s.path); err != nil {
+		return nil
+	}
+	f := s.read()
+	changed := false
+
+	for queue, order := range f.Columns {
+		kept := make([]string, 0, len(order))
+		for _, k := range order {
+			if _, ok := keys[k]; ok {
+				kept = append(kept, k)
+			}
+		}
+		if len(kept) != len(order) {
+			f.Columns[queue] = kept
+			changed = true
+		}
+	}
+	keptHidden := make([]string, 0, len(f.Hidden))
+	for _, k := range f.Hidden {
+		if _, ok := keys[k]; ok {
+			keptHidden = append(keptHidden, k)
+		}
+	}
+	if len(keptHidden) != len(f.Hidden) {
+		f.Hidden = keptHidden
+		changed = true
+	}
+
+	if !changed {
+		return nil
+	}
+	return s.write(f)
+}
+
+func prefsOf(f fileFormat) Prefs {
+	p := Prefs{Columns: f.Columns, Hidden: make(map[string]struct{}, len(f.Hidden))}
+	if p.Columns == nil {
+		p.Columns = map[string][]string{}
+	}
+	for _, k := range f.Hidden {
+		p.Hidden[k] = struct{}{}
+	}
+	return p
+}
+
+// read loads the file tolerantly; callers hold s.mu.
+func (s *Store) read() fileFormat {
+	empty := fileFormat{Version: currentVersion, Columns: map[string][]string{}}
+	data, err := os.ReadFile(s.path) // #nosec G304 — path fixed at construction
+	if err != nil {
+		return empty
+	}
+	var f fileFormat
+	if json.Unmarshal(data, &f) != nil || f.Version != currentVersion {
+		return empty
+	}
+	if f.Columns == nil {
+		f.Columns = map[string][]string{}
+	}
+	return f
+}
+
+// write persists atomically via temp+rename so a crash mid-write can never
+// leave a half-written file that would silently reset every preference;
+// callers hold s.mu.
+func (s *Store) write(f fileFormat) error {
+	f.Version = currentVersion
+	data, err := json.Marshal(f)
+	if err != nil {
+		return errors.WrapWithDetails(err, "marshal board prefs", "path", s.path)
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return errors.WrapWithDetails(err, "create board prefs dir", "path", s.path)
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return errors.WrapWithDetails(err, "write board prefs", "path", tmp)
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		_ = os.Remove(tmp)
+		return errors.WrapWithDetails(err, "rename board prefs", "path", s.path)
+	}
+	return nil
+}

--- a/internal/boardprefs/store_test.go
+++ b/internal/boardprefs/store_test.go
@@ -1,0 +1,154 @@
+package boardprefs
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	return NewStore(filepath.Join(t.TempDir(), "boardprefs.json"))
+}
+
+func TestStore_SetOrder_RoundTrip(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.SetOrder("product", []string{"SC-2", "SC-1"}))
+	require.NoError(t, s.SetOrder("building", []string{"SC-9"}))
+
+	p := s.Snapshot()
+	assert.Equal(t, []string{"SC-2", "SC-1"}, p.Columns["product"])
+	assert.Equal(t, []string{"SC-9"}, p.Columns["building"])
+}
+
+func TestStore_SetOrder_ReplacesQueue(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.SetOrder("product", []string{"SC-1", "SC-2"}))
+	require.NoError(t, s.SetOrder("product", []string{"SC-2", "SC-1"}))
+
+	assert.Equal(t, []string{"SC-2", "SC-1"}, s.Snapshot().Columns["product"])
+}
+
+func TestStore_SetHidden_AddAndRemove(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.SetHidden("SC-1", true))
+	require.NoError(t, s.SetHidden("SC-2", true))
+	_, hidden := s.Snapshot().Hidden["SC-1"]
+	assert.True(t, hidden)
+
+	require.NoError(t, s.SetHidden("SC-1", false))
+	p := s.Snapshot()
+	_, hidden = p.Hidden["SC-1"]
+	assert.False(t, hidden)
+	_, hidden = p.Hidden["SC-2"]
+	assert.True(t, hidden)
+}
+
+func TestStore_SetHidden_Idempotent(t *testing.T) {
+	// Hiding twice must not duplicate the key on disk (an unhide would then
+	// only remove one copy).
+	s := newTestStore(t)
+
+	require.NoError(t, s.SetHidden("SC-1", true))
+	require.NoError(t, s.SetHidden("SC-1", true))
+	require.NoError(t, s.SetHidden("SC-1", false))
+
+	_, hidden := s.Snapshot().Hidden["SC-1"]
+	assert.False(t, hidden)
+}
+
+func TestStore_Snapshot_MissingFile(t *testing.T) {
+	s := newTestStore(t)
+	p := s.Snapshot()
+	assert.Empty(t, p.Columns)
+	assert.Empty(t, p.Hidden)
+}
+
+func TestStore_Snapshot_CorruptFile(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, os.WriteFile(s.path, []byte("{not json"), 0o600))
+
+	p := s.Snapshot()
+	assert.Empty(t, p.Columns)
+	assert.Empty(t, p.Hidden)
+}
+
+func TestStore_Snapshot_FutureVersion(t *testing.T) {
+	// A future format must read as empty rather than be misinterpreted.
+	s := newTestStore(t)
+	data := `{"version":2,"columns":{"product":["SC-1"]},"hidden":["SC-1"]}`
+	require.NoError(t, os.WriteFile(s.path, []byte(data), 0o600))
+
+	p := s.Snapshot()
+	assert.Empty(t, p.Columns)
+	assert.Empty(t, p.Hidden)
+}
+
+func TestStore_PruneExcept_DropsVanishedTickets(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.SetOrder("product", []string{"SC-1", "SC-2", "SC-3"}))
+	require.NoError(t, s.SetHidden("SC-2", true))
+	require.NoError(t, s.SetHidden("SC-9", true))
+
+	require.NoError(t, s.PruneExcept(map[string]struct{}{
+		"SC-1": {}, "SC-2": {},
+	}))
+
+	p := s.Snapshot()
+	assert.Equal(t, []string{"SC-1", "SC-2"}, p.Columns["product"])
+	_, hidden := p.Hidden["SC-2"]
+	assert.True(t, hidden)
+	_, gone := p.Hidden["SC-9"]
+	assert.False(t, gone)
+}
+
+func TestStore_PruneExcept_MissingFileIsNoOp(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.PruneExcept(map[string]struct{}{"SC-1": {}}))
+	_, err := os.Stat(s.path)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestStore_PruneExcept_NoChangeNoWrite(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.SetOrder("product", []string{"SC-1"}))
+	before, err := os.ReadFile(s.path)
+	require.NoError(t, err)
+
+	require.NoError(t, s.PruneExcept(map[string]struct{}{"SC-1": {}}))
+
+	after, err := os.ReadFile(s.path)
+	require.NoError(t, err)
+	assert.Equal(t, before, after)
+}
+
+func TestStore_ConcurrentWrites(t *testing.T) {
+	// Racing binding calls must not lose updates; the mutex serializes the
+	// read-modify-write cycles.
+	s := newTestStore(t)
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = s.SetOrder("product", []string{"SC-1"})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = s.SetHidden("SC-2", true)
+		}()
+	}
+	wg.Wait()
+
+	p := s.Snapshot()
+	assert.Equal(t, []string{"SC-1"}, p.Columns["product"])
+	_, hidden := p.Hidden["SC-2"]
+	assert.True(t, hidden)
+}


### PR DESCRIPTION
Two board view preferences, both purely local (`~/.human/boardprefs.json`) — arranging or parking cards never touches the ticket on the tracker.

**SC-624 — hand-sorted columns**: dropping a card within its own column now sorts it there ("Sort here" verb), in every workflow column including Ready to Deploy (which stays impossible to transition into). The order survives refreshes and restarts; new arrivals append at the bottom. Mirrors the idea-space placement pattern (`internal/boardprefs` alongside `internal/ideaspace`).

**SC-625 — hide/unhide**: right-click → Hide ticket parks a card off the board. While hidden tickets exist the header shows an Unhide/Hide toggle with the count; revealed hidden cards carry an H pill before the title and offer Unhide in their menu. Applies to workflow columns, the idea space, and the Bugs pane.

Both preference kinds prune automatically when tickets leave the board, atomically written temp+rename.

- `internal/boardprefs` tests: 84.8% coverage
- Frontend tests: 19/19 (new pure helpers `sortByHandOrder` / `insertKeyAt` covered)
- `make check`: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)