### PR TITLE
[SC-1116] Board builds run headless: no questions, branch-anchored handoffs

### DIFF
--- a/cmd/cmdhandoff/handoff.go
+++ b/cmd/cmdhandoff/handoff.go
@@ -119,7 +119,7 @@ func RunHandoffPost(ctx context.Context, p tracker.Provider, out io.Writer, dir,
 
 	commits := opts.Commits
 	if len(commits) == 0 {
-		derived, err := deriveCommits(ctx, dir, key, opts.Engineering)
+		derived, err := deriveCommits(ctx, dir, key, branch, opts.Engineering)
 		if err != nil {
 			return err
 		}
@@ -180,8 +180,10 @@ func RunHandoffShow(ctx context.Context, p tracker.Provider, out io.Writer, key 
 
 // deriveCommits collects the short SHAs referencing the work keys (the
 // engineering keys in split topology, the ticket itself otherwise), oldest
-// first so the handoff reads in commit order.
-func deriveCommits(ctx context.Context, dir, key string, engineering []string) ([]string, error) {
+// first so the handoff reads in commit order. Discovery is anchored at the
+// handed-off BRANCH, not HEAD — in a board workspace the caller's checkout
+// usually sits on main while the work lives on the branch (the 1087 deadlock).
+func deriveCommits(ctx context.Context, dir, key, branch string, engineering []string) ([]string, error) {
 	workKeys := engineering
 	if len(workKeys) == 0 {
 		workKeys = []string{key}
@@ -189,7 +191,7 @@ func deriveCommits(ctx context.Context, dir, key string, engineering []string) (
 	var shas []string
 	seen := map[string]bool{}
 	for _, workKey := range workKeys {
-		found, err := gitrepo.CommitsFor(ctx, dir, workKey)
+		found, err := gitrepo.CommitsForRev(ctx, dir, workKey, branch)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/cmdhandoff/handoff_test.go
+++ b/cmd/cmdhandoff/handoff_test.go
@@ -49,15 +49,15 @@ func (s *stubProvider) ListStatuses(context.Context, string) ([]tracker.Status, 
 
 func stubGit(t *testing.T, branch string, commitsByKey map[string][]gitrepo.Commit, reachable map[string]bool) {
 	t.Helper()
-	prevBranch, prevCommits, prevReach, prevFetch := gitrepo.CurrentBranch, gitrepo.CommitsFor, gitrepo.CommitReachable, gitrepo.Fetch
+	prevBranch, prevCommits, prevReach, prevFetch := gitrepo.CurrentBranch, gitrepo.CommitsForRev, gitrepo.CommitReachable, gitrepo.Fetch
 	gitrepo.CurrentBranch = func(context.Context, string) (string, error) { return branch, nil }
-	gitrepo.CommitsFor = func(_ context.Context, _, key string) ([]gitrepo.Commit, error) {
+	gitrepo.CommitsForRev = func(_ context.Context, _, key, _ string) ([]gitrepo.Commit, error) {
 		return commitsByKey[key], nil
 	}
 	gitrepo.CommitReachable = func(_ context.Context, _, _, sha string) bool { return reachable[sha] }
 	gitrepo.Fetch = func(context.Context, string, string) error { return nil }
 	t.Cleanup(func() {
-		gitrepo.CurrentBranch, gitrepo.CommitsFor, gitrepo.CommitReachable, gitrepo.Fetch = prevBranch, prevCommits, prevReach, prevFetch
+		gitrepo.CurrentBranch, gitrepo.CommitsForRev, gitrepo.CommitReachable, gitrepo.Fetch = prevBranch, prevCommits, prevReach, prevFetch
 	})
 }
 
@@ -188,4 +188,27 @@ func TestSplitList(t *testing.T) {
 	assert.Nil(t, splitList("  "))
 	assert.Equal(t, []string{"a", "b"}, splitList("a, b"))
 	assert.Equal(t, []string{"a"}, splitList("a,"))
+}
+
+func TestRunHandoffPost_derivesCommitsFromBranchNotHead(t *testing.T) {
+	// The 1087 deadlock: the caller's checkout sits on main while the work
+	// lives on the branch — derivation must anchor at the handed-off branch.
+	var gotRev string
+	prevBranch, prevCommits, prevReach, prevFetch := gitrepo.CurrentBranch, gitrepo.CommitsForRev, gitrepo.CommitReachable, gitrepo.Fetch
+	gitrepo.CurrentBranch = func(context.Context, string) (string, error) { return "main", nil }
+	gitrepo.CommitsForRev = func(_ context.Context, _, _, rev string) ([]gitrepo.Commit, error) {
+		gotRev = rev
+		return []gitrepo.Commit{{ShortSHA: "abc"}}, nil
+	}
+	gitrepo.CommitReachable = func(context.Context, string, string, string) bool { return true }
+	gitrepo.Fetch = func(context.Context, string, string) error { return nil }
+	t.Cleanup(func() {
+		gitrepo.CurrentBranch, gitrepo.CommitsForRev, gitrepo.CommitReachable, gitrepo.Fetch = prevBranch, prevCommits, prevReach, prevFetch
+	})
+
+	p := &stubProvider{}
+	var buf bytes.Buffer
+	err := RunHandoffPost(context.Background(), p, &buf, ".", "SC-1", PostOptions{Branch: "feat/sc-1", Verify: true})
+	require.NoError(t, err)
+	assert.Equal(t, "feat/sc-1", gotRev)
 }

--- a/internal/claude/embed/human-executor-agent.md
+++ b/internal/claude/embed/human-executor-agent.md
@@ -51,10 +51,12 @@ human <TRACKER> issue comment list <TICKET_KEY>
    ```
 6. **Hand off for review.** If the human-done verdict is pass, post the structured handoff comment on the **PM ticket** so a separate reviewer (today: another `human` user runs `/human-pickup-review`; later: the daemon polls for it) can pick the work up:
    ```bash
-   human handoff post <PM_KEY> --engineering <ENG_KEY>
+   human handoff post <PM_KEY> --branch <feature-branch> --engineering <ENG_KEY>
    ```
+   - Always pass `--branch` explicitly with the branch you committed on — commit derivation anchors at that branch, so the command works no matter which ref the workspace happens to have checked out.
    - Single-tracker topology (no engineering ticket): omit `--engineering` entirely — the reviewer works from the PM key the comment sits on.
    - If multiple engineering tickets were executed in this run, pass them all: `--engineering <K1>,<K2>` (the command unions their commit SHAs).
+   - **Board context** (the dispatch prompt contains "BOARD CONTEXT"): do NOT push — the container holds no push credentials and the daemon's Deploy stage ships the local branch. A local-only branch is a VALID handoff: the reachability check accepts local refs. Post the handoff and stop; never end the run asking whether to push — there is no user, and an unanswered question fails the stage.
    The command derives the rest — `branch:` from the current git branch, `commits:` from the commits referencing the work key(s), `daemon:` from the `HUMAN_DAEMON_ID` env var so the handoff is attributed to the machine's bot like every daemon-posted marker (SC-660 rule 1; the line is omitted when the var is unset) — then verifies every SHA is reachable on the branch (fetching origin first) and refuses to post otherwise. The posted comment looks like:
    ```
    [human:ready-for-review]

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -178,8 +178,8 @@ func (d BoardTransitionDeps) ApplyTransition(ctx context.Context, req BoardTrans
 	// findings, and the resulting handoff chains into a fresh review.
 	if isReworkTransition(req.To, card) {
 		return d.startAgentStage(ctx, req.PMKey, BoardImplementation, ImplementationStartedHeader,
-			"/human-execute "+dispatchKey(req.PMKey, card)+
-				" — a review found problems; address the findings in the latest [human:review-complete] comment on the ticket first")
+			executePrompt(dispatchKey(req.PMKey, card),
+				" — a review found problems; address the findings in the latest [human:review-complete] comment on the ticket first"))
 	}
 
 	// Planning retry: a failed planning run is relaunched in place. The retry
@@ -199,7 +199,7 @@ func (d BoardTransitionDeps) ApplyTransition(ctx context.Context, req BoardTrans
 	// executor picks it up.
 	if isBuildRetry(req.To, card) {
 		return d.startAgentStage(ctx, req.PMKey, BoardImplementation, ImplementationStartedHeader,
-			"/human-execute "+dispatchKey(req.PMKey, card))
+			executePrompt(dispatchKey(req.PMKey, card), ""))
 	}
 
 	// Review retry: a stage-failed review is otherwise a dead end. The rework
@@ -257,7 +257,7 @@ func (d BoardTransitionDeps) launchForwardStage(ctx context.Context, req BoardTr
 			"/human-plan "+req.PMKey)
 	case BoardImplementation:
 		return d.startAgentStage(ctx, req.PMKey, BoardImplementation, ImplementationStartedHeader,
-			"/human-execute "+dispatchKey(req.PMKey, card))
+			executePrompt(dispatchKey(req.PMKey, card), ""))
 	case BoardVerification:
 		return d.startAgentStage(ctx, req.PMKey, BoardVerification, ReviewStartedHeader,
 			reviewPrompt(dispatchKey(req.PMKey, card), card))
@@ -596,6 +596,16 @@ func (d BoardTransitionDeps) deployFailed(pmKey, prURL, reason string) error {
 	}
 	_, _ = d.Commenter.AddComment(postCtx, pmKey, StampDaemon(body, d.DaemonID))
 	return errors.WithDetails("deploy failed: "+reason, "pm", pmKey, "pr", prURL)
+}
+
+// executePrompt builds the implementation-stage dispatch. The BOARD CONTEXT
+// trailer mirrors the bug path's fixer dispatch: a board container holds no
+// push credentials and no user — an executor that pauses to ask permission
+// burns the whole run and fails the stage with nothing posted (the 1087
+// deadlock, three runs in a row).
+func executePrompt(key, extra string) string {
+	return "/human-execute " + key + extra +
+		" BOARD CONTEXT: do NOT run git push — leave the branch local; the daemon's Deploy stage ships it. There is no user to ask: never end the run with a question — post the review handoff (human handoff post with --branch) or report the failure."
 }
 
 // dispatchKey resolves the key an agent is dispatched on: the engineering

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -233,7 +233,8 @@ func TestApplyTransitionRetriesFailedBuild(t *testing.T) {
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardPlanning, To: BoardImplementation})
 	require.NoError(t, err)
 	assert.Equal(t, 1, l.calls)
-	assert.Equal(t, "/human-execute SC-1", l.prompt)
+	assert.Contains(t, l.prompt, "/human-execute SC-1")
+	assert.Contains(t, l.prompt, "BOARD CONTEXT", "headless dispatch must carry the no-push, no-questions rules")
 	assert.Equal(t, "board-SC-1-implementation", l.name)
 	require.Len(t, c.added, 1)
 	assert.Equal(t, ImplementationStartedHeader, c.added[0])
@@ -282,7 +283,8 @@ func TestApplyTransitionPlanningToImplementation(t *testing.T) {
 	deps := newDeps(c, l, &fakeDeployer{})
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardPlanning, To: BoardImplementation})
 	require.NoError(t, err)
-	assert.Equal(t, "/human-execute HUM-9", l.prompt)
+	assert.Contains(t, l.prompt, "/human-execute HUM-9")
+	assert.Contains(t, l.prompt, "BOARD CONTEXT", "headless dispatch must carry the no-push, no-questions rules")
 	assert.Contains(t, c.added, ImplementationStartedHeader)
 }
 
@@ -759,7 +761,8 @@ func TestApplyTransitionImplementationWithoutEngineeringKey(t *testing.T) {
 	deps := newDeps(c, l, &fakeDeployer{})
 	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", From: BoardPlanning, To: BoardImplementation})
 	require.NoError(t, err)
-	assert.Equal(t, "/human-execute SC-1", l.prompt)
+	assert.Contains(t, l.prompt, "/human-execute SC-1")
+	assert.Contains(t, l.prompt, "BOARD CONTEXT", "headless dispatch must carry the no-push, no-questions rules")
 }
 
 func TestApplyTransitionVerificationWithoutEngineeringKey(t *testing.T) {

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -262,8 +262,16 @@ func keyRefPattern(key string) string {
 // exact discovery agents otherwise hand-roll with git log --grep incantations.
 // Package var so callers can stub git access in tests.
 var CommitsFor = func(ctx context.Context, dir, key string) ([]Commit, error) {
+	return CommitsForRev(ctx, dir, key, "HEAD")
+}
+
+// CommitsForRev is CommitsFor anchored at an explicit rev instead of HEAD —
+// the review handoff derives commits from the handed-off BRANCH, which in a
+// board workspace is usually not the checked-out ref. Package var so callers
+// can stub git access in tests.
+var CommitsForRev = func(ctx context.Context, dir, key, rev string) ([]Commit, error) {
 	out, err := runner(ctx, "git", "-C", dir, "log", "--extended-regexp",
-		"--grep="+keyRefPattern(key), "--format=%H%x1f%h%x1f%s", "HEAD")
+		"--grep="+keyRefPattern(key), "--format=%H%x1f%h%x1f%s", rev)
 	if err != nil {
 		return nil, errors.WrapWithDetails(err, "listing commits for key", "dir", dir, "key", key)
 	}

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -680,3 +680,18 @@ func TestTouchedSince_sinceFallbackAndUntouched(t *testing.T) {
 		t.Errorf("args = %v", gotArgs)
 	}
 }
+
+func TestCommitsForRev_anchorsAtGivenRev(t *testing.T) {
+	var gotArgs []string
+	withRunner(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte(""), nil
+	})
+	_, err := CommitsForRev(context.Background(), ".", "SC-1", "feat/branch")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotArgs[len(gotArgs)-1] != "feat/branch" {
+		t.Errorf("args = %v, want rev anchor feat/branch", gotArgs)
+	}
+}


### PR DESCRIPTION
Resolves ticket 1116 — root cause of ticket 1087's three identical build failures (agent finished, DoD green, then asked the void for push permission; exit 0, no handoff, stage failed).

- `internal/daemon`: all three `/human-execute` dispatch sites go through `executePrompt`, which appends the BOARD CONTEXT trailer (mirroring the bug-fixer dispatch): no push, Deploy ships the local branch, never end the run with a question. Prompt-content asserted in the transition tests.
- `human-executor-agent.md`: board-context rules — local-only branch is a valid handoff (reachability accepts local refs), always pass `--branch`.
- `gitrepo.CommitsForRev` + `cmdhandoff`: handoff commit derivation anchors at the handed-off branch instead of HEAD — from a main checkout, derivation used to find zero commits and refuse, which is what made the agent believe pushing was required.
- 1087 itself was unblocked manually (handoff posted with explicit binding); this PR prevents the recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)