### PR TITLE
Failure marker claims agent 'died and was reaped' when the run exited cleanly

### DIFF
--- a/internal/agent/diagnose.go
+++ b/internal/agent/diagnose.go
@@ -163,14 +163,17 @@ func lastErrorLine(lines []string) string {
 }
 
 // headlineFor implements the interpretation table, most-specific signal first:
-// the hook's own error type beats artifact inference, a reap beats exit codes
-// (the reaped process's code is the killer's, not the cause), known exit codes
-// beat the error-line heuristic.
+// the hook's own error type beats artifact inference, a reap beats only a
+// nonzero (killed) exit code — the reaped process's code is the killer's, not
+// the cause — but a recorded clean exit (code 0) is direct evidence of a
+// normal self-termination and overrides the reap, known exit codes beat the
+// error-line heuristic.
 func headlineFor(hookErrorType string, reaped bool, exitCode int, haveExit bool, errLine string) string {
 	if h := hookHeadline(hookErrorType); h != "" {
 		return h
 	}
-	if reaped {
+	cleanExit := haveExit && exitCode == 0
+	if reaped && !cleanExit {
 		return "agent process died and was reaped (crashed or killed; daemon restart or container death)"
 	}
 	if haveExit {
@@ -201,7 +204,7 @@ func exitHeadline(code int, errLine string) string {
 		if errLine != "" {
 			return "agent finished without posting the stage handoff: " + errLine
 		}
-		return genericFailureHeadline
+		return "agent finished without posting the stage handoff"
 	case 124:
 		return "agent process timed out (exit 124)"
 	case 137:

--- a/internal/agent/diagnose_test.go
+++ b/internal/agent/diagnose_test.go
@@ -79,6 +79,40 @@ func TestDiagnoseFailure_Reaped(t *testing.T) {
 	}
 }
 
+// A run stamped "reaped" by the zombie sweep but carrying a recorded clean exit
+// (code 0) self-terminated normally — it must not be reported as a crash/kill.
+func TestHeadlineFor_ReapedButCleanExit(t *testing.T) {
+	got := headlineFor("", true, 0, true, "")
+	want := "agent finished without posting the stage handoff"
+	if got != want {
+		t.Fatalf("headline = %q, want %q", got, want)
+	}
+}
+
+// A reap still beats a nonzero (killed) exit code — the reaped process's code is
+// the killer's, not the cause.
+func TestHeadlineFor_ReapedNonzeroExitStaysReaped(t *testing.T) {
+	if got := headlineFor("", true, 137, true, ""); !strings.Contains(got, "reaped") {
+		t.Fatalf("headline = %q, want it to contain %q", got, "reaped")
+	}
+}
+
+// End-to-end: a reaped outcome plus a clean-exit trailer in output.log resolves
+// to the handoff-missing headline, never the reaped-crash wording.
+func TestDiagnoseFailure_ReapedWithCleanExitTrailer(t *testing.T) {
+	withLogRoot(t)
+	withInstantDiagnosis(t)
+	newRunFixture(t, "board-SC-878-planning", "all quiet\n"+execExitTrailerPrefix+"0\n",
+		&OutcomeRecord{Reason: "reaped", EndedAt: time.Now()})
+	d := DiagnoseFailure("board-SC-878-planning", "")
+	if d.Headline != "agent finished without posting the stage handoff" {
+		t.Fatalf("headline = %q", d.Headline)
+	}
+	if strings.Contains(d.Headline, "reaped") {
+		t.Fatalf("headline unexpectedly reaped: %q", d.Headline)
+	}
+}
+
 func TestDiagnoseFailure_Exit137(t *testing.T) {
 	withLogRoot(t)
 	withInstantDiagnosis(t)
@@ -120,12 +154,12 @@ func TestDiagnoseFailure_ExitZeroWithErrorLine(t *testing.T) {
 	}
 }
 
-func TestDiagnoseFailure_ExitZeroNoErrorLineIsGeneric(t *testing.T) {
+func TestDiagnoseFailure_ExitZeroNoErrorLineIsHandoffMissing(t *testing.T) {
 	withLogRoot(t)
 	withInstantDiagnosis(t)
 	newRunFixture(t, "board-SC-6-planning", "all quiet\n"+execExitTrailerPrefix+"0\n", nil)
 	d := DiagnoseFailure("board-SC-6-planning", "")
-	if d.Headline != genericFailureHeadline {
+	if d.Headline != "agent finished without posting the stage handoff" {
 		t.Fatalf("headline = %q", d.Headline)
 	}
 }


### PR DESCRIPTION
PM ticket: 878
Branch: autofix/878
