### PR TITLE
[SC-1170] Drop nilaway from the lint gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,8 @@ jobs:
         with:
           go-version-file: go.mod
       # golangci-lint's default set includes govet and the full staticcheck
-      # suite — one owner per analysis. nilaway and gocyclo are enforced here
-      # (CI wall-clock is parallel and free) and stay out of the local hot loop.
+      # suite — one owner per analysis.
       - run: go tool golangci-lint run ./...
-      - run: go tool nilaway ./...
       - run: go tool gocyclo -over 15 .
 
   test:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build fmt fmt-check install test check-test test-integration coverage coverage-check fuzz lint lint-deep sec secrets check clean upgrade-deps release hooks unhooks desktop desktop-deps desktop-dev desktop-package
+.PHONY: all build fmt fmt-check install test check-test test-integration coverage coverage-check fuzz lint sec secrets check clean upgrade-deps release hooks unhooks desktop desktop-deps desktop-dev desktop-package
 
 VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
 
@@ -56,18 +56,11 @@ fuzz:
 	go test -run=^$$ -fuzz=FuzzSanitizeFTSQuery -fuzztime=30s ./internal/index/...
 	go test -run=^$$ -fuzz=FuzzPeekClientHello -fuzztime=30s ./internal/proxy/...
 
-# Local lint is the lean hot-loop gate: golangci-lint's default set already
-# includes govet and the full staticcheck suite, so the standalone tools would
-# run the same analyses twice. nilaway (the slowest analyzer here) is enforced
-# by the CI lint job instead — agents and developers run `make check` several
-# times per change and must not pay it every time. `make lint-deep` runs the
-# full set locally when chasing a nil-panic before pushing.
+# golangci-lint's default set already includes govet and the full staticcheck
+# suite, so the standalone tools would run the same analyses twice.
 lint:
 	go tool golangci-lint run ./...
 	go tool gocyclo -over 15 .
-
-lint-deep: lint
-	go tool nilaway ./...
 
 sec:
 	# .claude/worktrees holds agent worktrees — stale snapshots there must not

--- a/go.mod
+++ b/go.mod
@@ -554,7 +554,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/nilaway v0.0.0-20260213150243-937701de96c7 // indirect
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
@@ -601,7 +600,6 @@ tool (
 	github.com/goreleaser/goreleaser/v2
 	github.com/securego/gosec/v2/cmd/gosec
 	github.com/zricethezav/gitleaks/v8
-	go.uber.org/nilaway/cmd/nilaway
 	golang.org/x/tools/cmd/goimports
 	golang.org/x/vuln/cmd/govulncheck
 	gotest.tools/gotestsum

--- a/go.sum
+++ b/go.sum
@@ -1549,8 +1549,6 @@ go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKY
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
-go.uber.org/nilaway v0.0.0-20260213150243-937701de96c7 h1:IXkgx4mcXr/b5ccZ3a+GcUOpYLimQURTyMxkWMNEMCg=
-go.uber.org/nilaway v0.0.0-20260213150243-937701de96c7/go.mod h1:pbGMVkhssd5Ee+eoqfgEk9mzoJoKZAhnTbl1QNcYDi0=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.16.0/go.mod h1:MA8QOfq0BHJwdXa996Y4dYkAqRKB8/1K1QMMZVaNZjQ=
 go.uber.org/zap v1.19.1/go.mod h1:j3DNczoxDZroyBnOT1L/Q79cfUMGZxlv/9dzN7SM1rI=

--- a/internal/chrome/socket_relay.go
+++ b/internal/chrome/socket_relay.go
@@ -90,7 +90,7 @@ func (r *SocketRelay) ListenAndServe(ctx context.Context) error {
 			continue
 		}
 		if conn == nil {
-			continue // satisfy nilaway; Accept never returns nil without error
+			continue // defensive: a nil conn with no error would panic downstream
 		}
 		r.Logger.Debug().Msg("chrome native host connected to relay")
 

--- a/main.go
+++ b/main.go
@@ -701,7 +701,7 @@ func printDaemonSkewWarning(clientVersion, daemonVersion string) {
 // like "human-browser" and returns the implied subcommand (e.g. "browser").
 // Returns "" when os.Args[0] is just "human" or unrecognised.
 func subcmdFromBinary() string {
-	base := filepath.Base(os.Args[0]) //nolint:nilaway // os.Args is always set in main
+	base := filepath.Base(os.Args[0])
 	// Strip common extensions (.exe on Windows).
 	base = strings.TrimSuffix(base, ".exe")
 	if strings.HasPrefix(base, "human-") {
@@ -764,7 +764,7 @@ func main() {
 	daemon.ClientVersion = version
 
 	// Busybox-style dispatch: "human-browser URL" → "human browser URL".
-	args := os.Args[1:] //nolint:nilaway // os.Args is always set in main
+	args := os.Args[1:]
 	if sub := subcmdFromBinary(); sub != "" {
 		args = append([]string{sub}, args...)
 	}


### PR DESCRIPTION
nilaway peaks near **15 GB resident** on this module — more than the CI runner can give it. The step had been OOM-killed (`signal: killed`, exit 143) on main for several runs, so the lint job was failing for a resource reason rather than a code one and no longer gated anything.

Removed:
- the `go tool nilaway ./...` step in the CI lint job
- the `lint-deep` make target (nilaway was its only content beyond `lint`)
- the `go.uber.org/nilaway` tool dependency in go.mod/go.sum
- the two `//nolint:nilaway` pragmas in main.go

The defensive nil-conn guard in `internal/chrome/socket_relay.go` stays — only its comment, which cited nilaway, is reworded.

`golangci-lint` (govet + full staticcheck) and `gocyclo` continue to gate the build.

## Verification
- `go build ./...` clean
- `make lint` — 0 issues, gocyclo clean
- `make test` — 4021 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)