### PR TITLE
[SC-1264] A frozen run is noticed in minutes, not never (+ repairs red main)

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -602,11 +602,24 @@ func runDaemonForeground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string,
 			daemon.StampDaemon(daemon.DeployedHeader+"\npr: "+prURL, ds.daemonID))
 		return err
 	}
+	// A live container is not a working agent. The hook stream is the progress
+	// signal — a crashed AND a hung agent both stop emitting — so the reconcile
+	// pass asks it before deciding a stage is stuck.
+	agentProgress := func(agentName string) (daemon.AgentProgress, bool) {
+		return ds.srv.HookEvents.AgentProgress(agentName)
+	}
+	// A hung agent still holds its container and workspace; it must be stopped
+	// before any relaunch, or two agents work the same stage.
+	stopHungAgent := func(agentName string) error {
+		stopCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		defer cancel()
+		return (&dockerAgentCleaner{}).DeleteAgent(stopCtx, agentName)
+	}
 	go daemon.RunBoardReconcile(ctx,
 		boardReconcileListerFunc(ds.srv.Projects, ds.vaultResolver),
 		branchReachable, commitsPresent, prMerged, postDeployed,
 		liveBoardAgents, postFailedMarkerFunc(ds.srv.Projects, ds.vaultResolver, ds.daemonID),
-		chainReview, stageRetry, ds.daemonID, daemon.BoardReconcileInterval, logger)
+		chainReview, stageRetry, agentProgress, stopHungAgent, ds.daemonID, daemon.BoardReconcileInterval, logger)
 
 	// Watch the binary so a rebuild re-execs into the new build, handing over the
 	// live sockets (no client sees a refused connection) and draining in-flight

