### PR TITLE
[SC-1010] Add pipeline runtime for multi-agent scan bookkeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Each module ships a short `README.md` describing what it does for you, in plain 
 - [Issue Trackers](internal/tracker/README.md) — Jira, Linear, GitHub, GitLab, Shortcut, Azure DevOps, ClickUp
 - [Code Forges](internal/forge/README.md) — open pull requests (GitHub)
 - [Marker Protocol](internal/marker/README.md) — post/read the structured `[human:*]` pipeline handoff comments
+- [Pipeline Runtime](internal/pipeline/README.md) — shared state, race-free finding IDs, and cleanup for multi-agent scans
 
 **Docs, design & analytics**
 

--- a/cmd/cmdpipeline/pipeline.go
+++ b/cmd/cmdpipeline/pipeline.go
@@ -1,0 +1,197 @@
+// Package cmdpipeline surfaces the scan-pipeline runtime (internal/pipeline)
+// as local CLI commands, so parallel finder agents share one safe
+// implementation of ID allocation, dedup, state, and cleanup.
+package cmdpipeline
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/pipeline"
+)
+
+// BuildPipelineCmd creates the top-level "pipeline" command.
+func BuildPipelineCmd() *cobra.Command {
+	pipelineCmd := &cobra.Command{
+		Use:   "pipeline",
+		Short: "Shared runtime for multi-agent scan pipelines (findings, state, reports)",
+	}
+	pipelineCmd.AddCommand(buildInitCmd(), buildAppendCmd(), buildCountCmd(), buildStateCmd(), buildReportCmd(), buildCleanupCmd())
+	return pipelineCmd
+}
+
+func buildInitCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "init NAME",
+		Short: "Create the pipeline workspace under .human/NAME and print its paths",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w, err := pipeline.Open(".", args[0])
+			if err != nil {
+				return err
+			}
+			return printJSON(cmd.OutOrStdout(), map[string]string{
+				"root":       w.Root(),
+				"candidates": w.CandidatesPath(),
+				"state":      w.StatePath(),
+			})
+		},
+	}
+}
+
+func buildAppendCmd() *cobra.Command {
+	var file, category, title, bodyFile string
+	var line int
+	cmd := &cobra.Command{
+		Use:   "append NAME",
+		Short: "Append a finding with a race-free ID; exact duplicates (file+line+category) are dropped",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w, err := pipeline.Open(".", args[0])
+			if err != nil {
+				return err
+			}
+			body, err := resolveBody(bodyFile, cmd.InOrStdin())
+			if err != nil {
+				return err
+			}
+			id, duplicate, err := w.Append(pipeline.Finding{File: file, Line: line, Category: category, Title: title, Body: body})
+			if err != nil {
+				return err
+			}
+			return printJSON(cmd.OutOrStdout(), map[string]any{"id": id, "duplicate": duplicate})
+		},
+	}
+	cmd.Flags().StringVar(&file, "file", "", "File the finding is in")
+	cmd.Flags().IntVar(&line, "line", 0, "Line the finding anchors to")
+	cmd.Flags().StringVar(&category, "category", "", "Finding category (dedup key together with file and line)")
+	cmd.Flags().StringVar(&title, "title", "", "One-line finding title")
+	cmd.Flags().StringVar(&bodyFile, "body-file", "", "Finding body from a file, or - for stdin")
+	_ = cmd.MarkFlagRequired("file")
+	_ = cmd.MarkFlagRequired("category")
+	_ = cmd.MarkFlagRequired("title")
+	return cmd
+}
+
+func buildCountCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "count NAME",
+		Short: "Print the number of candidate findings",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w, err := pipeline.Open(".", args[0])
+			if err != nil {
+				return err
+			}
+			count, err := w.Count()
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), count)
+			return err
+		},
+	}
+}
+
+func buildStateCmd() *cobra.Command {
+	stateCmd := &cobra.Command{
+		Use:   "state",
+		Short: "Read or write the pipeline's shared key-value state",
+	}
+	getCmd := &cobra.Command{
+		Use:   "get NAME KEY",
+		Short: "Print the value stored for KEY (empty when unset)",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w, err := pipeline.Open(".", args[0])
+			if err != nil {
+				return err
+			}
+			value, err := w.StateGet(args[1])
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), value)
+			return err
+		},
+	}
+	setCmd := &cobra.Command{
+		Use:   "set NAME KEY VALUE",
+		Short: "Store KEY: VALUE, replacing any existing entry",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w, err := pipeline.Open(".", args[0])
+			if err != nil {
+				return err
+			}
+			return w.StateSet(args[1], args[2])
+		},
+	}
+	stateCmd.AddCommand(getCmd, setCmd)
+	return stateCmd
+}
+
+func buildReportCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "report NAME",
+		Short: "Print the timestamped final-report path for the triage agent to write",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w, err := pipeline.Open(".", args[0])
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), w.ReportPath(time.Now()))
+			return err
+		},
+	}
+}
+
+func buildCleanupCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "cleanup NAME",
+		Short: "Remove the pipeline's intermediate dot-files, keeping final reports",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w, err := pipeline.Open(".", args[0])
+			if err != nil {
+				return err
+			}
+			return w.Cleanup()
+		},
+	}
+}
+
+func printJSON(out io.Writer, v any) error {
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// resolveBody reads the finding body from a file or stdin ("-"); empty when no
+// source given.
+func resolveBody(bodyFile string, stdin io.Reader) (string, error) {
+	switch bodyFile {
+	case "":
+		return "", nil
+	case "-":
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return "", errors.WrapWithDetails(err, "reading body from stdin")
+		}
+		return strings.TrimSpace(string(data)), nil
+	default:
+		data, err := os.ReadFile(bodyFile) // #nosec G304 -- path is an explicit user-supplied CLI argument
+		if err != nil {
+			return "", errors.WrapWithDetails(err, "reading body file", "path", bodyFile)
+		}
+		return strings.TrimSpace(string(data)), nil
+	}
+}

