### PR TITLE
[SC-1007] Add marker protocol package and human marker post/show/list

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Each module ships a short `README.md` describing what it does for you, in plain 
 
 - [Issue Trackers](internal/tracker/README.md) — Jira, Linear, GitHub, GitLab, Shortcut, Azure DevOps, ClickUp
 - [Code Forges](internal/forge/README.md) — open pull requests (GitHub)
+- [Marker Protocol](internal/marker/README.md) — post/read the structured `[human:*]` pipeline handoff comments
 
 **Docs, design & analytics**
 

--- a/cmd/cmdmarker/marker.go
+++ b/cmd/cmdmarker/marker.go
@@ -1,0 +1,195 @@
+// Package cmdmarker surfaces the [human:*] marker protocol as CLI commands so
+// pipeline agents post and read structured handoff comments through one
+// validated grammar instead of reproducing prose templates.
+package cmdmarker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gethuman-sh/human/cmd/cmdutil"
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/marker"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// BuildMarkerCmd creates the top-level "marker" command.
+func BuildMarkerCmd(deps cmdutil.Deps) *cobra.Command {
+	markerCmd := &cobra.Command{
+		Use:   "marker",
+		Short: "Post and read [human:*] pipeline marker comments on a ticket",
+		Long: `Post and read the structured [human:*] marker comments through which
+pipeline stages hand work to each other on a ticket.
+
+Known types (validated): ` + strings.Join(marker.KnownTypes(), ", ") + `
+Unknown types are allowed so new pipeline stages need no CLI release.`,
+	}
+	markerCmd.AddCommand(buildPostCmd(deps), buildShowCmd(deps), buildListCmd(deps))
+	return markerCmd
+}
+
+func buildPostCmd(deps cmdutil.Deps) *cobra.Command {
+	var fields []string
+	var head, body, bodyFile string
+	cmd := &cobra.Command{
+		Use:   "post KEY TYPE",
+		Short: "Post a [human:TYPE] marker comment (validated for known types)",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := cmdutil.ResolveAutoProvider(cmd.Context(), cmd, args[0], true, deps)
+			if err != nil {
+				return err
+			}
+			defer resolved.Cleanup()
+			bodyText, err := resolveBody(body, bodyFile, cmd.InOrStdin())
+			if err != nil {
+				return err
+			}
+			return RunMarkerPost(cmd.Context(), resolved.Provider, cmd.OutOrStdout(), resolved.Key, args[1], head, fields, bodyText)
+		},
+	}
+	cmd.Flags().StringArrayVar(&fields, "field", nil, "Field line as key=value (repeatable; posting order preserved)")
+	cmd.Flags().StringVar(&head, "head", "", "Token on the header line ([human:TYPE] TOKEN)")
+	cmd.Flags().StringVar(&body, "body", "", "Free-form body after the field block")
+	cmd.Flags().StringVar(&bodyFile, "body-file", "", "Read the body from a file, or - for stdin")
+	return cmd
+}
+
+func buildShowCmd(deps cmdutil.Deps) *cobra.Command {
+	var raw bool
+	cmd := &cobra.Command{
+		Use:   "show KEY TYPE",
+		Short: "Print the newest [human:TYPE] marker on a ticket (latest wins)",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := cmdutil.ResolveAutoProvider(cmd.Context(), cmd, args[0], true, deps)
+			if err != nil {
+				return err
+			}
+			defer resolved.Cleanup()
+			return RunMarkerShow(cmd.Context(), resolved.Provider, cmd.OutOrStdout(), resolved.Key, args[1], raw)
+		},
+	}
+	cmd.Flags().BoolVar(&raw, "raw", false, "Print the marker comment body verbatim instead of parsed JSON")
+	return cmd
+}
+
+func buildListCmd(deps cmdutil.Deps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list KEY",
+		Short: "List all [human:*] markers on a ticket, newest first (JSON)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := cmdutil.ResolveAutoProvider(cmd.Context(), cmd, args[0], true, deps)
+			if err != nil {
+				return err
+			}
+			defer resolved.Cleanup()
+			return RunMarkerList(cmd.Context(), resolved.Provider, cmd.OutOrStdout(), resolved.Key)
+		},
+	}
+	return cmd
+}
+
+// RunMarkerPost validates, renders, and posts a marker comment, echoing the
+// rendered body so the caller sees exactly what landed on the ticket.
+func RunMarkerPost(ctx context.Context, p tracker.Provider, out io.Writer, key, markerType, head string, fieldArgs []string, body string) error {
+	fields, order, err := parseFieldArgs(fieldArgs)
+	if err != nil {
+		return err
+	}
+	m := marker.Marker{Type: markerType, Head: head, Fields: fields, Body: body}
+	if err := marker.Validate(m); err != nil {
+		return err
+	}
+	rendered := marker.Render(m, order)
+	if _, err := p.AddComment(ctx, key, rendered); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(out, rendered)
+	return err
+}
+
+// RunMarkerShow prints the newest marker of markerType on the ticket.
+func RunMarkerShow(ctx context.Context, p tracker.Provider, out io.Writer, key, markerType string, raw bool) error {
+	comments, err := p.ListComments(ctx, key)
+	if err != nil {
+		return err
+	}
+	m, ok := marker.Latest(comments, markerType)
+	if !ok {
+		return errors.WithDetails("no such marker on ticket", "key", key, "type", markerType)
+	}
+	if raw {
+		_, err = fmt.Fprintln(out, marker.Render(m, nil))
+		return err
+	}
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(m)
+}
+
+// RunMarkerList prints every marker on the ticket, newest first.
+func RunMarkerList(ctx context.Context, p tracker.Provider, out io.Writer, key string) error {
+	comments, err := p.ListComments(ctx, key)
+	if err != nil {
+		return err
+	}
+	markers := marker.All(comments)
+	if markers == nil {
+		markers = []marker.Marker{}
+	}
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(markers)
+}
+
+// parseFieldArgs turns repeated key=value flags into a field map plus the
+// caller's ordering, which Render preserves.
+func parseFieldArgs(args []string) (map[string]string, []string, error) {
+	if len(args) == 0 {
+		return nil, nil, nil
+	}
+	fields := make(map[string]string, len(args))
+	order := make([]string, 0, len(args))
+	for _, arg := range args {
+		key, value, found := strings.Cut(arg, "=")
+		if !found || strings.TrimSpace(key) == "" {
+			return nil, nil, errors.WithDetails("field must be key=value", "got", arg)
+		}
+		key = strings.TrimSpace(key)
+		if _, dup := fields[key]; !dup {
+			order = append(order, key)
+		}
+		fields[key] = value
+	}
+	return fields, order, nil
+}
+
+// resolveBody picks the marker body from --body, --body-file, or stdin ("-").
+func resolveBody(body, bodyFile string, stdin io.Reader) (string, error) {
+	if body != "" && bodyFile != "" {
+		return "", errors.WithDetails("use either --body or --body-file, not both")
+	}
+	if bodyFile == "" {
+		return body, nil
+	}
+	if bodyFile == "-" {
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return "", errors.WrapWithDetails(err, "reading body from stdin")
+		}
+		return string(data), nil
+	}
+	data, err := os.ReadFile(bodyFile) // #nosec G304 -- path is an explicit user-supplied CLI argument
+	if err != nil {
+		return "", errors.WrapWithDetails(err, "reading body file", "path", bodyFile)
+	}
+	return string(data), nil
+}

