### PR TITLE
[SC-1084] Treat an expired access token with a refresh token as healthy

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -433,25 +433,7 @@ func runDaemonForeground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string,
 			Timestamp: time.Now().UTC(),
 		})
 	}, logger)
-	// Hold a systemd suspend block while agents run so an auto-suspending
-	// desktop cannot freeze Docker and the pipeline mid-run (SC-262). Off by
-	// default; the toggle is re-read each tick so a settings-UI change applies
-	// without a restart.
-	go daemon.RunSleepInhibitor(ctx, &dockerAgentSweeper{}, logindInhibitor{},
-		func() bool {
-			cfg, err := daemon.LoadPowerConfig(".")
-			if err != nil {
-				logger.Warn().Err(err).Msg("sleep inhibitor: cannot read power config; treating as disabled")
-				return false
-			}
-			return cfg.InhibitSleep
-		},
-		daemon.SleepInhibitInterval, logger)
-	if inhibitCfg, _ := daemon.LoadPowerConfig("."); inhibitCfg.InhibitSleep {
-		_, _ = fmt.Fprintln(out, "Sleep inhibition: enabled (suspend deferred while agents run)")
-	} else {
-		_, _ = fmt.Fprintln(out, "Sleep inhibition: disabled")
-	}
+	startSleepInhibitor(ctx, out, logger)
 	// The auto-review chain runs through the same launch gate: a daemon that
 	// cannot serve a review must leave the ready-for-review handoff unclaimed for
 	// one that can, not claim and fail it (SC-912). Doctor.Blockers is nil-safe.
@@ -2382,4 +2364,26 @@ func (s *dockerAgentSweeper) DeleteAgent(ctx context.Context, name string) error
 // human deploy CLI command, so there is exactly one deploy implementation.
 func NewForgeDeployer(resolver *vault.Resolver, lookup config.EnvLookup) daemon.Deployer {
 	return forgeDeployer{resolver: resolver, lookup: lookup}
+}
+
+// startSleepInhibitor holds a systemd suspend block while agents run so an
+// auto-suspending desktop cannot freeze Docker and the pipeline mid-run
+// (SC-262). Off by default; the toggle is re-read each tick so a settings-UI
+// change applies without a restart.
+func startSleepInhibitor(ctx context.Context, out io.Writer, logger zerolog.Logger) {
+	go daemon.RunSleepInhibitor(ctx, &dockerAgentSweeper{}, logindInhibitor{},
+		func() bool {
+			cfg, err := daemon.LoadPowerConfig(".")
+			if err != nil {
+				logger.Warn().Err(err).Msg("sleep inhibitor: cannot read power config; treating as disabled")
+				return false
+			}
+			return cfg.InhibitSleep
+		},
+		daemon.SleepInhibitInterval, logger)
+	if inhibitCfg, _ := daemon.LoadPowerConfig("."); inhibitCfg.InhibitSleep {
+		_, _ = fmt.Fprintln(out, "Sleep inhibition: enabled (suspend deferred while agents run)")
+	} else {
+		_, _ = fmt.Fprintln(out, "Sleep inhibition: disabled")
+	}
 }

--- a/cmd/cmddaemon/doctor_checks.go
+++ b/cmd/cmddaemon/doctor_checks.go
@@ -130,11 +130,14 @@ func checkAgentSkills(reg *daemon.ProjectRegistry) (bool, string) {
 }
 
 // claudeCreds is the slice of the Claude credential file the auth check reads:
-// the OAuth session's expiry. Only expiresAt matters — a present session whose
-// deadline has passed is the reported failure mode (SC-912).
+// the OAuth session's expiry and whether a refresh token exists. An expired
+// ACCESS token alone is the normal resting state between agent runs — Claude
+// Code refreshes it on launch — so only an expired token WITHOUT a refresh
+// token is a dead session the user must fix (SC-912).
 type claudeCreds struct {
 	ClaudeAiOauth struct {
-		ExpiresAt int64 `json:"expiresAt"`
+		ExpiresAt    int64  `json:"expiresAt"`
+		RefreshToken string `json:"refreshToken"`
 	} `json:"claudeAiOauth"`
 }
 
