### PR TITLE
[SC-1013] Add human commits keys/recency/touched for feature-map history

### DIFF
--- a/cmd/cmdcommits/commits.go
+++ b/cmd/cmdcommits/commits.go
@@ -44,8 +44,76 @@ func BuildCommitsCmd() *cobra.Command {
 		},
 	}
 
-	commitsCmd.AddCommand(forCmd, prefixCmd)
+	keysCmd := &cobra.Command{
+		Use:   "keys [PATH...]",
+		Short: "List ticket keys referenced by commits touching the paths (prefixed keys first, deduped)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunCommitKeys(cmd.Context(), cmd.OutOrStdout(), ".", args)
+		},
+	}
+
+	var recencyRef string
+	touchedCmd := &cobra.Command{
+		Use:   "touched [PATH...]",
+		Short: "Report whether the paths changed since the recency boundary (latest tag, else 30 days)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunCommitsTouched(cmd.Context(), cmd.OutOrStdout(), ".", recencyRef, args)
+		},
+	}
+	touchedCmd.Flags().StringVar(&recencyRef, "ref", "", "Boundary ref (default: resolved recency boundary)")
+
+	recencyCmd := &cobra.Command{
+		Use:   "recency",
+		Short: "Print the resolved recency boundary: latest tag, or the 30-day fallback window",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return RunCommitsRecency(cmd.Context(), cmd.OutOrStdout(), ".")
+		},
+	}
+
+	commitsCmd.AddCommand(forCmd, prefixCmd, keysCmd, touchedCmd, recencyCmd)
 	return commitsCmd
+}
+
+// RunCommitKeys prints the ticket keys referenced by commits touching paths.
+func RunCommitKeys(ctx context.Context, out io.Writer, dir string, paths []string) error {
+	keys, err := gitrepo.TicketKeys(ctx, dir, paths)
+	if err != nil {
+		return err
+	}
+	if keys == nil {
+		keys = []string{}
+	}
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(keys)
+}
+
+// RunCommitsRecency prints the resolved recency boundary as JSON: {"tag": ...}
+// when a tag exists, {"since": "30 days ago"} otherwise.
+func RunCommitsRecency(ctx context.Context, out io.Writer, dir string) error {
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	if tag := gitrepo.LatestTag(ctx, dir); tag != "" {
+		return enc.Encode(map[string]string{"tag": tag})
+	}
+	return enc.Encode(map[string]string{"since": "30 days ago"})
+}
+
+// RunCommitsTouched prints true/false: did any commit after the boundary touch
+// the paths. An explicit --ref wins; otherwise the resolved recency boundary
+// applies.
+func RunCommitsTouched(ctx context.Context, out io.Writer, dir, ref string, paths []string) error {
+	boundary := ref
+	if boundary == "" {
+		boundary = gitrepo.LatestTag(ctx, dir)
+	}
+	touched, err := gitrepo.TouchedSince(ctx, dir, boundary, paths)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(out, touched)
+	return err
 }
 
 // RunCommitsFor lists commits referencing key in the repository at dir.

--- a/cmd/cmdcommits/commits_test.go
+++ b/cmd/cmdcommits/commits_test.go
@@ -107,3 +107,77 @@ func TestBuildCommitsCmd_Subcommands(t *testing.T) {
 	assert.Contains(t, uses, "for KEY")
 	assert.Contains(t, uses, "prefix KEY [ENGINEERING_KEY]")
 }
