### PR TITLE
[SC-1012] Add human done/close and idea promote semantic shortcuts

### DIFF
--- a/cmd/cmdauto/semantic.go
+++ b/cmd/cmdauto/semantic.go
@@ -1,0 +1,123 @@
+package cmdauto
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gethuman-sh/human/cmd/cmdutil"
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// ideaLabels are the label spellings that mark a ticket as a raw idea. Both
+// forms classify (see CLAUDE.md "Tickets"), so promotion removes both.
+var ideaLabels = []string{"human/idea", "idea"}
+
+// BuildAutoDoneCmd creates the top-level "done" command: transition an issue
+// to its tracker's done-type status without knowing the status name.
+func BuildAutoDoneCmd(deps cmdutil.Deps) *cobra.Command {
+	return &cobra.Command{
+		Use:   "done KEY_OR_URL",
+		Short: "Move an issue to its done-type status (auto-detect tracker and status name)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := cmdutil.ResolveAutoProvider(cmd.Context(), cmd, args[0], true, deps)
+			if err != nil {
+				return err
+			}
+			defer result.Cleanup()
+			return RunSemanticTransition(cmd.Context(), result.Provider, cmd.OutOrStdout(), result.Key, tracker.CategoryDone, false)
+		},
+	}
+}
+
+// BuildAutoCloseCmd creates the top-level "close" command: transition an issue
+// to a closed/cancelled-type status, falling back to done-type on trackers
+// whose workflow has no closed bucket.
+func BuildAutoCloseCmd(deps cmdutil.Deps) *cobra.Command {
+	return &cobra.Command{
+		Use:   "close KEY_OR_URL",
+		Short: "Move an issue to a closed-type status (falls back to done-type when the workflow has none)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := cmdutil.ResolveAutoProvider(cmd.Context(), cmd, args[0], true, deps)
+			if err != nil {
+				return err
+			}
+			defer result.Cleanup()
+			return RunSemanticTransition(cmd.Context(), result.Provider, cmd.OutOrStdout(), result.Key, tracker.CategoryClosed, true)
+		},
+	}
+}
+
+// BuildAutoIdeaCmd creates the top-level "idea" command with the promote
+// subcommand: strip the idea labels when an idea graduates to a PM ticket.
+func BuildAutoIdeaCmd(deps cmdutil.Deps) *cobra.Command {
+	ideaCmd := &cobra.Command{
+		Use:   "idea",
+		Short: "Idea-stage ticket operations",
+	}
+	promoteCmd := &cobra.Command{
+		Use:   "promote KEY_OR_URL",
+		Short: "Remove the idea labels (human/idea, idea) — the ticket keeps its key and history",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := cmdutil.ResolveAutoProvider(cmd.Context(), cmd, args[0], true, deps)
+			if err != nil {
+				return err
+			}
+			defer result.Cleanup()
+			return RunIdeaPromote(cmd.Context(), result.Provider, cmd.OutOrStdout(), result.Key)
+		},
+	}
+	ideaCmd.AddCommand(promoteCmd)
+	return ideaCmd
+}
+
+// RunSemanticTransition moves the issue to the first status of the wanted
+// category. List order is the tracker's workflow order, so the pick is stable.
+// With fallbackToDone, a workflow without a closed bucket closes as done —
+// the closest terminal state the tracker offers.
+func RunSemanticTransition(ctx context.Context, p tracker.Provider, out io.Writer, key string, want tracker.Category, fallbackToDone bool) error {
+	statuses, err := p.ListStatuses(ctx, key)
+	if err != nil {
+		return err
+	}
+	status, ok := firstOfCategory(statuses, want)
+	if !ok && fallbackToDone {
+		if status, ok = firstOfCategory(statuses, tracker.CategoryDone); ok {
+			_, _ = fmt.Fprintf(out, "No %s-type status in this workflow — using done-type %q\n", want, status.Name)
+		}
+	}
+	if !ok {
+		return errors.WithDetails("workflow has no status of the wanted category",
+			"key", key, "category", string(want))
+	}
+	if err := p.TransitionIssue(ctx, key, status.Name); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(out, "Transitioned %s to %s\n", key, status.Name)
+	return err
+}
+
+// RunIdeaPromote strips the idea labels from the issue; labels it does not
+// carry are ignored by the edit layer, so promotion is idempotent.
+func RunIdeaPromote(ctx context.Context, p tracker.Provider, out io.Writer, key string) error {
+	if _, err := p.EditIssue(ctx, key, tracker.EditOptions{RemoveLabels: ideaLabels}); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(out, "Promoted %s: removed idea labels\n", key)
+	return err
+}
+
+func firstOfCategory(statuses []tracker.Status, want tracker.Category) (tracker.Status, bool) {
+	for _, s := range statuses {
+		if s.Category == want {
+			return s, true
+		}
+	}
+	return tracker.Status{}, false
+}

