### PR TITLE
[SC-1008] Add human handoff post/show for verified review handoffs

### DIFF
--- a/cmd/cmdhandoff/handoff.go
+++ b/cmd/cmdhandoff/handoff.go
@@ -1,0 +1,240 @@
+// Package cmdhandoff surfaces the review handoff — the [human:ready-for-review]
+// marker through which a finished build is handed to a reviewer — as a pair of
+// deterministic commands. Every field of the handoff is derivable (branch from
+// git, commits from the ticket-key commit search, daemon id from the
+// environment), and posting verifies the named commits are actually reachable
+// on the branch so a handoff can never bind a reviewer to commits that live
+// nowhere but a local checkout.
+package cmdhandoff
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gethuman-sh/human/cmd/cmdutil"
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/gitrepo"
+	"github.com/gethuman-sh/human/internal/marker"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// handoffType is the marker type this command family owns.
+const handoffType = "ready-for-review"
+
+// Handoff is the parsed review handoff, as printed by show.
+type Handoff struct {
+	Engineering []string `json:"engineering,omitempty"`
+	Branch      string   `json:"branch"`
+	Commits     []string `json:"commits"`
+	Daemon      string   `json:"daemon,omitempty"`
+}
+
+// BuildHandoffCmd creates the top-level "handoff" command.
+func BuildHandoffCmd(deps cmdutil.Deps) *cobra.Command {
+	handoffCmd := &cobra.Command{
+		Use:   "handoff",
+		Short: "Post and read the [human:ready-for-review] handoff on a ticket",
+	}
+	handoffCmd.AddCommand(buildPostCmd(deps), buildShowCmd(deps))
+	return handoffCmd
+}
+
+func buildPostCmd(deps cmdutil.Deps) *cobra.Command {
+	var engineering, branch, commits string
+	var noVerify bool
+	cmd := &cobra.Command{
+		Use:   "post KEY",
+		Short: "Post a verified review handoff (branch/commits derived from git when omitted)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := cmdutil.ResolveAutoProvider(cmd.Context(), cmd, args[0], true, deps)
+			if err != nil {
+				return err
+			}
+			defer resolved.Cleanup()
+			opts := PostOptions{
+				Engineering: splitList(engineering),
+				Branch:      branch,
+				Commits:     splitList(commits),
+				DaemonID:    os.Getenv("HUMAN_DAEMON_ID"),
+				Verify:      !noVerify,
+			}
+			return RunHandoffPost(cmd.Context(), resolved.Provider, cmd.OutOrStdout(), ".", resolved.Key, opts)
+		},
+	}
+	cmd.Flags().StringVar(&engineering, "engineering", "", "Engineering ticket keys, comma-separated (omit in single-tracker topology)")
+	cmd.Flags().StringVar(&branch, "branch", "", "Branch the commits live on (default: current branch)")
+	cmd.Flags().StringVar(&commits, "commits", "", "Short SHAs, comma-separated (default: commits referencing the work keys)")
+	cmd.Flags().BoolVar(&noVerify, "no-verify", false, "Skip verifying the commits are reachable on the branch")
+	return cmd
+}
+
+func buildShowCmd(deps cmdutil.Deps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show KEY",
+		Short: "Print the newest review handoff on a ticket as parsed JSON",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := cmdutil.ResolveAutoProvider(cmd.Context(), cmd, args[0], true, deps)
+			if err != nil {
+				return err
+			}
+			defer resolved.Cleanup()
+			return RunHandoffShow(cmd.Context(), resolved.Provider, cmd.OutOrStdout(), resolved.Key)
+		},
+	}
+	return cmd
+}
+
+// PostOptions carries the explicit overrides for a handoff post; zero values
+// mean "derive it".
+type PostOptions struct {
+	Engineering []string
+	Branch      string
+	Commits     []string
+	DaemonID    string
+	Verify      bool
+}
+
+// RunHandoffPost derives missing fields, verifies commit reachability, and
+// posts the handoff marker on the ticket.
+func RunHandoffPost(ctx context.Context, p tracker.Provider, out io.Writer, dir, key string, opts PostOptions) error {
+	branch := opts.Branch
+	if branch == "" {
+		derived, err := gitrepo.CurrentBranch(ctx, dir)
+		if err != nil {
+			return err
+		}
+		if derived == "HEAD" {
+			return errors.WithDetails("detached HEAD has no branch — pass --branch", "dir", dir)
+		}
+		branch = derived
+	}
+
+	commits := opts.Commits
+	if len(commits) == 0 {
+		derived, err := deriveCommits(ctx, dir, key, opts.Engineering)
+		if err != nil {
+			return err
+		}
+		commits = derived
+	}
+	if len(commits) == 0 {
+		return errors.WithDetails("no commits reference the work keys — commit first or pass --commits", "key", key)
+	}
+
+	if opts.Verify {
+		if err := verifyReachable(ctx, dir, branch, commits); err != nil {
+			return err
+		}
+	}
+
+	fields := map[string]string{
+		"branch":  branch,
+		"commits": strings.Join(commits, ", "),
+	}
+	if len(opts.Engineering) > 0 {
+		fields["engineering"] = strings.Join(opts.Engineering, ", ")
+	}
+	if strings.TrimSpace(opts.DaemonID) != "" {
+		fields["daemon"] = opts.DaemonID
+	}
+	m := marker.Marker{Type: handoffType, Fields: fields}
+	rendered := marker.Render(m, []string{"engineering", "branch", "commits", "daemon"})
+	if _, err := p.AddComment(ctx, key, rendered); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintln(out, rendered)
+	return err
+}
+
+// RunHandoffShow prints the newest handoff on the ticket as parsed JSON.
+func RunHandoffShow(ctx context.Context, p tracker.Provider, out io.Writer, key string) error {
+	comments, err := p.ListComments(ctx, key)
+	if err != nil {
+		return err
+	}
+	m, ok := marker.Latest(comments, handoffType)
+	if !ok {
+		return errors.WithDetails("no review handoff on ticket", "key", key)
+	}
+	h := Handoff{
+		Engineering: splitList(m.Fields["engineering"]),
+		Branch:      m.Fields["branch"],
+		Commits:     splitList(m.Fields["commits"]),
+		Daemon:      m.Fields["daemon"],
+	}
+	if h.Commits == nil {
+		h.Commits = []string{}
+	}
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(h)
+}
+
+// deriveCommits collects the short SHAs referencing the work keys (the
+// engineering keys in split topology, the ticket itself otherwise), oldest
+// first so the handoff reads in commit order.
+func deriveCommits(ctx context.Context, dir, key string, engineering []string) ([]string, error) {
+	workKeys := engineering
+	if len(workKeys) == 0 {
+		workKeys = []string{key}
+	}
+	var shas []string
+	seen := map[string]bool{}
+	for _, workKey := range workKeys {
+		found, err := gitrepo.CommitsFor(ctx, dir, workKey)
+		if err != nil {
+			return nil, err
+		}
+		// git log lists newest first; a handoff reads oldest first.
+		for i := len(found) - 1; i >= 0; i-- {
+			sha := found[i].ShortSHA
+			if !seen[sha] {
+				seen[sha] = true
+				shas = append(shas, sha)
+			}
+		}
+	}
+	return shas, nil
+}
+
+// verifyReachable rejects the handoff when any commit is not reachable on the
+// branch as known to origin — the exact failure that once bound reviewers to
+// commits living only in a local checkout. The fetch is best-effort: offline,
+// the local refs are still checked.
+func verifyReachable(ctx context.Context, dir, branch string, commits []string) error {
+	_ = gitrepo.Fetch(ctx, dir, branch)
+	var unreachable []string
+	for _, sha := range commits {
+		if !gitrepo.CommitReachable(ctx, dir, branch, sha) {
+			unreachable = append(unreachable, sha)
+		}
+	}
+	if len(unreachable) > 0 {
+		return errors.WithDetails("commits not reachable on branch — push first or pass --no-verify",
+			"branch", branch, "commits", strings.Join(unreachable, ", "))
+	}
+	return nil
+}
+
+// splitList splits a comma-separated list, trimming blanks.
+func splitList(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}

