### PR TITLE
[SC-1061] Wait out the forge's mergeability recompute; actionable deploy failures

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -1625,33 +1625,33 @@ func (p forgeDeployer) pushBranch(ctx context.Context, dir, branch string) error
 // branch out under the user (SC-1000). A rebase error is a real conflict the
 // mechanical path cannot resolve — the deploy must fail loudly rather than
 // merge blind (735).
-func (p forgeDeployer) EnsureMergeable(ctx context.Context, req daemon.PRRequest) error {
+func (p forgeDeployer) EnsureMergeable(ctx context.Context, req daemon.PRRequest) (bool, error) {
 	dir, branch := req.WorkspaceDir, req.Branch
 	base := gitrepo.DefaultBranch(ctx, dir)
 	if err := gitrepo.Fetch(ctx, dir, base); err != nil {
-		return err
+		return false, err
 	}
 	originBase := "origin/" + base
 	tip, onOrigin, err := branchTip(ctx, dir, branch)
 	if err != nil {
-		return err
+		return false, err
 	}
 	// Already current: the branch contains the base tip, so its PR is mergeable
 	// without touching it.
 	if gitrepo.IsAncestor(ctx, dir, originBase, tip) {
-		return nil
+		return false, nil
 	}
 	wt, cleanup, err := addEphemeralWorktree(ctx, dir, tip)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer cleanup()
 	if err := gitrepo.RebaseHead(ctx, wt, originBase); err != nil {
-		return err
+		return false, err
 	}
 	newTip, err := gitrepo.RevParse(ctx, wt, "HEAD")
 	if err != nil {
-		return err
+		return false, err
 	}
 	// The worktree rebased a detached HEAD, so publishing is a refspec push of
 	// the worktree's HEAD — the branch itself is never checked out anywhere.
@@ -1659,17 +1659,17 @@ func (p forgeDeployer) EnsureMergeable(ctx context.Context, req daemon.PRRequest
 	// a concurrent push is refused, not clobbered.
 	if onOrigin {
 		if err := gitrepo.PushHeadWithLease(ctx, wt, branch, tip); err != nil {
-			return err
+			return false, err
 		}
 	} else if err := gitrepo.PushHead(ctx, wt, branch); err != nil {
-		return err
+		return false, err
 	}
 	// A clean rebase that still does not contain the base tip means the branch
 	// could not be made mergeable — surface it rather than merge into a conflict.
 	if !gitrepo.IsAncestor(ctx, dir, originBase, newTip) {
-		return errors.WithDetails("branch still not mergeable after rebase", "branch", branch, "base", base)
+		return true, errors.WithDetails("branch still not mergeable after rebase", "branch", branch, "base", base)
 	}
-	return nil
+	return true, nil
 }
 
 // branchTip resolves the commit the freshness rebase starts from, preferring

--- a/cmd/cmddaemon/deployer_rebase_test.go
+++ b/cmd/cmddaemon/deployer_rebase_test.go
@@ -97,6 +97,11 @@ func (s *rebaseGitStubs) sawCall(prefix string) bool {
 const rebaseTestWorkspace = "/live/checkout"
 
 func ensureMergeable(t *testing.T, s *rebaseGitStubs) error {
+	_, err := ensureMergeableRebased(t, s)
+	return err
+}
+
+func ensureMergeableRebased(t *testing.T, s *rebaseGitStubs) (bool, error) {
 	t.Helper()
 	s.t = t
 	s.install()
@@ -230,9 +235,12 @@ func TestEnsureMergeable_realGit_dirtyWorkspaceUntouched(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := forgeDeployer{}.EnsureMergeable(context.Background(), daemon.PRRequest{WorkspaceDir: ws, Branch: "autofix/x"})
+	rebased, err := forgeDeployer{}.EnsureMergeable(context.Background(), daemon.PRRequest{WorkspaceDir: ws, Branch: "autofix/x"})
 	if err != nil {
 		t.Fatalf("EnsureMergeable on a dirty workspace must succeed, got: %v", err)
+	}
+	if !rebased {
+		t.Error("a stale branch that was rebased and re-pushed must report rebased=true")
 	}
 
 	// The published branch contains the advanced base.

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -32,7 +32,10 @@ type Deployer interface {
 	// and, when it is not, rebases the branch, re-pushes (lease), and re-verifies.
 	// A returned error is a real conflict the mechanical path cannot resolve — the
 	// deploy must NOT attempt the merge blind, but fail loudly instead.
-	EnsureMergeable(ctx context.Context, req PRRequest) error
+	// rebased reports whether the branch was rewritten and re-pushed: the forge
+	// then recomputes the PR's mergeability asynchronously, and merging inside
+	// that window draws a spurious 405 — the caller must wait it out first.
+	EnsureMergeable(ctx context.Context, req PRRequest) (rebased bool, err error)
 	// PullRequestMergeable reports the forge's own end-state (three-way) merge
 	// verdict for the PR. It is the fallback signal when the mechanical rebase in
 	// EnsureMergeable conflicts on an intermediate commit the end-state merge
@@ -66,6 +69,12 @@ type PRResult struct {
 var (
 	deployCheckInterval = 30 * time.Second
 	deployTimeout       = 45 * time.Minute
+	// Mergeability-recompute pacing: after a freshness rebase re-pushes the
+	// branch, the forge recomputes the PR's mergeability asynchronously and the
+	// merge endpoint 405s until it settles (ticket 910's deploy hit exactly
+	// this). The poll waits for a definitive verdict before merging.
+	mergeablePollInterval = 3 * time.Second
+	mergeablePollTimeout  = 60 * time.Second
 )
 
 // BoardTransitionRequest is the wire request for advancing a card one stage.
@@ -415,30 +424,46 @@ func (d BoardTransitionDeps) DeployBranch(ctx context.Context, pmKey, title, prB
 		Body:         prBody,
 	})
 	if err != nil {
-		return d.deployFailed(pmKey, "", errors.CauseChain(err))
+		return d.deployFailed(pmKey, "", deployReason(
+			"could not push "+branch+" and open its pull request — check the branch and forge access, then re-run Deploy",
+			err))
 	}
 	if err := d.waitForChecks(ctx, res); err != nil {
-		return d.deployFailed(pmKey, res.URL, errors.CauseChain(err))
+		return d.deployFailed(pmKey, res.URL, deployReason(ciFailureHeadline(err), err))
 	}
 	// Freshness stage: own the branch's mergeability BEFORE attempting the merge.
 	// When main has advanced past the branch point the forge would reject the
 	// merge (GitHub 405) and the card would dead-end; rebasing and re-pushing here
 	// turns that terminal failure into a mechanical, human-free recovery. A real
 	// conflict surfaces as a loud deploy-failed instead of a blind merge attempt.
-	if err := d.Deployer.EnsureMergeable(ctx, PRRequest{
+	rebased, ensureErr := d.Deployer.EnsureMergeable(ctx, PRRequest{
 		WorkspaceDir: d.WorkspaceDir,
 		Branch:       branch,
-	}); err != nil {
+	})
+	if ensureErr != nil {
 		// A rebase is strictly stronger than the forge's three-way end-state
 		// merge: it can conflict on an intermediate commit the merge never sees.
 		// Consult the forge's mergeable verdict and the green CI on the
 		// (rebase-aborted, unchanged) tip before redding the card (SC-804).
 		if !d.forgeMergeableFallback(ctx, res) {
-			return d.deployFailed(pmKey, res.URL, "branch could not be made mergeable: "+err.Error())
+			return d.deployFailed(pmKey, res.URL, deployReason(
+				"the branch conflicts with the base — resolve the conflict on "+branch+" (rebase it onto the base branch), then re-run Deploy",
+				ensureErr))
+		}
+	}
+	if rebased {
+		// The re-push invalidated the forge's cached mergeability; merging
+		// before the recompute settles draws a spurious 405 on a clean branch.
+		if err := d.awaitMergeable(ctx, res.Number); err != nil {
+			return d.deployFailed(pmKey, res.URL, deployReason(
+				"the forge still reports the pull request unmergeable after the freshness rebase — open the PR to see why, then re-run Deploy",
+				err))
 		}
 	}
 	if err := d.Deployer.MergePullRequest(ctx, d.WorkspaceDir, res.Number); err != nil {
-		return d.deployFailed(pmKey, res.URL, errors.CauseChain(err))
+		return d.deployFailed(pmKey, res.URL, deployReason(
+			"the forge refused the merge — open the PR to see why, then re-run Deploy",
+			err))
 	}
 	// Past the merge the work IS shipped: branch cleanup and the ticket close
 	// are best-effort and must never turn the card red. Best-effort here means
@@ -449,6 +474,51 @@ func (d BoardTransitionDeps) DeployBranch(ctx context.Context, pmKey, title, prB
 	_, _ = d.Commenter.AddComment(ctx, pmKey, StampDaemon(DeployedHeader+"\npr: "+res.URL, d.DaemonID))
 	d.closeTicketBestEffort(pmKey)
 	return nil
+}
+
+// failureReason renders a deploy-failed marker body per the marker-body
+// convention: an actionable headline first (the card badge/tooltip shows
+// exactly that line — it must tell the user what to do next), then the raw
+// cause as the detail block for the detail pane.
+func deployReason(headline string, cause error) string {
+	if cause == nil {
+		return headline
+	}
+	return headline + "\n\n" + errors.CauseChain(cause)
+}
+
+// ciFailureHeadline maps the CI gate's two failure modes to their next step.
+func ciFailureHeadline(err error) string {
+	if strings.Contains(err.Error(), "timed out") {
+		return "CI did not finish within the deploy window — check the PR's checks, then re-run Deploy"
+	}
+	return "CI checks failed on the pull request — fix the failing checks, then re-run Deploy"
+}
+
+// awaitMergeable waits for the forge's asynchronous mergeability recompute to
+// settle after a freshness-rebase re-push. Read errors and a false verdict
+// both retry — the recompute window routinely yields either — until the
+// timeout, which is the point where "still computing" and "genuinely
+// unmergeable" can no longer be told apart.
+func (d BoardTransitionDeps) awaitMergeable(ctx context.Context, number int) error {
+	deadline := time.Now().Add(mergeablePollTimeout)
+	for {
+		mergeable, err := d.Deployer.PullRequestMergeable(ctx, d.WorkspaceDir, number)
+		if err == nil && mergeable {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			if err != nil {
+				return err
+			}
+			return errors.WithDetails("forge reports the pull request unmergeable", "pr", number)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(mergeablePollInterval):
+		}
+	}
 }
 
 // forgeMergeableFallback reports whether the deploy may proceed to the merge

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -76,6 +76,9 @@ type fakeDeployer struct {
 	// ensured counts EnsureMergeable calls so a test can assert the freshness
 	// stage ran exactly once before the merge.
 	ensured int
+	// rebased is EnsureMergeable's report that it rewrote and re-pushed the
+	// branch — the deploy must then wait out the forge's mergeability recompute.
+	rebased bool
 	// mergeUntil models GitHub's 405 on a stale branch: MergePullRequest fails
 	// with a merge-conflict error until EnsureMergeable has run, then succeeds.
 	mergeUntil bool
@@ -84,6 +87,11 @@ type fakeDeployer struct {
 	// EnsureMergeable conflicts on an intermediate commit (SC-804).
 	mergeable    bool
 	mergeableErr error
+	// mergeableAfter models the forge's asynchronous mergeability recompute
+	// after a re-push: PullRequestMergeable reports false until it has been
+	// polled this many times, then true. Zero disables (verdict = mergeable).
+	mergeableAfter int
+	mergeableCalls int
 	// alreadyMerged models a branch whose work is already on the base: the deploy
 	// must short-circuit to a clean no-op instead of opening a doomed PR (SC-911).
 	alreadyMerged bool
@@ -110,14 +118,18 @@ func (f *fakeDeployer) PullRequestChecks(_ context.Context, _ string, _ int) (fo
 	return f.checks[i], nil
 }
 
-func (f *fakeDeployer) EnsureMergeable(_ context.Context, _ PRRequest) error {
+func (f *fakeDeployer) EnsureMergeable(_ context.Context, _ PRRequest) (bool, error) {
 	f.ensured++
-	return f.ensureErr
+	return f.rebased, f.ensureErr
 }
 
 func (f *fakeDeployer) PullRequestMergeable(_ context.Context, _ string, _ int) (bool, error) {
+	f.mergeableCalls++
 	if f.mergeableErr != nil {
 		return false, f.mergeableErr
+	}
+	if f.mergeableAfter > 0 {
+		return f.mergeableCalls >= f.mergeableAfter, nil
 	}
 	return f.mergeable, nil
 }
@@ -581,7 +593,11 @@ func TestApplyTransitionDeployEnsureMergeableConflict(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, failed)
-	assert.Contains(t, failed, "branch could not be made mergeable")
+	// The marker's first line is the card badge: it must tell the user the next
+	// step, with the raw cause following in the detail block.
+	headline := strings.SplitN(strings.TrimPrefix(failed, DeployFailedHeader+"\n"), "\n", 2)[0]
+	assert.Contains(t, headline, "resolve the conflict on feat/x")
+	assert.Contains(t, headline, "re-run Deploy")
 	assert.Contains(t, failed, "rebase hit a conflict")
 }
 
@@ -1007,7 +1023,9 @@ func (f *gateProbeDeployer) PullRequestChecks(_ context.Context, _ string, _ int
 	return forge.ChecksPassing, nil
 }
 
-func (f *gateProbeDeployer) EnsureMergeable(_ context.Context, _ PRRequest) error { return nil }
+func (f *gateProbeDeployer) EnsureMergeable(_ context.Context, _ PRRequest) (bool, error) {
+	return false, nil
+}
 
 func (f *gateProbeDeployer) PullRequestMergeable(_ context.Context, _ string, _ int) (bool, error) {
 	return true, nil
@@ -1047,4 +1065,91 @@ func TestDeploysQueueOneAtATime(t *testing.T) {
 	close(f.release)
 	assert.NotEqual(t, first, <-f.started, "the queued deploy must run after the first lands")
 	done.Wait()
+}
+
+// TestApplyTransitionDeployWaitsOutMergeabilityRecompute covers the race that
+// redded ticket 910's card: after the freshness rebase re-pushes the branch,
+// the forge recomputes mergeability asynchronously and the merge endpoint 405s
+// until it settles. A deploy that rebased must poll the verdict and merge only
+// once it turns true — never fail on the transient window.
+func TestApplyTransitionDeployWaitsOutMergeabilityRecompute(t *testing.T) {
+	syncDeploy(t)
+	origInterval, origTimeout := mergeablePollInterval, mergeablePollTimeout
+	mergeablePollInterval, mergeablePollTimeout = time.Millisecond, time.Second
+	t.Cleanup(func() { mergeablePollInterval, mergeablePollTimeout = origInterval, origTimeout })
+
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:ready-for-review]\nbranch: feat/x", time.Unix(1, 0)),
+		cmt("[human:review-complete]", time.Unix(2, 0)),
+	}}
+	p := &fakeDeployer{res: PRResult{URL: "https://example/pr/14", Number: 14},
+		checks:  []forge.ChecksState{forge.ChecksPassing},
+		rebased: true, mergeableAfter: 3}
+	deps := newDeps(c, &fakeLauncher{}, p)
+	err := deps.ApplyTransition(context.Background(),
+		BoardTransitionRequest{PMKey: "SC-1", From: BoardVerification, To: BoardDoneStage})
+	require.NoError(t, err)
+	assert.Equal(t, 1, p.merged, "merge must proceed once the recompute settles")
+	assert.GreaterOrEqual(t, p.mergeableCalls, 3, "the verdict must be polled through the recompute window")
+	for _, b := range c.added {
+		assert.False(t, strings.HasPrefix(b, DeployFailedHeader), "transient recompute must not red the card: %s", b)
+	}
+}
+
+// TestApplyTransitionDeployRecomputeStaysUnmergeable: when the verdict never
+// turns true, the failure marker must lead with an actionable headline.
+func TestApplyTransitionDeployRecomputeStaysUnmergeable(t *testing.T) {
+	syncDeploy(t)
+	origInterval, origTimeout := mergeablePollInterval, mergeablePollTimeout
+	mergeablePollInterval, mergeablePollTimeout = time.Millisecond, 5*time.Millisecond
+	t.Cleanup(func() { mergeablePollInterval, mergeablePollTimeout = origInterval, origTimeout })
+
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:ready-for-review]\nbranch: feat/x", time.Unix(1, 0)),
+		cmt("[human:review-complete]", time.Unix(2, 0)),
+	}}
+	p := &fakeDeployer{res: PRResult{URL: "https://example/pr/15", Number: 15},
+		checks:  []forge.ChecksState{forge.ChecksPassing},
+		rebased: true, mergeable: false}
+	deps := newDeps(c, &fakeLauncher{}, p)
+	err := deps.ApplyTransition(context.Background(),
+		BoardTransitionRequest{PMKey: "SC-1", From: BoardVerification, To: BoardDoneStage})
+	require.NoError(t, err)
+	assert.Zero(t, p.merged)
+	var failed string
+	for _, b := range c.added {
+		if strings.HasPrefix(b, DeployFailedHeader) {
+			failed = b
+		}
+	}
+	require.NotEmpty(t, failed)
+	headline := strings.SplitN(strings.TrimPrefix(failed, DeployFailedHeader+"\n"), "\n", 2)[0]
+	assert.Contains(t, headline, "open the PR to see why")
+	assert.Contains(t, headline, "re-run Deploy")
+}
+
+// TestApplyTransitionDeployCIFailureHeadline: a failing CI gate must red the
+// card with a fix-the-checks instruction, not a raw error chain.
+func TestApplyTransitionDeployCIFailureHeadline(t *testing.T) {
+	syncDeploy(t)
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:ready-for-review]\nbranch: feat/x", time.Unix(1, 0)),
+		cmt("[human:review-complete]", time.Unix(2, 0)),
+	}}
+	p := &fakeDeployer{res: PRResult{URL: "https://example/pr/16", Number: 16},
+		checks: []forge.ChecksState{forge.ChecksFailing}}
+	deps := newDeps(c, &fakeLauncher{}, p)
+	err := deps.ApplyTransition(context.Background(),
+		BoardTransitionRequest{PMKey: "SC-1", From: BoardVerification, To: BoardDoneStage})
+	require.NoError(t, err)
+	var failed string
+	for _, b := range c.added {
+		if strings.HasPrefix(b, DeployFailedHeader) {
+			failed = b
+		}
+	}
+	require.NotEmpty(t, failed)
+	headline := strings.SplitN(strings.TrimPrefix(failed, DeployFailedHeader+"\n"), "\n", 2)[0]
+	assert.Contains(t, headline, "fix the failing checks")
+	assert.Contains(t, headline, "re-run Deploy")
 }


### PR DESCRIPTION
Resolves ticket 1061, from the live diagnosis of ticket 910's failed deploy (PR #188's 405).

- `Deployer.EnsureMergeable` now returns `rebased`; after a re-push the deploy polls `PullRequestMergeable` (3s interval, 60s cap, test-pace vars) until the forge's asynchronous recompute settles, and only then merges. No rebase → no extra forge calls.
- All five deploy-failure sites now render the marker per the headline convention: first line = card badge with the next step ("fix the failing checks, then re-run Deploy", "resolve the conflict on <branch>…", "open the PR to see why…"), raw cause below for the detail pane.
- Tests: recompute window (verdict false→false→true must merge, never red), stuck-unmergeable headline, CI-failure headline; SC-804/SC-1000 fixtures updated for the new signature, dirty-workspace real-git test now also asserts `rebased=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)