### PR TITLE
[SC-776] Lean local lint: nilaway and duplicate analyses move to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,12 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
-      - run: go vet ./...
-      - run: go tool staticcheck ./...
+      # golangci-lint's default set includes govet and the full staticcheck
+      # suite — one owner per analysis. nilaway and gocyclo are enforced here
+      # (CI wall-clock is parallel and free) and stay out of the local hot loop.
       - run: go tool golangci-lint run ./...
+      - run: go tool nilaway ./...
+      - run: go tool gocyclo -over 15 .
 
   test:
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build fmt fmt-check install test check-test test-integration coverage coverage-check fuzz lint sec secrets check clean upgrade-deps release hooks unhooks desktop desktop-deps desktop-dev desktop-package
+.PHONY: all build fmt fmt-check install test check-test test-integration coverage coverage-check fuzz lint lint-deep sec secrets check clean upgrade-deps release hooks unhooks desktop desktop-deps desktop-dev desktop-package
 
 VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
 
@@ -56,12 +56,18 @@ fuzz:
 	go test -run=^$$ -fuzz=FuzzSanitizeFTSQuery -fuzztime=30s ./internal/index/...
 	go test -run=^$$ -fuzz=FuzzPeekClientHello -fuzztime=30s ./internal/proxy/...
 
+# Local lint is the lean hot-loop gate: golangci-lint's default set already
+# includes govet and the full staticcheck suite, so the standalone tools would
+# run the same analyses twice. nilaway (the slowest analyzer here) is enforced
+# by the CI lint job instead — agents and developers run `make check` several
+# times per change and must not pay it every time. `make lint-deep` runs the
+# full set locally when chasing a nil-panic before pushing.
 lint:
-	go vet ./...
-	go tool staticcheck ./...
 	go tool golangci-lint run ./...
-	go tool nilaway ./...
 	go tool gocyclo -over 15 .
+
+lint-deep: lint
+	go tool nilaway ./...
 
 sec:
 	# .claude/worktrees holds agent worktrees — stale snapshots there must not


### PR DESCRIPTION
## What

- Local `make lint` drops nilaway (measured: **~19s wall / 232s CPU per invocation**) and the standalone `go vet` + `staticcheck` runs (already fully covered by golangci-lint's default govet + staticcheck linters). Local lint: **~4s warm**, same findings coverage.
- CI's lint job gains `nilaway` and `gocyclo` (previously enforced nowhere in CI — local-only tax, backwards).
- `make lint-deep` keeps the full set for local nil-panic hunts.

## Why

Agents run `make check` 3–4× per bug fix in cold containers; nilaway alone was adding ~a minute of CPU-bound wall per pass while CI never enforced it. First slice of the pipeline-latency program (SC-776).

## Verification

`make check` green with the new lint set; nilaway/gocyclo verified green on this tree before moving (they gate this very PR in CI).

Closes SC-776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)