+
+func TestRunCommitKeys_JSON(t *testing.T) {
+	prev := gitrepo.TicketKeys
+	gitrepo.TicketKeys = func(_ context.Context, _ string, paths []string) ([]string, error) {
+		assert.Equal(t, []string{"internal/tracker"}, paths)
+		return []string{"SC-881", "42"}, nil
+	}
+	t.Cleanup(func() { gitrepo.TicketKeys = prev })
+
+	var buf bytes.Buffer
+	err := RunCommitKeys(context.Background(), &buf, ".", []string{"internal/tracker"})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), `"SC-881"`)
+	assert.Contains(t, buf.String(), `"42"`)
+}
+
+func TestRunCommitKeys_emptyIsArray(t *testing.T) {
+	prev := gitrepo.TicketKeys
+	gitrepo.TicketKeys = func(context.Context, string, []string) ([]string, error) { return nil, nil }
+	t.Cleanup(func() { gitrepo.TicketKeys = prev })
+
+	var buf bytes.Buffer
+	require.NoError(t, RunCommitKeys(context.Background(), &buf, ".", nil))
+	assert.Equal(t, "[]\n", buf.String())
+}
+
+func TestRunCommitsRecency_tagAndFallback(t *testing.T) {
+	prev := gitrepo.LatestTag
+	t.Cleanup(func() { gitrepo.LatestTag = prev })
+
+	gitrepo.LatestTag = func(context.Context, string) string { return "v0.21.0" }
+	var buf bytes.Buffer
+	require.NoError(t, RunCommitsRecency(context.Background(), &buf, "."))
+	assert.Contains(t, buf.String(), `"tag": "v0.21.0"`)
+
+	gitrepo.LatestTag = func(context.Context, string) string { return "" }
+	buf.Reset()
+	require.NoError(t, RunCommitsRecency(context.Background(), &buf, "."))
+	assert.Contains(t, buf.String(), `"since": "30 days ago"`)
+}
+
+func TestRunCommitsTouched_usesResolvedBoundary(t *testing.T) {
+	prevTag, prevTouched := gitrepo.LatestTag, gitrepo.TouchedSince
+	t.Cleanup(func() { gitrepo.LatestTag, gitrepo.TouchedSince = prevTag, prevTouched })
+
+	gitrepo.LatestTag = func(context.Context, string) string { return "v1.0.0" }
+	var gotBoundary string
+	gitrepo.TouchedSince = func(_ context.Context, _, boundary string, _ []string) (bool, error) {
+		gotBoundary = boundary
+		return true, nil
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, RunCommitsTouched(context.Background(), &buf, ".", "", []string{"cmd"}))
+	assert.Equal(t, "v1.0.0", gotBoundary)
+	assert.Equal(t, "true\n", buf.String())
+}
+
+func TestRunCommitsTouched_explicitRefWins(t *testing.T) {
+	prevTag, prevTouched := gitrepo.LatestTag, gitrepo.TouchedSince
+	t.Cleanup(func() { gitrepo.LatestTag, gitrepo.TouchedSince = prevTag, prevTouched })
+
+	gitrepo.LatestTag = func(context.Context, string) string { return "v1.0.0" }
+	var gotBoundary string
+	gitrepo.TouchedSince = func(_ context.Context, _, boundary string, _ []string) (bool, error) {
+		gotBoundary = boundary
+		return false, nil
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, RunCommitsTouched(context.Background(), &buf, ".", "v0.9.0", nil))
+	assert.Equal(t, "v0.9.0", gotBoundary)
+	assert.Equal(t, "false\n", buf.String())
+}

--- a/internal/gitrepo/README.md
+++ b/internal/gitrepo/README.md
@@ -8,4 +8,6 @@ Lets `human` read facts about the git repository you are working in, so it can f
 - Feeds forge and project detection automatically
 - Lists the commits referencing a ticket key in any accepted reference format (`human commits for KEY`), excluding merge-PR commits
 - Prints the canonical bracket-style commit-message prefix for a ticket (`human commits prefix PM_KEY [ENG_KEY]`)
+- Extracts the ticket keys referenced by commits touching given paths (`human commits keys [PATH...]`)
+- Resolves the recency boundary — latest tag, else a 30-day window — and whether paths changed since it (`human commits recency`, `human commits touched`)
 - Reports a clear error when no remote

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -292,3 +292,80 @@ var CurrentBranch = func(ctx context.Context, dir string) (string, error) {
 	}
 	return strings.TrimSpace(string(out)), nil
 }
