### PR TITLE
[SC-910] Clear nilaway findings blocking CI on main and PR 188

### DIFF
--- a/cmd/cmdauto/semantic_test.go
+++ b/cmd/cmdauto/semantic_test.go
@@ -27,8 +27,8 @@ func (s *semanticStub) ListIssues(context.Context, tracker.ListOptions) ([]track
 	return nil, nil
 }
 func (s *semanticStub) GetIssue(context.Context, string) (*tracker.Issue, error) { return nil, nil }
-func (s *semanticStub) CreateIssue(context.Context, *tracker.Issue) (*tracker.Issue, error) {
-	return nil, nil
+func (s *semanticStub) CreateIssue(_ context.Context, issue *tracker.Issue) (*tracker.Issue, error) {
+	return issue, nil
 }
 func (s *semanticStub) ListComments(context.Context, string) ([]tracker.Comment, error) {
 	return nil, nil

--- a/cmd/cmddeploy/deploy_test.go
+++ b/cmd/cmddeploy/deploy_test.go
@@ -26,8 +26,8 @@ func (s *stubProvider) ListIssues(context.Context, tracker.ListOptions) ([]track
 func (s *stubProvider) GetIssue(context.Context, string) (*tracker.Issue, error) {
 	return s.issue, nil
 }
-func (s *stubProvider) CreateIssue(context.Context, *tracker.Issue) (*tracker.Issue, error) {
-	return nil, nil
+func (s *stubProvider) CreateIssue(_ context.Context, issue *tracker.Issue) (*tracker.Issue, error) {
+	return issue, nil
 }
 func (s *stubProvider) ListComments(context.Context, string) ([]tracker.Comment, error) {
 	return s.comments, nil

--- a/cmd/cmdhandoff/handoff_test.go
+++ b/cmd/cmdhandoff/handoff_test.go
@@ -25,8 +25,8 @@ func (s *stubProvider) ListIssues(context.Context, tracker.ListOptions) ([]track
 	return nil, nil
 }
 func (s *stubProvider) GetIssue(context.Context, string) (*tracker.Issue, error) { return nil, nil }
-func (s *stubProvider) CreateIssue(context.Context, *tracker.Issue) (*tracker.Issue, error) {
-	return nil, nil
+func (s *stubProvider) CreateIssue(_ context.Context, issue *tracker.Issue) (*tracker.Issue, error) {
+	return issue, nil
 }
 func (s *stubProvider) ListComments(context.Context, string) ([]tracker.Comment, error) {
 	return s.comments, nil

--- a/cmd/cmdmarker/marker_test.go
+++ b/cmd/cmdmarker/marker_test.go
@@ -30,8 +30,8 @@ func (s *stubProvider) ListIssues(context.Context, tracker.ListOptions) ([]track
 	return nil, nil
 }
 func (s *stubProvider) GetIssue(context.Context, string) (*tracker.Issue, error) { return nil, nil }
-func (s *stubProvider) CreateIssue(context.Context, *tracker.Issue) (*tracker.Issue, error) {
-	return nil, nil
+func (s *stubProvider) CreateIssue(_ context.Context, issue *tracker.Issue) (*tracker.Issue, error) {
+	return issue, nil
 }
 func (s *stubProvider) ListComments(_ context.Context, key string) ([]tracker.Comment, error) {
 	s.listedKeys = append(s.listedKeys, key)

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -595,7 +595,7 @@ func TestApplyTransitionDeployEnsureMergeableConflict(t *testing.T) {
 	require.NotEmpty(t, failed)
 	// The marker's first line is the card badge: it must tell the user the next
 	// step, with the raw cause following in the detail block.
-	headline := strings.SplitN(strings.TrimPrefix(failed, DeployFailedHeader+"\n"), "\n", 2)[0]
+	headline, _, _ := strings.Cut(strings.TrimPrefix(failed, DeployFailedHeader+"\n"), "\n")
 	assert.Contains(t, headline, "resolve the conflict on feat/x")
 	assert.Contains(t, headline, "re-run Deploy")
 	assert.Contains(t, failed, "rebase hit a conflict")
@@ -1123,7 +1123,7 @@ func TestApplyTransitionDeployRecomputeStaysUnmergeable(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, failed)
-	headline := strings.SplitN(strings.TrimPrefix(failed, DeployFailedHeader+"\n"), "\n", 2)[0]
+	headline, _, _ := strings.Cut(strings.TrimPrefix(failed, DeployFailedHeader+"\n"), "\n")
 	assert.Contains(t, headline, "open the PR to see why")
 	assert.Contains(t, headline, "re-run Deploy")
 }
@@ -1149,7 +1149,7 @@ func TestApplyTransitionDeployCIFailureHeadline(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, failed)
-	headline := strings.SplitN(strings.TrimPrefix(failed, DeployFailedHeader+"\n"), "\n", 2)[0]
+	headline, _, _ := strings.Cut(strings.TrimPrefix(failed, DeployFailedHeader+"\n"), "\n")
 	assert.Contains(t, headline, "fix the failing checks")
 	assert.Contains(t, headline, "re-run Deploy")
 }

--- a/internal/daemon/ideation.go
+++ b/internal/daemon/ideation.go
@@ -468,6 +468,13 @@ func (e *IdeationEngine) createTicket(sessID, title, description string) {
 		e.sess.errMsg = errors.WrapWithDetails(err, "creating PM ticket from ideation", "project", project).Error()
 		return
 	}
+	if created == nil {
+		// A provider must return the created issue on success, but a broken
+		// one failing that contract must surface as an error, not a panic.
+		e.sess.state = IdeationError
+		e.sess.errMsg = "tracker returned no issue for the created ticket"
+		return
+	}
 	e.sess.state = IdeationDone
 	e.sess.createdKey = created.Key
 	e.sess.createdURL = created.URL

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -511,7 +511,7 @@ func TestCommitsFor_parsesAndFiltersMerges(t *testing.T) {
 	if commits[0].SHA != "aaa1" || commits[0].ShortSHA != "a1" || commits[0].Subject != "[SC-57] Add validation" {
 		t.Errorf("first commit = %+v", commits[0])
 	}
-	if gotArgs[0] != "git" || gotArgs[3] != "log" {
+	if len(gotArgs) < 4 || gotArgs[0] != "git" || gotArgs[3] != "log" {
 		t.Errorf("args = %v", gotArgs)
 	}
 }


### PR DESCRIPTION
PR #188 (ticket 910's fix) has a red lint check — but the failures are inherited from main: CI runs nilaway (`make lint-deep`), the local hot-loop `make check` deliberately does not, and recent test stubs slipped three findings past it.

- `internal/daemon/ideation.go`: nil-guard after CreateIssue — a provider breaking the contract surfaces as an ideation error, not a panic (this was the root of the cross-package nilaway trace)
- Test stubs (`cmddeploy`, `cmdmarker`, `cmdhandoff`, `cmdauto`) return the issue from CreateIssue instead of nil
- `gitrepo_test`: bound the recorded-args index; deploy tests: `strings.Cut` instead of `SplitN(...)[0]`

`make lint-deep` passes clean locally. Once merged, updating PR #188's branch turns its lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)