--- a/cmd/cmdpipeline/pipeline_test.go
+++ b/cmd/cmdpipeline/pipeline_test.go
@@ -1,0 +1,104 @@
+package cmdpipeline
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// run executes the pipeline command tree with args in a temp working dir.
+func run(t *testing.T, dir string, args ...string) (string, error) {
+	t.Helper()
+	prev, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	cmd := BuildPipelineCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	return buf.String(), err
+}
+
+func TestPipeline_initPrintsPaths(t *testing.T) {
+	dir := t.TempDir()
+	out, err := run(t, dir, "init", "bugs")
+	require.NoError(t, err)
+	assert.Contains(t, out, filepath.Join(".human", "bugs"))
+	assert.Contains(t, out, ".bugs-candidates.md")
+}
+
+func TestPipeline_appendCountReportCleanup(t *testing.T) {
+	dir := t.TempDir()
+
+	out, err := run(t, dir, "append", "bugs", "--file", "a.go", "--line", "10", "--category", "logic", "--title", "off by one")
+	require.NoError(t, err)
+	assert.Contains(t, out, `"id": "C-001"`)
+	assert.Contains(t, out, `"duplicate": false`)
+
+	out, err = run(t, dir, "append", "bugs", "--file", "a.go", "--line", "10", "--category", "logic", "--title", "again")
+	require.NoError(t, err)
+	assert.Contains(t, out, `"duplicate": true`)
+
+	out, err = run(t, dir, "count", "bugs")
+	require.NoError(t, err)
+	assert.Equal(t, "1", strings.TrimSpace(out))
+
+	out, err = run(t, dir, "report", "bugs")
+	require.NoError(t, err)
+	assert.Contains(t, out, filepath.Join(".human", "bugs", "bugs-"))
+
+	_, err = run(t, dir, "cleanup", "bugs")
+	require.NoError(t, err)
+	entries, err := os.ReadDir(filepath.Join(dir, ".human", "bugs"))
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestPipeline_appendBodyFromStdinLikeFile(t *testing.T) {
+	dir := t.TempDir()
+	bodyPath := filepath.Join(dir, "body.md")
+	require.NoError(t, os.WriteFile(bodyPath, []byte("evidence here\n"), 0o600))
+
+	_, err := run(t, dir, "append", "bugs", "--file", "a.go", "--line", "1", "--category", "logic", "--title", "t", "--body-file", bodyPath)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(dir, ".human", "bugs", ".bugs-candidates.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "evidence here")
+}
+
+func TestPipeline_stateRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	out, err := run(t, dir, "state", "get", "bugs", "iterations")
+	require.NoError(t, err)
+	assert.Equal(t, "", strings.TrimSpace(out))
+
+	_, err = run(t, dir, "state", "set", "bugs", "iterations", "3")
+	require.NoError(t, err)
+
+	out, err = run(t, dir, "state", "get", "bugs", "iterations")
+	require.NoError(t, err)
+	assert.Equal(t, "3", strings.TrimSpace(out))
+}
+
+func TestPipeline_missingRequiredFlags(t *testing.T) {
+	dir := t.TempDir()
+	_, err := run(t, dir, "append", "bugs", "--line", "1")
+	require.Error(t, err)
+}
+
+func TestPipeline_badName(t *testing.T) {
+	dir := t.TempDir()
+	_, err := run(t, dir, "init", "../escape")
+	require.Error(t, err)
+}

--- a/internal/pipeline/README.md
+++ b/internal/pipeline/README.md
@@ -1,0 +1,11 @@
+# Pipeline Runtime
+
+Shared bookkeeping for the multi-agent scan pipelines (findbugs, security, gardening, brainstorm), surfaced as `human pipeline`. Finder agents run in parallel and contribute judgment; this runtime owns the mechanics they used to hand-roll per prompt.
+
+- Creates the pipeline workspace under `.human/<name>/` (`human pipeline init`)
+- Appends findings with race-free sequential IDs — parallel agents can no longer collide on C-NNN allocation (`human pipeline append`)
+- Drops exact duplicates mechanically (same file, line, and category); same-root-cause merging stays with triage judgment
+- Counts candidates (`human pipeline count`) — replaces per-agent count files
+- Shared key-value state for iteration bookkeeping (`human pipeline state get|set`)
+- Hands out the timestamped final-report path (`human pipeline report`)
+- Cleans up all intermediate dot-files while keeping final reports (`human pipeline cleanup`)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1,0 +1,276 @@
+// Package pipeline is the shared runtime for multi-agent scan pipelines
+// (findbugs, security, gardening, brainstorm). The pipelines previously
+// hand-rolled the same bookkeeping in every prompt: hidden handoff files,
+// candidate IDs read from the last heading (racy under parallel agents),
+// count files, duplicate filtering, timestamped reports, and cleanup lists.
+// This package owns that mechanic; agents only contribute judgment.
+package pipeline
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gethuman-sh/human/errors"
+)
+
+// Workspace is one pipeline's scratch area under .human/<name>/.
+type Workspace struct {
+	// Dir is the project directory holding .human/.
+	Dir string
+	// Name is the pipeline name (bugs, security, gardening, brainstorms).
+	Name string
+}
+
+// Finding is one appended candidate finding.
+type Finding struct {
+	File     string `json:"file"`
+	Line     int    `json:"line"`
+	Category string `json:"category"`
+	Title    string `json:"title"`
+	Body     string `json:"body,omitempty"`
+}
+
+// Open returns the workspace for name under dir, creating its directory.
+func Open(dir, name string) (Workspace, error) {
+	if !nameOK.MatchString(name) {
+		return Workspace{}, errors.WithDetails("invalid pipeline name", "name", name)
+	}
+	w := Workspace{Dir: dir, Name: name}
+	if err := os.MkdirAll(w.Root(), 0o750); err != nil {
+		return Workspace{}, errors.WrapWithDetails(err, "creating pipeline workspace", "dir", w.Root())
+	}
+	return w, nil
+}
+
+var nameOK = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+
+// Root is the workspace directory, .human/<name>.
+func (w Workspace) Root() string { return filepath.Join(w.Dir, ".human", w.Name) }
+
+// CandidatesPath is the shared candidates file all finder agents append to.
+func (w Workspace) CandidatesPath() string {
+	return filepath.Join(w.Root(), "."+w.Name+"-candidates.md")
+}
+
+// StatePath is the shared key-value state file.
+func (w Workspace) StatePath() string {
+	return filepath.Join(w.Root(), "."+w.Name+"-state.md")
+}
+
+// lockPath guards candidate appends; mkdir is atomic on every platform.
+func (w Workspace) lockPath() string {
+	return filepath.Join(w.Root(), "."+w.Name+".lock")
+}
+
+// candidateHeading matches "### C-NNN: title" block headings.
+var candidateHeading = regexp.MustCompile(`(?m)^### (C-\d+)`)
+
+// locationLine matches the machine-readable location line of a finding block.
+var locationLine = regexp.MustCompile(`(?m)^- location: (.+):(\d+) \((.+)\)$`)
+
+// Append allocates the next candidate ID and appends the finding — unless an
+// existing finding already claims the same file, line, and category, in which
+// case the duplicate is dropped and the surviving ID returned. The whole
+// read-allocate-write runs under a lock so parallel finder agents cannot race
+// the ID sequence.
+func (w Workspace) Append(f Finding) (id string, duplicate bool, err error) {
+	unlock, err := w.lock()
+	if err != nil {
+		return "", false, err
+	}
+	defer unlock()
+
+	existing, err := w.readCandidates()
+	if err != nil {
+		return "", false, err
+	}
+
+	if dupID := findDuplicate(existing, f); dupID != "" {
+		return dupID, true, nil
+	}
+
+	id = nextID(existing)
+	block := renderFinding(id, f)
+	file, err := os.OpenFile(w.CandidatesPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return "", false, errors.WrapWithDetails(err, "opening candidates file", "path", w.CandidatesPath())
+	}
+	defer func() { _ = file.Close() }()
+	if _, err := file.WriteString(block); err != nil {
+		return "", false, errors.WrapWithDetails(err, "appending finding", "path", w.CandidatesPath())
+	}
+	return id, false, nil
+}
+
+// Count returns the number of candidate findings.
+func (w Workspace) Count() (int, error) {
+	content, err := w.readCandidates()
+	if err != nil {
+		return 0, err
+	}
+	return len(candidateHeading.FindAllString(content, -1)), nil
+}
+
+// StateGet returns the value stored for key, or "" when unset.
+func (w Workspace) StateGet(key string) (string, error) {
+	content, err := readIfExists(w.StatePath())
+	if err != nil {
+		return "", err
+	}
+	for line := range strings.SplitSeq(content, "\n") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), key+": "); ok {
+			return strings.TrimSpace(rest), nil
+		}
+	}
+	return "", nil
+}
+
+// StateSet stores key: value, replacing an existing entry for key.
+func (w Workspace) StateSet(key, value string) error {
+	if strings.ContainsAny(key, ":\n") || strings.Contains(value, "\n") {
+		return errors.WithDetails("state keys and values must be single-line and colon-free", "key", key)
+	}
+	unlock, err := w.lock()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	content, err := readIfExists(w.StatePath())
+	if err != nil {
+		return err
+	}
+	var lines []string
+	replaced := false
+	for line := range strings.SplitSeq(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), key+": ") {
+			if !replaced {
+				lines = append(lines, key+": "+value)
+				replaced = true
+			}
+			continue
+		}
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, line)
+		}
+	}
+	if !replaced {
+		lines = append(lines, key+": "+value)
+	}
+	data := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(w.StatePath(), []byte(data), 0o600); err != nil {
+		return errors.WrapWithDetails(err, "writing state file", "path", w.StatePath())
+	}
+	return nil
+}
+
+// ReportPath returns the timestamped final-report path for now, without
+// creating the file — the triage agent writes the content.
+func (w Workspace) ReportPath(now time.Time) string {
+	return filepath.Join(w.Root(), w.Name+"-"+now.Format("20060102-150405")+".md")
+}
+
+// Cleanup removes every intermediate dot-file of the workspace, keeping final
+// reports (which do not start with a dot).
+func (w Workspace) Cleanup() error {
+	entries, err := os.ReadDir(w.Root())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.WrapWithDetails(err, "reading pipeline workspace", "dir", w.Root())
+	}
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(w.Root(), entry.Name())); err != nil {
+			return errors.WrapWithDetails(err, "removing pipeline scratch file", "file", entry.Name())
+		}
+	}
+	return nil
+}
+
+// lock acquires the workspace lock, spinning briefly so parallel agents
+// serialize instead of failing. mkdir is the portable atomic primitive.
+func (w Workspace) lock() (func(), error) {
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		err := os.Mkdir(w.lockPath(), 0o750)
+		if err == nil {
+			return func() { _ = os.Remove(w.lockPath()) }, nil
+		}
+		if !os.IsExist(err) {
+			return nil, errors.WrapWithDetails(err, "acquiring pipeline lock", "path", w.lockPath())
+		}
+		if time.Now().After(deadline) {
+			return nil, errors.WithDetails("pipeline lock held too long — remove it if a crashed agent left it behind", "path", w.lockPath())
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func (w Workspace) readCandidates() (string, error) {
+	return readIfExists(w.CandidatesPath())
+}
+
+func readIfExists(path string) (string, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- workspace-internal path built from a validated pipeline name
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", errors.WrapWithDetails(err, "reading pipeline file", "path", path)
+	}
+	return string(data), nil
+}
+
+// findDuplicate returns the ID of an existing finding at the same file, line,
+// and category — the mechanical duplicate rule; same-root-cause merging stays
+// with the triage agent's judgment.
+func findDuplicate(content string, f Finding) string {
+	headings := candidateHeading.FindAllStringSubmatchIndex(content, -1)
+	for i, h := range headings {
+		end := len(content)
+		if i+1 < len(headings) {
+			end = headings[i+1][0]
+		}
+		block := content[h[0]:end]
+		match := locationLine.FindStringSubmatch(block)
+		if match == nil {
+			continue
+		}
+		line, _ := strconv.Atoi(match[2])
+		if match[1] == f.File && line == f.Line && match[3] == f.Category {
+			return content[h[2]:h[3]]
+		}
+	}
+	return ""
+}
+
+// nextID allocates the ID after the highest existing one, so IDs stay unique
+// even when earlier findings were merged away.
+func nextID(content string) string {
+	max := 0
+	for _, m := range candidateHeading.FindAllStringSubmatch(content, -1) {
+		if n, err := strconv.Atoi(strings.TrimPrefix(m[1], "C-")); err == nil && n > max {
+			max = n
+		}
+	}
+	return fmt.Sprintf("C-%03d", max+1)
+}
+
+func renderFinding(id string, f Finding) string {
+	var b strings.Builder
+	b.WriteString("\n### " + id + ": " + f.Title + "\n\n")
+	b.WriteString("- location: " + f.File + ":" + strconv.Itoa(f.Line) + " (" + f.Category + ")\n")
+	if f.Body != "" {
+		b.WriteString("\n" + strings.TrimSpace(f.Body) + "\n")
+	}
+	return b.String()
+}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1,0 +1,169 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func open(t *testing.T) Workspace {
+	t.Helper()
+	w, err := Open(t.TempDir(), "bugs")
+	require.NoError(t, err)
+	return w
+}
+
+func TestOpen_createsWorkspaceDir(t *testing.T) {
+	w := open(t)
+	info, err := os.Stat(w.Root())
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestOpen_rejectsBadName(t *testing.T) {
+	_, err := Open(t.TempDir(), "../escape")
+	require.Error(t, err)
+	_, err = Open(t.TempDir(), "Bad Name")
+	require.Error(t, err)
+}
+
+func TestAppend_allocatesSequentialIDs(t *testing.T) {
+	w := open(t)
+
+	id1, dup, err := w.Append(Finding{File: "a.go", Line: 10, Category: "logic", Title: "first"})
+	require.NoError(t, err)
+	assert.False(t, dup)
+	assert.Equal(t, "C-001", id1)
+
+	id2, dup, err := w.Append(Finding{File: "b.go", Line: 20, Category: "logic", Title: "second", Body: "details"})
+	require.NoError(t, err)
+	assert.False(t, dup)
+	assert.Equal(t, "C-002", id2)
+
+	content, err := os.ReadFile(w.CandidatesPath())
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "### C-001: first")
+	assert.Contains(t, string(content), "- location: b.go:20 (logic)")
+	assert.Contains(t, string(content), "details")
+}
+
+func TestAppend_dropsExactDuplicates(t *testing.T) {
+	w := open(t)
+
+	id1, _, err := w.Append(Finding{File: "a.go", Line: 10, Category: "logic", Title: "first"})
+	require.NoError(t, err)
+
+	id2, dup, err := w.Append(Finding{File: "a.go", Line: 10, Category: "logic", Title: "same place"})
+	require.NoError(t, err)
+	assert.True(t, dup)
+	assert.Equal(t, id1, id2, "duplicate reports the surviving ID")
+
+	count, err := w.Count()
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestAppend_sameLineDifferentCategoryIsNotDuplicate(t *testing.T) {
+	w := open(t)
+	_, _, err := w.Append(Finding{File: "a.go", Line: 10, Category: "logic", Title: "x"})
+	require.NoError(t, err)
+	_, dup, err := w.Append(Finding{File: "a.go", Line: 10, Category: "security", Title: "y"})
+	require.NoError(t, err)
+	assert.False(t, dup)
+}
+
+func TestAppend_parallelAgentsGetUniqueIDs(t *testing.T) {
+	w := open(t)
+	const n = 20
+	ids := make([]string, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id, _, err := w.Append(Finding{File: "f.go", Line: i, Category: "logic", Title: "t"})
+			require.NoError(t, err)
+			ids[i] = id
+		}(i)
+	}
+	wg.Wait()
+
+	seen := map[string]bool{}
+	for _, id := range ids {
+		assert.False(t, seen[id], "duplicate ID %s allocated", id)
+		seen[id] = true
+	}
+	count, err := w.Count()
+	require.NoError(t, err)
+	assert.Equal(t, n, count)
+}
+
+func TestCount_emptyWorkspace(t *testing.T) {
+	w := open(t)
+	count, err := w.Count()
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestState_getSetReplace(t *testing.T) {
+	w := open(t)
+
+	value, err := w.StateGet("iterations")
+	require.NoError(t, err)
+	assert.Empty(t, value)
+
+	require.NoError(t, w.StateSet("iterations", "1"))
+	require.NoError(t, w.StateSet("status", "running"))
+	require.NoError(t, w.StateSet("iterations", "2"))
+
+	value, err = w.StateGet("iterations")
+	require.NoError(t, err)
+	assert.Equal(t, "2", value)
+	value, err = w.StateGet("status")
+	require.NoError(t, err)
+	assert.Equal(t, "running", value)
+}
+
+func TestStateSet_rejectsMultiline(t *testing.T) {
+	w := open(t)
+	assert.Error(t, w.StateSet("key", "a\nb"))
+	assert.Error(t, w.StateSet("bad:key", "v"))
+}
+
+func TestReportPath_timestamped(t *testing.T) {
+	w := open(t)
+	ts := time.Date(2026, 7, 20, 21, 4, 5, 0, time.UTC)
+	assert.Equal(t, filepath.Join(w.Root(), "bugs-20260720-210405.md"), w.ReportPath(ts))
+}
+
+func TestCleanup_removesDotFilesKeepsReports(t *testing.T) {
+	w := open(t)
+	_, _, err := w.Append(Finding{File: "a.go", Line: 1, Category: "logic", Title: "x"})
+	require.NoError(t, err)
+	require.NoError(t, w.StateSet("k", "v"))
+	report := w.ReportPath(time.Now())
+	require.NoError(t, os.WriteFile(report, []byte("final"), 0o600))
+
+	require.NoError(t, w.Cleanup())
+
+	entries, err := os.ReadDir(w.Root())
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.False(t, strings.HasPrefix(entries[0].Name(), "."))
+}
+
+func TestCleanup_missingWorkspaceIsFine(t *testing.T) {
+	w := Workspace{Dir: t.TempDir(), Name: "never-opened"}
+	assert.NoError(t, w.Cleanup())
+}
+
+func TestNextID_skipsMergedGaps(t *testing.T) {
+	assert.Equal(t, "C-001", nextID(""))
+	assert.Equal(t, "C-043", nextID("### C-007: a\n### C-042: b\n"))
+}

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gethuman-sh/human/cmd/cmdmarker"
 	"github.com/gethuman-sh/human/cmd/cmdnotion"
 	"github.com/gethuman-sh/human/cmd/cmdping"
+	"github.com/gethuman-sh/human/cmd/cmdpipeline"
 	"github.com/gethuman-sh/human/cmd/cmdplan"
 	"github.com/gethuman-sh/human/cmd/cmdprovider"
 	"github.com/gethuman-sh/human/cmd/cmdproxy"
@@ -245,6 +246,10 @@ Configure trackers and tools in .humanconfig.yaml or pass credentials via flags/
 	handoffCmd := cmdhandoff.BuildHandoffCmd(autoDeps)
 	handoffCmd.GroupID = "shortcuts"
 	rootCmd.AddCommand(handoffCmd)
+
+	pipelineCmd := cmdpipeline.BuildPipelineCmd()
+	pipelineCmd.GroupID = "utility"
+	rootCmd.AddCommand(pipelineCmd)
 
 	// --- Provider commands (dynamic registration) ---
 	providers := []string{"jira", "github", "gitlab", "linear", "azuredevops", "shortcut", "clickup"}
@@ -532,6 +537,7 @@ var localSubcommands = map[string]bool{
 	"daemon":        true,
 	"chrome-bridge": true,
 	"commits":       true,
+	"pipeline":      true,
 	"install":       true,
 	"init":          true,
 	"usage":         true,


### PR DESCRIPTION
Resolves ticket 1010: the scan pipelines' shared runtime, previously duplicated as prose bookkeeping across 27 prompt files (and racy — parallel finders allocated candidate IDs by reading the last `### C-NNN` heading).

- `internal/pipeline`: workspace under `.human/<name>/`, mkdir-lock serialized appends (unique-ID property covered by a 20-goroutine test), mechanical dedup on (file, line, category), key-value state, timestamped report path, dot-file cleanup that keeps final reports
- `human pipeline init|append|count|state get/set|report|cleanup NAME` — runs locally (filesystem only)
- Prompt migration follows in the cross-cutting sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)