+
+// prefixedKeyPattern and numericRefPattern are the fixed extraction grammar
+// for ticket keys in commit subjects: bracketed-or-bare PREFIX-N keys and #N
+// numeric references.
+var (
+	prefixedKeyPattern = regexp.MustCompile(`\[?([A-Z]{2,}-[0-9]+)\]?`)
+	numericRefPattern  = regexp.MustCompile(`#([0-9]+)`)
+)
+
+// TicketKeys extracts the ticket keys referenced by commits touching paths
+// (all history when paths is empty): prefixed keys first, then numeric ones,
+// each deduped in order of first appearance (newest commit first). Package var
+// so callers can stub git access in tests.
+var TicketKeys = func(ctx context.Context, dir string, paths []string) ([]string, error) {
+	args := []string{"-C", dir, "log", "--format=%s"}
+	if len(paths) > 0 {
+		args = append(append(args, "--"), paths...)
+	}
+	out, err := runner(ctx, "git", args...)
+	if err != nil {
+		return nil, errors.WrapWithDetails(err, "listing commit subjects", "dir", dir)
+	}
+	var prefixed, numeric []string
+	seen := map[string]bool{}
+	for _, subject := range strings.Split(string(out), "\n") {
+		for _, m := range prefixedKeyPattern.FindAllStringSubmatch(subject, -1) {
+			if !seen[m[1]] {
+				seen[m[1]] = true
+				prefixed = append(prefixed, m[1])
+			}
+		}
+		for _, m := range numericRefPattern.FindAllStringSubmatch(subject, -1) {
+			if !seen[m[1]] {
+				seen[m[1]] = true
+				numeric = append(numeric, m[1])
+			}
+		}
+	}
+	return append(prefixed, numeric...), nil
+}
+
+// LatestTag resolves the recency boundary tag: the nearest reachable tag,
+// else the newest tag by creation date, else "" (caller falls back to a time
+// window). Package var so callers can stub git access in tests.
+var LatestTag = func(ctx context.Context, dir string) string {
+	if out, err := runner(ctx, "git", "-C", dir, "describe", "--tags", "--abbrev=0"); err == nil {
+		if tag := strings.TrimSpace(string(out)); tag != "" {
+			return tag
+		}
+	}
+	if out, err := runner(ctx, "git", "-C", dir, "tag", "--sort=-creatordate"); err == nil {
+		if lines := strings.Fields(strings.TrimSpace(string(out))); len(lines) > 0 {
+			return lines[0]
+		}
+	}
+	return ""
+}
+
+// TouchedSince reports whether any commit after boundary touches paths.
+// boundary is a ref (tag) for ref..HEAD, or empty for the fixed 30-day
+// fallback window. Package var so callers can stub git access in tests.
+var TouchedSince = func(ctx context.Context, dir, boundary string, paths []string) (bool, error) {
+	args := []string{"-C", dir, "log", "--format=%H", "-1"}
+	if boundary != "" {
+		args = append(args, boundary+"..HEAD")
+	} else {
+		args = append(args, "--since=30 days ago")
+	}
+	if len(paths) > 0 {
+		args = append(append(args, "--"), paths...)
+	}
+	out, err := runner(ctx, "git", args...)
+	if err != nil {
+		return false, errors.WrapWithDetails(err, "checking recent commits", "dir", dir, "boundary", boundary)
+	}
+	return strings.TrimSpace(string(out)) != "", nil
+}

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -573,3 +573,110 @@ func TestCurrentBranch_error(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+func TestTicketKeys_prefixedFirstDeduped(t *testing.T) {
+	out := "[SC-881] Offer move\nFix typo #42 and #42 again\n[HUM-59] [SC-79] Add validation\nPlain subject\n"
+	withRunner(t, func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return []byte(out), nil
+	})
+	keys, err := TicketKeys(context.Background(), ".", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"SC-881", "HUM-59", "SC-79", "42"}
+	if len(keys) != len(want) {
+		t.Fatalf("keys = %v, want %v", keys, want)
+	}
+	for i := range want {
+		if keys[i] != want[i] {
+			t.Errorf("keys[%d] = %q, want %q", i, keys[i], want[i])
+		}
+	}
+}
+
+func TestTicketKeys_pathsAppendedAfterSeparator(t *testing.T) {
+	var gotArgs []string
+	withRunner(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte(""), nil
+	})
+	_, err := TicketKeys(context.Background(), ".", []string{"internal/tracker"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(gotArgs, " ")
+	if !strings.Contains(joined, "-- internal/tracker") {
+		t.Errorf("args = %v, want path after --", gotArgs)
+	}
+}
+
+func TestLatestTag_describeWins(t *testing.T) {
+	withRunner(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		if args[2] == "describe" {
+			return []byte("v0.21.0\n"), nil
+		}
+		return []byte("v0.99.0\n"), nil
+	})
+	if tag := LatestTag(context.Background(), "."); tag != "v0.21.0" {
+		t.Errorf("tag = %q", tag)
+	}
+}
+
+func TestLatestTag_fallbackToNewestByDate(t *testing.T) {
+	withRunner(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		if args[2] == "describe" {
+			return nil, errors.New("no tags reachable")
+		}
+		return []byte("v0.20.0\nv0.19.0\n"), nil
+	})
+	if tag := LatestTag(context.Background(), "."); tag != "v0.20.0" {
+		t.Errorf("tag = %q", tag)
+	}
+}
+
+func TestLatestTag_none(t *testing.T) {
+	withRunner(t, func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return nil, errors.New("no tags")
+	})
+	if tag := LatestTag(context.Background(), "."); tag != "" {
+		t.Errorf("tag = %q, want empty", tag)
+	}
+}
+
+func TestTouchedSince_refRange(t *testing.T) {
+	var gotArgs []string
+	withRunner(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte("abc123\n"), nil
+	})
+	touched, err := TouchedSince(context.Background(), ".", "v0.21.0", []string{"cmd"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !touched {
+		t.Error("touched = false, want true")
+	}
+	joined := strings.Join(gotArgs, " ")
+	if !strings.Contains(joined, "v0.21.0..HEAD") {
+		t.Errorf("args = %v", gotArgs)
+	}
+}
+
+func TestTouchedSince_sinceFallbackAndUntouched(t *testing.T) {
+	var gotArgs []string
+	withRunner(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte("\n"), nil
+	})
+	touched, err := TouchedSince(context.Background(), ".", "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if touched {
+		t.Error("touched = true, want false")
+	}
+	joined := strings.Join(gotArgs, " ")
+	if !strings.Contains(joined, "--since=30 days ago") {
+		t.Errorf("args = %v", gotArgs)
+	}
+}


### PR DESCRIPTION
Resolves ticket 1013: the ticket-history mechanics of the feature-map pipeline as deterministic commands.

- `human commits keys [PATH...]` — ticket keys from commit subjects (fixed extraction grammar: bracketed/bare PREFIX-N, #N), prefixed keys first, deduped in appearance order
- `human commits recency` — boundary via the fixed fallback chain: nearest reachable tag → newest tag by date → 30-day window
- `human commits touched [PATH...] [--ref R]` — whether paths changed since the boundary
- Verified against this repo: `commits keys internal/marker` → SC-1008, SC-1007

The cross-feature sweep filter (drop keys on >40% of features, cap 5) stays in the features-synthesis skill — it needs all features at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)