--- a/cmd/cmdauto/semantic_test.go
+++ b/cmd/cmdauto/semantic_test.go
@@ -1,0 +1,149 @@
+package cmdauto
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// semanticStub implements tracker.Provider; only statuses, transitions, and
+// edits carry behavior.
+type semanticStub struct {
+	statuses    []tracker.Status
+	transitions []string
+	editOpts    []tracker.EditOptions
+	listErr     error
+	transErr    error
+	editErr     error
+}
+
+func (s *semanticStub) ListIssues(context.Context, tracker.ListOptions) ([]tracker.Issue, error) {
+	return nil, nil
+}
+func (s *semanticStub) GetIssue(context.Context, string) (*tracker.Issue, error) { return nil, nil }
+func (s *semanticStub) CreateIssue(context.Context, *tracker.Issue) (*tracker.Issue, error) {
+	return nil, nil
+}
+func (s *semanticStub) ListComments(context.Context, string) ([]tracker.Comment, error) {
+	return nil, nil
+}
+func (s *semanticStub) AddComment(context.Context, string, string) (*tracker.Comment, error) {
+	return nil, nil
+}
+func (s *semanticStub) LinkIssues(context.Context, string, string) error { return nil }
+func (s *semanticStub) DeleteIssue(context.Context, string) error        { return nil }
+func (s *semanticStub) TransitionIssue(_ context.Context, _, status string) error {
+	s.transitions = append(s.transitions, status)
+	return s.transErr
+}
+func (s *semanticStub) AssignIssue(context.Context, string, string) error { return nil }
+func (s *semanticStub) GetCurrentUser(context.Context) (string, error)    { return "", nil }
+func (s *semanticStub) EditIssue(_ context.Context, _ string, opts tracker.EditOptions) (*tracker.Issue, error) {
+	s.editOpts = append(s.editOpts, opts)
+	return nil, s.editErr
+}
+func (s *semanticStub) ListStatuses(context.Context, string) ([]tracker.Status, error) {
+	return s.statuses, s.listErr
+}
+
+func workflow() []tracker.Status {
+	return []tracker.Status{
+		{Name: "Backlog", Category: tracker.CategoryUnstarted},
+		{Name: "In Progress", Category: tracker.CategoryStarted},
+		{Name: "Done", Category: tracker.CategoryDone},
+		{Name: "Cancelled", Category: tracker.CategoryClosed},
+	}
+}
+
+func TestRunSemanticTransition_done(t *testing.T) {
+	p := &semanticStub{statuses: workflow()}
+	var buf bytes.Buffer
+
+	err := RunSemanticTransition(context.Background(), p, &buf, "SC-1", tracker.CategoryDone, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Done"}, p.transitions)
+	assert.Contains(t, buf.String(), "Transitioned SC-1 to Done")
+}
+
+func TestRunSemanticTransition_closed(t *testing.T) {
+	p := &semanticStub{statuses: workflow()}
+	var buf bytes.Buffer
+
+	err := RunSemanticTransition(context.Background(), p, &buf, "SC-1", tracker.CategoryClosed, true)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Cancelled"}, p.transitions)
+}
+
+func TestRunSemanticTransition_closedFallsBackToDone(t *testing.T) {
+	p := &semanticStub{statuses: []tracker.Status{
+		{Name: "To Do", Category: tracker.CategoryUnstarted},
+		{Name: "Done", Category: tracker.CategoryDone},
+	}}
+	var buf bytes.Buffer
+
+	err := RunSemanticTransition(context.Background(), p, &buf, "SC-1", tracker.CategoryClosed, true)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Done"}, p.transitions)
+	assert.Contains(t, buf.String(), "No closed-type status")
+}
+
+func TestRunSemanticTransition_doneHasNoFallback(t *testing.T) {
+	p := &semanticStub{statuses: []tracker.Status{
+		{Name: "To Do", Category: tracker.CategoryUnstarted},
+	}}
+	var buf bytes.Buffer
+
+	err := RunSemanticTransition(context.Background(), p, &buf, "SC-1", tracker.CategoryDone, false)
+	require.Error(t, err)
+	assert.Empty(t, p.transitions)
+}
+
+func TestRunSemanticTransition_firstOfCategoryWins(t *testing.T) {
+	p := &semanticStub{statuses: []tracker.Status{
+		{Name: "Shipped", Category: tracker.CategoryDone},
+		{Name: "Archived", Category: tracker.CategoryDone},
+	}}
+	var buf bytes.Buffer
+
+	err := RunSemanticTransition(context.Background(), p, &buf, "SC-1", tracker.CategoryDone, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Shipped"}, p.transitions)
+}
+
+func TestRunSemanticTransition_listError(t *testing.T) {
+	p := &semanticStub{listErr: errors.WithDetails("tracker down")}
+	var buf bytes.Buffer
+	err := RunSemanticTransition(context.Background(), p, &buf, "SC-1", tracker.CategoryDone, false)
+	require.Error(t, err)
+}
+
+func TestRunSemanticTransition_transitionError(t *testing.T) {
+	p := &semanticStub{statuses: workflow(), transErr: errors.WithDetails("forbidden")}
+	var buf bytes.Buffer
+	err := RunSemanticTransition(context.Background(), p, &buf, "SC-1", tracker.CategoryDone, false)
+	require.Error(t, err)
+}
+
+func TestRunIdeaPromote_removesBothLabelSpellings(t *testing.T) {
+	p := &semanticStub{}
+	var buf bytes.Buffer
+
+	err := RunIdeaPromote(context.Background(), p, &buf, "SC-1")
+	require.NoError(t, err)
+	require.Len(t, p.editOpts, 1)
+	assert.Equal(t, []string{"human/idea", "idea"}, p.editOpts[0].RemoveLabels)
+	assert.Contains(t, buf.String(), "Promoted SC-1")
+}
+
+func TestRunIdeaPromote_editError(t *testing.T) {
+	p := &semanticStub{editErr: errors.WithDetails("forbidden")}
+	var buf bytes.Buffer
+	err := RunIdeaPromote(context.Background(), p, &buf, "SC-1")
+	require.Error(t, err)
+}

--- a/internal/tracker/README.md
+++ b/internal/tracker/README.md
@@ -9,6 +9,8 @@
 - Read and add comments on an issue
 - Link two related issues ("relates to"; on GitHub, recorded as a cross-reference comment)
 - Move an issue to a new status
+- Finish or close an issue semantically (`human done KEY`, `human close KEY`) — the done/closed-type status is picked from the workflow, no status name needed
+- Promote an idea ticket (`human idea promote KEY`) — strips the `human/idea`/`idea` labels, keeping key and history
 - Assign an issue to a user
 - Edit an issue's title and description
 - Auto-detects the right tracker from a key

--- a/main.go
+++ b/main.go
@@ -210,6 +210,18 @@ Configure trackers and tools in .humanconfig.yaml or pass credentials via flags/
 	autoStatusCmd.GroupID = "shortcuts"
 	rootCmd.AddCommand(autoStatusCmd)
 
+	autoDoneCmd := cmdauto.BuildAutoDoneCmd(autoDeps)
+	autoDoneCmd.GroupID = "shortcuts"
+	rootCmd.AddCommand(autoDoneCmd)
+
+	autoCloseCmd := cmdauto.BuildAutoCloseCmd(autoDeps)
+	autoCloseCmd.GroupID = "shortcuts"
+	rootCmd.AddCommand(autoCloseCmd)
+
+	autoIdeaCmd := cmdauto.BuildAutoIdeaCmd(autoDeps)
+	autoIdeaCmd.GroupID = "shortcuts"
+	rootCmd.AddCommand(autoIdeaCmd)
+
 	autoLinkCmd := cmdauto.BuildAutoLinkCmd(autoDeps)
 	autoLinkCmd.GroupID = "shortcuts"
 	rootCmd.AddCommand(autoLinkCmd)


### PR DESCRIPTION
Resolves ticket 1012: semantic status transitions and the idea-label convention as commands.

- `human done KEY` — transition to the workflow's first done-type status (Category enum, no status name needed)
- `human close KEY` — first closed-type status; falls back to done-type with a note when the workflow has no closed bucket (e.g. Shortcut default workflow)
- `human idea promote KEY` — removes `human/idea` and `idea` labels idempotently

🤖 Generated with [Claude Code](https://claude.com/claude-code)