### PR TITLE
[SC-1083] Age badge and Replan for Engineering-backlog cards

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/gethuman-sh/human/errors"
 	"github.com/gethuman-sh/human/internal/board"
@@ -83,6 +84,10 @@ type Card struct {
 	// Verdict is the latest review's verdict line; a failing verdict pins the
 	// card in the Code lane with a warning instead of letting it advance.
 	Verdict string `json:"verdict,omitempty"`
+	// StageEnteredAt is when the newest marker of the card's current stage
+	// landed (RFC3339); the board's age badge renders how long the card has
+	// been sitting. Empty when the card has no derived stage yet.
+	StageEnteredAt string `json:"stageEnteredAt,omitempty"`
 	// Labels and Description feed the Ideas→Backlog promotion: labels tell
 	// the evolve session which idea labels to remove, the description seeds
 	// the ideation conversation alongside the title.
@@ -334,6 +339,7 @@ func boardFromResults(results []daemon.TrackerIssuesResult, dockerAvailable bool
 			PRURL:          card.PRURL,
 			Error:          card.Error,
 			Verdict:        card.Verdict,
+			StageEnteredAt: formatStageTime(card.StageEnteredAt),
 			Labels:         issue.Labels,
 			Description:    issue.Description,
 			Assignee:       issue.Assignee,
@@ -349,6 +355,15 @@ func boardFromResults(results []daemon.TrackerIssuesResult, dockerAvailable bool
 		})
 	}
 	return data
+}
+
+// formatStageTime renders a marker time for the frontend, empty when the card
+// has no derived stage timestamp (e.g. the quick-fetch path).
+func formatStageTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format(time.RFC3339)
 }
 
 // DaemonStatus reports whether the human daemon is currently reachable. The

--- a/desktop/frontend/dist/board-queue.js
+++ b/desktop/frontend/dist/board-queue.js
@@ -35,6 +35,46 @@ export function queueOf(card) {
 export function isReworkable(card) {
     return card.stage === "verification" && card.state === "done" && (verdictFailed(card.verdict) || !card.branch);
 }
+// ageDays converts a card's stage timestamp into whole days elapsed, or null
+// when the timestamp is absent or unparseable.
+export function ageDays(stageEnteredAt, now) {
+    if (!stageEnteredAt)
+        return null;
+    const t = Date.parse(stageEnteredAt);
+    if (Number.isNaN(t))
+        return null;
+    const days = Math.floor((now.getTime() - t) / 86_400_000);
+    return days >= 0 ? days : null;
+}
+// Age escalation thresholds: a plan is presumed fresh for a week, suspect for
+// a second week, and stale after that — the badge color escalates so rotting
+// Engineering-backlog work is visible without reading numbers.
+const AGE_WARN_DAYS = 7;
+const AGE_HOT_DAYS = 14;
+// ageBadge describes the "<n>d" pill for a card sitting planned in the
+// Engineering backlog. Only done-state planning cards get one — a running
+// plan shows the spinner badge and a failed one its error; under a day the
+// pill is suppressed rather than shouting "0d" at fresh plans.
+export function ageBadge(card, now) {
+    if (card.bug || card.stage !== "planning" || card.state !== "done")
+        return null;
+    const days = ageDays(card.stageEnteredAt, now);
+    if (days === null || days < 1)
+        return null;
+    let cls = "age";
+    if (days >= AGE_HOT_DAYS)
+        cls = "age hot";
+    else if (days >= AGE_WARN_DAYS)
+        cls = "age warn";
+    return { text: `${days}d`, cls };
+}
+// isReplannable reports a card whose finished plan can be regenerated in
+// place: a feature ticket sitting planned in the Engineering backlog. The
+// codebase may have moved since the plan landed; replanning posts a fresh
+// [human:plan] that supersedes the old one (latest wins).
+export function isReplannable(card) {
+    return !card.bug && card.stage === "planning" && card.state === "done";
+}
 // isReviewRetryable reports a stage-failed review — a [human:review-failed] card
 // (verification/failed). It is a dead end on the board otherwise: the rework
 // re-drop needs a DONE verification with a failing verdict, so a failed binding

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -14,7 +14,7 @@ import { initMockupsView, showMockups, setPendingMockupSlug } from "./mockupsvie
 import { initSettingsView, showSettings, settingsIndex, saveSetting, setPaletteOpener, setActiveSection, } from "./settingsview.js";
 import { initPalette, openPalette, isPaletteChord } from "./palette.js";
 import { initStatsView, showStats, startStatsPoll, stopStatsPoll, } from "./statsview.js";
-import { QUEUES, QUEUE_TRANSITION_TO, queueOf, isReworkable, isReviewRetryable, forwardDropAllowed, badgeInfo, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReadyToDeploy, deployableCards, deployControlView, } from "./board-queue.js";
+import { QUEUES, QUEUE_TRANSITION_TO, queueOf, isReworkable, isReviewRetryable, ageBadge, isReplannable, forwardDropAllowed, badgeInfo, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReadyToDeploy, deployableCards, deployControlView, } from "./board-queue.js";
 import { buildDeployControl } from "./board-deploy.js";
 import { buildDetailSections, buildOptionsSection } from "./board-detail.js";
 import { ideationInputEnabled, shouldCloseIdeation } from "./board-ideation.js";
@@ -146,6 +146,13 @@ function renderCard(card) {
     const b = badge(card);
     if (b)
         meta.push(b);
+    // Age pill: how long the finished plan has been sitting in the Engineering
+    // backlog — color escalates so rotting plans are visible at a glance.
+    const age = ageBadge(card, new Date());
+    if (age) {
+        const planned = card.stageEnteredAt ? new Date(card.stageEnteredAt).toLocaleDateString() : "";
+        meta.push(`<span class="badge ${age.cls}" title="${escapeAttr("planned " + planned)}">${escapeHtml(age.text)}</span>`);
+    }
     if (card.engineeringKey)
         meta.push(`<span>${escapeHtml(card.engineeringKey)}</span>`);
     if (card.prURL)
@@ -232,6 +239,24 @@ function showCardMenu(card, x, y) {
             void transition(card.key, card.title, "backlog", "planning");
         });
         menu.appendChild(retryPlan);
+    }
+    // A finished plan can rot while the ticket waits in the Engineering
+    // backlog — code moves on, the plan doesn't. Replan relaunches /human-plan
+    // in place; the fresh plan comment supersedes the old one (latest wins).
+    // Same wire shape as Retry plan: from is inert for validation.
+    if (isReplannable(card)) {
+        const replanItem = document.createElement("button");
+        replanItem.type = "button";
+        replanItem.className = "context-menu-item";
+        replanItem.textContent = "Replan";
+        replanItem.disabled = !current.dockerAvailable;
+        if (replanItem.disabled)
+            replanItem.title = "Docker required";
+        replanItem.addEventListener("click", () => {
+            menu.remove();
+            void transition(card.key, card.title, "backlog", "planning");
+        });
+        menu.appendChild(replanItem);
     }
     // A failed build is otherwise a dead end on the workflow board: the rework
     // re-drop requires a failed REVIEW verdict and Retry fix is bug-pane-only

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -749,6 +749,22 @@ body {
   font-weight: 600;
 }
 
