### PR TITLE
[SC-783] Project-declared cache volumes for agent containers

### DIFF
--- a/.humanconfig.example
+++ b/.humanconfig.example
@@ -82,3 +82,17 @@ policies:
   confirm:
     - transition:Done   # log a warning before marking tickets as done
     - create            # log a warning before creating new tickets
+
+# Persistent build caches for agent containers (explicit opt-in, no
+# autodetection). Each entry becomes a named Docker volume
+# (human-cache-<name>) mounted at the given container path, so consecutive
+# agent runs build warm instead of re-downloading and recompiling everything.
+# Clean up with: docker volume rm human-cache-<name>
+caches:
+  - name: go-build
+    path: /home/vscode/.cache/go-build   # go env GOCACHE for the container user
+  - name: go-mod
+    path: /go/pkg/mod                    # go env GOMODCACHE
+  # A Node project would declare npm instead:
+  # - name: npm
+  #   path: /home/vscode/.npm

--- a/internal/devcontainer/README.md
+++ b/internal/devcontainer/README.md
@@ -10,3 +10,4 @@ Spins up an isolated, reproducible container from your project's `devcontainer.j
 - Mounts your project source into the container
 - Connects the container to the human daemon
 - Runs commands inside the running container
+- Mounts project-declared cache volumes into every container it creates: the `caches:` section of `.humanconfig` names persistent Docker volumes (`human-cache-<name>`) and their container paths, so consecutive agent runs build warm — explicit opt-in per project, any ecosystem is a config entry, invalid entries degrade to a cold start with a warning, cleanup via `docker volume rm human-cache-<name>`

--- a/internal/devcontainer/config.go
+++ b/internal/devcontainer/config.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/gethuman-sh/human/errors"
@@ -24,6 +25,44 @@ func LoadHumanConfig(dir string) (*HumanConfig, error) {
 		return nil, err
 	}
 	return &cfg, nil
