### PR TITLE
[SC-1011] Add human commits for/prefix for deterministic commit mechanics

### DIFF
--- a/cmd/cmdcommits/commits.go
+++ b/cmd/cmdcommits/commits.go
@@ -1,0 +1,96 @@
+// Package cmdcommits surfaces the deterministic commit mechanics agents
+// otherwise hand-roll in prompts: discovering which commits reference a ticket
+// key, and assembling the bracket-style commit-message prefix that carries the
+// PM → engineering → commit trail.
+package cmdcommits
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gethuman-sh/human/internal/gitrepo"
+)
+
+// BuildCommitsCmd creates the "commits" command with for and prefix subcommands.
+func BuildCommitsCmd() *cobra.Command {
+	commitsCmd := &cobra.Command{
+		Use:   "commits",
+		Short: "Deterministic commit mechanics for ticket keys",
+	}
+
+	var forTable bool
+	forCmd := &cobra.Command{
+		Use:   "for KEY",
+		Short: "List commits referencing a ticket key (any accepted reference format, merge PRs excluded)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunCommitsFor(cmd.Context(), cmd.OutOrStdout(), ".", args[0], forTable)
+		},
+	}
+	forCmd.Flags().BoolVar(&forTable, "table", false, "Output as human-readable table instead of JSON")
+
+	prefixCmd := &cobra.Command{
+		Use:   "prefix KEY [ENGINEERING_KEY]",
+		Short: "Print the commit-message prefix for a ticket (PM key first, engineering key second in split topology)",
+		Args:  cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunCommitPrefix(cmd.OutOrStdout(), args)
+		},
+	}
+
+	commitsCmd.AddCommand(forCmd, prefixCmd)
+	return commitsCmd
+}
+
+// RunCommitsFor lists commits referencing key in the repository at dir.
+func RunCommitsFor(ctx context.Context, out io.Writer, dir, key string, table bool) error {
+	commits, err := gitrepo.CommitsFor(ctx, dir, key)
+	if err != nil {
+		return err
+	}
+	if table {
+		return printCommitsTable(out, commits)
+	}
+	if commits == nil {
+		commits = []gitrepo.Commit{}
+	}
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(commits)
+}
+
+// RunCommitPrefix prints the canonical commit-message prefix for the given
+// keys: each key bracketed, PM before engineering, ready to prepend to a
+// subject line. Keys already carrying brackets pass through unchanged.
+func RunCommitPrefix(out io.Writer, keys []string) error {
+	parts := make([]string, len(keys))
+	for i, key := range keys {
+		trimmed := strings.TrimSpace(key)
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			parts[i] = trimmed
+			continue
+		}
+		parts[i] = "[" + trimmed + "]"
+	}
+	_, err := fmt.Fprintln(out, strings.Join(parts, " "))
+	return err
+}
+
+func printCommitsTable(out io.Writer, commits []gitrepo.Commit) error {
+	if len(commits) == 0 {
+		_, _ = fmt.Fprintln(out, "No commits reference this key")
+		return nil
+	}
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "SHORT\tSUBJECT")
+	for _, c := range commits {
+		_, _ = fmt.Fprintf(w, "%s\t%s\n", c.ShortSHA, c.Subject)
+	}
+	return w.Flush()
+}