@@ -143,7 +146,9 @@ type claudeCreds struct {
 // The in-container Claude store is bind-mounted from the host at
 // <entry.Dir>/.devcontainer/claude/ → ~/.claude, so the probe reads the host
 // copy of .credentials.json. It is fail-open by design: only a present,
-// parseable session carrying an expiresAt in the past is a failure. An absent,
+// parseable session that is past its expiresAt AND has no refresh token is a
+// failure — with a refresh token the next launched Claude renews the access
+// token itself, so an expired access token between runs is healthy. An absent,
 // unreadable, unparseable, or expiresAt-less file degrades to pre-fix behaviour
 // (ok=true) so a path/schema mismatch never blocks a healthy daemon.
 func checkClaudeAuth(reg *daemon.ProjectRegistry) (bool, string) {
@@ -162,13 +167,19 @@ func checkClaudeAuth(reg *daemon.ProjectRegistry) (bool, string) {
 		if creds.ClaudeAiOauth.ExpiresAt == 0 {
 			continue // fail-open: no expiry recorded → cannot judge freshness
 		}
+		// An expired ACCESS token with a refresh token present is the normal
+		// resting state between agent runs — the next launched Claude refreshes
+		// it silently. Only a session that can no longer refresh is dead.
+		if creds.ClaudeAiOauth.RefreshToken != "" {
+			continue
+		}
 		if creds.ClaudeAiOauth.ExpiresAt <= nowMS {
 			expired = append(expired, entry.Dir)
 		}
 	}
 	if len(expired) > 0 {
 		return false, "Claude session expired for " + strings.Join(expired, ", ") +
-			" — re-authenticate Claude on this host (run 'claude' and sign in); the daemon will resume picking up board work once the session is fresh"
+			" — sign in to the project's container credential store: run 'human agent start reauth --interactive' in the project, /login inside it, then 'human agent stop reauth'; the daemon resumes picking up board work once the session is fresh"
 	}
 	return true, "session valid"
 }

--- a/cmd/cmddaemon/doctor_checks.go
+++ b/cmd/cmddaemon/doctor_checks.go
@@ -137,7 +137,7 @@ func checkAgentSkills(reg *daemon.ProjectRegistry) (bool, string) {
 type claudeCreds struct {
 	ClaudeAiOauth struct {
 		ExpiresAt    int64  `json:"expiresAt"`
-		RefreshToken string `json:"refreshToken"`
+		RefreshToken string `json:"refreshToken"` // #nosec G117 -- read for presence only; the value is never logged, compared, or persisted
 	} `json:"claudeAiOauth"`
 }
 

--- a/cmd/cmddaemon/doctor_checks_test.go
+++ b/cmd/cmddaemon/doctor_checks_test.go
@@ -17,13 +17,17 @@ import (
 // expiry (epoch-ms) under a temp project dir and returns a registry over it. A
 // zero expiry writes no expiresAt field, exercising the missing-expiry path.
 func claudeAuthRegistry(t *testing.T, expiresAtMS int64) *daemon.ProjectRegistry {
+	return claudeAuthRegistryRefresh(t, expiresAtMS, "")
+}
+
+func claudeAuthRegistryRefresh(t *testing.T, expiresAtMS int64, refreshToken string) *daemon.ProjectRegistry {
 	t.Helper()
 	dir := t.TempDir()
 	credDir := filepath.Join(dir, ".devcontainer", "claude")
 	require.NoError(t, os.MkdirAll(credDir, 0o755))
 	body := `{"claudeAiOauth":{}}`
 	if expiresAtMS != 0 {
-		body = fmt.Sprintf(`{"claudeAiOauth":{"expiresAt":%d}}`, expiresAtMS)
+		body = fmt.Sprintf(`{"claudeAiOauth":{"expiresAt":%d,"refreshToken":%q}}`, expiresAtMS, refreshToken)
 	}
 	require.NoError(t, os.WriteFile(filepath.Join(credDir, ".credentials.json"), []byte(body), 0o600))
 	reg, err := daemon.NewProjectRegistry([]string{dir})
@@ -65,7 +69,7 @@ func TestCheckClaudeAuth_expired(t *testing.T) {
 	reg := claudeAuthRegistry(t, time.Now().Add(-time.Hour).UnixMilli())
 	ok, detail := checkClaudeAuth(reg)
 	assert.False(t, ok)
-	assert.Contains(t, detail, "re-authenticate Claude")
+	assert.Contains(t, detail, "container credential store")
 }
 
 // A session whose expiresAt is in the future is fresh — the daemon may serve work.
@@ -91,4 +95,14 @@ func TestCheckClaudeAuth_missingExpiryFailsOpen(t *testing.T) {
 	reg := claudeAuthRegistry(t, 0)
 	ok, _ := checkClaudeAuth(reg)
 	assert.True(t, ok)
+}
+
+// An expired ACCESS token with a refresh token present is the normal resting
+// state between agent runs — the next launched Claude renews it. The check
+// must not block launches (the "but Claude IS authenticated" false positive).
+func TestCheckClaudeAuth_expiredAccessTokenWithRefreshTokenIsHealthy(t *testing.T) {
+	reg := claudeAuthRegistryRefresh(t, time.Now().Add(-time.Hour).UnixMilli(), "rt-present")
+	ok, detail := checkClaudeAuth(reg)
+	assert.True(t, ok)
+	assert.Equal(t, "session valid", detail)
 }


### PR DESCRIPTION
Resolves ticket 1084 — the board banner "launch blocked by failing Claude authentication check" while Claude was demonstrably signed in.

- `checkClaudeAuth` now reads `refreshToken` alongside `expiresAt`: with a refresh token present, an expired access token is the normal between-runs resting state (the launched agent renews it) — check stays green. Verified against the live store that triggered the banner: access token 3.4h past expiry, refresh token present, session fine.
- Failure message now names the actual fix — sign in to the project's **container credential store** (`human agent start reauth --interactive` + `/login`) — instead of "run 'claude' on this host", which refreshes the wrong store and never cleared the check.
- Fail-open behavior for absent/unparseable/expiry-less files unchanged; tests cover the new healthy path and the reworded failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)