### PR TITLE
[SC-651] Modernize board frontend to current TypeScript constructs

### DIFF
--- a/desktop/frontend/dist/board-detail.js
+++ b/desktop/frontend/dist/board-detail.js
@@ -6,7 +6,7 @@
 // escapeText is a minimal HTML escaper for the option labels/context, which
 // come from ticket comments (agent-written, but still untrusted text).
 function escapeText(s) {
-    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+    return s.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
 }
 // buildOptionsSection renders a card's open decision block: the one-line
 // context and one button per option. The buttons carry data-option-id; the

--- a/desktop/frontend/dist/board-queue.js
+++ b/desktop/frontend/dist/board-queue.js
@@ -77,11 +77,11 @@ export function badgeInfo(card) {
         return {
             cls: "decision",
             text: "decision needed",
-            title: "The review offers " + card.options.length + " ways forward — open the card to choose",
+            title: `The review offers ${card.options.length} ways forward — open the card to choose`,
         };
     }
     if (card.stage === "verification" && card.state === "done" && verdictFailed(card.verdict)) {
-        return { cls: "warning", text: "⚠ review found problems", title: "Review verdict: " + (card.verdict ?? "") };
+        return { cls: "warning", text: "⚠ review found problems", title: `Review verdict: ${card.verdict ?? ""}` };
     }
     if (card.stage === "verification" && card.state === "done" && !card.branch) {
         // A passed review with no recorded branch has nothing to ship — deploying

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -15,6 +15,7 @@ import { initSettingsView, showSettings, settingsIndex, saveSetting, setPaletteO
 import { initPalette, openPalette, isPaletteChord } from "./palette.js";
 import { QUEUES, QUEUE_TRANSITION_TO, queueOf, isReworkable, forwardDropAllowed, verdictFailed, badgeInfo, sortByHandOrder, insertKeyAt, } from "./board-queue.js";
 import { buildDetailSections, buildOptionsSection } from "./board-detail.js";
+export {};
 // openExternal routes a URL to the system browser via the Wails runtime.
 // Anchor clicks with target=_blank are NOT reliably forwarded by the Linux
 // webview (WebKitGTK swallows the new-window request), so every external
@@ -93,7 +94,7 @@ const DAEMON_POLL_MS = 3000;
 // daemon event, so without a slow re-fetch they stay invisible until an
 // unrelated event fires. Event-driven refresh remains the primary path; this
 // only bounds the staleness window.
-const BOARD_SAFETY_POLL_MS = 90000;
+const BOARD_SAFETY_POLL_MS = 90_000;
 let daemonReachable = false;
 function go() {
     const app = window.go?.main?.App;
@@ -786,7 +787,7 @@ function dropAllowed(target) {
             return false;
         return bugAreaOf(card) === "grid" || isReworkable(card);
     }
-    const toQueue = target.dataset.dropQueue || "";
+    const toQueue = target.dataset.dropQueue ?? "";
     // A drop back into the card's own column is a local reorder — it launches
     // nothing, so neither the Docker gate nor forward-adjacency applies.
     if (!card.bug && toQueue === queueOf(card))
@@ -818,7 +819,7 @@ function setHoverTarget(target) {
     if (ok && target.dataset.drop === "queue" && drag) {
         const card = current.cards.find((c) => c.key === drag.key);
         const sorting = !!card && target.dataset.dropQueue === queueOf(card);
-        const verb = sorting ? "Sort here" : QUEUE_VERB[target.dataset.dropQueue || ""];
+        const verb = sorting ? "Sort here" : QUEUE_VERB[target.dataset.dropQueue ?? ""];
         if (verb)
             target.dataset.verb = verb;
         else
@@ -954,7 +955,7 @@ function performDrop(target, info, pt) {
         void fixBug(info.key, info.title);
         return;
     }
-    const toQueue = target.dataset.dropQueue || "";
+    const toQueue = target.dataset.dropQueue ?? "";
     const dropped = current.cards.find((c) => c.key === info.key);
     if (dropped && !dropped.bug && toQueue === queueOf(dropped)) {
         // A drop into the card's own column sorts it — mirrors the idea-space
@@ -969,7 +970,7 @@ function performDrop(target, info, pt) {
         void promoteIdea(info.key);
         return;
     }
-    const to = QUEUE_TRANSITION_TO[toQueue] || "";
+    const to = QUEUE_TRANSITION_TO[toQueue] ?? "";
     if (!to)
         return;
     celebrateDrop(pt, { key: info.key, fromStage: info.stage, done: false });
@@ -987,8 +988,8 @@ function reorderWithinQueue(queue, key, dropY) {
         return;
     const resting = [];
     const midpoints = [];
-    for (const el of Array.from(body.querySelectorAll(".card"))) {
-        const k = el.dataset.key || "";
+    for (const el of body.querySelectorAll(".card")) {
+        const k = el.dataset.key ?? "";
         if (!k || k === key)
             continue;
         const r = el.getBoundingClientRect();
@@ -1022,7 +1023,7 @@ async function promoteIdea(key) {
     }
     let seed = card.title;
     if (card.description)
-        seed += "\n\n" + card.description;
+        seed += `\n\n${card.description}`;
     const panel = document.getElementById("ideation-panel");
     if (panel)
         panel.classList.remove("hidden");
@@ -1321,7 +1322,7 @@ async function initialLoad() {
     try {
         const quick = await go().CardsQuick();
         current = {
-            cards: quick.cards || [],
+            cards: quick.cards ?? [],
             dockerAvailable: !!quick.dockerAvailable,
             // Suppress the quick-phase error: the full reconcile surfaces it, and
             // clearing it here avoids a banner that flickers away a moment later.
@@ -1354,9 +1355,9 @@ async function reconcile() {
         if (epoch !== reconcileEpoch)
             return;
         current = {
-            cards: data.cards || [],
+            cards: data.cards ?? [],
             dockerAvailable: !!data.dockerAvailable,
-            error: data.error || "",
+            error: data.error ?? "",
         };
     }
     catch (err) {
@@ -1389,13 +1390,13 @@ function errMessage(err) {
     return String(err);
 }
 function escapeHtml(s) {
-    return String(s == null ? "" : s)
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;");
+    return String(s ?? "")
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;");
 }
 function escapeAttr(s) {
-    return escapeHtml(s).replace(/"/g, "&quot;");
+    return escapeHtml(s).replaceAll('"', "&quot;");
 }
 // --- Ideation chat panel -----------------------------------------------
 //
@@ -1489,11 +1490,11 @@ function renderIdeationDraft() {
     // user edits on every poll tick).
     if (titleInput && titleInput.dataset.sessionId !== ideation.sessionId) {
         titleInput.value = ideation.draft.title;
-        titleInput.dataset.sessionId = ideation.sessionId || "";
+        titleInput.dataset.sessionId = ideation.sessionId ?? "";
     }
     if (descInput && descInput.dataset.sessionId !== ideation.sessionId) {
         descInput.value = ideation.draft.description;
-        descInput.dataset.sessionId = ideation.sessionId || "";
+        descInput.dataset.sessionId = ideation.sessionId ?? "";
     }
 }
 function renderIdeation() {
@@ -1515,7 +1516,7 @@ function renderIdeation() {
             statusLine.classList.add("error");
         }
         else if (ideation.state === "done") {
-            statusLine.textContent = "Created " + (ideation.createdKey || "");
+            statusLine.textContent = `Created ${ideation.createdKey ?? ""}`;
         }
         else {
             statusLine.classList.add("hidden");
@@ -1562,7 +1563,7 @@ const chosenOptions = new Map();
 // optionsSignature identifies one decision block by its content, so stale
 // re-offers of a consumed block are distinguishable from a genuinely new one.
 function optionsSignature(options) {
-    return (options ?? []).map((o) => o.id + ":" + o.label).join("|");
+    return (options ?? []).map((o) => `${o.id}:${o.label}`).join("|");
 }
 // liveOptions returns the card's options with the session's consumed block
 // suppressed — and retires the suppression once the server catches up or a
@@ -1921,7 +1922,7 @@ async function maybeOfferStartProject() {
     // A failed probe (info.error) means "don't offer", never a broken app.
     if (info.error || !info.emptyProject)
         return;
-    wizardTemplates = info.templates || [];
+    wizardTemplates = info.templates ?? [];
     if (wizardTemplates.length === 0)
         return;
     openStartWizard();
@@ -2110,10 +2111,10 @@ async function pollAgents() {
     renderAgents();
 }
 function formatTokens(n) {
-    if (n >= 1000000)
-        return (n / 1e6).toFixed(1) + "M";
-    if (n >= 1000)
-        return (n / 1e3).toFixed(1) + "K";
+    if (n >= 1_000_000)
+        return `${(n / 1e6).toFixed(1)}M`;
+    if (n >= 1_000)
+        return `${(n / 1e3).toFixed(1)}K`;
     return String(n);
 }
 // formatElapsedUnix mirrors the TUI's formatElapsed: seconds under a minute,
@@ -2212,7 +2213,7 @@ function renderAgentRow(a) {
         chips.push(`<span class="agent-chip slug">${escapeHtml(a.slug)}</span>`);
     const ctx = a.errorType || a.blockedTool || a.currentTool;
     if (ctx)
-        chips.push(`<span class="agent-chip ctx">${escapeHtml(a.errorType ? a.errorType : a.blockedTool ? "⚠ " + a.blockedTool : "[" + a.currentTool + "]")}</span>`);
+        chips.push(`<span class="agent-chip ctx">${escapeHtml(a.errorType ? a.errorType : a.blockedTool ? `⚠ ${a.blockedTool}` : `[${a.currentTool}]`)}</span>`);
     const rowClass = a.status === "blocked" ? "agent-row blocked" : "agent-row";
     return `<div class="${rowClass}">
     <div class="agent-head">
@@ -2275,13 +2276,11 @@ function featureSig(doc) {
     if (!doc.exists)
         return "«sent»";
     const walk = (gs = []) => gs
-        .map((g) => g.group +
-        "|" +
-        (g.features ?? []).map((f) => f.name + ":" + f.description + (f.recent ? "*" : "")).join(",") +
-        "|" +
-        walk(g.groups))
+        .map((g) => `${g.group}|${(g.features ?? [])
+        .map((f) => `${f.name}:${f.description}${f.recent ? "*" : ""}`)
+        .join(",")}|${walk(g.groups)}`)
         .join(";");
-    return (doc.product ?? "") + "¦" + (doc.tagline ?? "") + "¦" + walk(doc.groups);
+    return `${doc.product ?? ""}¦${doc.tagline ?? ""}¦${walk(doc.groups)}`;
 }
 function stopFeaturesPoll() {
     if (featuresPollTimer !== undefined) {
@@ -2341,7 +2340,7 @@ async function onGenerateFeatures() {
     }
     catch (err) {
         featuresGenerating = false;
-        featuresNote = "Couldn't start generation: " + errMessage(err);
+        featuresNote = `Couldn't start generation: ${errMessage(err)}`;
         renderFeatures(currentFeatureDoc);
         return;
     }

--- a/desktop/frontend/dist/fancy.js
+++ b/desktop/frontend/dist/fancy.js
@@ -28,7 +28,7 @@ const EFFECTS = {
 };
 const THEME_KEY = "human.theme";
 const MOTE_TARGET = 32;
-const STREAK_WINDOW_MS = 10000;
+const STREAK_WINDOW_MS = 10_000;
 // --- Theme state --------------------------------------------------------
 export function isFancy() {
     return document.documentElement.dataset.theme === "fancy";
@@ -177,7 +177,7 @@ function removeAfterAnimation(el, fallbackMs) {
     window.setTimeout(() => el.remove(), fallbackMs);
 }
 function cssEscape(v) {
-    return typeof CSS !== "undefined" && CSS.escape ? CSS.escape(v) : v.replace(/["\\]/g, "\\$&");
+    return globalThis.CSS?.escape?.(v) ?? v.replace(/["\\]/g, "\\$&");
 }
 // --- Cursor spotlight + holographic sheen (shared pointermove) ------------
 let spotlight = null;

--- a/desktop/frontend/dist/mockupsview.js
+++ b/desktop/frontend/dist/mockupsview.js
@@ -19,7 +19,7 @@ function host() {
     return document.getElementById("mockups");
 }
 function escapeHtml(s) {
-    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+    return s.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
 }
 function renderList() {
     const h = host();

--- a/desktop/frontend/dist/palette.js
+++ b/desktop/frontend/dist/palette.js
@@ -51,7 +51,7 @@ function scoreAgainst(text, q) {
         const found = lower.indexOf(ch, ti);
         if (found < 0)
             return null;
-        const prev = positions[positions.length - 1];
+        const prev = positions.at(-1);
         if (prev !== undefined && found === prev + 1)
             score += 3; // contiguous run
         if (found === 0 || lower[found - 1] === "." || lower[found - 1] === " ")
@@ -82,7 +82,7 @@ function hits() {
     return out.slice(0, MAX_HITS);
 }
 function escapeHtml(s) {
-    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+    return s.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
 }
 function markPath(path, positions) {
     if (positions.length === 0)
@@ -191,7 +191,7 @@ function renderEditor(v) {
             ? "comma-separated"
             : "";
     return (`<div class="palette-editor">` +
-        `<div class="palette-editor-label">${escapeHtml(v.label)}${v.description ? " — " + escapeHtml(v.description) : ""}</div>` +
+        `<div class="palette-editor-label">${escapeHtml(v.label)}${v.description ? ` — ${escapeHtml(v.description)}` : ""}</div>` +
         `<input id="palette-editor-input" type="text" autocomplete="off" spellcheck="false" value="${escapeHtml(raw)}" placeholder="${escapeHtml(placeholder)}" />` +
         `<div id="palette-editor-msg" class="palette-editor-hint">↵ save · esc back</div>` +
         `</div>`);

--- a/desktop/frontend/dist/permissions.js
+++ b/desktop/frontend/dist/permissions.js
@@ -55,7 +55,7 @@ export function formatAge(createdAt, now = new Date()) {
     return `${Math.floor(s / 3600)}h`;
 }
 function escapeHtml(s) {
-    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+    return s.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
 }
 function render() {
     const e = els();

--- a/desktop/frontend/dist/settingsview.js
+++ b/desktop/frontend/dist/settingsview.js
@@ -61,7 +61,7 @@ function host() {
     return document.getElementById("settings");
 }
 function escapeHtml(s) {
-    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+    return s.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
 }
 function firstSection() {
     return data?.doc?.values[0]?.section ?? "";

--- a/desktop/frontend/src/board-detail.ts
+++ b/desktop/frontend/src/board-detail.ts
@@ -18,7 +18,7 @@ export interface DetailOption {
 // escapeText is a minimal HTML escaper for the option labels/context, which
 // come from ticket comments (agent-written, but still untrusted text).
 function escapeText(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  return s.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
 }
 
 // buildOptionsSection renders a card's open decision block: the one-line

--- a/desktop/frontend/src/board-queue.ts
+++ b/desktop/frontend/src/board-queue.ts
@@ -103,11 +103,11 @@ export function badgeInfo(card: QueueCard): BadgeInfo | null {
     return {
       cls: "decision",
       text: "decision needed",
-      title: "The review offers " + card.options.length + " ways forward — open the card to choose",
+      title: `The review offers ${card.options.length} ways forward — open the card to choose`,
     };
   }
   if (card.stage === "verification" && card.state === "done" && verdictFailed(card.verdict)) {
-    return { cls: "warning", text: "⚠ review found problems", title: "Review verdict: " + (card.verdict ?? "") };
+    return { cls: "warning", text: "⚠ review found problems", title: `Review verdict: ${card.verdict ?? ""}` };
   }
   if (card.stage === "verification" && card.state === "done" && !card.branch) {
     // A passed review with no recorded branch has nothing to ship — deploying

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -17,8 +17,8 @@ import {
   toggleTheme,
   trail,
 } from "./fancy.js";
-import { initPermissions, PermissionRequest } from "./permissions.js";
-import { initMockupsView, showMockups, setPendingMockupSlug, MockupSet } from "./mockupsview.js";
+import { initPermissions, type PermissionRequest } from "./permissions.js";
+import { initMockupsView, showMockups, setPendingMockupSlug, type MockupSet } from "./mockupsview.js";
 import {
   initSettingsView,
   showSettings,
@@ -26,7 +26,7 @@ import {
   saveSetting,
   setPaletteOpener,
   setActiveSection,
-  SettingsData,
+  type SettingsData,
 } from "./settingsview.js";
 import { initPalette, openPalette, isPaletteChord } from "./palette.js";
 import {
@@ -1059,7 +1059,7 @@ function dropAllowed(target: HTMLElement): boolean {
     if (!card.bug || !current.dockerAvailable) return false;
     return bugAreaOf(card) === "grid" || isReworkable(card);
   }
-  const toQueue = target.dataset.dropQueue || "";
+  const toQueue = target.dataset.dropQueue ?? "";
   // A drop back into the card's own column is a local reorder — it launches
   // nothing, so neither the Docker gate nor forward-adjacency applies.
   if (!card.bug && toQueue === queueOf(card)) return true;
@@ -1089,7 +1089,7 @@ function setHoverTarget(target: HTMLElement | null): void {
   if (ok && target.dataset.drop === "queue" && drag) {
     const card = current.cards.find((c) => c.key === drag.key);
     const sorting = !!card && target.dataset.dropQueue === queueOf(card);
-    const verb = sorting ? "Sort here" : QUEUE_VERB[target.dataset.dropQueue || ""];
+    const verb = sorting ? "Sort here" : QUEUE_VERB[target.dataset.dropQueue ?? ""];
     if (verb) target.dataset.verb = verb;
     else delete target.dataset.verb;
   }
@@ -1230,7 +1230,7 @@ function performDrop(
     void fixBug(info.key, info.title);
     return;
   }
-  const toQueue = target.dataset.dropQueue || "";
+  const toQueue = target.dataset.dropQueue ?? "";
   const dropped = current.cards.find((c) => c.key === info.key);
   if (dropped && !dropped.bug && toQueue === queueOf(dropped)) {
     // A drop into the card's own column sorts it — mirrors the idea-space
@@ -1245,7 +1245,7 @@ function performDrop(
     void promoteIdea(info.key);
     return;
   }
-  const to = QUEUE_TRANSITION_TO[toQueue] || "";
+  const to = QUEUE_TRANSITION_TO[toQueue] ?? "";
   if (!to) return;
   celebrateDrop(pt, { key: info.key, fromStage: info.stage, done: false });
   void transition(info.key, info.title, info.stage, to);
@@ -1262,8 +1262,8 @@ function reorderWithinQueue(queue: string, key: string, dropY: number): void {
   if (!body) return;
   const resting: string[] = [];
   const midpoints: number[] = [];
-  for (const el of Array.from(body.querySelectorAll<HTMLElement>(".card"))) {
-    const k = el.dataset.key || "";
+  for (const el of body.querySelectorAll<HTMLElement>(".card")) {
+    const k = el.dataset.key ?? "";
     if (!k || k === key) continue;
     const r = el.getBoundingClientRect();
     resting.push(k);
@@ -1300,7 +1300,7 @@ async function promoteIdea(key: string): Promise<void> {
   }
 
   let seed = card.title;
-  if (card.description) seed += "\n\n" + card.description;
+  if (card.description) seed += `\n\n${card.description}`;
 
   const panel = document.getElementById("ideation-panel");
   if (panel) panel.classList.remove("hidden");
@@ -1608,7 +1608,7 @@ async function initialLoad(): Promise<void> {
   try {
     const quick = await go().CardsQuick();
     current = {
-      cards: quick.cards || [],
+      cards: quick.cards ?? [],
       dockerAvailable: !!quick.dockerAvailable,
       // Suppress the quick-phase error: the full reconcile surfaces it, and
       // clearing it here avoids a banner that flickers away a moment later.
@@ -1641,9 +1641,9 @@ async function reconcile(): Promise<void> {
     const data = await go().Cards();
     if (epoch !== reconcileEpoch) return;
     current = {
-      cards: data.cards || [],
+      cards: data.cards ?? [],
       dockerAvailable: !!data.dockerAvailable,
-      error: data.error || "",
+      error: data.error ?? "",
     };
   } catch (err) {
     if (epoch !== reconcileEpoch) return;
@@ -1675,14 +1675,14 @@ function errMessage(err: unknown): string {
 }
 
 function escapeHtml(s: unknown): string {
-  return String(s == null ? "" : s)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+  return String(s ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
 }
 
 function escapeAttr(s: unknown): string {
-  return escapeHtml(s).replace(/"/g, "&quot;");
+  return escapeHtml(s).replaceAll('"', "&quot;");
 }
 
 // --- Ideation chat panel -----------------------------------------------
@@ -1781,11 +1781,11 @@ function renderIdeationDraft(): void {
   // user edits on every poll tick).
   if (titleInput && titleInput.dataset.sessionId !== ideation.sessionId) {
     titleInput.value = ideation.draft.title;
-    titleInput.dataset.sessionId = ideation.sessionId || "";
+    titleInput.dataset.sessionId = ideation.sessionId ?? "";
   }
   if (descInput && descInput.dataset.sessionId !== ideation.sessionId) {
     descInput.value = ideation.draft.description;
-    descInput.dataset.sessionId = ideation.sessionId || "";
+    descInput.dataset.sessionId = ideation.sessionId ?? "";
   }
 }
 
@@ -1806,7 +1806,7 @@ function renderIdeation(): void {
       statusLine.textContent = ideation.error || "Ideation session failed";
       statusLine.classList.add("error");
     } else if (ideation.state === "done") {
-      statusLine.textContent = "Created " + (ideation.createdKey || "");
+      statusLine.textContent = `Created ${ideation.createdKey ?? ""}`;
     } else {
       statusLine.classList.add("hidden");
     }
@@ -1857,7 +1857,7 @@ const chosenOptions = new Map<string, { signature: string; optionID: string }>()
 // optionsSignature identifies one decision block by its content, so stale
 // re-offers of a consumed block are distinguishable from a genuinely new one.
 function optionsSignature(options: { id: string; label: string }[] | undefined): string {
-  return (options ?? []).map((o) => o.id + ":" + o.label).join("|");
+  return (options ?? []).map((o) => `${o.id}:${o.label}`).join("|");
 }
 
 // liveOptions returns the card's options with the session's consumed block
@@ -2222,7 +2222,7 @@ async function maybeOfferStartProject(): Promise<void> {
   }
   // A failed probe (info.error) means "don't offer", never a broken app.
   if (info.error || !info.emptyProject) return;
-  wizardTemplates = info.templates || [];
+  wizardTemplates = info.templates ?? [];
   if (wizardTemplates.length === 0) return;
   openStartWizard();
 }
@@ -2419,8 +2419,8 @@ async function pollAgents(): Promise<void> {
 }
 
 function formatTokens(n: number): string {
-  if (n >= 1_000_000) return (n / 1e6).toFixed(1) + "M";
-  if (n >= 1_000) return (n / 1e3).toFixed(1) + "K";
+  if (n >= 1_000_000) return `${(n / 1e6).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1e3).toFixed(1)}K`;
   return String(n);
 }
 
@@ -2508,7 +2508,7 @@ function renderAgentRow(a: AgentInstance): string {
   if (elapsed) chips.push(`<span class="agent-chip">${elapsed}</span>`);
   if (a.slug) chips.push(`<span class="agent-chip slug">${escapeHtml(a.slug)}</span>`);
   const ctx = a.errorType || a.blockedTool || a.currentTool;
-  if (ctx) chips.push(`<span class="agent-chip ctx">${escapeHtml(a.errorType ? a.errorType : a.blockedTool ? "⚠ " + a.blockedTool : "[" + a.currentTool + "]")}</span>`);
+  if (ctx) chips.push(`<span class="agent-chip ctx">${escapeHtml(a.errorType ? a.errorType : a.blockedTool ? `⚠ ${a.blockedTool}` : `[${a.currentTool}]`)}</span>`);
 
   const rowClass = a.status === "blocked" ? "agent-row blocked" : "agent-row";
   return `<div class="${rowClass}">
@@ -2577,14 +2577,12 @@ function featureSig(doc: FeatureDoc): string {
     gs
       .map(
         (g) =>
-          g.group +
-          "|" +
-          (g.features ?? []).map((f) => f.name + ":" + f.description + (f.recent ? "*" : "")).join(",") +
-          "|" +
-          walk(g.groups),
+          `${g.group}|${(g.features ?? [])
+            .map((f) => `${f.name}:${f.description}${f.recent ? "*" : ""}`)
+            .join(",")}|${walk(g.groups)}`,
       )
       .join(";");
-  return (doc.product ?? "") + "¦" + (doc.tagline ?? "") + "¦" + walk(doc.groups);
+  return `${doc.product ?? ""}¦${doc.tagline ?? ""}¦${walk(doc.groups)}`;
 }
 
 function stopFeaturesPoll(): void {
@@ -2644,7 +2642,7 @@ async function onGenerateFeatures(): Promise<void> {
     await go().GenerateFeatures();
   } catch (err) {
     featuresGenerating = false;
-    featuresNote = "Couldn't start generation: " + errMessage(err);
+    featuresNote = `Couldn't start generation: ${errMessage(err)}`;
     renderFeatures(currentFeatureDoc);
     return;
   }

--- a/desktop/frontend/src/fancy.ts
+++ b/desktop/frontend/src/fancy.ts
@@ -206,7 +206,7 @@ function removeAfterAnimation(el: HTMLElement, fallbackMs: number): void {
 }
 
 function cssEscape(v: string): string {
-  return typeof CSS !== "undefined" && CSS.escape ? CSS.escape(v) : v.replace(/["\\]/g, "\\$&");
+  return globalThis.CSS?.escape?.(v) ?? v.replace(/["\\]/g, "\\$&");
 }
 
 // --- Cursor spotlight + holographic sheen (shared pointermove) ------------

--- a/desktop/frontend/src/mockupsview.ts
+++ b/desktop/frontend/src/mockupsview.ts
@@ -43,7 +43,7 @@ function host(): HTMLElement | null {
 }
 
 function escapeHtml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  return s.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
 }
 
 function renderList(): void {

--- a/desktop/frontend/src/palette.ts
+++ b/desktop/frontend/src/palette.ts
@@ -69,7 +69,7 @@ function scoreAgainst(text: string, q: string): { score: number; positions: numb
   for (const ch of needle) {
     const found = lower.indexOf(ch, ti);
     if (found < 0) return null;
-    const prev = positions[positions.length - 1];
+    const prev = positions.at(-1);
     if (prev !== undefined && found === prev + 1) score += 3; // contiguous run
     if (found === 0 || lower[found - 1] === "." || lower[found - 1] === " ") score += 2;
     score += 1;
@@ -99,7 +99,7 @@ function hits(): Hit[] {
 }
 
 function escapeHtml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  return s.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
 }
 
 function markPath(path: string, positions: number[]): string {
@@ -210,7 +210,7 @@ function renderEditor(v: SettingValue): string {
       : "";
   return (
     `<div class="palette-editor">` +
-    `<div class="palette-editor-label">${escapeHtml(v.label)}${v.description ? " — " + escapeHtml(v.description) : ""}</div>` +
+    `<div class="palette-editor-label">${escapeHtml(v.label)}${v.description ? ` — ${escapeHtml(v.description)}` : ""}</div>` +
     `<input id="palette-editor-input" type="text" autocomplete="off" spellcheck="false" value="${escapeHtml(raw)}" placeholder="${escapeHtml(placeholder)}" />` +
     `<div id="palette-editor-msg" class="palette-editor-hint">↵ save · esc back</div>` +
     `</div>`

--- a/desktop/frontend/src/permissions.ts
+++ b/desktop/frontend/src/permissions.ts
@@ -77,7 +77,7 @@ export function formatAge(createdAt: string, now: Date = new Date()): string {
 }
 
 function escapeHtml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  return s.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
 }
 
 function render(): void {

--- a/desktop/frontend/src/settingsview.ts
+++ b/desktop/frontend/src/settingsview.ts
@@ -112,7 +112,7 @@ function host(): HTMLElement | null {
 }
 
 function escapeHtml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  return s.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
 }
 
 function firstSection(): string {

--- a/desktop/frontend/tsconfig.json
+++ b/desktop/frontend/tsconfig.json
@@ -1,14 +1,15 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ES2020",
+    "target": "ES2023",
+    "module": "ES2022",
     "moduleResolution": "bundler",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "esModuleInterop": true,
+    "verbatimModuleSyntax": true,
     "skipLibCheck": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "outDir": "build",
     "rootDir": "src"
   },


### PR DESCRIPTION
Language-construct sweep of `desktop/frontend/src` for SC-651 — everything current TypeScript (7.0.2) supports that the code predated:

- `verbatimModuleSyntax` enabled; type-only imports now carry `type` modifiers (tsc enumerated the violations)
- `target`/`lib` ES2020 → ES2023, `module` → ES2022 (both webview runtimes support it)
- `String.replaceAll` replaces the `/x/g` regex chains in every `escapeHtml`/`escapeAttr`
- Nullish coalescing (`??`) where the intent is nullish — deliberately kept truthiness (`||`/ternary) where an empty string must fall through (`errorType` chip, `Number(x) || 0` NaN guards)
- `.at(-1)`, template literals over string concatenation, direct `NodeList` iteration (DOM.Iterable), `globalThis.CSS?.escape?.()` over the `typeof` guard

No behavior change. Frontend tests 19/19, `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)