### PR TITLE
[SC-1009] Add human tracker topology to resolve PM/engineering roles

### DIFF
--- a/cmd/cmdtracker/tracker.go
+++ b/cmd/cmdtracker/tracker.go
@@ -57,7 +57,17 @@ func BuildTrackerCmd(loader func(string) ([]tracker.Instance, error)) *cobra.Com
 	}
 	findCmd.Flags().BoolVar(&findTable, "table", false, "Output as human-readable table instead of JSON")
 
-	trackerCmd.AddCommand(listCmd, findCmd)
+	var topologyTable bool
+	topologyCmd := &cobra.Command{
+		Use:   "topology",
+		Short: "Resolve tracker roles: PM tracker, engineering tracker, single vs split topology",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return RunTrackerTopology(cmd.OutOrStdout(), ".", topologyTable, loader)
+		},
+	}
+	topologyCmd.Flags().BoolVar(&topologyTable, "table", false, "Output as human-readable table instead of JSON")
+
+	trackerCmd.AddCommand(listCmd, findCmd, topologyCmd)
 	return trackerCmd
 }
 
@@ -80,6 +90,57 @@ func RunTrackerList(out io.Writer, dir string, table bool, loader func(string) (
 		return PrintTrackerTable(out, entries)
 	}
 	return PrintTrackerJSON(out, entries)
+}
+
+// TopologyResult is the JSON output structure for tracker topology.
+type TopologyResult struct {
+	Topology    string        `json:"topology"`
+	PM          *TrackerEntry `json:"pm,omitempty"`
+	Engineering *TrackerEntry `json:"engineering,omitempty"`
+}
+
+// RunTrackerTopology resolves and prints the tracker topology so agents stop
+// re-deriving it from the tracker list.
+func RunTrackerTopology(out io.Writer, dir string, table bool, loader func(string) ([]tracker.Instance, error)) error {
+	if dir == "" {
+		dir = "."
+	}
+	instances, err := loader(dir)
+	if err != nil {
+		return err
+	}
+
+	top := tracker.ResolveTopology(instances)
+	result := TopologyResult{Topology: top.Mode, PM: toEntry(top.PM), Engineering: toEntry(top.Engineering)}
+
+	if table {
+		return PrintTopologyTable(out, result)
+	}
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}
+
+func toEntry(inst *tracker.Instance) *TrackerEntry {
+	if inst == nil {
+		return nil
+	}
+	return &TrackerEntry{Name: inst.Name, Type: inst.Kind, URL: inst.URL, User: inst.User, Role: inst.InferRole(), Description: inst.Description}
+}
+
+// PrintTopologyTable prints a topology result as a table.
+func PrintTopologyTable(out io.Writer, result TopologyResult) error {
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintf(w, "TOPOLOGY\t%s\n", result.Topology)
+	if result.PM != nil {
+		_, _ = fmt.Fprintf(w, "PM\t%s (%s)\n", result.PM.Name, result.PM.Type)
+	} else {
+		_, _ = fmt.Fprintln(w, "PM\t(ambiguous — declare role: pm in .humanconfig)")
+	}
+	if result.Engineering != nil {
+		_, _ = fmt.Fprintf(w, "ENGINEERING\t%s (%s)\n", result.Engineering.Name, result.Engineering.Type)
+	}
+	return w.Flush()
 }
 
 // RunTrackerFind finds which tracker owns a key.

--- a/cmd/cmdtracker/tracker_test.go
+++ b/cmd/cmdtracker/tracker_test.go
@@ -465,3 +465,64 @@ func TestRunTrackerList_MapsInstanceFields(t *testing.T) {
 	assert.Contains(t, out, `"user": "usr1"`)
 	assert.Contains(t, out, `"description": "d1"`)
 }
