### PR TITLE
Deploy freshness gate fails on intermediate rebase conflicts when the end-state merge is clean

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -1653,6 +1653,18 @@ func (p forgeDeployer) PullRequestChecks(ctx context.Context, workspaceDir strin
 	return checker.PullRequestChecks(ctx, repo, number)
 }
 
+func (p forgeDeployer) PullRequestMergeable(ctx context.Context, workspaceDir string, number int) (bool, error) {
+	creator, repo, err := resolveForge(workspaceDir, p.lookup, p.resolver)
+	if err != nil {
+		return false, err
+	}
+	reader, ok := creator.(forge.MergeReader)
+	if !ok {
+		return false, errors.WithDetails("forge does not support reading mergeability", "repo", repo)
+	}
+	return reader.PullRequestMergeable(ctx, repo, number)
+}
+
 func (p forgeDeployer) MergePullRequest(ctx context.Context, workspaceDir string, number int) error {
 	creator, repo, err := resolveForge(workspaceDir, p.lookup, p.resolver)
 	if err != nil {

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -33,6 +33,11 @@ type Deployer interface {
 	// A returned error is a real conflict the mechanical path cannot resolve — the
 	// deploy must NOT attempt the merge blind, but fail loudly instead.
 	EnsureMergeable(ctx context.Context, req PRRequest) error
+	// PullRequestMergeable reports the forge's own end-state (three-way) merge
+	// verdict for the PR. It is the fallback signal when the mechanical rebase in
+	// EnsureMergeable conflicts on an intermediate commit the end-state merge
+	// never sees (SC-804).
+	PullRequestMergeable(ctx context.Context, workspaceDir string, number int) (bool, error)
 	MergePullRequest(ctx context.Context, workspaceDir string, number int) error
 	DeleteRemoteBranch(ctx context.Context, workspaceDir, branch string) error
 }
@@ -367,8 +372,14 @@ func (d BoardTransitionDeps) deploy(ctx context.Context, req BoardTransitionRequ
 		WorkspaceDir: d.WorkspaceDir,
 		Branch:       card.Branch,
 	}); err != nil {
-		d.deployFailed(req.PMKey, res.URL, "branch could not be made mergeable: "+err.Error())
-		return
+		// A rebase is strictly stronger than the forge's three-way end-state
+		// merge: it can conflict on an intermediate commit the merge never sees.
+		// Consult the forge's mergeable verdict and the green CI on the
+		// (rebase-aborted, unchanged) tip before redding the card (SC-804).
+		if !d.forgeMergeableFallback(ctx, res) {
+			d.deployFailed(req.PMKey, res.URL, "branch could not be made mergeable: "+err.Error())
+			return
+		}
 	}
 	if err := d.Deployer.MergePullRequest(ctx, d.WorkspaceDir, res.Number); err != nil {
 		d.deployFailed(req.PMKey, res.URL, err.Error())
@@ -382,6 +393,19 @@ func (d BoardTransitionDeps) deploy(ctx context.Context, req BoardTransitionRequ
 	_ = d.Deployer.DeleteRemoteBranch(ctx, d.WorkspaceDir, card.Branch)
 	_, _ = d.Commenter.AddComment(ctx, req.PMKey, StampDaemon(DeployedHeader+"\npr: "+res.URL, d.DaemonID))
 	d.closeTicketBestEffort(req.PMKey)
+}
+
+// forgeMergeableFallback reports whether the deploy may proceed to the merge
+// despite a failed mechanical rebase: true only when the forge reports the PR
+// mergeable AND CI is green on the tip. Any read error is treated as "do not
+// proceed" so the card reds rather than merging on an unknown state (SC-804).
+func (d BoardTransitionDeps) forgeMergeableFallback(ctx context.Context, res PRResult) bool {
+	mergeable, err := d.Deployer.PullRequestMergeable(ctx, d.WorkspaceDir, res.Number)
+	if err != nil || !mergeable {
+		return false
+	}
+	state, err := d.Deployer.PullRequestChecks(ctx, d.WorkspaceDir, res.Number)
+	return err == nil && state == forge.ChecksPassing
 }
 
 // closeTicketBestEffort runs the automated post-merge close. It never fails the

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -73,6 +73,11 @@ type fakeDeployer struct {
 	// mergeUntil models GitHub's 405 on a stale branch: MergePullRequest fails
 	// with a merge-conflict error until EnsureMergeable has run, then succeeds.
 	mergeUntil bool
+	// mergeable is the forge's own end-state merge verdict reported by
+	// PullRequestMergeable — the fallback signal when the mechanical rebase in
+	// EnsureMergeable conflicts on an intermediate commit (SC-804).
+	mergeable    bool
+	mergeableErr error
 }
 
 func (f *fakeDeployer) PushAndCreatePR(_ context.Context, req PRRequest) (PRResult, error) {
@@ -99,6 +104,13 @@ func (f *fakeDeployer) PullRequestChecks(_ context.Context, _ string, _ int) (fo
 func (f *fakeDeployer) EnsureMergeable(_ context.Context, _ PRRequest) error {
 	f.ensured++
 	return f.ensureErr
+}
+
+func (f *fakeDeployer) PullRequestMergeable(_ context.Context, _ string, _ int) (bool, error) {
+	if f.mergeableErr != nil {
+		return false, f.mergeableErr
+	}
+	return f.mergeable, nil
 }
 
 func (f *fakeDeployer) MergePullRequest(_ context.Context, _ string, _ int) error {
@@ -490,9 +502,10 @@ func TestApplyTransitionDeployRebasesStaleBranch(t *testing.T) {
 	}
 }
 
-// TestApplyTransitionDeployEnsureMergeableConflict covers a genuine rebase
-// conflict: EnsureMergeable fails, the deploy must NOT attempt the merge and
-// must red the card with a mergeability reason.
+// TestApplyTransitionDeployEnsureMergeableConflict covers a genuine end-state
+// conflict: the mechanical rebase in EnsureMergeable fails AND the forge itself
+// declines the merge (mergeable false). The deploy must NOT attempt the merge
+// and must red the card with a mergeability reason (SC-804).
 func TestApplyTransitionDeployEnsureMergeableConflict(t *testing.T) {
 	syncDeploy(t)
 	c := &fakeCommenter{comments: []tracker.Comment{
@@ -500,7 +513,8 @@ func TestApplyTransitionDeployEnsureMergeableConflict(t *testing.T) {
 		cmt("[human:review-complete]", time.Unix(2, 0)),
 	}}
 	p := &fakeDeployer{res: PRResult{URL: "https://example/pr/13", Number: 13},
-		checks: []forge.ChecksState{forge.ChecksPassing}, ensureErr: errors.New("rebase hit a conflict")}
+		checks:    []forge.ChecksState{forge.ChecksPassing},
+		ensureErr: errors.New("rebase hit a conflict"), mergeable: false}
 	deps := newDeps(c, &fakeLauncher{}, p)
 	err := deps.ApplyTransition(context.Background(),
 		BoardTransitionRequest{PMKey: "SC-1", From: BoardVerification, To: BoardDoneStage})
@@ -516,6 +530,37 @@ func TestApplyTransitionDeployEnsureMergeableConflict(t *testing.T) {
 	require.NotEmpty(t, failed)
 	assert.Contains(t, failed, "branch could not be made mergeable")
 	assert.Contains(t, failed, "rebase hit a conflict")
+}
+
+// TestApplyTransitionDeployRebaseConflictForgeMergeableFallback is the SC-804
+// regression: the mechanical rebase in EnsureMergeable conflicts on an
+// intermediate commit the forge's end-state three-way merge never sees, yet the
+// forge reports the PR mergeable and CI is green on the (rebase-aborted,
+// unchanged) tip. The deploy must fall back to the forge verdict and proceed to
+// the real merge instead of redding the card. On the pre-fix deploy() (which
+// reds on any EnsureMergeable error) the card reds and no merge happens — this
+// test fails there.
+func TestApplyTransitionDeployRebaseConflictForgeMergeableFallback(t *testing.T) {
+	syncDeploy(t)
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:ready-for-review]\nbranch: feat/x", time.Unix(1, 0)),
+		cmt("[human:review-complete]", time.Unix(2, 0)),
+	}}
+	p := &fakeDeployer{res: PRResult{URL: "https://example/pr/14", Number: 14},
+		checks:    []forge.ChecksState{forge.ChecksPassing},
+		ensureErr: errors.New("rebasing branch onto base"), mergeable: true}
+	deps := newDeps(c, &fakeLauncher{}, p)
+	err := deps.ApplyTransition(context.Background(),
+		BoardTransitionRequest{PMKey: "SC-1", PMTitle: "My feature", From: BoardVerification, To: BoardDoneStage})
+	require.NoError(t, err)
+	assert.Equal(t, 1, p.ensured, "the freshness stage must still run once")
+	assert.Equal(t, 1, p.merged, "a forge-mergeable, green-CI PR must merge despite the rebase conflict")
+	assert.Equal(t, []string{"feat/x"}, p.deleted)
+	assert.Contains(t, c.added, DeployedHeader+"\npr: https://example/pr/14")
+	for _, b := range c.added {
+		assert.False(t, strings.HasPrefix(b, DeployFailedHeader),
+			"a forge-mergeable PR must merge, never dead-end on deploy-failed: %q", b)
+	}
 }
 
 // TestIsDeployRetry pins the retry predicate: a failed done stage re-dropped on
@@ -910,6 +955,10 @@ func (f *gateProbeDeployer) PullRequestChecks(_ context.Context, _ string, _ int
 }
 
 func (f *gateProbeDeployer) EnsureMergeable(_ context.Context, _ PRRequest) error { return nil }
+
+func (f *gateProbeDeployer) PullRequestMergeable(_ context.Context, _ string, _ int) (bool, error) {
+	return true, nil
+}
 
 func (f *gateProbeDeployer) MergePullRequest(_ context.Context, _ string, _ int) error { return nil }
 

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -54,6 +54,13 @@ type Merger interface {
 	MergePullRequest(ctx context.Context, repo string, number int) error
 }
 
+// MergeReader reports the forge's own verdict on whether a pull request can be
+// merged into its base (the end-state three-way merge). It is consulted as a
+// fallback when a stronger local rebase conflicts on an intermediate commit.
+type MergeReader interface {
+	PullRequestMergeable(ctx context.Context, repo string, number int) (bool, error)
+}
+
 // BranchDeleter deletes a remote branch, used to clean up a pull request's
 // source branch after merging.
 type BranchDeleter interface {

--- a/internal/forge/github/client.go
+++ b/internal/forge/github/client.go
@@ -172,6 +172,27 @@ func (c *Client) pullHeadSHA(ctx context.Context, owner, repo string, number int
 	return pull.Head.SHA, nil
 }
 
+// PullRequestMergeable implements forge.MergeReader. GitHub computes the
+// mergeable flag asynchronously and returns null until it is ready; a null
+// value is reported as not mergeable so a caller never merges on an unknown
+// state.
+func (c *Client) PullRequestMergeable(ctx context.Context, repoName string, number int) (bool, error) {
+	owner, repo, err := splitProject(repoName)
+	if err != nil {
+		return false, err
+	}
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d", url.PathEscape(owner), url.PathEscape(repo), number)
+	resp, err := c.api.Do(ctx, http.MethodGet, path, "", nil)
+	if err != nil {
+		return false, err
+	}
+	var pull pullGetResponse
+	if err := apiclient.DecodeJSON(resp, &pull, "number", number); err != nil {
+		return false, err
+	}
+	return pull.Mergeable != nil && *pull.Mergeable, nil
+}
+
 // MergePullRequest implements forge.Merger with a merge commit, preserving the
 // branch's individual commits (and their ticket references) on the mainline.
 func (c *Client) MergePullRequest(ctx context.Context, repoName string, number int) error {

--- a/internal/forge/github/client_test.go
+++ b/internal/forge/github/client_test.go
@@ -118,6 +118,35 @@ func TestPullRequestChecks_verdicts(t *testing.T) {
 	}
 }
 
+func TestPullRequestMergeable_verdicts(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"mergeable true", `{"mergeable":true}`, true},
+		{"mergeable false", `{"mergeable":false}`, false},
+		// GitHub returns null while it computes the value asynchronously — treat
+		// it as not mergeable so a caller never merges on an unknown state.
+		{"mergeable null", `{"mergeable":null}`, false},
+		{"mergeable absent", `{}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/repos/octocat/hello-world/pulls/7", r.URL.Path)
+				_, _ = fmt.Fprint(w, tc.body)
+			}))
+			defer srv.Close()
+			client := New(srv.URL, "ghp_test")
+			mergeable, err := client.PullRequestMergeable(context.Background(), "octocat/hello-world", 7)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, mergeable)
+		})
+	}
+}
+
 func TestMergePullRequest_happy(t *testing.T) {
 	var gotBody mergeRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/forge/github/types.go
+++ b/internal/forge/github/types.go
@@ -17,6 +17,9 @@ type pullGetResponse struct {
 	Head struct {
 		SHA string `json:"sha"`
 	} `json:"head"`
+	// Mergeable is GitHub's end-state merge verdict. It is null while GitHub
+	// computes it asynchronously; a nil pointer is treated as not-yet-mergeable.
+	Mergeable *bool `json:"mergeable"`
 }
 
 type checkRunsResponse struct {


### PR DESCRIPTION
PM ticket: 804
Branch: autofix/804