--- a/cmd/cmdmarker/marker_test.go
+++ b/cmd/cmdmarker/marker_test.go
@@ -1,0 +1,195 @@
+package cmdmarker
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/cmd/cmdutil"
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// stubProvider implements tracker.Provider; only the comment methods carry
+// behavior, the rest satisfy the interface.
+type stubProvider struct {
+	comments   []tracker.Comment
+	added      []string
+	listErr    error
+	addErr     error
+	addedKeys  []string
+	listedKeys []string
+}
+
+func (s *stubProvider) ListIssues(context.Context, tracker.ListOptions) ([]tracker.Issue, error) {
+	return nil, nil
+}
+func (s *stubProvider) GetIssue(context.Context, string) (*tracker.Issue, error) { return nil, nil }
+func (s *stubProvider) CreateIssue(context.Context, *tracker.Issue) (*tracker.Issue, error) {
+	return nil, nil
+}
+func (s *stubProvider) ListComments(_ context.Context, key string) ([]tracker.Comment, error) {
+	s.listedKeys = append(s.listedKeys, key)
+	return s.comments, s.listErr
+}
+func (s *stubProvider) AddComment(_ context.Context, key, body string) (*tracker.Comment, error) {
+	s.addedKeys = append(s.addedKeys, key)
+	s.added = append(s.added, body)
+	if s.addErr != nil {
+		return nil, s.addErr
+	}
+	return &tracker.Comment{Body: body}, nil
+}
+func (s *stubProvider) LinkIssues(context.Context, string, string) error      { return nil }
+func (s *stubProvider) DeleteIssue(context.Context, string) error             { return nil }
+func (s *stubProvider) TransitionIssue(context.Context, string, string) error { return nil }
+func (s *stubProvider) AssignIssue(context.Context, string, string) error     { return nil }
+func (s *stubProvider) GetCurrentUser(context.Context) (string, error)        { return "", nil }
+func (s *stubProvider) EditIssue(context.Context, string, tracker.EditOptions) (*tracker.Issue, error) {
+	return nil, nil
+}
+func (s *stubProvider) ListStatuses(context.Context, string) ([]tracker.Status, error) {
+	return nil, nil
+}
+
+func TestRunMarkerPost_rendersAndPosts(t *testing.T) {
+	p := &stubProvider{}
+	var buf bytes.Buffer
+
+	err := RunMarkerPost(context.Background(), p, &buf, "SC-1", "ready-for-review", "",
+		[]string{"engineering=HUM-89", "branch=main", "commits=abc, def"}, "")
+	require.NoError(t, err)
+
+	require.Len(t, p.added, 1)
+	assert.Equal(t, "[human:ready-for-review]\nengineering: HUM-89\nbranch: main\ncommits: abc, def", p.added[0])
+	assert.Equal(t, []string{"SC-1"}, p.addedKeys)
+	assert.Contains(t, buf.String(), "[human:ready-for-review]")
+}
+
+func TestRunMarkerPost_validationBlocksBadMarker(t *testing.T) {
+	p := &stubProvider{}
+	var buf bytes.Buffer
+
+	err := RunMarkerPost(context.Background(), p, &buf, "SC-1", "ready-for-review", "", []string{"branch=main"}, "")
+	require.Error(t, err)
+	assert.Empty(t, p.added, "invalid marker must not be posted")
+}
+
+func TestRunMarkerPost_headToken(t *testing.T) {
+	p := &stubProvider{}
+	var buf bytes.Buffer
+
+	err := RunMarkerPost(context.Background(), p, &buf, "SC-1", "bug-verify", "NOT DONE", nil, "gap: no regression test")
+	require.NoError(t, err)
+	require.Len(t, p.added, 1)
+	assert.Equal(t, "[human:bug-verify] NOT DONE\n\ngap: no regression test", p.added[0])
+}
+
+func TestRunMarkerPost_badFieldSyntax(t *testing.T) {
+	p := &stubProvider{}
+	var buf bytes.Buffer
+	err := RunMarkerPost(context.Background(), p, &buf, "SC-1", "plan-ready", "", []string{"noequals"}, "")
+	require.Error(t, err)
+}
+
+func TestRunMarkerPost_addCommentError(t *testing.T) {
+	p := &stubProvider{addErr: errors.WithDetails("tracker down")}
+	var buf bytes.Buffer
+	err := RunMarkerPost(context.Background(), p, &buf, "SC-1", "review-started", "", nil, "")
+	require.Error(t, err)
+}
+
+func TestRunMarkerShow_JSON(t *testing.T) {
+	now := time.Now()
+	p := &stubProvider{comments: []tracker.Comment{
+		{Body: "[human:deployed]\npr: https://x/1", Created: now.Add(-time.Hour)},
+		{Body: "[human:deployed]\npr: https://x/2", Created: now},
+	}}
+	var buf bytes.Buffer
+
+	err := RunMarkerShow(context.Background(), p, &buf, "SC-1", "deployed", false)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), `"type": "deployed"`)
+	assert.Contains(t, buf.String(), "https://x/2")
+	assert.NotContains(t, buf.String(), "https://x/1", "latest wins")
+}
+
+func TestRunMarkerShow_raw(t *testing.T) {
+	p := &stubProvider{comments: []tracker.Comment{{Body: "[human:review-started]", Created: time.Now()}}}
+	var buf bytes.Buffer
+
+	err := RunMarkerShow(context.Background(), p, &buf, "SC-1", "review-started", true)
+	require.NoError(t, err)
+	assert.Equal(t, "[human:review-started]\n", buf.String())
+}
+
+func TestRunMarkerShow_missing(t *testing.T) {
+	p := &stubProvider{}
+	var buf bytes.Buffer
+	err := RunMarkerShow(context.Background(), p, &buf, "SC-1", "deployed", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no such marker")
+}
+
+func TestRunMarkerShow_listError(t *testing.T) {
+	p := &stubProvider{listErr: errors.WithDetails("tracker down")}
+	var buf bytes.Buffer
+	err := RunMarkerShow(context.Background(), p, &buf, "SC-1", "deployed", false)
+	require.Error(t, err)
+}
+
+func TestRunMarkerList_newestFirstJSON(t *testing.T) {
+	now := time.Now()
+	p := &stubProvider{comments: []tracker.Comment{
+		{Body: "[human:review-started]", Created: now.Add(-time.Hour)},
+		{Body: "plain comment", Created: now},
+		{Body: "[human:deployed]\npr: https://x/1", Created: now},
+	}}
+	var buf bytes.Buffer
+
+	err := RunMarkerList(context.Background(), p, &buf, "SC-1")
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Less(t, strings.Index(out, "deployed"), strings.Index(out, "review-started"))
+}
+
+func TestRunMarkerList_emptyIsArray(t *testing.T) {
+	p := &stubProvider{}
+	var buf bytes.Buffer
+	require.NoError(t, RunMarkerList(context.Background(), p, &buf, "SC-1"))
+	assert.Equal(t, "[]\n", buf.String())
+}
+
+func TestParseFieldArgs_orderAndDuplicates(t *testing.T) {
+	fields, order, err := parseFieldArgs([]string{"b=2", "a=1", "b=3"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"b", "a"}, order)
+	assert.Equal(t, map[string]string{"a": "1", "b": "3"}, fields)
+}
+
+func TestResolveBody_sources(t *testing.T) {
+	body, err := resolveBody("inline", "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "inline", body)
+
+	body, err = resolveBody("", "-", strings.NewReader("from stdin"))
+	require.NoError(t, err)
+	assert.Equal(t, "from stdin", body)
+
+	_, err = resolveBody("x", "y", nil)
+	require.Error(t, err)
+}
+
+func TestBuildMarkerCmd_Subcommands(t *testing.T) {
+	cmd := BuildMarkerCmd(cmdutil.DefaultDeps())
+	names := make([]string, 0)
+	for _, sub := range cmd.Commands() {
+		names = append(names, strings.Fields(sub.Use)[0])
+	}
+	assert.ElementsMatch(t, []string{"post", "show", "list"}, names)
+}

--- a/internal/marker/README.md
+++ b/internal/marker/README.md
@@ -1,0 +1,10 @@
+# Marker Protocol
+
+The `[human:*]` marker comments are how pipeline stages hand work to each other on a ticket — plan attached, ready for review, review verdict, deploy result. This package is the single shared grammar for building and reading them, surfaced as `human marker post|show|list`.
+
+- Posts any marker with validated fields (`human marker post KEY TYPE --field k=v --head TOKEN --body/--body-file`)
+- Reads the newest marker of a type as parsed JSON or verbatim (`human marker show KEY TYPE [--raw]`)
+- Lists every marker on a ticket, newest first (`human marker list KEY`)
+- Enforces required fields and head-token enums for known types at post time
+- Accepts unknown marker types so new pipeline stages need no CLI release
+- Latest-wins semantics: a re-posted marker supersedes older ones without history edits

--- a/internal/marker/marker.go
+++ b/internal/marker/marker.go
@@ -1,0 +1,234 @@
+// Package marker implements the [human:*] comment protocol — the structured
+// marker comments through which pipeline stages hand work to each other on a
+// ticket (plan attached, ready for review, review verdict, deploy result).
+// Agents previously assembled and re-parsed these blocks from prose templates
+// in their prompts; this package is the single grammar both sides share.
+package marker
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// Marker is one parsed [human:<type>] comment.
+type Marker struct {
+	// Type is the marker name inside the header, e.g. "ready-for-review".
+	Type string `json:"type"`
+	// Head is the optional token following the header on the same line
+	// ([human:bug-verdict] confirmed → Head "confirmed").
+	Head string `json:"head,omitempty"`
+	// Fields are the "key: value" lines following the header, before the
+	// first blank line. Indented continuation lines belong to the preceding
+	// field (the reviews: map in review-complete).
+	Fields map[string]string `json:"fields,omitempty"`
+	// Body is the free-form remainder after the field block.
+	Body string `json:"body,omitempty"`
+}
+
+// spec captures the validation contract of a known marker type. Unknown types
+// stay postable — the protocol must stay open for new pipeline stages — but
+// known types enforce their required fields and head enums so a malformed
+// handoff fails at post time, not at the reader.
+type spec struct {
+	required  []string
+	headEnum  []string
+	needsHead bool
+}
+
+var specs = map[string]spec{
+	"plan":             {},
+	"plan-ready":       {},
+	"ready-for-review": {required: []string{"branch", "commits"}},
+	"review-started":   {},
+	"review-complete":  {required: []string{"verdict"}},
+	"review-failed":    {required: []string{"reason"}},
+	"no-fix-needed":    {required: []string{"verdict"}},
+	"nothing-to-do":    {required: []string{"evidence"}},
+	"deploy-started":   {},
+	"deploy-failed":    {required: []string{"reason"}},
+	"deployed":         {required: []string{"pr"}},
+	"bug-verdict":      {needsHead: true, headEnum: []string{"confirmed", "not-a-bug", "undetermined"}},
+	"bug-verify":       {needsHead: true, headEnum: []string{"DONE", "NOT DONE"}},
+	"options":          {required: []string{"stage"}},
+}
+
+// KnownTypes lists the marker types with a validation contract, sorted.
+func KnownTypes() []string {
+	types := make([]string, 0, len(specs))
+	for t := range specs {
+		types = append(types, t)
+	}
+	sort.Strings(types)
+	return types
+}
+
+// Validate checks m against its type's contract. Unknown types pass — only a
+// syntactically valid type name is required.
+func Validate(m Marker) error {
+	if !typeNamePattern.MatchString(m.Type) {
+		return errors.WithDetails("invalid marker type name", "type", m.Type)
+	}
+	s, known := specs[m.Type]
+	if !known {
+		return nil
+	}
+	for _, req := range s.required {
+		if strings.TrimSpace(m.Fields[req]) == "" {
+			return errors.WithDetails("marker is missing a required field", "type", m.Type, "field", req)
+		}
+	}
+	if s.needsHead && strings.TrimSpace(m.Head) == "" {
+		return errors.WithDetails("marker requires a head token", "type", m.Type, "allowed", strings.Join(s.headEnum, "|"))
+	}
+	if len(s.headEnum) > 0 && m.Head != "" {
+		for _, allowed := range s.headEnum {
+			if m.Head == allowed {
+				return nil
+			}
+		}
+		return errors.WithDetails("marker head token not in allowed set", "type", m.Type, "head", m.Head, "allowed", strings.Join(s.headEnum, "|"))
+	}
+	return nil
+}
+
+var (
+	typeNamePattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+	headerPattern   = regexp.MustCompile(`^\[human:([a-z][a-z0-9-]*)\][ \t]*(.*)$`)
+	fieldPattern    = regexp.MustCompile(`^([a-z][a-z0-9_-]*):[ \t]*(.*)$`)
+)
+
+// Render serializes m into the canonical comment body: header line (with head
+// token when present), field lines with indented continuations for multiline
+// values, then a blank line and the body.
+func Render(m Marker, fieldOrder []string) string {
+	var b strings.Builder
+	b.WriteString("[human:" + m.Type + "]")
+	if m.Head != "" {
+		b.WriteString(" " + m.Head)
+	}
+	b.WriteString("\n")
+	for _, key := range orderedKeys(m.Fields, fieldOrder) {
+		value := m.Fields[key]
+		lines := strings.Split(value, "\n")
+		b.WriteString(key + ": " + lines[0] + "\n")
+		for _, cont := range lines[1:] {
+			b.WriteString("  " + cont + "\n")
+		}
+	}
+	if m.Body != "" {
+		b.WriteString("\n" + strings.TrimSpace(m.Body) + "\n")
+	}
+	return strings.TrimSuffix(b.String(), "\n")
+}
+
+// orderedKeys returns fields' keys with the caller's explicit order first
+// (posting order matters for readability: engineering, branch, commits) and
+// any remaining keys sorted for stable output.
+func orderedKeys(fields map[string]string, explicit []string) []string {
+	seen := make(map[string]bool, len(fields))
+	keys := make([]string, 0, len(fields))
+	for _, key := range explicit {
+		if _, ok := fields[key]; ok && !seen[key] {
+			keys = append(keys, key)
+			seen[key] = true
+		}
+	}
+	rest := make([]string, 0, len(fields))
+	for key := range fields {
+		if !seen[key] {
+			rest = append(rest, key)
+		}
+	}
+	sort.Strings(rest)
+	return append(keys, rest...)
+}
+
+// ParseBody parses one comment body into a Marker. ok is false when the body
+// is not a marker comment at all.
+func ParseBody(body string) (Marker, bool) {
+	lines := strings.Split(strings.TrimSpace(body), "\n")
+	if len(lines) == 0 {
+		return Marker{}, false
+	}
+	header := headerPattern.FindStringSubmatch(strings.TrimSpace(lines[0]))
+	if header == nil {
+		return Marker{}, false
+	}
+	m := Marker{Type: header[1], Head: strings.TrimSpace(header[2])}
+
+	fields := map[string]string{}
+	var currentField string
+	bodyStart := len(lines)
+	for i := 1; i < len(lines); i++ {
+		line := lines[i]
+		if strings.TrimSpace(line) == "" {
+			bodyStart = i + 1
+			break
+		}
+		if match := fieldPattern.FindStringSubmatch(line); match != nil {
+			currentField = match[1]
+			fields[currentField] = match[2]
+			continue
+		}
+		if (strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t")) && currentField != "" {
+			fields[currentField] += "\n" + strings.TrimSpace(line)
+			continue
+		}
+		// A non-field, non-continuation line without a preceding blank line:
+		// treat everything from here as body — tolerant reading beats
+		// rejecting a slightly hand-edited marker.
+		bodyStart = i
+		break
+	}
+	if len(fields) > 0 {
+		m.Fields = fields
+	}
+	if bodyStart < len(lines) {
+		m.Body = strings.TrimSpace(strings.Join(lines[bodyStart:], "\n"))
+	}
+	return m, true
+}
+
+// Latest returns the newest marker of markerType among comments, using the
+// same latest-wins rule as the plan comment: a re-post supersedes older
+// markers without history edits.
+func Latest(comments []tracker.Comment, markerType string) (Marker, bool) {
+	var latest Marker
+	var found bool
+	latestIdx := -1
+	for i, c := range comments {
+		m, ok := ParseBody(c.Body)
+		if !ok || m.Type != markerType {
+			continue
+		}
+		if latestIdx == -1 || c.Created.After(comments[latestIdx].Created) {
+			latestIdx = i
+			latest = m
+			found = true
+		}
+	}
+	return latest, found
+}
+
+// All returns every marker among comments, newest first.
+func All(comments []tracker.Comment) []Marker {
+	indexed := make([]int, 0, len(comments))
+	for i := range comments {
+		if _, ok := ParseBody(comments[i].Body); ok {
+			indexed = append(indexed, i)
+		}
+	}
+	sort.SliceStable(indexed, func(a, b int) bool {
+		return comments[indexed[a]].Created.After(comments[indexed[b]].Created)
+	})
+	markers := make([]Marker, 0, len(indexed))
+	for _, i := range indexed {
+		m, _ := ParseBody(comments[i].Body)
+		markers = append(markers, m)
+	}
+	return markers
+}

--- a/internal/marker/marker_test.go
+++ b/internal/marker/marker_test.go
@@ -1,0 +1,137 @@
+package marker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+func TestRender_headerFieldsBody(t *testing.T) {
+	m := Marker{
+		Type:   "ready-for-review",
+		Fields: map[string]string{"branch": "main", "commits": "2037e40, 64bb370", "engineering": "HUM-89"},
+	}
+	out := Render(m, []string{"engineering", "branch", "commits"})
+	assert.Equal(t, "[human:ready-for-review]\nengineering: HUM-89\nbranch: main\ncommits: 2037e40, 64bb370", out)
+}
+
+func TestRender_headToken(t *testing.T) {
+	m := Marker{Type: "bug-verdict", Head: "confirmed", Body: "root cause: nil check"}
+	out := Render(m, nil)
+	assert.Equal(t, "[human:bug-verdict] confirmed\n\nroot cause: nil check", out)
+}
+
+func TestRender_multilineFieldIndentsContinuations(t *testing.T) {
+	m := Marker{
+		Type:   "review-complete",
+		Fields: map[string]string{"verdict": "pass", "reviews": "HUM-89: pass — .human/reviews/hum-89.md\nHUM-90: pass — .human/reviews/hum-90.md"},
+		Body:   "## Findings\nnone",
+	}
+	out := Render(m, []string{"verdict", "reviews"})
+	assert.Equal(t,
+		"[human:review-complete]\nverdict: pass\nreviews: HUM-89: pass — .human/reviews/hum-89.md\n  HUM-90: pass — .human/reviews/hum-90.md\n\n## Findings\nnone",
+		out)
+}
+
+func TestParseBody_roundTrip(t *testing.T) {
+	orig := Marker{
+		Type:   "ready-for-review",
+		Fields: map[string]string{"branch": "main", "commits": "abc, def", "daemon": "d-1"},
+		Body:   "extra notes",
+	}
+	parsed, ok := ParseBody(Render(orig, []string{"branch", "commits", "daemon"}))
+	require.True(t, ok)
+	assert.Equal(t, orig, parsed)
+}
+
+func TestParseBody_multilineFieldRoundTrip(t *testing.T) {
+	orig := Marker{
+		Type:   "review-complete",
+		Fields: map[string]string{"verdict": "pass", "reviews": "A: pass\nB: fail"},
+	}
+	parsed, ok := ParseBody(Render(orig, []string{"verdict", "reviews"}))
+	require.True(t, ok)
+	assert.Equal(t, orig, parsed)
+}
+
+func TestParseBody_notAMarker(t *testing.T) {
+	_, ok := ParseBody("just a regular comment")
+	assert.False(t, ok)
+	_, ok = ParseBody("")
+	assert.False(t, ok)
+}
+
+func TestParseBody_headToken(t *testing.T) {
+	m, ok := ParseBody("[human:bug-verify] NOT DONE\n\ndetails here")
+	require.True(t, ok)
+	assert.Equal(t, "bug-verify", m.Type)
+	assert.Equal(t, "NOT DONE", m.Head)
+	assert.Equal(t, "details here", m.Body)
+}
+
+func TestParseBody_unexpectedLineBecomesBody(t *testing.T) {
+	m, ok := ParseBody("[human:plan]\nThis is prose, not a field line.\nMore prose.")
+	require.True(t, ok)
+	assert.Empty(t, m.Fields)
+	assert.Equal(t, "This is prose, not a field line.\nMore prose.", m.Body)
+}
+
+func TestValidate_requiredFields(t *testing.T) {
+	err := Validate(Marker{Type: "ready-for-review", Fields: map[string]string{"branch": "main"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required field")
+
+	assert.NoError(t, Validate(Marker{Type: "ready-for-review", Fields: map[string]string{"branch": "main", "commits": "abc"}}))
+}
+
+func TestValidate_headEnum(t *testing.T) {
+	assert.Error(t, Validate(Marker{Type: "bug-verdict"}))
+	assert.Error(t, Validate(Marker{Type: "bug-verdict", Head: "maybe"}))
+	assert.NoError(t, Validate(Marker{Type: "bug-verdict", Head: "confirmed"}))
+	assert.NoError(t, Validate(Marker{Type: "bug-verify", Head: "NOT DONE"}))
+}
+
+func TestValidate_unknownTypeAllowed(t *testing.T) {
+	assert.NoError(t, Validate(Marker{Type: "future-stage"}))
+	assert.Error(t, Validate(Marker{Type: "Not A Type"}))
+}
+
+func TestLatest_newestWins(t *testing.T) {
+	now := time.Now()
+	comments := []tracker.Comment{
+		{Body: "[human:plan]\n\nold plan", Created: now.Add(-time.Hour)},
+		{Body: "unrelated", Created: now},
+		{Body: "[human:plan]\n\nnew plan", Created: now.Add(-time.Minute)},
+	}
+	m, ok := Latest(comments, "plan")
+	require.True(t, ok)
+	assert.Equal(t, "new plan", m.Body)
+
+	_, ok = Latest(comments, "deployed")
+	assert.False(t, ok)
+}
+
+func TestAll_newestFirst(t *testing.T) {
+	now := time.Now()
+	comments := []tracker.Comment{
+		{Body: "[human:review-started]", Created: now.Add(-time.Hour)},
+		{Body: "not a marker", Created: now},
+		{Body: "[human:deployed]\npr: http://x", Created: now.Add(-time.Minute)},
+	}
+	markers := All(comments)
+	require.Len(t, markers, 2)
+	assert.Equal(t, "deployed", markers[0].Type)
+	assert.Equal(t, "review-started", markers[1].Type)
+}
+
+func TestKnownTypes_sortedAndComplete(t *testing.T) {
+	types := KnownTypes()
+	assert.Contains(t, types, "plan")
+	assert.Contains(t, types, "ready-for-review")
+	assert.Contains(t, types, "bug-verify")
+	assert.IsIncreasing(t, types)
+}

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gethuman-sh/human/cmd/cmdfigma"
 	"github.com/gethuman-sh/human/cmd/cmdindex"
 	"github.com/gethuman-sh/human/cmd/cmdinit"
+	"github.com/gethuman-sh/human/cmd/cmdmarker"
 	"github.com/gethuman-sh/human/cmd/cmdnotion"
 	"github.com/gethuman-sh/human/cmd/cmdping"
 	"github.com/gethuman-sh/human/cmd/cmdplan"
@@ -223,6 +224,10 @@ Configure trackers and tools in .humanconfig.yaml or pass credentials via flags/
 	commitsCmd := cmdcommits.BuildCommitsCmd()
 	commitsCmd.GroupID = "shortcuts"
 	rootCmd.AddCommand(commitsCmd)
+
+	markerCmd := cmdmarker.BuildMarkerCmd(autoDeps)
+	markerCmd.GroupID = "shortcuts"
+	rootCmd.AddCommand(markerCmd)
 
 	// --- Provider commands (dynamic registration) ---
 	providers := []string{"jira", "github", "gitlab", "linear", "azuredevops", "shortcut", "clickup"}


### PR DESCRIPTION
Resolves ticket 1007: the `[human:*]` marker grammar lived only as prose templates across ~12 agent prompts. `internal/marker` is now the one shared implementation, surfaced as `human marker post|show|list`.

- Fixed grammar: `[human:TYPE] [HEAD]` header, `key: value` field lines with indented continuations (covers the `reviews:` map), blank line, free body — round-trip tested
- Known types validated at post time (required fields, head enums for bug-verdict/bug-verify); unknown types allowed for forward compatibility
- Latest-wins selection matches `plan show` semantics
- Rendered markers parse cleanly with the daemon's existing `review_handoff.go`/`board_markers.go` line parsers; consolidating those onto `internal/marker` is a sensible follow-up refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)