+}
+
+// CacheVolume is one project-declared persistent cache: a named Docker volume
+// mounted at a fixed container path so consecutive agent runs build warm. The
+// declaration is deliberately explicit — no ecosystem autodetection — so a new
+// platform (npm, cargo, …) is a config entry, not a code change (SC-783).
+type CacheVolume struct {
+	Name string `yaml:"name"`
+	Path string `yaml:"path"`
+}
+
+// VolumeName returns the Docker named-volume identifier for this cache. The
+// human-cache- prefix namespaces the volumes for discovery and cleanup
+// (`docker volume rm human-cache-<name>`); volumes are shared across projects
+// by design — build caches are content-addressed, the same trade a developer
+// machine makes.
+func (c CacheVolume) VolumeName() string { return "human-cache-" + c.Name }
+
+// validCacheName rejects anything Docker would not accept as a volume name —
+// crucially any '/', which would silently turn the bind source into a host
+// path mount instead of a named volume.
+var validCacheName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`)
+
+// Valid reports whether the declaration is usable: a Docker-safe volume name
+// and an absolute container path. Invalid entries are skipped with a warning
+// rather than failing the launch — a bad cache declaration must only cost the
+// warm start, never the run.
+func (c CacheVolume) Valid() bool {
+	return validCacheName.MatchString(c.Name) && strings.HasPrefix(c.Path, "/")
+}
+
+// LoadCaches reads the top-level caches section from .humanconfig.
+func LoadCaches(dir string) ([]CacheVolume, error) {
+	var caches []CacheVolume
+	if err := config.UnmarshalSection(dir, "caches", &caches); err != nil {
+		return nil, err
+	}
+	return caches, nil
 }
 
 // DevcontainerConfig represents a parsed devcontainer.json.

--- a/internal/devcontainer/config_test.go
+++ b/internal/devcontainer/config_test.go
@@ -442,3 +442,50 @@ func containsStr(s, sub string) bool {
 	}
 	return false
 }
+
+func TestCacheVolume_Valid(t *testing.T) {
+	cases := []struct {
+		name  string
+		cv    CacheVolume
+		valid bool
+	}{
+		{"go pair", CacheVolume{Name: "go-build", Path: "/home/vscode/.cache/go-build"}, true},
+		{"dots and underscore", CacheVolume{Name: "npm_v10.x", Path: "/root/.npm"}, true},
+		{"relative path", CacheVolume{Name: "good", Path: "cache"}, false},
+		{"slash in name", CacheVolume{Name: "../escape", Path: "/data"}, false},
+		{"empty name", CacheVolume{Name: "", Path: "/data"}, false},
+		{"leading dash", CacheVolume{Name: "-x", Path: "/data"}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.cv.Valid(); got != c.valid {
+				t.Fatalf("Valid() = %v, want %v", got, c.valid)
+			}
+		})
+	}
+}
+
+func TestLoadCaches(t *testing.T) {
+	dir := t.TempDir()
+	content := "caches:\n  - name: go-build\n    path: /home/vscode/.cache/go-build\n"
+	if err := os.WriteFile(filepath.Join(dir, ".humanconfig.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	caches, err := LoadCaches(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(caches) != 1 || caches[0].VolumeName() != "human-cache-go-build" || caches[0].Path != "/home/vscode/.cache/go-build" {
+		t.Fatalf("unexpected caches: %+v", caches)
+	}
+}
+
+func TestLoadCaches_AbsentIsEmpty(t *testing.T) {
+	caches, err := LoadCaches(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(caches) != 0 {
+		t.Fatalf("want empty, got %+v", caches)
+	}
+}

--- a/internal/devcontainer/manager.go
+++ b/internal/devcontainer/manager.go
@@ -641,7 +641,7 @@ func (m *Manager) loadCacheVolumes(projectDir string, out io.Writer) []CacheVolu
 			valid = append(valid, c)
 			continue
 		}
-		_, _ = fmt.Fprintf(out, "Warning: ignoring invalid cache volume %q (need a docker-safe name and an absolute path)\n", c.Name)
+		_, _ = fmt.Fprintf(out, "Warning: ignoring invalid cache volume %q (need a docker-safe name and an absolute path)\n", c.Name) // #nosec G705 -- CLI terminal output, not web
 	}
 	return valid
 }

--- a/internal/devcontainer/manager.go
+++ b/internal/devcontainer/manager.go
@@ -37,6 +37,10 @@ type UpOptions struct {
 	// shared-checkout and non-git workspaces, whose .git travels with the
 	// source mount itself.
 	GitDir string
+
+	// cacheVolumes is populated by Up from the project's .humanconfig caches
+	// section — callers never set it directly.
+	cacheVolumes []CacheVolume
 }
 
 // Up creates and starts a devcontainer. If the container already exists and is
@@ -52,6 +56,11 @@ func (m *Manager) Up(ctx context.Context, opts UpOptions) (*Meta, error) {
 	if err != nil {
 		return nil, errors.WrapWithDetails(err, "resolving project directory")
 	}
+
+	// Project-declared cache volumes ride every container of this project so
+	// consecutive runs build warm (SC-783). Loaded here so both the agent and
+	// direct devcontainer paths get them.
+	opts.cacheVolumes = m.loadCacheVolumes(projectDir, out)
 
 	// 1. Find and parse devcontainer.json.
 	configPath, err := FindConfig(projectDir)
@@ -118,7 +127,7 @@ func (m *Manager) createFresh(ctx context.Context, cfg *DevcontainerConfig, proj
 	}
 	// Docker bind mounts require absolute paths.
 	sourceDir, _ = filepath.Abs(sourceDir)
-	createOpts := m.buildCreateOptions(cfg, sourceDir, projectDir, containerName, imageName, workspaceDir, hash, opts.DaemonInfo, opts.GitDir)
+	createOpts := m.buildCreateOptions(cfg, sourceDir, projectDir, containerName, imageName, workspaceDir, hash, opts.DaemonInfo, opts.GitDir, opts.cacheVolumes)
 	ParseRunArgs(cfg.RunArgs, &createOpts, m.Logger)
 
 	_, _ = fmt.Fprintf(out, "Creating container %s...\n", containerName)
@@ -129,6 +138,12 @@ func (m *Manager) createFresh(ctx context.Context, cfg *DevcontainerConfig, proj
 
 	if err := m.Docker.ContainerStart(ctx, containerID); err != nil {
 		return nil, errors.WrapWithDetails(err, "starting container", "id", containerID)
+	}
+
+	if err := m.prepareCacheVolumes(ctx, containerID, remoteUser, opts.cacheVolumes); err != nil {
+		// A cache that cannot be made writable must only cost the warm start,
+		// never the run — the build falls back to an in-container cold cache.
+		_, _ = fmt.Fprintf(out, "Warning: cache volumes not writable, continuing cold: %v\n", err)
 	}
 
 	// Features are already baked into the image by EnsureImage.
@@ -265,7 +280,7 @@ func (m *Manager) handleExisting(ctx context.Context, existing ContainerSummary,
 
 // buildCreateOptions creates ContainerCreateOptions from the devcontainer config.
 // configDir is the directory containing .devcontainer/devcontainer.json (may differ from projectDir).
-func (m *Manager) buildCreateOptions(cfg *DevcontainerConfig, projectDir, configDir, containerName, imageName, workspaceDir, hash string, daemonInfo *daemon.DaemonInfo, gitDir string) ContainerCreateOptions {
+func (m *Manager) buildCreateOptions(cfg *DevcontainerConfig, projectDir, configDir, containerName, imageName, workspaceDir, hash string, daemonInfo *daemon.DaemonInfo, gitDir string, caches []CacheVolume) ContainerCreateOptions {
 	env := make([]string, 0)
 	for k, v := range cfg.ContainerEnv {
 		env = append(env, k+"="+v)
@@ -287,6 +302,12 @@ func (m *Manager) buildCreateOptions(cfg *DevcontainerConfig, projectDir, config
 
 	binds := []string{
 		projectDir + ":" + workspaceDir,
+	}
+
+	// Project-declared persistent caches: a bind whose source is not a path is
+	// a named volume, which Docker auto-creates on first use — no extra API.
+	for _, c := range caches {
+		binds = append(binds, c.VolumeName()+":"+c.Path)
 	}
 
 	// A worktree workspace resolves git through the parent repo's .git, which
@@ -603,4 +624,44 @@ func runHostCommand(cmd any, projectDir string) error {
 	default:
 		return nil
 	}
+}
+
+// loadCacheVolumes reads the project's declared cache volumes, dropping
+// invalid entries with a warning — a bad declaration costs the warm start,
+// never the launch.
+func (m *Manager) loadCacheVolumes(projectDir string, out io.Writer) []CacheVolume {
+	all, err := LoadCaches(projectDir)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "Warning: ignoring caches config: %v\n", err)
+		return nil
+	}
+	var valid []CacheVolume
+	for _, c := range all {
+		if c.Valid() {
+			valid = append(valid, c)
+			continue
+		}
+		_, _ = fmt.Fprintf(out, "Warning: ignoring invalid cache volume %q (need a docker-safe name and an absolute path)\n", c.Name)
+	}
+	return valid
+}
+
+// prepareCacheVolumes makes freshly created cache volumes writable for the
+// remote user: Docker creates an empty named volume root-owned, so a non-root
+// container's first run could not write its cache. Only the volume roots are
+// chowned (non-recursive) — everything below is created by the remote user
+// afterwards, so the top-level fix is sufficient and idempotent across runs.
+func (m *Manager) prepareCacheVolumes(ctx context.Context, containerID, remoteUser string, caches []CacheVolume) error {
+	if len(caches) == 0 || remoteUser == "" || remoteUser == "root" {
+		return nil
+	}
+	paths := make([]string, 0, len(caches))
+	for _, c := range caches {
+		paths = append(paths, c.Path)
+	}
+	// Discrete argv (no shell) so paths never need quoting.
+	if err := execInContainer(ctx, m.Docker, containerID, "root", append([]string{"mkdir", "-p"}, paths...), nil, m.Logger); err != nil {
+		return err
+	}
+	return execInContainer(ctx, m.Docker, containerID, "root", append([]string{"chown", remoteUser}, paths...), nil, m.Logger)
 }

--- a/internal/devcontainer/manager_test.go
+++ b/internal/devcontainer/manager_test.go
@@ -1026,3 +1026,128 @@ func TestNeedsValue(t *testing.T) {
 		}
 	}
 }
+
+// SC-783: project-declared cache volumes become named-volume binds so
+// consecutive runs build warm; the volume roots are chowned for a non-root
+// remote user because Docker creates fresh named volumes root-owned.
+func TestManager_Up_CacheVolumes(t *testing.T) {
+	projectDir, mock, docker := setupTestProject(t, `{"image": "ubuntu:22.04", "remoteUser": "vscode"}`)
+	writeCachesConfig(t, projectDir, `caches:
+  - name: go-build
+    path: /home/vscode/.cache/go-build
+  - name: go-mod
+    path: /go/pkg/mod
+`)
+
+	mgr := &Manager{Docker: docker, Logger: testLogger()}
+	_, err := mgr.Up(context.Background(), UpOptions{ProjectDir: projectDir, Out: &bytes.Buffer{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	binds := mock.createCalls[0].Binds
+	for _, want := range []string{
+		"human-cache-go-build:/home/vscode/.cache/go-build",
+		"human-cache-go-mod:/go/pkg/mod",
+	} {
+		if !slices.Contains(binds, want) {
+			t.Errorf("missing %q in binds: %v", want, binds)
+		}
+	}
+
+	// Ownership fix: exactly one mkdir and one chown exec as root.
+	var mkdirAsRoot, chownAsRoot bool
+	for _, c := range mock.execCalls {
+		if c.Opts.User != "root" {
+			continue
+		}
+		if len(c.Cmd) > 0 && c.Cmd[0] == "mkdir" && slices.Contains(c.Cmd, "/go/pkg/mod") {
+			mkdirAsRoot = true
+		}
+		if len(c.Cmd) > 0 && c.Cmd[0] == "chown" && slices.Contains(c.Cmd, "vscode") {
+			chownAsRoot = true
+		}
+	}
+	if !mkdirAsRoot || !chownAsRoot {
+		t.Errorf("expected root mkdir+chown for cache roots, got execs: %+v", mock.execCalls)
+	}
+}
+
+func TestManager_Up_CacheVolumes_RootUserSkipsChown(t *testing.T) {
+	projectDir, mock, docker := setupTestProject(t, `{"image": "ubuntu:22.04"}`)
+	writeCachesConfig(t, projectDir, "caches:\n  - name: go-mod\n    path: /go/pkg/mod\n")
+
+	mgr := &Manager{Docker: docker, Logger: testLogger()}
+	_, err := mgr.Up(context.Background(), UpOptions{ProjectDir: projectDir, Out: &bytes.Buffer{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(mock.createCalls[0].Binds, "human-cache-go-mod:/go/pkg/mod") {
+		t.Fatalf("volume bind missing: %v", mock.createCalls[0].Binds)
+	}
+	for _, c := range mock.execCalls {
+		if len(c.Cmd) > 0 && c.Cmd[0] == "chown" {
+			t.Errorf("root remoteUser must not trigger a chown exec: %+v", c)
+		}
+	}
+}
+
+func TestManager_Up_CacheVolumes_InvalidSkippedWithWarning(t *testing.T) {
+	projectDir, mock, docker := setupTestProject(t, `{"image": "ubuntu:22.04"}`)
+	writeCachesConfig(t, projectDir, `caches:
+  - name: ../escape
+    path: /data
+  - name: relative
+    path: data
+  - name: good
+    path: /data
+`)
+
+	var out bytes.Buffer
+	mgr := &Manager{Docker: docker, Logger: testLogger()}
+	_, err := mgr.Up(context.Background(), UpOptions{ProjectDir: projectDir, Out: &out})
+	if err != nil {
+		t.Fatal(err)
+	}
+	binds := mock.createCalls[0].Binds
+	if !slices.Contains(binds, "human-cache-good:/data") {
+		t.Errorf("valid entry missing: %v", binds)
+	}
+	for _, b := range binds {
+		if strings.Contains(b, "escape") || strings.Contains(b, "relative") {
+			t.Errorf("invalid entry reached binds: %v", binds)
+		}
+	}
+	if !strings.Contains(out.String(), "ignoring invalid cache volume") {
+		t.Errorf("expected warning, got: %s", out.String())
+	}
+}
+
+func TestManager_Up_NoCachesNoExtraExecs(t *testing.T) {
+	projectDir, mock, docker := setupTestProject(t, `{"image": "ubuntu:22.04", "remoteUser": "vscode"}`)
+
+	mgr := &Manager{Docker: docker, Logger: testLogger()}
+	_, err := mgr.Up(context.Background(), UpOptions{ProjectDir: projectDir, Out: &bytes.Buffer{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range mock.execCalls {
+		if len(c.Cmd) > 0 && (c.Cmd[0] == "chown" || c.Cmd[0] == "mkdir") {
+			t.Errorf("no caches declared but ownership exec ran: %+v", c)
+		}
+	}
+	for _, b := range mock.createCalls[0].Binds {
+		if strings.HasPrefix(b, "human-cache-") {
+			t.Errorf("unexpected cache bind: %v", b)
+		}
+	}
+}
+
+// writeCachesConfig drops a .humanconfig.yaml with the given content into the
+// test project dir.
+func writeCachesConfig(t *testing.T, projectDir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(projectDir, ".humanconfig.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/settings/schema.go
+++ b/internal/settings/schema.go
@@ -178,6 +178,10 @@ func buildRegistry() []SectionDef {
 				{Section: "devcontainer", Label: "Devcontainer", Fields: []Field{
 					{Key: "configdir", Label: "Config dir", Type: TypeString, Description: "Devcontainer config directory"},
 				}},
+				{Section: "caches", Label: "Cache volumes", Kind: "cache", IsList: true, Fields: []Field{
+					{Key: "name", Label: "Name", Type: TypeString, Description: "Named volume suffix (mounted as human-cache-<name>)"},
+					{Key: "path", Label: "Container path", Type: TypeString, Description: "Absolute path inside agent containers to keep warm across runs"},
+				}},
 			},
 		},
 	}


### PR DESCRIPTION
## What

The `caches:` section of `.humanconfig` declares persistent named Docker volumes and their container mount paths:

```yaml
caches:
  - name: go-build
    path: /home/vscode/.cache/go-build
  - name: go-mod
    path: /go/pkg/mod
