### PR TITLE
[SC-881] Offer Move to feature from the ideation done state

### DIFF
--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -1583,6 +1583,41 @@ function renderIdeationDraft() {
         descInput.dataset.sessionId = ideation.sessionId ?? "";
     }
 }
+// Keys whose "Move to feature" was already triggered this session: the board
+// snapshot can lag the transition for a poll tick or two, and the guard keeps
+// the button from re-arming (and double-launching an agent) in that window.
+const ideationMovedKeys = new Set();
+// renderIdeationDone fills the done-state status line. The created ticket is a
+// Product-backlog card, but the panel used to dead-end at "Created SC-XXX"
+// with no way to act on it (SC-881) — so the line carries a right-aligned
+// "Move to feature" action that launches the same backlog→planning transition
+// a drag onto the Engineering backlog would, for both chat and guided modes.
+function renderIdeationDone(statusLine) {
+    const key = ideation.createdKey ?? "";
+    statusLine.textContent = `Created ${key}`;
+    if (!key)
+        return;
+    const card = current.cards.find((c) => c.key === key);
+    // Once the ticket has left the backlog — via this button or a board drag —
+    // the move is spent; showing it armed again would offer a second launch.
+    const moved = ideationMovedKeys.has(key) || (card !== undefined && card.stage !== "backlog");
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "ideation-move-feature";
+    btn.textContent = moved ? "Moved to feature" : "Move to feature";
+    btn.disabled = moved || !current.dockerAvailable;
+    if (!moved && !current.dockerAvailable) {
+        btn.title = "Docker is required to launch the planning agent";
+    }
+    btn.onclick = () => {
+        if (ideationMovedKeys.has(key))
+            return;
+        ideationMovedKeys.add(key);
+        renderIdeation();
+        void transition(key, card?.title ?? "", card?.stage ?? "backlog", "planning");
+    };
+    statusLine.appendChild(btn);
+}
 function renderIdeation() {
     const transcript = document.getElementById("ideation-transcript");
     if (!transcript)
@@ -1602,7 +1637,7 @@ function renderIdeation() {
             statusLine.classList.add("error");
         }
         else if (ideation.state === "done") {
-            statusLine.textContent = `Created ${ideation.createdKey ?? ""}`;
+            renderIdeationDone(statusLine);
         }
         else {
             statusLine.classList.add("hidden");

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -996,9 +996,31 @@ body {
 }
 
 .ideation-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   padding: 6px 12px;
   font-size: 12px;
   color: var(--muted);
+}
+
+/* Done-state forward action (SC-881): right-aligned so the status text and
+   the ticket's next move read as one line, never a second dead-end row. */
+.ideation-move-feature {
+  margin-left: auto;
+  background: var(--accent);
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.ideation-move-feature:disabled {
+  opacity: 0.55;
+  cursor: default;
 }
 
 .ideation-status.hidden {

--- a/desktop/frontend/scripts/ideation-done.test.mjs
+++ b/desktop/frontend/scripts/ideation-done.test.mjs
@@ -1,0 +1,41 @@
+// Regression guard for SC-881: the ideation panel's done state must not
+// dead-end at "Created SC-XXX" — it has to offer the created ticket's forward
+// move ("Move to feature", the backlog→planning transition a drag onto the
+// Engineering backlog would launch). The frontend is intentionally
+// dependency-free (no DOM test runner), so this asserts the source wiring
+// rather than rendering, like style.test.mjs.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const ts = readFileSync(resolve(here, "..", "src", "board.ts"), "utf8");
+const css = readFileSync(resolve(here, "..", "static", "style.css"), "utf8");
+
+test("done state renders an action, not a bare created line", () => {
+  assert.match(
+    ts,
+    /state === "done"\)\s*\{\s*renderIdeationDone\(/,
+    "the done branch must delegate to renderIdeationDone so the state carries an affordance",
+  );
+});
+
+test("Move to feature launches the backlog→planning transition", () => {
+  const fn = ts.slice(ts.indexOf("function renderIdeationDone"));
+  assert.ok(fn.length > 0, "renderIdeationDone must exist");
+  const body = fn.slice(0, fn.indexOf("\n}"));
+  assert.match(body, /ideation-move-feature/, "the action button must carry its style hook");
+  assert.match(body, /transition\([^)]*"planning"\)/, "the button must launch the planning transition");
+  assert.match(body, /ideationMovedKeys/, "a spent move must not re-arm (double agent launch)");
+  assert.match(body, /dockerAvailable/, "the launch must gate on Docker like every queue drop");
+});
+
+test("the action is styled as a right-aligned status-line button", () => {
+  const stripped = css.replace(/\/\*[\s\S]*?\*\//g, "");
+  const m = stripped.match(/\.ideation-move-feature\s*\{([^}]*)\}/);
+  assert.ok(m, ".ideation-move-feature rule must exist");
+  assert.match(m[1], /margin-left:\s*auto/, "button must right-align inside the status line");
+  assert.match(stripped, /\.ideation-move-feature:disabled\s*\{[^}]*opacity/, "spent/blocked state needs a visible disabled style");
+});

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -1898,6 +1898,42 @@ function renderIdeationDraft(): void {
   }
 }
 
+// Keys whose "Move to feature" was already triggered this session: the board
+// snapshot can lag the transition for a poll tick or two, and the guard keeps
+// the button from re-arming (and double-launching an agent) in that window.
+const ideationMovedKeys = new Set<string>();
+
+// renderIdeationDone fills the done-state status line. The created ticket is a
+// Product-backlog card, but the panel used to dead-end at "Created SC-XXX"
+// with no way to act on it (SC-881) — so the line carries a right-aligned
+// "Move to feature" action that launches the same backlog→planning transition
+// a drag onto the Engineering backlog would, for both chat and guided modes.
+function renderIdeationDone(statusLine: HTMLElement): void {
+  const key = ideation.createdKey ?? "";
+  statusLine.textContent = `Created ${key}`;
+  if (!key) return;
+
+  const card = current.cards.find((c) => c.key === key);
+  // Once the ticket has left the backlog — via this button or a board drag —
+  // the move is spent; showing it armed again would offer a second launch.
+  const moved = ideationMovedKeys.has(key) || (card !== undefined && card.stage !== "backlog");
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "ideation-move-feature";
+  btn.textContent = moved ? "Moved to feature" : "Move to feature";
+  btn.disabled = moved || !current.dockerAvailable;
+  if (!moved && !current.dockerAvailable) {
+    btn.title = "Docker is required to launch the planning agent";
+  }
+  btn.onclick = () => {
+    if (ideationMovedKeys.has(key)) return;
+    ideationMovedKeys.add(key);
+    renderIdeation();
+    void transition(key, card?.title ?? "", card?.stage ?? "backlog", "planning");
+  };
+  statusLine.appendChild(btn);
+}
+
 function renderIdeation(): void {
   const transcript = document.getElementById("ideation-transcript");
   if (!transcript) return;
@@ -1915,7 +1951,7 @@ function renderIdeation(): void {
       statusLine.textContent = ideation.error || "Ideation session failed";
       statusLine.classList.add("error");
     } else if (ideation.state === "done") {
-      statusLine.textContent = `Created ${ideation.createdKey ?? ""}`;
+      renderIdeationDone(statusLine);
     } else {
       statusLine.classList.add("hidden");
     }

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -996,9 +996,31 @@ body {
 }
 
 .ideation-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   padding: 6px 12px;
   font-size: 12px;
   color: var(--muted);
+}
+
+/* Done-state forward action (SC-881): right-aligned so the status text and
+   the ticket's next move read as one line, never a second dead-end row. */
+.ideation-move-feature {
+  margin-left: auto;
+  background: var(--accent);
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.ideation-move-feature:disabled {
+  opacity: 0.55;
+  cursor: default;
 }
 
 .ideation-status.hidden {


### PR DESCRIPTION
Fixes SC-881 (confirmed design gap: the ideation panel dead-ended after ticket creation).

After approving a draft (guided) or the agent creating the ticket (chat), the New-ticket panel showed only `Created SC-XXX` — no action on the created ticket was reachable from that state. The created ticket is a Product-backlog card, so the meaningful forward move is the same one a drag onto the Engineering backlog performs.

- The done-state status line now carries a right-aligned **Move to feature** button that launches the `backlog → planning` transition on the created key (both chat and guided modes — the done branch is mode-agnostic).
- Gated on Docker availability like every queue drop (`targetEnabled` semantics), with a tooltip when blocked.
- Spent after one use: a session-local guard plus the card's live stage keep the button from re-arming and double-launching a planning agent while the board snapshot lags.
- Regression test `scripts/ideation-done.test.mjs` (source-assertion style, like `style.test.mjs`): fails 3/3 before the fix, passes after.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)