### PR TITLE
commits prefix returns [1117] not [SC-1117] for a bare number // human commits prefix with a bare numeric key echoes it un-normalized, orphaning agent commits

### DIFF
--- a/cmd/cmdcommits/commits.go
+++ b/cmd/cmdcommits/commits.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/gethuman-sh/human/internal/gitrepo"
+	"github.com/gethuman-sh/human/internal/tracker"
 )
 
 // BuildCommitsCmd creates the "commits" command with for and prefix subcommands.
@@ -139,12 +140,10 @@ func RunCommitsFor(ctx context.Context, out io.Writer, dir, key string, table bo
 func RunCommitPrefix(out io.Writer, keys []string) error {
 	parts := make([]string, len(keys))
 	for i, key := range keys {
-		trimmed := strings.TrimSpace(key)
-		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
-			parts[i] = trimmed
-			continue
-		}
-		parts[i] = "[" + trimmed + "]"
+		// Canonicalize before bracketing so a bare numeric key (the form the
+		// board passes internally) resolves to the tracker-attributable
+		// reference rather than an orphaned "[1117]" (SC-1134).
+		parts[i] = "[" + tracker.CanonicalCommitKey(key) + "]"
 	}
 	_, err := fmt.Fprintln(out, strings.Join(parts, " "))
 	return err

--- a/cmd/cmdcommits/commits_test.go
+++ b/cmd/cmdcommits/commits_test.go
@@ -98,6 +98,21 @@ func TestRunCommitPrefix_AlreadyBracketed(t *testing.T) {
 	assert.Equal(t, "[SC-79] [HUM-59]\n", buf.String())
 }
 
+func TestRunCommitPrefix_BareNumericKeyCanonicalized(t *testing.T) {
+	// The board/pipeline passes bare numeric keys internally; the prefix must
+	// resolve them to the canonical "SC-nnn" form so agent commits stay
+	// attributable and hook-compliant (SC-1134).
+	var buf bytes.Buffer
+	require.NoError(t, RunCommitPrefix(&buf, []string{"1117"}))
+	assert.Equal(t, "[SC-1117]\n", buf.String())
+}
+
+func TestRunCommitPrefix_BareNumericInBrackets(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, RunCommitPrefix(&buf, []string{"[1117]"}))
+	assert.Equal(t, "[SC-1117]\n", buf.String())
+}
+
 func TestBuildCommitsCmd_Subcommands(t *testing.T) {
 	cmd := BuildCommitsCmd()
 	uses := make([]string, 0, len(cmd.Commands()))

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -96,6 +96,30 @@ func ExtractProject(key string) string {
 	return ""
 }
 
+// shortcutCommitPrefix is Shortcut's fixed universal display prefix. A bare
+// numeric story ID is not attributable in a commit reference on its own, so it
+// is normalized to this prefixed form — the same key Shortcut prints and that
+// `human commits for` and the commit-msg hook expect. It is hardcoded (not
+// configured per workspace) for the same reason shortcutDisplayRe is.
+const shortcutCommitPrefix = "SC-"
+
+// CanonicalCommitKey normalizes a ticket key to the canonical form used in
+// commit references. Callers in the fix pipeline pass bare keys internally; a
+// purely numeric key is a Shortcut story ID whose canonical commit form carries
+// the "SC-" display prefix, so an agent that commits with the returned key
+// stays attributable via `human commits for` and passes the commit-msg hook.
+// Every other key format already carries its own project prefix (or is a repo
+// path) and is returned unchanged after trimming surrounding whitespace and
+// brackets.
+func CanonicalCommitKey(key string) string {
+	trimmed := strings.TrimSpace(key)
+	trimmed = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "["), "]"))
+	if numericRe.MatchString(trimmed) {
+		return shortcutCommitPrefix + trimmed
+	}
+	return trimmed
+}
+
 // FindResult holds the outcome of FindTracker.
 type FindResult struct {
 	Provider string `json:"provider"`

--- a/internal/tracker/tracker_test.go
+++ b/internal/tracker/tracker_test.go
@@ -327,6 +327,31 @@ func TestExtractProject(t *testing.T) {
 	}
 }
 
+func TestCanonicalCommitKey(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want string
+	}{
+		// A bare Shortcut story ID must resolve to the tool's canonical "SC-nnn"
+		// display form so agent commits match the commit->ticket trail and the
+		// commit-msg hook accepts them.
+		{name: "bare numeric gains SC prefix", key: "1117", want: "SC-1117"},
+		{name: "surrounding whitespace trimmed", key: " 1134 ", want: "SC-1134"},
+		// Keys already carrying their own project prefix pass through unchanged.
+		{name: "shortcut display key unchanged", key: "SC-1117", want: "SC-1117"},
+		{name: "jira key unchanged", key: "KAN-42", want: "KAN-42"},
+		{name: "engineering key unchanged", key: "HUM-59", want: "HUM-59"},
+		{name: "github issue unchanged", key: "octocat/repo#42", want: "octocat/repo#42"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, CanonicalCommitKey(tt.key))
+		})
+	}
+}
+
 // --- FindTracker tests ---
 
 func TestFindTracker_singleConfigured(t *testing.T) {


### PR DESCRIPTION
PM ticket: 1134
Branch: autofix/sc-1134