+
+// --- Topology ---
+
+func TestRunTrackerTopology_SplitJSON(t *testing.T) {
+	instances := []tracker.Instance{
+		{Name: "board", Kind: "shortcut"},
+		{Name: "eng", Kind: "linear", Role: "engineering"},
+	}
+	var buf bytes.Buffer
+	err := RunTrackerTopology(&buf, ".", false, loaderOK(instances))
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, `"topology": "split"`)
+	assert.Contains(t, out, `"name": "board"`)
+	assert.Contains(t, out, `"name": "eng"`)
+}
+
+func TestRunTrackerTopology_SingleOmitsEngineering(t *testing.T) {
+	instances := []tracker.Instance{{Name: "board", Kind: "shortcut"}}
+	var buf bytes.Buffer
+	err := RunTrackerTopology(&buf, ".", false, loaderOK(instances))
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, `"topology": "single"`)
+	assert.NotContains(t, out, `"engineering"`)
+}
+
+func TestRunTrackerTopology_Table(t *testing.T) {
+	instances := []tracker.Instance{
+		{Name: "board", Kind: "shortcut"},
+		{Name: "eng", Kind: "linear", Role: "engineering"},
+	}
+	var buf bytes.Buffer
+	err := RunTrackerTopology(&buf, ".", true, loaderOK(instances))
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "TOPOLOGY")
+	assert.Contains(t, out, "split")
+	assert.Contains(t, out, "board (shortcut)")
+	assert.Contains(t, out, "eng (linear)")
+}
+
+func TestRunTrackerTopology_TableAmbiguousPM(t *testing.T) {
+	instances := []tracker.Instance{
+		{Name: "a", Kind: "jira"},
+		{Name: "b", Kind: "linear"},
+	}
+	var buf bytes.Buffer
+	err := RunTrackerTopology(&buf, ".", true, loaderOK(instances))
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "ambiguous")
+}
+
+func TestRunTrackerTopology_LoaderError(t *testing.T) {
+	var buf bytes.Buffer
+	err := RunTrackerTopology(&buf, ".", false, loaderErr(errors.WithDetails("load failed", "reason", "boom")))
+	require.Error(t, err)
+}

--- a/internal/tracker/README.md
+++ b/internal/tracker/README.md
@@ -12,4 +12,5 @@
 - Assign an issue to a user
 - Edit an issue's title and description
 - Auto-detects the right tracker from a key
+- Resolves tracker roles and topology (`human tracker topology`): which tracker is PM, which is engineering, single vs split
 - Guards deletes and edits with safe-mode policies

--- a/internal/tracker/topology.go
+++ b/internal/tracker/topology.go
@@ -1,0 +1,48 @@
+package tracker
+
+// Topology is the resolved answer to the question every pipeline agent
+// otherwise re-derives from `human tracker list` output: which tracker carries
+// the PM role, which (if any) carries the engineering role, and therefore
+// whether work runs single-tracker or split topology.
+type Topology struct {
+	// Mode is "single" or "split". Split turns on only via an explicit
+	// role: engineering declaration — never inferred from tracker kind
+	// ([SC-254]).
+	Mode        string
+	PM          *Instance
+	Engineering *Instance
+}
+
+// ResolveTopology resolves the tracker topology from the configured instances.
+// The first tracker per role wins so the answer is stable across runs. When no
+// tracker declares the pm role, the working tracker is only unambiguous if
+// exactly one non-engineering tracker exists — with several candidates PM stays
+// nil rather than guessing.
+func ResolveTopology(instances []Instance) Topology {
+	t := Topology{Mode: "single"}
+	for i := range instances {
+		switch instances[i].InferRole() {
+		case "engineering":
+			if t.Engineering == nil {
+				t.Engineering = &instances[i]
+				t.Mode = "split"
+			}
+		case "pm":
+			if t.PM == nil {
+				t.PM = &instances[i]
+			}
+		}
+	}
+	if t.PM == nil {
+		var candidates []*Instance
+		for i := range instances {
+			if instances[i].InferRole() != "engineering" {
+				candidates = append(candidates, &instances[i])
+			}
+		}
+		if len(candidates) == 1 {
+			t.PM = candidates[0]
+		}
+	}
+	return t
+}