+/* Age of a finished plan sitting in the Engineering backlog. Muted while
+   fresh; escalates amber then red as the plan's code context rots, so stale
+   work is visible without reading the number. */
+.badge.age {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.badge.age.warn {
+  color: var(--running);
+}
+
+.badge.age.hot {
+  color: var(--failed);
+}
+
 /* Right-click card menu: administrative actions that are not pipeline
    transitions (close ticket, open in tracker). */
 .context-menu {

--- a/desktop/frontend/scripts/board-queue.test.mjs
+++ b/desktop/frontend/scripts/board-queue.test.mjs
@@ -171,3 +171,40 @@ test("insertKeyAt places dragged key by drop midpoint", () => {
   assert.deepEqual(insertKeyAt(resting, mids, "X", 999), ["A", "B", "C", "X"]);
   assert.deepEqual(insertKeyAt([], [], "X", 10), ["X"]);
 });
+
+// --- Engineering-backlog age badge + Replan gating ---
+
+test("ageDays: absent, unparseable, negative, and whole-day conversion", async () => {
+  const { ageDays } = await import("../build/board-queue.js");
+  const now = new Date("2026-07-21T12:00:00Z");
+  assert.equal(ageDays(undefined, now), null);
+  assert.equal(ageDays("not-a-date", now), null);
+  assert.equal(ageDays("2026-07-22T12:00:00Z", now), null, "future timestamps yield null, not negative days");
+  assert.equal(ageDays("2026-07-21T02:00:00Z", now), 0);
+  assert.equal(ageDays("2026-07-14T12:00:00Z", now), 7);
+});
+
+test("ageBadge: only done-state planning feature cards, from 1 day up", async () => {
+  const { ageBadge } = await import("../build/board-queue.js");
+  const now = new Date("2026-07-21T12:00:00Z");
+  const daysAgo = (n) => new Date(now.getTime() - n * 86_400_000).toISOString();
+
+  assert.equal(ageBadge({ stage: "planning", state: "done", stageEnteredAt: daysAgo(0) }, now), null, "under a day: no 0d noise");
+  assert.deepEqual(ageBadge({ stage: "planning", state: "done", stageEnteredAt: daysAgo(3) }, now), { text: "3d", cls: "age" });
+  assert.deepEqual(ageBadge({ stage: "planning", state: "done", stageEnteredAt: daysAgo(7) }, now), { text: "7d", cls: "age warn" });
+  assert.deepEqual(ageBadge({ stage: "planning", state: "done", stageEnteredAt: daysAgo(14) }, now), { text: "14d", cls: "age hot" });
+
+  assert.equal(ageBadge({ stage: "planning", state: "running", stageEnteredAt: daysAgo(3) }, now), null, "running plans show the spinner instead");
+  assert.equal(ageBadge({ stage: "implementation", state: "done", stageEnteredAt: daysAgo(3) }, now), null, "only the Engineering backlog ages");
+  assert.equal(ageBadge({ stage: "planning", state: "done", bug: true, stageEnteredAt: daysAgo(3) }, now), null, "bug cards live in the Bugs pane");
+  assert.equal(ageBadge({ stage: "planning", state: "done" }, now), null, "no timestamp, no badge");
+});
+
+test("isReplannable: planned feature cards only", async () => {
+  const { isReplannable } = await import("../build/board-queue.js");
+  assert.equal(isReplannable({ stage: "planning", state: "done" }), true);
+  assert.equal(isReplannable({ stage: "planning", state: "failed" }), false, "failed plans get Retry plan, not Replan");
+  assert.equal(isReplannable({ stage: "planning", state: "running" }), false);
+  assert.equal(isReplannable({ stage: "implementation", state: "done" }), false);
+  assert.equal(isReplannable({ stage: "planning", state: "done", bug: true }), false);
+});

--- a/desktop/frontend/src/board-queue.ts
+++ b/desktop/frontend/src/board-queue.ts
@@ -13,6 +13,9 @@ export interface QueueCard {
   // pane's ready cards.
   bug?: boolean;
   options?: { id: string; label: string }[];
+  // RFC3339 time the newest marker of the card's current stage landed; feeds
+  // the Engineering-backlog age badge. Absent for cards with no derived stage.
+  stageEnteredAt?: string;
 }
 
 export const QUEUES = ["ideas", "product", "engineering", "building", "deploy"] as const;
@@ -52,6 +55,44 @@ export function queueOf(card: QueueCard): string {
 
 export function isReworkable(card: QueueCard): boolean {
   return card.stage === "verification" && card.state === "done" && (verdictFailed(card.verdict) || !card.branch);
+}
+
+// ageDays converts a card's stage timestamp into whole days elapsed, or null
+// when the timestamp is absent or unparseable.
+export function ageDays(stageEnteredAt: string | undefined, now: Date): number | null {
+  if (!stageEnteredAt) return null;
+  const t = Date.parse(stageEnteredAt);
+  if (Number.isNaN(t)) return null;
+  const days = Math.floor((now.getTime() - t) / 86_400_000);
+  return days >= 0 ? days : null;
+}
+
+// Age escalation thresholds: a plan is presumed fresh for a week, suspect for
+// a second week, and stale after that — the badge color escalates so rotting
+// Engineering-backlog work is visible without reading numbers.
+const AGE_WARN_DAYS = 7;
+const AGE_HOT_DAYS = 14;
+
+// ageBadge describes the "<n>d" pill for a card sitting planned in the
+// Engineering backlog. Only done-state planning cards get one — a running
+// plan shows the spinner badge and a failed one its error; under a day the
+// pill is suppressed rather than shouting "0d" at fresh plans.
+export function ageBadge(card: QueueCard, now: Date): { text: string; cls: string } | null {
+  if (card.bug || card.stage !== "planning" || card.state !== "done") return null;
+  const days = ageDays(card.stageEnteredAt, now);
+  if (days === null || days < 1) return null;
+  let cls = "age";
+  if (days >= AGE_HOT_DAYS) cls = "age hot";
+  else if (days >= AGE_WARN_DAYS) cls = "age warn";
+  return { text: `${days}d`, cls };
+}
+
+// isReplannable reports a card whose finished plan can be regenerated in
+// place: a feature ticket sitting planned in the Engineering backlog. The
+// codebase may have moved since the plan landed; replanning posts a fresh
+// [human:plan] that supersedes the old one (latest wins).
+export function isReplannable(card: QueueCard): boolean {
+  return !card.bug && card.stage === "planning" && card.state === "done";
 }
 
 // isReviewRetryable reports a stage-failed review — a [human:review-failed] card

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -42,6 +42,8 @@ import {
   queueOf,
   isReworkable,
   isReviewRetryable,
+  ageBadge,
+  isReplannable,
   forwardDropAllowed,
   badgeInfo,
   sortByHandOrder,
@@ -76,6 +78,9 @@ interface Card {
   trackerKind?: string;
   error?: string;
   verdict?: string;
+  // RFC3339 time the newest marker of the card's current stage landed; feeds
+  // the Engineering-backlog age badge.
+  stageEnteredAt?: string;
   // Idea-space sub-column (0 loosest … 4 most concrete) for Ideas-stage cards.
   // Locally persisted preference; absent means leftmost.
   ideaColumn?: number;
@@ -431,6 +436,13 @@ function renderCard(card: Card): HTMLElement {
   }
   const b = badge(card);
   if (b) meta.push(b);
+  // Age pill: how long the finished plan has been sitting in the Engineering
+  // backlog — color escalates so rotting plans are visible at a glance.
+  const age = ageBadge(card, new Date());
+  if (age) {
+    const planned = card.stageEnteredAt ? new Date(card.stageEnteredAt).toLocaleDateString() : "";
+    meta.push(`<span class="badge ${age.cls}" title="${escapeAttr("planned " + planned)}">${escapeHtml(age.text)}</span>`);
+  }
   if (card.engineeringKey) meta.push(`<span>${escapeHtml(card.engineeringKey)}</span>`);
   if (card.prURL) meta.push(`<a href="${escapeAttr(card.prURL)}" target="_blank">PR</a>`);
 
@@ -520,6 +532,24 @@ function showCardMenu(card: Card, x: number, y: number): void {
       void transition(card.key, card.title, "backlog", "planning");
     });
     menu.appendChild(retryPlan);
+  }
+
+  // A finished plan can rot while the ticket waits in the Engineering
+  // backlog — code moves on, the plan doesn't. Replan relaunches /human-plan
+  // in place; the fresh plan comment supersedes the old one (latest wins).
+  // Same wire shape as Retry plan: from is inert for validation.
+  if (isReplannable(card)) {
+    const replanItem = document.createElement("button");
+    replanItem.type = "button";
+    replanItem.className = "context-menu-item";
+    replanItem.textContent = "Replan";
+    replanItem.disabled = !current.dockerAvailable;
+    if (replanItem.disabled) replanItem.title = "Docker required";
+    replanItem.addEventListener("click", () => {
+      menu.remove();
+      void transition(card.key, card.title, "backlog", "planning");
+    });
+    menu.appendChild(replanItem);
   }
 
   // A failed build is otherwise a dead end on the workflow board: the rework

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -749,6 +749,22 @@ body {
   font-weight: 600;
 }
 
+/* Age of a finished plan sitting in the Engineering backlog. Muted while
+   fresh; escalates amber then red as the plan's code context rots, so stale
+   work is visible without reading the number. */
+.badge.age {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.badge.age.warn {
+  color: var(--running);
+}
+
+.badge.age.hot {
+  color: var(--failed);
+}
+
 /* Right-click card menu: administrative actions that are not pipeline
    transitions (close ticket, open in tracker). */
 .context-menu {

--- a/internal/daemon/board_state.go
+++ b/internal/daemon/board_state.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"strings"
+	"time"
 
 	"github.com/gethuman-sh/human/internal/tracker"
 )
@@ -38,6 +39,10 @@ type BoardCard struct {
 	Options        []BoardOption `json:"options,omitempty"`
 	OptionsContext string        `json:"options_context,omitempty"`
 	OptionsStage   BoardStage    `json:"options_stage,omitempty"`
+	// StageEnteredAt is the Created time of the newest marker in the card's
+	// current stage — for a plan-done card, when the current plan landed. The
+	// board renders it as an age badge so work rotting in a queue is visible.
+	StageEnteredAt time.Time `json:"stage_entered_at,omitzero"`
 }
 
 // VerdictFailed reports whether a review verdict blocks the card from moving
@@ -107,7 +112,7 @@ func DeriveBoardCard(comments []tracker.Comment, statusType tracker.Category, is
 		}
 	}
 
-	card := BoardCard{Stage: furthest, State: state, HasPlan: hasPlan}
+	card := BoardCard{Stage: furthest, State: state, HasPlan: hasPlan, StageEnteredAt: latest.Created}
 	card.EngineeringKey = firstEngineeringKey(comments)
 	card.Branch = latestPrefixedLine(comments, ReadyForReviewHeader, "branch:")
 	card.Commits = latestPrefixedLine(comments, ReadyForReviewHeader, "commits:")

--- a/internal/daemon/board_state_test.go
+++ b/internal/daemon/board_state_test.go
@@ -269,3 +269,17 @@ func TestLatestPlanComment(t *testing.T) {
 		assert.False(t, ok)
 	})
 }
+
+func TestDeriveBoardCard_stageEnteredAt(t *testing.T) {
+	planned := time.Unix(5000, 0)
+	card := DeriveBoardCard([]tracker.Comment{
+		cmt("[human:planning-started]", time.Unix(1000, 0)),
+		cmt("[human:plan-ready]", planned),
+	}, tracker.CategoryUnstarted, false)
+	// The newest marker in the current stage stamps the card: for a plan-done
+	// card that is when the current plan landed, which the age badge renders.
+	assert.Equal(t, planned, card.StageEnteredAt)
+
+	backlog := DeriveBoardCard(nil, tracker.CategoryUnstarted, false)
+	assert.True(t, backlog.StageEnteredAt.IsZero(), "a no-marker backlog card carries no stage time")
+}

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -647,12 +647,16 @@ func isReworkTransition(to BoardStage, card BoardCard) bool {
 }
 
 // isPlanningRetry reports the second sanctioned non-forward move: relaunching
-// planning on a card whose planning run failed. Failed-state only — a running
-// planning card is protected by ApplyTransition's idempotency guard (SC-355).
+// planning on a card sitting in the planning stage. Failed state is the retry
+// case (SC-355); done state is the replan case — a finished plan whose code
+// context drifted while the ticket waited in the Engineering backlog gets a
+// fresh plan, which supersedes the old one by the plan layer's latest-wins
+// rule. A running planning card is protected by ApplyTransition's idempotency
+// guard either way.
 func isPlanningRetry(to BoardStage, card BoardCard) bool {
 	return to == BoardPlanning &&
 		card.Stage == BoardPlanning &&
-		card.State == BoardFailed
+		(card.State == BoardFailed || card.State == BoardDone)
 }
 
 // isBuildRetry mirrors isPlanningRetry for the implementation stage: failed

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -1153,3 +1153,35 @@ func TestApplyTransitionDeployCIFailureHeadline(t *testing.T) {
 	assert.Contains(t, headline, "fix the failing checks")
 	assert.Contains(t, headline, "re-run Deploy")
 }
+
+func TestApplyTransitionReplansDonePlanning(t *testing.T) {
+	// A finished plan sitting in the Engineering backlog can rot while the
+	// codebase moves on. The Replan gesture relaunches planning in place; the
+	// fresh plan supersedes the old one by the plan layer's latest-wins rule.
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:planning-started]", time.Unix(1, 0)),
+		cmt("[human:plan-ready]", time.Unix(2, 0)),
+	}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardBacklog, To: BoardPlanning})
+	require.NoError(t, err)
+	assert.Equal(t, 1, l.calls)
+	assert.Equal(t, "/human-plan SC-1", l.prompt)
+	require.Len(t, c.added, 1)
+	assert.Equal(t, PlanningStartedHeader, c.added[0])
+}
+
+func TestApplyTransitionReplanRejectedBeyondPlanning(t *testing.T) {
+	// Replan is scoped to the Engineering backlog: a card already in
+	// implementation keeps the forward-only rule for To=planning.
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:plan-ready]", time.Unix(1, 0)),
+		cmt("[human:implementation-started]", time.Unix(2, 0)),
+	}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardImplementation, To: BoardPlanning})
+	require.Error(t, err)
+	assert.Zero(t, l.calls)
+}


### PR DESCRIPTION
Resolves ticket 1083.

**Age badge** — `BoardCard.StageEnteredAt` (newest in-stage marker time) flows daemon → Wails bridge (RFC3339) → frontend; `ageBadge` in the DOM-free `board-queue.ts` renders `<n>d` on done-state planning feature cards only (running shows the spinner, <1 day suppressed), muted → amber ≥7d → red ≥14d.

**Replan** — context-menu action on planned feature cards; `isPlanningRetry` now accepts the done state so the existing `board-transition` wire relaunches `/human-plan` in place. New plan supersedes by latest-wins; the idempotency guard still blocks double launches; `To=planning` from implementation+ stays rejected (test).

Tests: derivation timestamp, replan-from-done, replan-rejected-beyond-planning (Go); ageDays/ageBadge boundaries and isReplannable gating (node --test). `dist/` regenerated via `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)