--- a/cmd/cmddaemon/handover_integration_test.go
+++ b/cmd/cmddaemon/handover_integration_test.go
@@ -44,8 +44,9 @@ func TestReexecChildSuccess(t *testing.T) {
 	var handed atomic.Bool
 	stopped := make(chan struct{})
 	c := &handoverCoordinator{
-		listeners:  ls,
-		logger:     zerolog.Nop(),
+		listeners: ls,
+		logger:    zerolog.Nop(),
+		//nolint:nilaway // os.Args is always set for a running process
 		execPath:   os.Args[0], // the test binary stands in for the rebuilt daemon
 		handedOver: &handed,
 		stop:       func() { close(stopped) },

--- a/cmd/cmddaemon/handover_test.go
+++ b/cmd/cmddaemon/handover_test.go
@@ -58,6 +58,9 @@ func TestOpenListenersInheritRoundTrip(t *testing.T) {
 		t.Fatalf("files: %v", err)
 	}
 	defer closeAllFiles(files)
+	if len(files) < 3 {
+		t.Fatalf("files: got %d listener files, want 3", len(files))
+	}
 	// The parent keeps serving on its own copies; the child adopts the dups.
 	defer func() {
 		_ = parent.daemon.Close()

--- a/cmd/cmddaemon/handover_unix.go
+++ b/cmd/cmddaemon/handover_unix.go
@@ -222,7 +222,10 @@ func reexecChild(ctx context.Context, c *handoverCoordinator) error {
 	extra := append(files, readyW) // #nosec G601 -- files is not retained after this call
 	readyFD := 3 + len(files)
 
-	cmd := exec.Command(c.execPath, os.Args[1:]...) // #nosec G204 -- re-exec of our own binary with our own args
+	// #nosec G204 G702 -- re-exec of our own binary with our own args: the
+	// path is our own resolved executable and the args are this process's,
+	// neither reaches us from an external caller.
+	cmd := exec.Command(c.execPath, os.Args[1:]...) //nolint:nilaway // os.Args is always set for a running process
 	cmd.Env = append(os.Environ(),
 		daemonChildEnv+"=1",
 		envInheritListeners+"="+handoverListenerSpec,

--- a/internal/daemon/agentprogress.go
+++ b/internal/daemon/agentprogress.go
@@ -1,0 +1,114 @@
+package daemon
+
+import (
+	"time"
+
+	"github.com/gethuman-sh/human/internal/claude/hookevents"
+)
+
+// Idle budgets after which an agent that is still running is treated as hung.
+//
+// They are deliberately two numbers, not one, because "no event for N minutes"
+// means something different depending on what the agent was doing. Between tool
+// calls a model acts within seconds, so silence is abnormal fast; inside a tool
+// call the agent is legitimately blocked on a command that may run for a long
+// time (a full test suite), and no event can arrive until it returns.
+//
+// A single fixed timeout cannot serve both, which is exactly why the wall-clock
+// grace it replaces was wrong in both directions at once.
+var (
+	// ThinkingIdleGrace bounds silence between tool calls.
+	ThinkingIdleGrace = 3 * time.Minute
+	// ToolIdleGrace bounds one tool call. Generous on purpose: killing a
+	// running suite is far worse than noticing a hang a few minutes later.
+	ToolIdleGrace = 30 * time.Minute
+)
+
+// AgentProgress is the last observed sign of life from one agent.
+//
+// It is progress, not existence. A crashed agent and a hung agent both stop
+// emitting hook events, while a container-liveness check reports a hung agent
+// as perfectly healthy — which is why liveness alone can never detect a hang.
+type AgentProgress struct {
+	// LastEventAt is when this agent last did anything observable.
+	LastEventAt time.Time
+	// LastEvent is the hook event name that produced LastEventAt.
+	LastEvent string
+	// Tool is the tool currently executing, when InsideTool is set.
+	Tool string
+	// InsideTool reports a PreToolUse with no matching PostToolUse yet: the
+	// agent is waiting on a command, not idle.
+	InsideTool bool
+	// Blocked reports the agent is waiting on a human (a permission prompt).
+	// That is neither progress nor a hang — it needs an answer, not a retry.
+	Blocked bool
+}
+
+// IdleBudget is how long this agent may stay silent before it counts as hung.
+func (p AgentProgress) IdleBudget() time.Duration {
+	if p.InsideTool {
+		return ToolIdleGrace
+	}
+	return ThinkingIdleGrace
+}
+
+// Stalled reports whether the agent has been silent past its budget, and for
+// how long. A blocked agent is never stalled: it is waiting for a person, and
+// relaunching it would discard the question rather than answer it.
+func (p AgentProgress) Stalled(now time.Time) (bool, time.Duration) {
+	idle := now.Sub(p.LastEventAt)
+	if p.Blocked {
+		return false, idle
+	}
+	return idle > p.IdleBudget(), idle
+}
+
+// AgentProgressProbe reports the last progress seen from an agent. The second
+// result is false when nothing is known about it — a daemon that restarted, or
+// an agent that has yet to emit its first event.
+type AgentProgressProbe func(agentName string) (AgentProgress, bool)
+
+// trackProgress folds one hook event into the per-agent progress map.
+//
+// This is kept as its own map rather than derived from the event ring on
+// demand: the ring evicts under load (a 200-event per-session cap) and is empty
+// after a restart, so a quiet-but-working agent could have its last event aged
+// out and be misread as hung. Losing progress that way kills live work, which is
+// the one direction this must never fail in. One entry per agent is cheap and
+// cannot be evicted by another agent's traffic.
+func trackProgress(progress map[string]AgentProgress, evt hookevents.Event) {
+	if evt.AgentName == "" {
+		return
+	}
+	// A finished agent is not a stalled one; drop it so a completed run cannot
+	// later be mistaken for a hang.
+	if evt.EventName == "Stop" || evt.EventName == "SessionEnd" || evt.EventName == "StopFailure" {
+		delete(progress, evt.AgentName)
+		return
+	}
+
+	at := evt.Timestamp
+	if at.IsZero() {
+		at = time.Now()
+	}
+	p := progress[evt.AgentName]
+	p.LastEventAt = at
+	p.LastEvent = evt.EventName
+
+	switch evt.EventName {
+	case "PreToolUse":
+		p.InsideTool = true
+		p.Tool = evt.ToolName
+		p.Blocked = false
+	case "PostToolUse":
+		p.InsideTool = false
+		p.Tool = ""
+		p.Blocked = false
+	case "Notification":
+		// Claude is asking for permission: the agent is waiting on a human.
+		p.Blocked = true
+	default:
+		p.Blocked = false
+	}
+	progress[evt.AgentName] = p
+}

--- a/internal/daemon/agentprogress_test.go
+++ b/internal/daemon/agentprogress_test.go
@@ -1,0 +1,131 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/claude/hookevents"
+)
+
+func evt(name, agent, tool string, at time.Time) hookevents.Event {
+	return hookevents.Event{EventName: name, AgentName: agent, ToolName: tool, Timestamp: at}
+}
+
+// A tool call in flight is not idleness: no event can arrive until the command
+// returns, so the agent gets the long budget.
+func TestAgentProgress_InsideToolUsesTheLongBudget(t *testing.T) {
+	progress := map[string]AgentProgress{}
+	start := time.Unix(1000, 0)
+	trackProgress(progress, evt("PreToolUse", "board-SC-1-implementation", "Bash", start))
+
+	p := progress["board-SC-1-implementation"]
+	require.True(t, p.InsideTool)
+	require.Equal(t, ToolIdleGrace, p.IdleBudget())
+
+	// Ten minutes into a test suite is normal work, not a hang.
+	stalled, _ := p.Stalled(start.Add(10 * time.Minute))
+	require.False(t, stalled)
+
+	stalled, idle := p.Stalled(start.Add(ToolIdleGrace + time.Minute))
+	require.True(t, stalled, "past the tool budget it is hung")
+	require.Greater(t, idle, ToolIdleGrace)
+}
+
+// Between tool calls a model acts within seconds, so silence is abnormal fast.
+func TestAgentProgress_ThinkingUsesTheShortBudget(t *testing.T) {
+	progress := map[string]AgentProgress{}
+	start := time.Unix(1000, 0)
+	trackProgress(progress, evt("PreToolUse", "a", "Bash", start))
+	trackProgress(progress, evt("PostToolUse", "a", "Bash", start.Add(time.Minute)))
+
+	p := progress["a"]
+	require.False(t, p.InsideTool, "the tool finished")
+	require.Equal(t, ThinkingIdleGrace, p.IdleBudget())
+
+	stalled, _ := p.Stalled(start.Add(time.Minute + ThinkingIdleGrace + time.Second))
+	require.True(t, stalled)
+}
+
+// The whole point: a long stage that keeps working never looks hung, however
+// long it runs. Wall-clock duration must not enter the decision.
+func TestAgentProgress_LongRunningButActiveIsNeverStalled(t *testing.T) {
+	progress := map[string]AgentProgress{}
+	now := time.Unix(1000, 0)
+
+	// Three hours of steady tool calls.
+	for i := 0; i < 180; i++ {
+		now = now.Add(time.Minute)
+		trackProgress(progress, evt("PreToolUse", "a", "Bash", now))
+		trackProgress(progress, evt("PostToolUse", "a", "Bash", now.Add(2*time.Second)))
+	}
+
+	p := progress["a"]
+	stalled, _ := p.Stalled(now.Add(30 * time.Second))
+	require.False(t, stalled, "a working agent is never stalled regardless of total runtime")
+}
+
+// An agent waiting on a permission prompt needs an answer, not a relaunch —
+// retrying it would discard the question.
+func TestAgentProgress_BlockedIsNotStalled(t *testing.T) {
+	progress := map[string]AgentProgress{}
+	start := time.Unix(1000, 0)
+	trackProgress(progress, evt("Notification", "a", "", start))
+
+	p := progress["a"]
+	require.True(t, p.Blocked)
+
+	stalled, _ := p.Stalled(start.Add(time.Hour))
+	require.False(t, stalled, "blocked on a human is not a hang")
+}
+
+func TestAgentProgress_BlockedClearsOnNextAction(t *testing.T) {
+	progress := map[string]AgentProgress{}
+	start := time.Unix(1000, 0)
+	trackProgress(progress, evt("Notification", "a", "", start))
+	trackProgress(progress, evt("PostToolUse", "a", "Bash", start.Add(time.Minute)))
+
+	require.False(t, progress["a"].Blocked, "the human answered and the agent moved on")
+}
+
+// A finished agent must not linger as a hang candidate.
+func TestAgentProgress_TerminalEventsDropTheAgent(t *testing.T) {
+	for _, ending := range []string{"Stop", "SessionEnd", "StopFailure"} {
+		progress := map[string]AgentProgress{}
+		trackProgress(progress, evt("PreToolUse", "a", "Bash", time.Unix(1000, 0)))
+		trackProgress(progress, evt(ending, "a", "", time.Unix(1001, 0)))
+		require.NotContains(t, progress, "a", "%s must clear the agent", ending)
+	}
+}
+
+func TestAgentProgress_IgnoresEventsWithNoAgent(t *testing.T) {
+	progress := map[string]AgentProgress{}
+	trackProgress(progress, evt("PreToolUse", "", "Bash", time.Unix(1000, 0)))
+	require.Empty(t, progress)
+}
+
+// The store must keep progress outside the event ring: a per-session cap of 200
+// evicts events, and a quiet-but-working agent whose last event aged out would
+// be misread as hung — the one direction this must never fail in.
+func TestHookEventStore_ProgressSurvivesRingEviction(t *testing.T) {
+	s := NewHookEventStore()
+	at := time.Unix(1000, 0)
+	s.Append(evt("PreToolUse", "board-SC-1-implementation", "Bash", at))
+
+	// Flood the same session well past its cap.
+	for i := 0; i < maxHookEventsPerSession+50; i++ {
+		s.Append(hookevents.Event{EventName: "PostToolUse", SessionID: "s1", Timestamp: at})
+	}
+
+	p, ok := s.AgentProgress("board-SC-1-implementation")
+	require.True(t, ok, "progress must outlive ring eviction")
+	require.True(t, p.InsideTool)
+	require.Equal(t, at, p.LastEventAt)
+}
+
+func TestHookEventStore_UnknownAgentIsNotKnown(t *testing.T) {
+	s := NewHookEventStore()
+	_, ok := s.AgentProgress("board-SC-9-planning")
+	require.False(t, ok)
+}

--- a/internal/daemon/board_reconcile.go
+++ b/internal/daemon/board_reconcile.go
@@ -91,7 +91,7 @@ type FailedMarkerPoster func(ctx context.Context, pmKey, body string) error
 // It runs one pass immediately at start (recovers a restart-orphaned handoff
 // without waiting a full interval) then on a ticker, mirroring
 // RunAgentZombieSweep. nil deps disable it.
-func RunBoardReconcile(ctx context.Context, listCards ReconcileLister, reachable BranchReachable, commitsPresent CommitsPresent, mergedProbe PRMergedProbe, postDeployed DeployedPoster, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, chainReview func(pmKey string) error, retry StageRetry, daemonID string, interval time.Duration, logger zerolog.Logger) {
+func RunBoardReconcile(ctx context.Context, listCards ReconcileLister, reachable BranchReachable, commitsPresent CommitsPresent, mergedProbe PRMergedProbe, postDeployed DeployedPoster, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, chainReview func(pmKey string) error, retry StageRetry, progress AgentProgressProbe, stopAgent func(agentName string) error, daemonID string, interval time.Duration, logger zerolog.Logger) {
 	if listCards == nil || chainReview == nil {
 		return
 	}
@@ -101,14 +101,14 @@ func RunBoardReconcile(ctx context.Context, listCards ReconcileLister, reachable
 	// Recover a restart-orphaned handoff immediately, before the first wait. The
 	// jitter applies only to subsequent cycles, so a restart-orphan is never made
 	// to wait a full interval.
-	reconcileOnce(ctx, listCards, reachable, commitsPresent, mergedProbe, postDeployed, liveAgents, postFailed, chainReview, retry, daemonID, logger)
+	reconcileOnce(ctx, listCards, reachable, commitsPresent, mergedProbe, postDeployed, liveAgents, postFailed, chainReview, retry, progress, stopAgent, daemonID, logger)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-time.After(jitteredInterval(interval, BoardReconcileJitter)):
-			reconcileOnce(ctx, listCards, reachable, commitsPresent, mergedProbe, postDeployed, liveAgents, postFailed, chainReview, retry, daemonID, logger)
+			reconcileOnce(ctx, listCards, reachable, commitsPresent, mergedProbe, postDeployed, liveAgents, postFailed, chainReview, retry, progress, stopAgent, daemonID, logger)
 		}
 	}
 }
@@ -131,7 +131,7 @@ func jitteredInterval(d time.Duration, fraction float64) time.Duration {
 
 // reconcileOnce runs a single reconcile pass. A transient list error is logged
 // and skipped so a momentary tracker blip never kills the loop.
-func reconcileOnce(ctx context.Context, listCards ReconcileLister, reachable BranchReachable, commitsPresent CommitsPresent, mergedProbe PRMergedProbe, postDeployed DeployedPoster, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, chainReview func(pmKey string) error, retry StageRetry, daemonID string, logger zerolog.Logger) {
+func reconcileOnce(ctx context.Context, listCards ReconcileLister, reachable BranchReachable, commitsPresent CommitsPresent, mergedProbe PRMergedProbe, postDeployed DeployedPoster, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, chainReview func(pmKey string) error, retry StageRetry, progress AgentProgressProbe, stopAgent func(agentName string) error, daemonID string, logger zerolog.Logger) {
 	cards, err := listCards(ctx)
 	if err != nil {
 		logger.Warn().Err(err).Msg("board reconcile: cannot list PM cards")
@@ -143,9 +143,26 @@ func reconcileOnce(ctx context.Context, listCards ReconcileLister, reachable Bra
 	if n := reconcileShippedFailures(ctx, cards, mergedProbe, postDeployed, logger); n > 0 {
 		logger.Info().Int("cleared", n).Msg("board reconcile: confirmed shipped, cleared stale deploy-failed red")
 	}
-	if n := reconcileStuckRunning(ctx, cards, liveAgents, postFailed, retry, daemonID, time.Now(), logger); n > 0 {
+	if n := reconcileStuckRunning(ctx, cards, liveAgents, postFailed, retry, progress, stopAgent, daemonID, time.Now(), logger); n > 0 {
 		logger.Info().Int("reddened", n).Msg("board reconcile: reddened stuck-running cards with no live agent")
 	}
+}
+
+// stageStalled reports whether a live agent has stopped making progress.
+//
+// An unknown agent (no probe, or a daemon that restarted and lost its progress
+// map) is NOT treated as stalled: killing live work on absent evidence is the
+// one failure this must never risk, and the container-liveness check has
+// already established something is running.
+func stageStalled(progress AgentProgressProbe, agentName string, now time.Time) (bool, time.Duration) {
+	if progress == nil {
+		return false, 0
+	}
+	p, ok := progress(agentName)
+	if !ok {
+		return false, 0
+	}
+	return p.Stalled(now)
 }
 
 // reconcileStuckRunning reds the dead-end a NOT DONE bug-verify (and any other
@@ -164,7 +181,7 @@ func reconcileOnce(ctx context.Context, listCards ReconcileLister, reachable Bra
 // once the *-failed marker lands the card derives BoardFailed, so the next tick
 // skips it and never double-posts. Reuses DeriveBoardCard verbatim so detection
 // can never disagree with the board's rendered state. Returns the number reddened.
-func reconcileStuckRunning(ctx context.Context, cards []ReconcileCard, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, retry StageRetry, daemonID string, now time.Time, logger zerolog.Logger) int {
+func reconcileStuckRunning(ctx context.Context, cards []ReconcileCard, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, retry StageRetry, progress AgentProgressProbe, stopAgent func(agentName string) error, daemonID string, now time.Time, logger zerolog.Logger) int {
 	if liveAgents == nil || postFailed == nil {
 		return 0
 	}
@@ -194,9 +211,29 @@ func reconcileStuckRunning(ctx context.Context, cards []ReconcileCard, liveAgent
 			// Young enough to still be genuine in-flight work.
 			continue
 		}
-		if _, ok := alive[agentNameFor(card.Key, derived.Stage)]; ok {
-			// A live owner is working this stage — slow, not stuck.
-			continue
+		agentName := agentNameFor(card.Key, derived.Stage)
+		if _, ok := alive[agentName]; ok {
+			// A live container is not the same as a working agent: a hung agent
+			// looks perfectly healthy here, which is why a hang was previously
+			// never detected at all. Ask whether it is still making progress.
+			stalled, idle := stageStalled(progress, agentName, now)
+			if !stalled {
+				continue // genuinely working, however long it has been running
+			}
+			logger.Warn().Str("pm", card.Key).Str("stage", string(derived.Stage)).
+				Dur("idle", idle).Msg("board reconcile: agent alive but making no progress, treating as hung")
+			// A hung agent still holds its container and workspace, so it must be
+			// stopped before anything relaunches — otherwise two agents work the
+			// same stage. A stop that fails leaves the card alone rather than
+			// risking that.
+			if stopAgent == nil {
+				continue
+			}
+			if err := stopAgent(agentName); err != nil {
+				logger.Warn().Err(err).Str("agent", agentName).
+					Msg("board reconcile: cannot stop hung agent, leaving the card as-is")
+				continue
+			}
 		}
 		body := header + "\n" + stuckRunningReason(derived.Stage)
 		if err := postFailed(ctx, card.Key, body); err != nil {

--- a/internal/daemon/board_reconcile_hang_test.go
+++ b/internal/daemon/board_reconcile_hang_test.go
@@ -1,0 +1,148 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// runningCard is an aged, still-running implementation card whose agent is
+// alive — the shape a hung stage takes.
+func runningCard(now time.Time) []ReconcileCard {
+	return []ReconcileCard{{
+		Key:      "SC-1",
+		Comments: []tracker.Comment{cmt("[human:implementation-started]", now.Add(-StuckRunningGrace-time.Minute))},
+	}}
+}
+
+func progressAt(last time.Time, insideTool, blocked bool) AgentProgressProbe {
+	return func(string) (AgentProgress, bool) {
+		return AgentProgress{LastEventAt: last, InsideTool: insideTool, Blocked: blocked}, true
+	}
+}
+
+// The defect this fixes: a hung agent keeps its container alive, so the old
+// liveness check skipped it forever and the hang was never detected at all.
+func TestReconcileStuckRunning_HungAgentIsStoppedReddenedAndRelaunched(t *testing.T) {
+	now := time.Unix(100_000, 0)
+	var posted []struct{ Key, Body string }
+	var stopped []string
+	var relaunched []BoardStage
+	retry := StageRetry{
+		Max:      2,
+		Outcome:  func(string, BoardStage) (string, bool) { return "", false },
+		Attempts: func(string, BoardStage) (int, error) { return 1, nil },
+		Relaunch: func(_ string, s BoardStage) error { relaunched = append(relaunched, s); return nil },
+	}
+
+	n := reconcileStuckRunning(context.Background(), runningCard(now),
+		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), retry,
+		progressAt(now.Add(-ThinkingIdleGrace-time.Minute), false, false),
+		func(name string) error { stopped = append(stopped, name); return nil },
+		"d1", now, zerolog.Nop())
+
+	require.Equal(t, 1, n, "the hung card is reddened")
+	require.Equal(t, []string{"board-SC-1-implementation"}, stopped,
+		"the hung agent must be stopped before anything relaunches")
+	require.Equal(t, []BoardStage{BoardImplementation}, relaunched)
+}
+
+// The other half: an agent that is genuinely working must never be killed,
+// however long the stage has been running.
+func TestReconcileStuckRunning_ActiveAgentIsLeftAlone(t *testing.T) {
+	now := time.Unix(100_000, 0)
+	var posted []struct{ Key, Body string }
+	var stopped []string
+
+	n := reconcileStuckRunning(context.Background(), runningCard(now),
+		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), StageRetry{},
+		progressAt(now.Add(-10*time.Second), false, false),
+		func(name string) error { stopped = append(stopped, name); return nil },
+		"d1", now, zerolog.Nop())
+
+	require.Equal(t, 0, n)
+	require.Empty(t, posted)
+	require.Empty(t, stopped)
+}
+
+// A ten-minute Bash call emits nothing until it returns; that is work, not a
+// hang, and the tool budget must cover it.
+func TestReconcileStuckRunning_LongToolCallIsNotAHang(t *testing.T) {
+	now := time.Unix(100_000, 0)
+	var posted []struct{ Key, Body string }
+	var stopped []string
+
+	n := reconcileStuckRunning(context.Background(), runningCard(now),
+		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), StageRetry{},
+		progressAt(now.Add(-10*time.Minute), true, false), // inside a tool call
+		func(name string) error { stopped = append(stopped, name); return nil },
+		"d1", now, zerolog.Nop())
+
+	require.Equal(t, 0, n, "a running suite must not be killed")
+	require.Empty(t, stopped)
+}
+
+// Waiting on a permission prompt needs an answer, not a relaunch.
+func TestReconcileStuckRunning_BlockedAgentIsNotHung(t *testing.T) {
+	now := time.Unix(100_000, 0)
+	var posted []struct{ Key, Body string }
+	var stopped []string
+
+	n := reconcileStuckRunning(context.Background(), runningCard(now),
+		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), StageRetry{},
+		progressAt(now.Add(-time.Hour), false, true), // blocked on a human
+		func(name string) error { stopped = append(stopped, name); return nil },
+		"d1", now, zerolog.Nop())
+
+	require.Equal(t, 0, n)
+	require.Empty(t, stopped)
+}
+
+// Absent evidence must never kill live work: an unknown agent (daemon restarted
+// and lost its progress map) is left alone.
+func TestReconcileStuckRunning_UnknownProgressLeavesLiveWorkAlone(t *testing.T) {
+	now := time.Unix(100_000, 0)
+	var posted []struct{ Key, Body string }
+
+	unknown := func(string) (AgentProgress, bool) { return AgentProgress{}, false }
+	n := reconcileStuckRunning(context.Background(), runningCard(now),
+		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), StageRetry{},
+		unknown, func(string) error { return nil }, "d1", now, zerolog.Nop())
+
+	require.Equal(t, 0, n)
+
+	// Same when no probe is wired at all — previous behaviour, unchanged.
+	n = reconcileStuckRunning(context.Background(), runningCard(now),
+		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), StageRetry{},
+		nil, nil, "d1", now, zerolog.Nop())
+	require.Equal(t, 0, n)
+}
+
+// If the hung agent cannot be stopped, the card must be left as-is rather than
+// relaunched into a second agent on the same stage.
+func TestReconcileStuckRunning_FailedStopDoesNotRelaunch(t *testing.T) {
+	now := time.Unix(100_000, 0)
+	var posted []struct{ Key, Body string }
+	var relaunched []BoardStage
+	retry := StageRetry{
+		Max:      2,
+		Outcome:  func(string, BoardStage) (string, bool) { return "", false },
+		Attempts: func(string, BoardStage) (int, error) { return 1, nil },
+		Relaunch: func(_ string, s BoardStage) error { relaunched = append(relaunched, s); return nil },
+	}
+
+	n := reconcileStuckRunning(context.Background(), runningCard(now),
+		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), retry,
+		progressAt(now.Add(-time.Hour), false, false),
+		func(string) error { return errors.New("docker unavailable") },
+		"d1", now, zerolog.Nop())
+
+	require.Equal(t, 0, n)
+	require.Empty(t, relaunched, "never relaunch while the hung agent may still be running")
+}

--- a/internal/daemon/board_reconcile_retry_test.go
+++ b/internal/daemon/board_reconcile_retry_test.go
@@ -33,7 +33,7 @@ func TestReconcileStuckRunning_RelaunchesAfterReddening(t *testing.T) {
 	}
 
 	n := reconcileStuckRunning(context.Background(), cards, liveAgents(),
-		capturingPoster(&posted), retry, "d1", now, zerolog.Nop())
+		capturingPoster(&posted), retry, nil, nil, "d1", now, zerolog.Nop())
 
 	require.Equal(t, 1, n, "the card is reddened")
 	require.Len(t, posted, 1, "the failed marker is the trail record")
@@ -59,7 +59,7 @@ func TestReconcileStuckRunning_RelaunchRespectsTheBudget(t *testing.T) {
 	}
 
 	n := reconcileStuckRunning(context.Background(), cards, liveAgents(),
-		capturingPoster(&posted), retry, "d1", now, zerolog.Nop())
+		capturingPoster(&posted), retry, nil, nil, "d1", now, zerolog.Nop())
 
 	require.Equal(t, 1, n, "the card is still reddened for a human")
 	require.Empty(t, relaunched, "a spent budget stops the automatic relaunch")

--- a/internal/daemon/board_reconcile_test.go
+++ b/internal/daemon/board_reconcile_test.go
@@ -171,7 +171,7 @@ func TestRunBoardReconcile_RecoversOrphanWithNoLiveEvent(t *testing.T) {
 	ctx := t.Context()
 	// A long interval proves the recovery comes from the immediate startup pass,
 	// not a ticker tick.
-	go RunBoardReconcile(ctx, lister, alwaysReachable, nil, nil, nil, nil, nil, chain, StageRetry{}, "", time.Hour, zerolog.Nop())
+	go RunBoardReconcile(ctx, lister, alwaysReachable, nil, nil, nil, nil, nil, chain, StageRetry{}, nil, nil, "", time.Hour, zerolog.Nop())
 
 	select {
 	case pmKey := <-chained:
@@ -274,7 +274,7 @@ func TestReconcileStuckRunning_FailsAgedRunningOrphanWithNoAgent(t *testing.T) {
 		Comments: []tracker.Comment{cmt("[human:implementation-started]", now.Add(-StuckRunningGrace-time.Minute))},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), StageRetry{}, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
 
 	assert.Equal(t, 1, n)
 	assert.Len(t, posted, 1)
@@ -292,7 +292,7 @@ func TestReconcileStuckRunning_SkipsWithinGrace(t *testing.T) {
 		Comments: []tracker.Comment{cmt("[human:implementation-started]", now.Add(-time.Minute))},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), StageRetry{}, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
 
 	assert.Equal(t, 0, n)
 	assert.Empty(t, posted)
@@ -308,7 +308,7 @@ func TestReconcileStuckRunning_SkipsWhenAgentAlive(t *testing.T) {
 	}}
 	var posted []struct{ Key, Body string }
 	live := liveAgents(agentNameFor("SC-1", BoardImplementation))
-	n := reconcileStuckRunning(context.Background(), cards, live, capturingPoster(&posted), StageRetry{}, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), cards, live, capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
 
 	assert.Equal(t, 0, n)
 	assert.Empty(t, posted)
@@ -326,7 +326,7 @@ func TestReconcileStuckRunning_SkipsNonRunning(t *testing.T) {
 		},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), StageRetry{}, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
 
 	assert.Equal(t, 0, n)
 	assert.Empty(t, posted)
@@ -341,7 +341,7 @@ func TestReconcileStuckRunning_CoversVerificationStage(t *testing.T) {
 		Comments: []tracker.Comment{cmt("[human:review-started]", now.Add(-StuckRunningGrace-time.Minute))},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), StageRetry{}, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
 
 	assert.Equal(t, 1, n)
 	assert.Len(t, posted, 1)
@@ -357,7 +357,7 @@ func TestReconcileStuckRunning_NilListerDisables(t *testing.T) {
 		Comments: []tracker.Comment{cmt("[human:implementation-started]", now.Add(-StuckRunningGrace-time.Minute))},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), cards, nil, capturingPoster(&posted), StageRetry{}, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), cards, nil, capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
 
 	assert.Equal(t, 0, n)
 	assert.Empty(t, posted)

--- a/internal/daemon/hookstore.go
+++ b/internal/daemon/hookstore.go
@@ -28,6 +28,9 @@ type HookEventStore struct {
 	eventSeqs   []uint64 // monotonic id per event, index-aligned with events
 	appended    uint64   // total events ever appended (last assigned sequence)
 	subscribers []chan struct{}
+	// progress is the last sign of life per agent, kept outside the ring so
+	// eviction cannot make a quiet-but-working agent look hung.
+	progress map[string]AgentProgress
 	// persist is an optional durable sink invoked for every appended event.
 	// The in-memory ring evicts under load and is empty after a restart, so a
 	// hook event tied to a since-reaped agent run is otherwise lost; the sink
@@ -40,6 +43,7 @@ func NewHookEventStore() *HookEventStore {
 	return &HookEventStore{
 		events:    make([]hookevents.Event, 0, maxHookEvents),
 		eventSeqs: make([]uint64, 0, maxHookEvents),
+		progress:  make(map[string]AgentProgress),
 	}
 }
 
@@ -78,6 +82,10 @@ func (s *HookEventStore) Append(evt hookevents.Event) {
 			}
 		}
 	}
+	if s.progress == nil {
+		s.progress = make(map[string]AgentProgress)
+	}
+	trackProgress(s.progress, evt)
 	s.appended++
 	s.events = append(s.events, evt)
 	s.eventSeqs = append(s.eventSeqs, s.appended)
@@ -103,6 +111,15 @@ func (s *HookEventStore) Append(evt hookevents.Event) {
 		default: // non-blocking — subscriber already has a pending notification
 		}
 	}
+}
+
+// AgentProgress returns the last progress seen from an agent. ok is false when
+// nothing is known — the daemon restarted, or the agent has not acted yet.
+func (s *HookEventStore) AgentProgress(agentName string) (AgentProgress, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.progress[agentName]
+	return p, ok
 }
 
 // Subscribe returns a channel that receives a signal whenever a new event is


### PR DESCRIPTION
## The bug

A hung stage was **never detected**, at any grace period. `reconcileStuckRunning` skipped every card whose agent appeared in the live-agent list — and a hung agent is perfectly alive by that measure: it holds its container and answers the liveness probe while doing nothing at all.

Existence was the wrong question. (Worth stating plainly: the first mechanism I proposed for this — a container-liveness heartbeat — would have made the blindness permanent.)

## The signal was already arriving, unused

`human install` registers PreToolUse/PostToolUse hooks, so the daemon already receives an event per tool call carrying agent, timestamp and tool. A crashed agent stops emitting and **so does a hung one** — one signal covers both — and it is independent of how long a stage runs.

That retires the fixed 15-minute wall-clock grace, which was wrong in both directions at once: too short for stages that legitimately run longer, too long to wait once something has actually frozen.

## Two budgets, not one number

"No event for N minutes" means different things depending on what the agent was doing:

| State | Meaning | Budget |
|---|---|---|
| inside a tool call (`PreToolUse`, no `PostToolUse` yet) | blocked on a command that may legitimately run long | 30 min |
| between calls (`PostToolUse`) | a model acts within seconds; silence is abnormal | 3 min |
| permission prompt (`Notification`) | waiting on a **person** — neither progress nor a hang | never retried |

## Guards against the dangerous direction

Killing live work is far worse than noticing a hang late, so:

- Progress is tracked in its own per-agent map, **not** scanned from the event ring — the ring evicts at 200 events/session and is empty after a restart, so an aged-out event would fake a hang for a working agent.
- An **unknown** agent (daemon restarted, progress lost) is never treated as stalled. Absent evidence does not justify ending live work.
- A long-running-but-active stage is never stalled regardless of total runtime.

## On a detected hang: stop → red → relaunch

In that order. A hung agent still holds its container and workspace, so relaunching first would put two agents on one stage. A stop that fails aborts rather than risking it.

## Testing

14 new tests, including the previously undetectable hang and four "must not kill live work" guards. `make test` (4211) and `make lint` (0 issues) green.

**Note:** `make check` currently fails on one *pre-existing* gosec G702 finding in `cmd/cmddaemon/handover_unix.go:225` (from SC-1263), reproduced on `origin/main` — not from this branch. Its existing `#nosec G204` annotation does not cover the newer G702 taint rule.

**Not yet proven live:** a real container hanging and being recovered has not been observed; this is validated by code and unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)