### PR TITLE
[SC-1216] Add CI concurrency control to stop burst-time run pile-up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [main]
 
+# One run per ref: a new push (or a deploy's rebase force-push) supersedes the
+# in-progress run for the same branch/PR and cancels it, instead of piling up.
+# During a burst of merges this stops the parallel runs from starving the runner
+# pool — the symptom was jobs stuck "pending" for minutes and superseded runs
+# surfacing as red "operation was canceled" failures.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -20,6 +20,12 @@ on:
       - "desktop/**"
       - ".github/workflows/desktop.yml"
 
+# One run per ref: supersede the in-progress matrix build on a new push to the
+# same branch/PR rather than running stale multi-OS builds in parallel.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
CI appeared to "always fail" during rapid-merge bursts. Every failure was a `push`-triggered run cancelled mid-flight (`The operation was canceled` on lint); every quiet-time run is green, and lint itself completes in ~2.5 min. Root cause: no `concurrency` group on either workflow, so bursts spawn parallel runs that starve the runner pool and surface superseded runs as red failures.

Adds a per-ref `concurrency` group with `cancel-in-progress: true` to `ci.yml` and `desktop.yml`. A new push (or a deploy's rebase force-push) supersedes the in-progress run for the same branch/PR; the latest ref always gets a full run.

Separate gap noted on SC-1216: `make check` omits nilaway (CI-only), so local green ≠ CI green — worth closing next.

[SC-1216]

🤖 Generated with [Claude Code](https://claude.com/claude-code)