--- a/cmd/cmdcommits/commits_test.go
+++ b/cmd/cmdcommits/commits_test.go
@@ -1,0 +1,109 @@
+package cmdcommits
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/gitrepo"
+)
+
+func withCommitsFor(t *testing.T, fn func(ctx context.Context, dir, key string) ([]gitrepo.Commit, error)) {
+	t.Helper()
+	prev := gitrepo.CommitsFor
+	gitrepo.CommitsFor = fn
+	t.Cleanup(func() { gitrepo.CommitsFor = prev })
+}
+
+func TestRunCommitsFor_JSON(t *testing.T) {
+	withCommitsFor(t, func(_ context.Context, dir, key string) ([]gitrepo.Commit, error) {
+		assert.Equal(t, ".", dir)
+		assert.Equal(t, "SC-57", key)
+		return []gitrepo.Commit{{SHA: "aaa", ShortSHA: "a1", Subject: "[SC-57] Add validation"}}, nil
+	})
+
+	var buf bytes.Buffer
+	err := RunCommitsFor(context.Background(), &buf, ".", "SC-57", false)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, `"sha": "aaa"`)
+	assert.Contains(t, out, `"short": "a1"`)
+	assert.Contains(t, out, `"subject": "[SC-57] Add validation"`)
+}
+
+func TestRunCommitsFor_JSONEmptyIsArray(t *testing.T) {
+	withCommitsFor(t, func(_ context.Context, _, _ string) ([]gitrepo.Commit, error) {
+		return nil, nil
+	})
+
+	var buf bytes.Buffer
+	err := RunCommitsFor(context.Background(), &buf, ".", "42", false)
+	require.NoError(t, err)
+	assert.Equal(t, "[]\n", buf.String())
+}
+
+func TestRunCommitsFor_Table(t *testing.T) {
+	withCommitsFor(t, func(_ context.Context, _, _ string) ([]gitrepo.Commit, error) {
+		return []gitrepo.Commit{{SHA: "aaa", ShortSHA: "a1", Subject: "s1"}}, nil
+	})
+
+	var buf bytes.Buffer
+	err := RunCommitsFor(context.Background(), &buf, ".", "SC-57", true)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "SHORT")
+	assert.Contains(t, buf.String(), "a1")
+}
+
+func TestRunCommitsFor_TableEmpty(t *testing.T) {
+	withCommitsFor(t, func(_ context.Context, _, _ string) ([]gitrepo.Commit, error) {
+		return nil, nil
+	})
+
+	var buf bytes.Buffer
+	err := RunCommitsFor(context.Background(), &buf, ".", "SC-57", true)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "No commits reference this key")
+}
+
+func TestRunCommitsFor_Error(t *testing.T) {
+	withCommitsFor(t, func(_ context.Context, _, _ string) ([]gitrepo.Commit, error) {
+		return nil, errors.WithDetails("not a repository", "dir", ".")
+	})
+
+	var buf bytes.Buffer
+	err := RunCommitsFor(context.Background(), &buf, ".", "SC-57", false)
+	require.Error(t, err)
+}
+
+func TestRunCommitPrefix_SingleKey(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, RunCommitPrefix(&buf, []string{"SC-79"}))
+	assert.Equal(t, "[SC-79]\n", buf.String())
+}
+
+func TestRunCommitPrefix_SplitTopologyKeys(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, RunCommitPrefix(&buf, []string{"SC-79", "HUM-59"}))
+	assert.Equal(t, "[SC-79] [HUM-59]\n", buf.String())
+}
+
+func TestRunCommitPrefix_AlreadyBracketed(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, RunCommitPrefix(&buf, []string{"[SC-79]", " HUM-59 "}))
+	assert.Equal(t, "[SC-79] [HUM-59]\n", buf.String())
+}
+
+func TestBuildCommitsCmd_Subcommands(t *testing.T) {
+	cmd := BuildCommitsCmd()
+	uses := make([]string, 0, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
+		uses = append(uses, sub.Use)
+	}
+	assert.Contains(t, uses, "for KEY")
+	assert.Contains(t, uses, "prefix KEY [ENGINEERING_KEY]")
+}

--- a/internal/gitrepo/README.md
+++ b/internal/gitrepo/README.md
@@ -6,4 +6,6 @@ Lets `human` read facts about the git repository you are working in, so it can f
 - Works on the current directory by default
 - Targets any repository by path
 - Feeds forge and project detection automatically