```

Each entry mounts `human-cache-<name>` at the declared path in every container of the project — consecutive agent runs build warm instead of cold-downloading modules and recompiling the dependency tree (measured as the top time sink in 30+ min autofix runs). **Explicit opt-in, no autodetection**: a new ecosystem (npm, cargo, …) is a config entry, not a code change.

## How

- Named volumes ride the existing `Binds` plumbing (a non-path bind source is a named volume Docker auto-creates) — zero docker-wrapper changes.
- Loaded once in `devcontainer.Up` from ProjectDir, covering both the agent path and direct devcontainer use; invalid entries (relative path, slash in name) are skipped with a warning — a bad declaration costs the warm start, never the run.
- Fresh named volumes are root-owned, so for non-root remote users the volume roots get one non-recursive `mkdir -p` + `chown` exec as root after start (first root-exec in the codebase, scoped to the declared paths).
- Registered in the settings schema so the desktop Settings pane round-trips the key; documented in `.humanconfig.example` and the devcontainer README.

## Verification

Test-first: config validation table, Up bind assertions, chown-exec assertions (non-root yes / root no / no-caches no), invalid-entry warning, settings round-trip. `make check` green. Live dogfood after merge: add the two Go entries to the local `.humanconfig`, rebuild the daemon, run any board stage twice — second run's first build should be dramatically warmer (`docker volume ls | grep human-cache`).

Closes SC-783.

🤖 Generated with [Claude Code](https://claude.com/claude-code)