--- a/internal/tracker/topology_test.go
+++ b/internal/tracker/topology_test.go
@@ -46,3 +46,67 @@ func TestDiagnoseTrackers_capturesRole(t *testing.T) {
 	require.NotNil(t, found, "expected linear/eng in results")
 	assert.Equal(t, "engineering", found.Role)
 }
+
+func TestResolveTopology_splitOnExplicitEngineering(t *testing.T) {
+	instances := []Instance{
+		{Name: "board", Kind: "shortcut"},
+		{Name: "eng", Kind: "linear", Role: "engineering"},
+	}
+	top := ResolveTopology(instances)
+	assert.Equal(t, "split", top.Mode)
+	require.NotNil(t, top.PM)
+	assert.Equal(t, "board", top.PM.Name)
+	require.NotNil(t, top.Engineering)
+	assert.Equal(t, "eng", top.Engineering.Name)
+}
+
+func TestResolveTopology_singleWithoutEngineeringRole(t *testing.T) {
+	instances := []Instance{
+		{Name: "board", Kind: "shortcut"},
+		{Name: "issues", Kind: "linear"},
+	}
+	top := ResolveTopology(instances)
+	assert.Equal(t, "single", top.Mode)
+	require.NotNil(t, top.PM)
+	assert.Equal(t, "board", top.PM.Name)
+	assert.Nil(t, top.Engineering)
+}
+
+func TestResolveTopology_pmFallbackToSoleTracker(t *testing.T) {
+	instances := []Instance{{Name: "only", Kind: "jira"}}
+	top := ResolveTopology(instances)
+	assert.Equal(t, "single", top.Mode)
+	require.NotNil(t, top.PM)
+	assert.Equal(t, "only", top.PM.Name)
+}
+
+func TestResolveTopology_pmAmbiguousStaysNil(t *testing.T) {
+	instances := []Instance{
+		{Name: "a", Kind: "jira"},
+		{Name: "b", Kind: "linear"},
+	}
+	top := ResolveTopology(instances)
+	assert.Equal(t, "single", top.Mode)
+	assert.Nil(t, top.PM)
+}
+
+func TestResolveTopology_firstRoleWins(t *testing.T) {
+	instances := []Instance{
+		{Name: "pm1", Kind: "shortcut"},
+		{Name: "pm2", Kind: "shortcut"},
+		{Name: "eng1", Kind: "linear", Role: "engineering"},
+		{Name: "eng2", Kind: "github", Role: "engineering"},
+	}
+	top := ResolveTopology(instances)
+	require.NotNil(t, top.PM)
+	require.NotNil(t, top.Engineering)
+	assert.Equal(t, "pm1", top.PM.Name)
+	assert.Equal(t, "eng1", top.Engineering.Name)
+}
+
+func TestResolveTopology_empty(t *testing.T) {
+	top := ResolveTopology(nil)
+	assert.Equal(t, "single", top.Mode)
+	assert.Nil(t, top.PM)
+	assert.Nil(t, top.Engineering)
+}


### PR DESCRIPTION
Resolves ticket 1009: agents currently re-derive tracker topology (PM tracker, engineering tracker, single vs split) from `human tracker list` output via a prose recipe repeated across ~17 prompt files. This adds `human tracker topology` — a deterministic resolution command.

- `internal/tracker.ResolveTopology`: first tracker per role wins; PM falls back to the sole non-engineering tracker; engineering is never inferred (SC-254 rule preserved)
- `human tracker topology` prints JSON (`--table` for humans), omitting `engineering` in single mode
- Prompt migration to the new command follows as a separate sweep once the sibling commands land

🤖 Generated with [Claude Code](https://claude.com/claude-code)