### PR TITLE
[SC-1000] Isolate the deploy freshness rebase in an ephemeral worktree

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -1603,9 +1603,13 @@ func (p forgeDeployer) pushBranch(ctx context.Context, dir, branch string) error
 // EnsureMergeable makes the handoff branch current with the base before the
 // deploy attempts the merge: it fetches the base, and when the branch does not
 // already contain the base tip it rebases the branch onto origin/<base>,
-// re-pushes (lease when the branch is on origin), and re-verifies. A rebase error
-// is a real conflict the mechanical path cannot resolve — the deploy must fail
-// loudly rather than merge blind (735).
+// re-pushes (lease when the branch is on origin), and re-verifies. The rebase
+// runs in an ephemeral detached worktree, never in the live workspace checkout:
+// git refuses to rebase in a dirty worktree, so ANY uncommitted user change
+// would fail every deploy — and a rebase that did run would check the handoff
+// branch out under the user (SC-1000). A rebase error is a real conflict the
+// mechanical path cannot resolve — the deploy must fail loudly rather than
+// merge blind (735).
 func (p forgeDeployer) EnsureMergeable(ctx context.Context, req daemon.PRRequest) error {
 	dir, branch := req.WorkspaceDir, req.Branch
 	base := gitrepo.DefaultBranch(ctx, dir)
@@ -1613,38 +1617,77 @@ func (p forgeDeployer) EnsureMergeable(ctx context.Context, req daemon.PRRequest
 		return err
 	}
 	originBase := "origin/" + base
-	// Already current: the branch contains the base tip, so its PR is mergeable
-	// without touching it.
-	if gitrepo.IsAncestor(ctx, dir, originBase, branch) {
-		return nil
-	}
-	// Record the remote tip so the post-rebase push can lease against it — only
-	// meaningful when the branch is already on origin.
-	var remoteSHA string
-	onOrigin := gitrepo.BranchExistsRemote(ctx, dir, branch)
-	if onOrigin {
-		sha, err := gitrepo.RevParse(ctx, dir, "origin/"+branch)
-		if err != nil {
-			return err
-		}
-		remoteSHA = sha
-	}
-	if err := gitrepo.Rebase(ctx, dir, originBase, branch); err != nil {
+	tip, onOrigin, err := branchTip(ctx, dir, branch)
+	if err != nil {
 		return err
 	}
+	// Already current: the branch contains the base tip, so its PR is mergeable
+	// without touching it.
+	if gitrepo.IsAncestor(ctx, dir, originBase, tip) {
+		return nil
+	}
+	wt, cleanup, err := addEphemeralWorktree(ctx, dir, tip)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	if err := gitrepo.RebaseHead(ctx, wt, originBase); err != nil {
+		return err
+	}
+	newTip, err := gitrepo.RevParse(ctx, wt, "HEAD")
+	if err != nil {
+		return err
+	}
+	// The worktree rebased a detached HEAD, so publishing is a refspec push of
+	// the worktree's HEAD — the branch itself is never checked out anywhere.
+	// Lease against the recorded pre-rebase tip when the branch is on origin so
+	// a concurrent push is refused, not clobbered.
 	if onOrigin {
-		if err := gitrepo.PushWithLease(ctx, dir, branch, remoteSHA); err != nil {
+		if err := gitrepo.PushHeadWithLease(ctx, wt, branch, tip); err != nil {
 			return err
 		}
-	} else if err := gitrepo.Push(ctx, dir, branch); err != nil {
+	} else if err := gitrepo.PushHead(ctx, wt, branch); err != nil {
 		return err
 	}
 	// A clean rebase that still does not contain the base tip means the branch
 	// could not be made mergeable — surface it rather than merge into a conflict.
-	if !gitrepo.IsAncestor(ctx, dir, originBase, branch) {
+	if !gitrepo.IsAncestor(ctx, dir, originBase, newTip) {
 		return errors.WithDetails("branch still not mergeable after rebase", "branch", branch, "base", base)
 	}
 	return nil
+}
+
+// branchTip resolves the commit the freshness rebase starts from, preferring
+// the origin ref: the deploy serves the PR (which lives on origin), and the
+// local ref may lag a prior deploy's rebase — the ephemeral-worktree rebase
+// publishes to origin without rewriting local branches. The origin ref is
+// fetched first so the recorded tip is the actual remote state, not a stale
+// tracking ref.
+func branchTip(ctx context.Context, dir, branch string) (sha string, onOrigin bool, err error) {
+	if gitrepo.BranchExistsRemote(ctx, dir, branch) {
+		if err := gitrepo.Fetch(ctx, dir, branch); err != nil {
+			return "", true, err
+		}
+		sha, err := gitrepo.RevParse(ctx, dir, "origin/"+branch)
+		return sha, true, err
+	}
+	sha, err = gitrepo.RevParse(ctx, dir, branch)
+	return sha, false, err
+}
+
+// addEphemeralWorktree creates a throwaway detached worktree at tip, sharing
+// dir's object DB, and returns its path plus a cleanup that removes it. The
+// rebase result's objects survive removal in the shared DB.
+func addEphemeralWorktree(ctx context.Context, dir, tip string) (string, func(), error) {
+	wt, err := os.MkdirTemp("", "human-deploy-rebase-")
+	if err != nil {
+		return "", nil, errors.WrapWithDetails(err, "creating ephemeral rebase worktree dir")
+	}
+	if err := gitrepo.WorktreeAdd(ctx, dir, wt, tip); err != nil {
+		_ = os.RemoveAll(wt)
+		return "", nil, err
+	}
+	return wt, func() { _ = gitrepo.WorktreeRemove(ctx, dir, wt) }, nil
 }
 
 func (p forgeDeployer) PullRequestChecks(ctx context.Context, workspaceDir string, number int) (forge.ChecksState, error) {

--- a/cmd/cmddaemon/deployer_rebase_test.go
+++ b/cmd/cmddaemon/deployer_rebase_test.go
@@ -1,0 +1,253 @@
+package cmddaemon
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/daemon"
+	"github.com/gethuman-sh/human/internal/gitrepo"
+)
+
+// rebaseGitStubs stubs every gitrepo entry point EnsureMergeable touches and
+// records the calls, so the tests can assert the freshness rebase never
+// operates on the live workspace checkout (SC-1000).
+type rebaseGitStubs struct {
+	t *testing.T
+	// call log entries: "<op> <dir> [args...]"
+	calls []string
+	// worktree path handed out by WorktreeAdd, to verify later ops target it
+	worktreePath string
+
+	branchOnRemote bool
+	localTip       string
+	remoteTip      string
+	ancestorAfter  bool
+	rebaseErr      error
+}
+
+func (s *rebaseGitStubs) install() {
+	prevDefault, prevFetch, prevExistsRemote, prevRevParse := gitrepo.DefaultBranch, gitrepo.Fetch, gitrepo.BranchExistsRemote, gitrepo.RevParse
+	prevIsAncestor, prevAdd, prevRemove := gitrepo.IsAncestor, gitrepo.WorktreeAdd, gitrepo.WorktreeRemove
+	prevRebaseHead, prevPushHead, prevPushHeadLease := gitrepo.RebaseHead, gitrepo.PushHead, gitrepo.PushHeadWithLease
+	s.t.Cleanup(func() {
+		gitrepo.DefaultBranch, gitrepo.Fetch, gitrepo.BranchExistsRemote, gitrepo.RevParse = prevDefault, prevFetch, prevExistsRemote, prevRevParse
+		gitrepo.IsAncestor, gitrepo.WorktreeAdd, gitrepo.WorktreeRemove = prevIsAncestor, prevAdd, prevRemove
+		gitrepo.RebaseHead, gitrepo.PushHead, gitrepo.PushHeadWithLease = prevRebaseHead, prevPushHead, prevPushHeadLease
+	})
+
+	gitrepo.DefaultBranch = func(_ context.Context, _ string) string { return "main" }
+	gitrepo.Fetch = func(_ context.Context, dir, branch string) error {
+		s.calls = append(s.calls, "fetch "+dir+" "+branch)
+		return nil
+	}
+	gitrepo.BranchExistsRemote = func(_ context.Context, _, _ string) bool { return s.branchOnRemote }
+	gitrepo.RevParse = func(_ context.Context, dir, rev string) (string, error) {
+		s.calls = append(s.calls, "rev-parse "+dir+" "+rev)
+		switch {
+		case rev == "HEAD":
+			return "rebasedtip", nil
+		case strings.HasPrefix(rev, "origin/"):
+			return s.remoteTip, nil
+		}
+		return s.localTip, nil
+	}
+	gitrepo.IsAncestor = func(_ context.Context, _, _, descendant string) bool {
+		if descendant == "rebasedtip" {
+			return s.ancestorAfter
+		}
+		return false
+	}
+	gitrepo.WorktreeAdd = func(_ context.Context, repoDir, worktreePath, base string) error {
+		s.worktreePath = worktreePath
+		s.calls = append(s.calls, "worktree-add "+repoDir+" "+base)
+		return nil
+	}
+	gitrepo.WorktreeRemove = func(_ context.Context, _, worktreePath string) error {
+		s.calls = append(s.calls, "worktree-remove "+worktreePath)
+		return nil
+	}
+	gitrepo.RebaseHead = func(_ context.Context, dir, base string) error {
+		s.calls = append(s.calls, "rebase "+dir+" "+base)
+		return s.rebaseErr
+	}
+	gitrepo.PushHead = func(_ context.Context, dir, branch string) error {
+		s.calls = append(s.calls, "push-head "+dir+" "+branch)
+		return nil
+	}
+	gitrepo.PushHeadWithLease = func(_ context.Context, dir, branch, expected string) error {
+		s.calls = append(s.calls, "push-head-lease "+dir+" "+branch+" "+expected)
+		return nil
+	}
+}
+
+func (s *rebaseGitStubs) sawCall(prefix string) bool {
+	for _, c := range s.calls {
+		if strings.HasPrefix(c, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+const rebaseTestWorkspace = "/live/checkout"
+
+func ensureMergeable(t *testing.T, s *rebaseGitStubs) error {
+	t.Helper()
+	s.t = t
+	s.install()
+	return forgeDeployer{}.EnsureMergeable(context.Background(), daemon.PRRequest{
+		WorkspaceDir: rebaseTestWorkspace,
+		Branch:       "autofix/999",
+	})
+}
+
+func TestEnsureMergeable_currentBranchSkipsRebase(t *testing.T) {
+	s := &rebaseGitStubs{branchOnRemote: true, remoteTip: "rebasedtip", ancestorAfter: true}
+	if err := ensureMergeable(t, s); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.sawCall("worktree-add") || s.sawCall("rebase") {
+		t.Errorf("branch already containing the base tip must not rebase, calls: %v", s.calls)
+	}
+}
+
+func TestEnsureMergeable_rebasesInEphemeralWorktreeNotWorkspace(t *testing.T) {
+	s := &rebaseGitStubs{branchOnRemote: true, remoteTip: "staletip", ancestorAfter: true}
+	if err := ensureMergeable(t, s); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !s.sawCall("worktree-add "+rebaseTestWorkspace+" staletip") {
+		t.Errorf("expected detached worktree at the origin tip, calls: %v", s.calls)
+	}
+	if s.worktreePath == rebaseTestWorkspace || s.worktreePath == "" {
+		t.Fatalf("worktree path must be an ephemeral dir, got %q", s.worktreePath)
+	}
+	if !s.sawCall("rebase " + s.worktreePath + " origin/main") {
+		t.Errorf("rebase must run in the ephemeral worktree, calls: %v", s.calls)
+	}
+	if s.sawCall("rebase " + rebaseTestWorkspace) {
+		t.Errorf("rebase must never run in the live workspace checkout, calls: %v", s.calls)
+	}
+	if !s.sawCall("push-head-lease " + s.worktreePath + " autofix/999 staletip") {
+		t.Errorf("rebased tip must lease-push from the worktree against the recorded remote tip, calls: %v", s.calls)
+	}
+	if !s.sawCall("worktree-remove " + s.worktreePath) {
+		t.Errorf("ephemeral worktree must be removed, calls: %v", s.calls)
+	}
+}
+
+func TestEnsureMergeable_conflictStillRemovesWorktree(t *testing.T) {
+	s := &rebaseGitStubs{branchOnRemote: true, remoteTip: "staletip", rebaseErr: errors.WithDetails("conflict")}
+	if err := ensureMergeable(t, s); err == nil {
+		t.Fatal("expected the rebase conflict to fail the deploy")
+	}
+	if !s.sawCall("worktree-remove") {
+		t.Errorf("ephemeral worktree must be removed after a conflict, calls: %v", s.calls)
+	}
+	if s.sawCall("push-head") {
+		t.Errorf("a failed rebase must not push, calls: %v", s.calls)
+	}
+}
+
+func TestEnsureMergeable_localOnlyBranchPushesPlain(t *testing.T) {
+	s := &rebaseGitStubs{branchOnRemote: false, localTip: "localtip", ancestorAfter: true}
+	if err := ensureMergeable(t, s); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !s.sawCall("worktree-add "+rebaseTestWorkspace+" localtip") {
+		t.Errorf("local-only branch must rebase from the local tip, calls: %v", s.calls)
+	}
+	if !s.sawCall("push-head " + s.worktreePath + " autofix/999") {
+		t.Errorf("local-only branch must plain-push (no lease target), calls: %v", s.calls)
+	}
+}
+
+func TestEnsureMergeable_stillBehindAfterRebaseFails(t *testing.T) {
+	s := &rebaseGitStubs{branchOnRemote: true, remoteTip: "staletip", ancestorAfter: false}
+	if err := ensureMergeable(t, s); err == nil {
+		t.Fatal("expected an error when the rebased tip still lacks the base")
+	}
+}
+
+// runGit is the real-git test helper: it runs git with a deterministic identity
+// and fails the test on any error, so setup reads as a script.
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	base := []string{"-C", dir, "-c", "user.name=t", "-c", "user.email=t@t", "-c", "commit.gpgsign=false"}
+	out, err := exec.Command("git", append(base, args...)...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// TestEnsureMergeable_realGit_dirtyWorkspaceUntouched drives the full freshness
+// rebase against a real repository: the workspace checkout is DIRTY (the exact
+// condition that used to fail every deploy) and must stay bit-for-bit untouched
+// while the stale handoff branch is rebased onto the advanced base and
+// published to origin (SC-1000).
+func TestEnsureMergeable_realGit_dirtyWorkspaceUntouched(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	root := t.TempDir()
+	origin := filepath.Join(root, "origin.git")
+	runGit(t, root, "init", "--bare", "-b", "main", origin)
+	ws := filepath.Join(root, "ws")
+	runGit(t, root, "clone", origin, ws)
+
+	// Base commit on main.
+	if err := os.WriteFile(filepath.Join(ws, "a.txt"), []byte("one\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, ws, "add", "a.txt")
+	runGit(t, ws, "commit", "-m", "base")
+	runGit(t, ws, "push", "-u", "origin", "main")
+
+	// Handoff branch with its own commit, pushed, then main advances past it.
+	runGit(t, ws, "checkout", "-b", "autofix/x")
+	if err := os.WriteFile(filepath.Join(ws, "fix.txt"), []byte("fix\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, ws, "add", "fix.txt")
+	runGit(t, ws, "commit", "-m", "fix")
+	runGit(t, ws, "push", "origin", "autofix/x")
+	runGit(t, ws, "checkout", "main")
+	if err := os.WriteFile(filepath.Join(ws, "b.txt"), []byte("two\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, ws, "add", "b.txt")
+	runGit(t, ws, "commit", "-m", "advance")
+	runGit(t, ws, "push", "origin", "main")
+
+	// The user's live state: HEAD on main with an uncommitted modification.
+	if err := os.WriteFile(filepath.Join(ws, "a.txt"), []byte("uncommitted edit\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := forgeDeployer{}.EnsureMergeable(context.Background(), daemon.PRRequest{WorkspaceDir: ws, Branch: "autofix/x"})
+	if err != nil {
+		t.Fatalf("EnsureMergeable on a dirty workspace must succeed, got: %v", err)
+	}
+
+	// The published branch contains the advanced base.
+	runGit(t, ws, "fetch", "origin")
+	mainTip := runGit(t, ws, "rev-parse", "origin/main")
+	if out, e := exec.Command("git", "-C", ws, "merge-base", "--is-ancestor", mainTip, "origin/autofix/x").CombinedOutput(); e != nil {
+		t.Errorf("origin/autofix/x must contain the base tip after the deploy rebase: %s", out)
+	}
+
+	// The user's checkout is untouched: same branch, same dirty edit.
+	if head := runGit(t, ws, "rev-parse", "--abbrev-ref", "HEAD"); head != "main" {
+		t.Errorf("workspace HEAD moved to %q — the deploy hijacked the checkout", head)
+	}
+	content, err := os.ReadFile(filepath.Join(ws, "a.txt"))
+	if err != nil || string(content) != "uncommitted edit\n" {
+		t.Errorf("uncommitted user edit was disturbed: %q (err %v)", content, err)
+	}
+}

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -79,18 +79,46 @@ var RevParse = func(ctx context.Context, dir, rev string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// Rebase replays branch onto base in the repository at dir (running
-// `git -C <dir> rebase <base> <branch>`). On failure it aborts the in-progress
-// rebase so the worktree is never left mid-rebase for the next pipeline step;
-// the returned error signals a real conflict the mechanical path cannot resolve.
-// Package var so callers can stub git access in tests.
-var Rebase = func(ctx context.Context, dir, base, branch string) error {
-	if _, err := runner(ctx, "git", "-C", dir, "rebase", base, branch); err != nil {
+// RebaseHead replays the current (detached) HEAD of the worktree at dir onto
+// base (running `git -C <dir> rebase <base>`). The deploy's freshness rebase
+// runs through this in an ephemeral detached worktree so the live workspace
+// checkout — whose dirty state would refuse the rebase and whose HEAD must
+// never be hijacked — is not involved (SC-1000). On failure it aborts the
+// in-progress rebase so the worktree is never left mid-rebase; the returned
+// error signals a real conflict the mechanical path cannot resolve. Package var
+// so callers can stub git access in tests.
+var RebaseHead = func(ctx context.Context, dir, base string) error {
+	if _, err := runner(ctx, "git", "-C", dir, "rebase", base); err != nil {
 		// Leaving a half-applied rebase would strand the worktree; abort so a
 		// retry starts from a clean state. The abort's own error is irrelevant —
 		// the conflict is the failure we report.
 		_, _ = runner(ctx, "git", "-C", dir, "rebase", "--abort")
-		return errors.WrapWithDetails(err, "rebasing branch onto base", "dir", dir, "base", base, "branch", branch)
+		return errors.WrapWithDetails(err, "rebasing branch onto base", "dir", dir, "base", base)
+	}
+	return nil
+}
+
+// PushHead pushes the current HEAD of the worktree at dir to refs/heads/<branch>
+// on origin (running `git -C <dir> push origin HEAD:refs/heads/<branch>`),
+// publishing a detached rebase result without ever checking the branch out.
+// Package var so callers can stub git access in tests.
+var PushHead = func(ctx context.Context, dir, branch string) error {
+	if _, err := runner(ctx, "git", "-C", dir, "push", "origin", "HEAD:refs/heads/"+branch); err != nil {
+		return errors.WrapWithDetails(err, "pushing HEAD to origin branch", "dir", dir, "branch", branch)
+	}
+	return nil
+}
+
+// PushHeadWithLease force-pushes the current HEAD of the worktree at dir to
+// refs/heads/<branch> on origin only if the remote tip still matches
+// expectedRemoteSHA. Like PushWithLease, the lease is what lets a rebased tip
+// advance a diverged remote WITHOUT clobbering a concurrent push; like
+// PushHead, the refspec form publishes a detached HEAD without a branch
+// checkout. Package var so callers can stub git access in tests.
+var PushHeadWithLease = func(ctx context.Context, dir, branch, expectedRemoteSHA string) error {
+	lease := "--force-with-lease=" + branch + ":" + expectedRemoteSHA
+	if _, err := runner(ctx, "git", "-C", dir, "push", lease, "origin", "HEAD:refs/heads/"+branch); err != nil {
+		return errors.WrapWithDetails(err, "lease-pushing HEAD to origin branch", "dir", dir, "branch", branch, "expected", expectedRemoteSHA)
 	}
 	return nil
 }

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -286,42 +286,6 @@ func TestRevParse_error(t *testing.T) {
 	}
 }
 
-func TestRebase_argv(t *testing.T) {
-	var gotArgs []string
-	withRunner(t, func(_ context.Context, name string, args ...string) ([]byte, error) {
-		gotArgs = append([]string{name}, args...)
-		return nil, nil
-	})
-	if err := Rebase(context.Background(), "/repo", "origin/main", "feat/x"); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	assertArgs(t, gotArgs, []string{"git", "-C", "/repo", "rebase", "origin/main", "feat/x"})
-}
-
-func TestRebase_conflictAborts(t *testing.T) {
-	var calls [][]string
-	withRunner(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
-		calls = append(calls, args)
-		// The rebase itself fails; the abort (a later call) must still run.
-		if len(args) >= 3 && args[2] == "rebase" && (len(args) < 4 || args[3] != "--abort") {
-			return nil, errors.New("conflict")
-		}
-		return nil, nil
-	})
-	if err := Rebase(context.Background(), "/repo", "origin/main", "feat/x"); err == nil {
-		t.Fatal("expected error on rebase conflict")
-	}
-	var sawAbort bool
-	for _, c := range calls {
-		if len(c) >= 4 && c[2] == "rebase" && c[3] == "--abort" {
-			sawAbort = true
-		}
-	}
-	if !sawAbort {
-		t.Error("rebase conflict must abort the in-progress rebase")
-	}
-}
-
 func TestPushWithLease_argv(t *testing.T) {
 	var gotArgs []string
 	withRunner(t, func(_ context.Context, name string, args ...string) ([]byte, error) {
@@ -452,5 +416,76 @@ func TestWorktreeRemove_error(t *testing.T) {
 	})
 	if err := WorktreeRemove(context.Background(), "/repo", "/wt"); err == nil {
 		t.Fatal("expected error when worktree remove fails")
+	}
+}
+
+func TestRebaseHead_argv(t *testing.T) {
+	var gotArgs []string
+	withRunner(t, func(_ context.Context, name string, args ...string) ([]byte, error) {
+		gotArgs = append([]string{name}, args...)
+		return nil, nil
+	})
+	if err := RebaseHead(context.Background(), "/wt", "origin/main"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertArgs(t, gotArgs, []string{"git", "-C", "/wt", "rebase", "origin/main"})
+}
+
+func TestRebaseHead_conflictAborts(t *testing.T) {
+	var calls [][]string
+	withRunner(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		calls = append(calls, args)
+		if len(args) >= 3 && args[2] == "rebase" && (len(args) < 4 || args[3] != "--abort") {
+			return nil, errors.New("conflict")
+		}
+		return nil, nil
+	})
+	if err := RebaseHead(context.Background(), "/wt", "origin/main"); err == nil {
+		t.Fatal("expected error on rebase conflict")
+	}
+	var sawAbort bool
+	for _, c := range calls {
+		if len(c) >= 4 && c[2] == "rebase" && c[3] == "--abort" {
+			sawAbort = true
+		}
+	}
+	if !sawAbort {
+		t.Error("rebase conflict must abort the in-progress rebase")
+	}
+}
+
+func TestPushHead_argv(t *testing.T) {
+	var gotArgs []string
+	withRunner(t, func(_ context.Context, name string, args ...string) ([]byte, error) {
+		gotArgs = append([]string{name}, args...)
+		return nil, nil
+	})
+	if err := PushHead(context.Background(), "/wt", "feat/x"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertArgs(t, gotArgs, []string{"git", "-C", "/wt", "push", "origin", "HEAD:refs/heads/feat/x"})
+}
+
+func TestPushHeadWithLease_argv(t *testing.T) {
+	var gotArgs []string
+	withRunner(t, func(_ context.Context, name string, args ...string) ([]byte, error) {
+		gotArgs = append([]string{name}, args...)
+		return nil, nil
+	})
+	if err := PushHeadWithLease(context.Background(), "/wt", "feat/x", "cafe12"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertArgs(t, gotArgs, []string{"git", "-C", "/wt", "push", "--force-with-lease=feat/x:cafe12", "origin", "HEAD:refs/heads/feat/x"})
+}
+
+func TestPushHead_error(t *testing.T) {
+	withRunner(t, func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return nil, errors.New("rejected")
+	})
+	if err := PushHead(context.Background(), "/wt", "feat/x"); err == nil {
+		t.Fatal("expected error when push fails")
+	}
+	if err := PushHeadWithLease(context.Background(), "/wt", "feat/x", "cafe12"); err == nil {
+		t.Fatal("expected error when lease push fails")
 	}
 }


### PR DESCRIPTION
## What

The deploy stage's freshness rebase ran `git rebase` inside the daemon's live workspace checkout. Git refuses to start a rebase in a dirty worktree, so ANY uncommitted user change made every deploy that needed the rebase fail with the identical 'branch could not be made mergeable: rebasing branch onto base' error — observed 2026-07-20 as five cards (876, 878, 910, 911, 912) stuck in Fix while four of their five PRs were MERGEABLE on the forge. When the checkout was clean the rebase was still harmful: it checked the handoff branch out into the user's working directory and could collide with branches checked out in live agent worktrees.

`EnsureMergeable` now:
- resolves the branch tip preferring the origin ref (the deploy serves the PR; local refs may lag a prior deploy's rebase, which no longer rewrites them), fetching it first so the lease target is the real remote state,
- replays that tip onto `origin/<base>` in a throwaway **detached** worktree sharing the workspace's object DB,
- publishes the result as a refspec push of the worktree's HEAD (`HEAD:refs/heads/<branch>`), leased against the recorded pre-rebase tip,
- removes the worktree on every path.

The live checkout is never touched beyond ref lookups: dirty state, the user's HEAD, and agent worktrees are structurally out of the blast radius. The SC-804 forge-mergeability fallback stays as the second line of defense. The branch-form `gitrepo.Rebase` falls away with its only caller; `RebaseHead`/`PushHead`/`PushHeadWithLease` are its worktree-shaped replacements.

## Verification

- Stub-level wiring tests assert the rebase runs in the ephemeral worktree and never in the workspace, the lease push originates from the worktree, and the worktree is removed even on conflict.
- A real-git integration test builds an origin + dirty clone, advances the base past the handoff branch, runs the real `EnsureMergeable`, and asserts the branch lands on origin containing the base tip while the user's branch and uncommitted edit stay bit-for-bit untouched.
- `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)