--- a/cmd/cmdhandoff/handoff_test.go
+++ b/cmd/cmdhandoff/handoff_test.go
@@ -1,0 +1,191 @@
+package cmdhandoff
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/gitrepo"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// stubProvider implements tracker.Provider; only the comment methods matter.
+type stubProvider struct {
+	comments []tracker.Comment
+	added    []string
+	addErr   error
+}
+
+func (s *stubProvider) ListIssues(context.Context, tracker.ListOptions) ([]tracker.Issue, error) {
+	return nil, nil
+}
+func (s *stubProvider) GetIssue(context.Context, string) (*tracker.Issue, error) { return nil, nil }
+func (s *stubProvider) CreateIssue(context.Context, *tracker.Issue) (*tracker.Issue, error) {
+	return nil, nil
+}
+func (s *stubProvider) ListComments(context.Context, string) ([]tracker.Comment, error) {
+	return s.comments, nil
+}
+func (s *stubProvider) AddComment(_ context.Context, _, body string) (*tracker.Comment, error) {
+	s.added = append(s.added, body)
+	return &tracker.Comment{Body: body}, s.addErr
+}
+func (s *stubProvider) LinkIssues(context.Context, string, string) error      { return nil }
+func (s *stubProvider) DeleteIssue(context.Context, string) error             { return nil }
+func (s *stubProvider) TransitionIssue(context.Context, string, string) error { return nil }
+func (s *stubProvider) AssignIssue(context.Context, string, string) error     { return nil }
+func (s *stubProvider) GetCurrentUser(context.Context) (string, error)        { return "", nil }
+func (s *stubProvider) EditIssue(context.Context, string, tracker.EditOptions) (*tracker.Issue, error) {
+	return nil, nil
+}
+func (s *stubProvider) ListStatuses(context.Context, string) ([]tracker.Status, error) {
+	return nil, nil
+}
+
+func stubGit(t *testing.T, branch string, commitsByKey map[string][]gitrepo.Commit, reachable map[string]bool) {
+	t.Helper()
+	prevBranch, prevCommits, prevReach, prevFetch := gitrepo.CurrentBranch, gitrepo.CommitsFor, gitrepo.CommitReachable, gitrepo.Fetch
+	gitrepo.CurrentBranch = func(context.Context, string) (string, error) { return branch, nil }
+	gitrepo.CommitsFor = func(_ context.Context, _, key string) ([]gitrepo.Commit, error) {
+		return commitsByKey[key], nil
+	}
+	gitrepo.CommitReachable = func(_ context.Context, _, _, sha string) bool { return reachable[sha] }
+	gitrepo.Fetch = func(context.Context, string, string) error { return nil }
+	t.Cleanup(func() {
+		gitrepo.CurrentBranch, gitrepo.CommitsFor, gitrepo.CommitReachable, gitrepo.Fetch = prevBranch, prevCommits, prevReach, prevFetch
+	})
+}
+
+func TestRunHandoffPost_derivesEverything(t *testing.T) {
+	stubGit(t, "autofix/sc-1", map[string][]gitrepo.Commit{
+		"SC-1": {{ShortSHA: "bbb"}, {ShortSHA: "aaa"}}, // git log order: newest first
+	}, map[string]bool{"aaa": true, "bbb": true})
+	p := &stubProvider{}
+	var buf bytes.Buffer
+
+	err := RunHandoffPost(context.Background(), p, &buf, ".", "SC-1", PostOptions{Verify: true})
+	require.NoError(t, err)
+	require.Len(t, p.added, 1)
+	assert.Equal(t, "[human:ready-for-review]\nbranch: autofix/sc-1\ncommits: aaa, bbb", p.added[0])
+}
+
+func TestRunHandoffPost_splitTopologyFieldsAndDaemon(t *testing.T) {
+	stubGit(t, "main", map[string][]gitrepo.Commit{
+		"HUM-89": {{ShortSHA: "abc"}},
+		"HUM-90": {{ShortSHA: "def"}},
+	}, map[string]bool{"abc": true, "def": true})
+	p := &stubProvider{}
+	var buf bytes.Buffer
+
+	opts := PostOptions{Engineering: []string{"HUM-89", "HUM-90"}, DaemonID: "d-1", Verify: true}
+	err := RunHandoffPost(context.Background(), p, &buf, ".", "SC-1", opts)
+	require.NoError(t, err)
+	require.Len(t, p.added, 1)
+	assert.Equal(t,
+		"[human:ready-for-review]\nengineering: HUM-89, HUM-90\nbranch: main\ncommits: abc, def\ndaemon: d-1",
+		p.added[0])
+}
+
+func TestRunHandoffPost_unreachableCommitBlocks(t *testing.T) {
+	stubGit(t, "main", map[string][]gitrepo.Commit{
+		"SC-1": {{ShortSHA: "aaa"}},
+	}, map[string]bool{})
+	p := &stubProvider{}
+	var buf bytes.Buffer
+
+	err := RunHandoffPost(context.Background(), p, &buf, ".", "SC-1", PostOptions{Verify: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not reachable")
+	assert.Empty(t, p.added)
+}
+
+func TestRunHandoffPost_noVerifySkipsReachability(t *testing.T) {
+	stubGit(t, "main", map[string][]gitrepo.Commit{
+		"SC-1": {{ShortSHA: "aaa"}},
+	}, map[string]bool{})
+	p := &stubProvider{}
+	var buf bytes.Buffer
+
+	err := RunHandoffPost(context.Background(), p, &buf, ".", "SC-1", PostOptions{Verify: false})
+	require.NoError(t, err)
+	require.Len(t, p.added, 1)
+}
+
+func TestRunHandoffPost_noCommitsFails(t *testing.T) {
+	stubGit(t, "main", map[string][]gitrepo.Commit{}, nil)
+	p := &stubProvider{}
+	var buf bytes.Buffer
+
+	err := RunHandoffPost(context.Background(), p, &buf, ".", "SC-1", PostOptions{Verify: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no commits reference")
+}
+
+func TestRunHandoffPost_detachedHeadFails(t *testing.T) {
+	stubGit(t, "HEAD", nil, nil)
+	p := &stubProvider{}
+	var buf bytes.Buffer
+
+	err := RunHandoffPost(context.Background(), p, &buf, ".", "SC-1", PostOptions{Verify: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "detached HEAD")
+}
+
+func TestRunHandoffPost_explicitOverridesSkipDerivation(t *testing.T) {
+	stubGit(t, "wrong-branch", nil, map[string]bool{"x1": true})
+	p := &stubProvider{}
+	var buf bytes.Buffer
+
+	opts := PostOptions{Branch: "release", Commits: []string{"x1"}, Verify: true}
+	err := RunHandoffPost(context.Background(), p, &buf, ".", "SC-1", opts)
+	require.NoError(t, err)
+	assert.Contains(t, p.added[0], "branch: release")
+	assert.Contains(t, p.added[0], "commits: x1")
+}
+
+func TestRunHandoffShow_parsesNewestHandoff(t *testing.T) {
+	now := time.Now()
+	p := &stubProvider{comments: []tracker.Comment{
+		{Body: "[human:ready-for-review]\nbranch: old\ncommits: zzz", Created: now.Add(-time.Hour)},
+		{Body: "[human:ready-for-review]\nengineering: HUM-89, HUM-90\nbranch: main\ncommits: abc, def\ndaemon: d-1", Created: now},
+	}}
+	var buf bytes.Buffer
+
+	err := RunHandoffShow(context.Background(), p, &buf, "SC-1")
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, `"engineering": [`)
+	assert.Contains(t, out, `"HUM-89"`)
+	assert.Contains(t, out, `"branch": "main"`)
+	assert.Contains(t, out, `"abc"`)
+	assert.Contains(t, out, `"daemon": "d-1"`)
+	assert.NotContains(t, out, "zzz", "latest handoff wins")
+}
+
+func TestRunHandoffShow_missing(t *testing.T) {
+	p := &stubProvider{}
+	var buf bytes.Buffer
+	err := RunHandoffShow(context.Background(), p, &buf, "SC-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no review handoff")
+}
+
+func TestRunHandoffPost_addCommentError(t *testing.T) {
+	stubGit(t, "main", map[string][]gitrepo.Commit{"SC-1": {{ShortSHA: "aaa"}}}, map[string]bool{"aaa": true})
+	p := &stubProvider{addErr: errors.WithDetails("tracker down")}
+	var buf bytes.Buffer
+	err := RunHandoffPost(context.Background(), p, &buf, ".", "SC-1", PostOptions{Verify: true})
+	require.Error(t, err)
+}
+
+func TestSplitList(t *testing.T) {
+	assert.Nil(t, splitList(""))
+	assert.Nil(t, splitList("  "))
+	assert.Equal(t, []string{"a", "b"}, splitList("a, b"))
+	assert.Equal(t, []string{"a"}, splitList("a,"))
+}

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -280,3 +280,15 @@ var CommitsFor = func(ctx context.Context, dir, key string) ([]Commit, error) {
 	}
 	return commits, nil
 }
+
+// CurrentBranch returns the checked-out branch name of the repository at dir
+// (running `git -C <dir> rev-parse --abbrev-ref HEAD`). A detached HEAD yields
+// "HEAD", which callers should treat as "no branch". Package var so callers can
+// stub git access in tests.
+var CurrentBranch = func(ctx context.Context, dir string) (string, error) {
+	out, err := runner(ctx, "git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", errors.WrapWithDetails(err, "reading current branch", "dir", dir)
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -551,3 +551,25 @@ func TestKeyRefPattern_numericVsPrefixed(t *testing.T) {
 		t.Errorf("prefixed pattern %q must not carry the numeric hash form", pre)
 	}
 }
+
+func TestCurrentBranch(t *testing.T) {
+	withRunner(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		return []byte("feature/x\n"), nil
+	})
+	branch, err := CurrentBranch(context.Background(), ".")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if branch != "feature/x" {
+		t.Errorf("branch = %q", branch)
+	}
+}
+
+func TestCurrentBranch_error(t *testing.T) {
+	withRunner(t, func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return nil, errors.New("exit status 128")
+	})
+	if _, err := CurrentBranch(context.Background(), "."); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/marker/README.md
+++ b/internal/marker/README.md
@@ -8,3 +8,4 @@ The `[human:*]` marker comments are how pipeline stages hand work to each other 
 - Enforces required fields and head-token enums for known types at post time
 - Accepts unknown marker types so new pipeline stages need no CLI release
 - Latest-wins semantics: a re-posted marker supersedes older ones without history edits
+- Review handoffs get dedicated commands (`human handoff post|show KEY`): branch, commits, and daemon id are derived from git and the environment, and posting verifies every commit is reachable on the branch

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gethuman-sh/human/cmd/cmddaemon"
 	"github.com/gethuman-sh/human/cmd/cmddoctor"
 	"github.com/gethuman-sh/human/cmd/cmdfigma"
+	"github.com/gethuman-sh/human/cmd/cmdhandoff"
 	"github.com/gethuman-sh/human/cmd/cmdindex"
 	"github.com/gethuman-sh/human/cmd/cmdinit"
 	"github.com/gethuman-sh/human/cmd/cmdmarker"
@@ -228,6 +229,10 @@ Configure trackers and tools in .humanconfig.yaml or pass credentials via flags/
 	markerCmd := cmdmarker.BuildMarkerCmd(autoDeps)
 	markerCmd.GroupID = "shortcuts"
 	rootCmd.AddCommand(markerCmd)
+
+	handoffCmd := cmdhandoff.BuildHandoffCmd(autoDeps)
+	handoffCmd.GroupID = "shortcuts"
+	rootCmd.AddCommand(handoffCmd)
 
 	// --- Provider commands (dynamic registration) ---
 	providers := []string{"jira", "github", "gitlab", "linear", "azuredevops", "shortcut", "clickup"}


### PR DESCRIPTION
Resolves ticket 1008: the review handoff build/parse pair, previously hand-rolled in 4+ prompt files.

- `human handoff post KEY [--engineering ...] [--branch ...] [--commits ...] [--no-verify]` — derives branch (current), commits (via the SC-1011 commit search, oldest first, deduped), daemon id (env); verifies every commit is reachable on the branch before posting
- `human handoff show KEY` — newest handoff parsed to JSON (engineering[], branch, commits[], daemon)
- Emits through the SC-1007 marker grammar; line-compatible with the daemon's handoff parsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)