+- Lists the commits referencing a ticket key in any accepted reference format (`human commits for KEY`), excluding merge-PR commits
+- Prints the canonical bracket-style commit-message prefix for a ticket (`human commits prefix PM_KEY [ENG_KEY]`)
 - Reports a clear error when no remote

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -6,6 +6,7 @@ package gitrepo
 import (
 	"context"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/gethuman-sh/human/errors"
@@ -233,4 +234,49 @@ var WorktreeRemove = func(ctx context.Context, repoDir, worktreePath string) err
 		return errors.WrapWithDetails(err, "removing git worktree", "repo", repoDir, "worktree", worktreePath)
 	}
 	return nil
+}
+
+// Commit is one commit that references a ticket key, as returned by CommitsFor.
+type Commit struct {
+	SHA      string `json:"sha"`
+	ShortSHA string `json:"short"`
+	Subject  string `json:"subject"`
+}
+
+// keyRefPattern builds the extended-regexp grep pattern matching every accepted
+// commit-message reference form for key (the .githooks/commit-msg grammar):
+// bracket style ([SC-57]), "Issue SC-57" / "Issue #123", and guarded bare or
+// path-style occurrences (owner/repo#42, MyProject/42). Guards keep a numeric
+// key from matching inside longer numbers and a prefixed key from matching
+// inside longer keys (SC-5 must not match SC-57).
+func keyRefPattern(key string) string {
+	esc := regexp.QuoteMeta(key)
+	if regexp.MustCompile(`^[0-9]+$`).MatchString(key) {
+		return `\[#?` + esc + `\]|(^|[^0-9])#` + esc + `([^0-9]|$)|Issue #?` + esc + `([^0-9]|$)|/` + esc + `([^0-9]|$)`
+	}
+	return `\[` + esc + `\]|Issue ` + esc + `([^0-9]|$)|(^|[^A-Za-z0-9-])` + esc + `([^0-9]|$)`
+}
+
+// CommitsFor lists the commits on HEAD whose message references key in any
+// accepted reference format, newest first, excluding merge-PR commits — the
+// exact discovery agents otherwise hand-roll with git log --grep incantations.
+// Package var so callers can stub git access in tests.
+var CommitsFor = func(ctx context.Context, dir, key string) ([]Commit, error) {
+	out, err := runner(ctx, "git", "-C", dir, "log", "--extended-regexp",
+		"--grep="+keyRefPattern(key), "--format=%H%x1f%h%x1f%s", "HEAD")
+	if err != nil {
+		return nil, errors.WrapWithDetails(err, "listing commits for key", "dir", dir, "key", key)
+	}
+	var commits []Commit
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		parts := strings.SplitN(line, "\x1f", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		if strings.HasPrefix(parts[2], "Merge pull request") {
+			continue
+		}
+		commits = append(commits, Commit{SHA: parts[0], ShortSHA: parts[1], Subject: parts[2]})
+	}
+	return commits, nil
 }

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -3,6 +3,7 @@ package gitrepo
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -487,5 +488,66 @@ func TestPushHead_error(t *testing.T) {
 	}
 	if err := PushHeadWithLease(context.Background(), "/wt", "feat/x", "cafe12"); err == nil {
 		t.Fatal("expected error when lease push fails")
+	}
+}
+
+func TestCommitsFor_parsesAndFiltersMerges(t *testing.T) {
+	out := "aaa1\x1fa1\x1f[SC-57] Add validation\n" +
+		"bbb2\x1fb2\x1fMerge pull request #12 from x/y\n" +
+		"ccc3\x1fc3\x1fIssue SC-57 follow-up\n"
+	var gotArgs []string
+	withRunner(t, func(_ context.Context, name string, args ...string) ([]byte, error) {
+		gotArgs = append([]string{name}, args...)
+		return []byte(out), nil
+	})
+
+	commits, err := CommitsFor(context.Background(), "/repo", "SC-57")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(commits) != 2 {
+		t.Fatalf("commits = %d, want 2 (merge PR filtered)", len(commits))
+	}
+	if commits[0].SHA != "aaa1" || commits[0].ShortSHA != "a1" || commits[0].Subject != "[SC-57] Add validation" {
+		t.Errorf("first commit = %+v", commits[0])
+	}
+	if gotArgs[0] != "git" || gotArgs[3] != "log" {
+		t.Errorf("args = %v", gotArgs)
+	}
+}
+
+func TestCommitsFor_emptyOutput(t *testing.T) {
+	withRunner(t, func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return []byte("\n"), nil
+	})
+	commits, err := CommitsFor(context.Background(), ".", "42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(commits) != 0 {
+		t.Errorf("commits = %v, want none", commits)
+	}
+}
+
+func TestCommitsFor_gitError(t *testing.T) {
+	withRunner(t, func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return nil, errors.New("exit status 128")
+	})
+	if _, err := CommitsFor(context.Background(), ".", "SC-57"); err == nil {
+		t.Fatal("expected error when git fails")
+	}
+}
+
+func TestKeyRefPattern_numericVsPrefixed(t *testing.T) {
+	num := keyRefPattern("42")
+	if want := `\[#?42\]`; !strings.Contains(num, want) {
+		t.Errorf("numeric pattern %q missing %q", num, want)
+	}
+	pre := keyRefPattern("SC-57")
+	if want := `\[SC-57\]`; !strings.Contains(pre, want) {
+		t.Errorf("prefixed pattern %q missing %q", pre, want)
+	}
+	if strings.Contains(pre, `#?SC-57\]`) {
+		t.Errorf("prefixed pattern %q must not carry the numeric hash form", pre)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gethuman-sh/human/cmd/cmdbrowser"
 	"github.com/gethuman-sh/human/cmd/cmdclickup"
 	"github.com/gethuman-sh/human/cmd/cmdcodenav"
+	"github.com/gethuman-sh/human/cmd/cmdcommits"
 	"github.com/gethuman-sh/human/cmd/cmddaemon"
 	"github.com/gethuman-sh/human/cmd/cmddoctor"
 	"github.com/gethuman-sh/human/cmd/cmdfigma"
@@ -218,6 +219,10 @@ Configure trackers and tools in .humanconfig.yaml or pass credentials via flags/
 	planCmd := cmdplan.BuildPlanCmd(autoDeps)
 	planCmd.GroupID = "shortcuts"
 	rootCmd.AddCommand(planCmd)
+
+	commitsCmd := cmdcommits.BuildCommitsCmd()
+	commitsCmd.GroupID = "shortcuts"
+	rootCmd.AddCommand(commitsCmd)
 
 	// --- Provider commands (dynamic registration) ---
 	providers := []string{"jira", "github", "gitlab", "linear", "azuredevops", "shortcut", "clickup"}
@@ -504,6 +509,7 @@ func resolveEventName(data []byte, structVal string) string {
 var localSubcommands = map[string]bool{
 	"daemon":        true,
 	"chrome-bridge": true,
+	"commits":       true,
 	"install":       true,
 	"init":          true,
 	"usage":         true,


### PR DESCRIPTION
Resolves ticket 1011: agents hand-roll `git log --grep` incantations (3 prompt files) and restate the commit-message bracket-prefix rule (8 prompt files). This makes both a deterministic command:

- `human commits for KEY` — commits referencing the key in any accepted reference format (the .githooks/commit-msg grammar), newest first, merge-PR commits excluded; JSON default, `--table` for humans
- `human commits prefix PM_KEY [ENG_KEY]` — canonical bracket prefix, split-topology aware ordering
- `gitrepo.CommitsFor` follows the package's stub-friendly package-var idiom; `commits` added to localSubcommands so it always reads the caller's repo, not the daemon's

🤖 Generated with [Claude Code](https://claude.com/claude-code)