### PR TITLE
Document dev-mode PATH gotcha for human-board.app

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -54,3 +54,23 @@ make desktop-deps   # pinned Wails CLI
 make desktop        # build for the current OS (cannot cross-compile)
 make desktop-dev    # live-reload dev loop
 ```
+
+### Dev-mode PATH gotcha (`human` CLI not found)
+
+`make install` (`go install .`) puts the `human` binary in `$GOBIN`/`$GOPATH/bin`
+(e.g. `~/go/bin`), which is only on PATH for shells that source your profile —
+GUI apps launched from Finder/Dock/Spotlight inherit macOS's minimal default
+PATH instead, so `ResolveCLIPath` (`internal/daemon/lifecycle.go`) fails with
+"human CLI not found on PATH" even though `human` works fine from a terminal.
+
+This only affects building `human` from source (development mode). A normal
+install via `brew` places the binary directly in `/opt/homebrew/bin` or
+`/usr/local/bin`, which GUI apps do see, so this never comes up for installed
+users.
+
+Fix for local dev: symlink the built binary into a directory on the default
+GUI PATH, e.g.:
+
+```bash
+ln -sf "$(go env GOPATH)/bin/human" /opt/homebrew/bin/human
+```


### PR DESCRIPTION
## Summary
- `human-board.app` fails with "human CLI not found on PATH" when `human` was built with `go install .` (dev mode) and the app is launched from Finder/Dock, because GUI apps inherit macOS's minimal default PATH, not the shell's `~/go/bin`-inclusive one.
- A `brew install` never hits this — Homebrew lands the binary directly in `/opt/homebrew/bin`/`/usr/local/bin`, which GUI apps do see.
- Rather than changing `ResolveCLIPath` (`internal/daemon/lifecycle.go`) to handle a case real installed users never hit, this documents the dev-setup workaround (symlink into a directory already on the default GUI PATH) in `desktop/README.md`.

## Test plan
- [x] Docs-only change; no code touched, no build/test required.
- [x] Verified the symlink workaround resolves the error locally (`human-board.app` now finds `human`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)