### PR TITLE
After a decision, the card must read as 'replanning picked up', never a stale failure

### DIFF
--- a/desktop/frontend/dist/board-queue.js
+++ b/desktop/frontend/dist/board-queue.js
@@ -92,6 +92,13 @@ export const RUNNING_LABELS = {
     verification: "reviewing…",
     done: "deploying…",
 };
+// The verb per chosen stage for a card a recorded decision has (re)queued but
+// whose fresh agent has not yet posted its started marker (SC-1320).
+export const QUEUED_LABELS = {
+    planning: "replanning",
+    implementation: "rebuild",
+    verification: "re-review",
+};
 // badgeInfo classifies a card's live state into a badge descriptor, or null
 // when the card rests and needs none — its queue position IS the statement of
 // completion. A review that found problems is a WARNING, not a stage failure:
@@ -102,6 +109,19 @@ export function badgeInfo(card) {
             cls: "running",
             text: RUNNING_LABELS[card.stage] ?? "working…",
             title: "Agent running",
+            spinner: true,
+        };
+    }
+    // A recorded decision has (re)queued the chosen stage but the relaunched
+    // agent has not posted its started marker yet — or the launch was deferred to
+    // a healthy daemon. An in-progress, non-failing signal: never red, never a
+    // blank card, so the user always sees the choice re-queued the work (SC-1320).
+    if (card.state === "queued") {
+        const verb = QUEUED_LABELS[card.stage] ?? "work";
+        return {
+            cls: "queued",
+            text: `decision recorded — ${verb} picked up`,
+            title: "A direction was chosen — a fresh agent will pick up the work",
             spinner: true,
         };
     }

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -749,6 +749,13 @@ body {
   font-weight: 600;
 }
 
+/* A recorded decision that has (re)queued the chosen stage (SC-1320): in-play,
+   accent-colored like the running/decision states — never red. */
+.badge.queued {
+  color: var(--running);
+  font-weight: 600;
+}
+
 /* Age of a finished plan sitting in the Engineering backlog. Muted while
    fresh; escalates amber then red as the plan's code context rots, so stale
    work is visible without reading the number. */

--- a/desktop/frontend/scripts/board-queue.test.mjs
+++ b/desktop/frontend/scripts/board-queue.test.mjs
@@ -169,6 +169,20 @@ test("renderCard gates the error subtitle on cardError, not raw card.error (SC-1
   );
 });
 
+test("queued state renders the decision-recorded note, not a failure (SC-1320)", () => {
+  const info = badgeInfo({ stage: "planning", state: "queued" });
+  assert.equal(info.cls, "queued");
+  assert.match(info.text, /decision recorded — replanning picked up/);
+});
+
+test("queued verb is stage-aware (SC-1320)", () => {
+  assert.match(badgeInfo({ stage: "implementation", state: "queued" }).text, /rebuild picked up/);
+});
+
+test("a queued card shows no red error subtitle (SC-1320)", () => {
+  assert.equal(cardError({ stage: "planning", state: "queued", error: "Stuck in planning" }), "");
+});
+
 // SC-624: columns render in the user's hand-sorted order; cards without a
 // saved slot keep fetch order after the sorted ones.
 test("sortByHandOrder: listed keys first in saved order, rest stable after", () => {

--- a/desktop/frontend/src/board-queue.ts
+++ b/desktop/frontend/src/board-queue.ts
@@ -125,6 +125,14 @@ export const RUNNING_LABELS: Record<string, string> = {
   done: "deploying…",
 };
 
+// The verb per chosen stage for a card a recorded decision has (re)queued but
+// whose fresh agent has not yet posted its started marker (SC-1320).
+export const QUEUED_LABELS: Record<string, string> = {
+  planning: "replanning",
+  implementation: "rebuild",
+  verification: "re-review",
+};
+
 // badgeInfo classifies a card's live state into a badge descriptor, or null
 // when the card rests and needs none — its queue position IS the statement of
 // completion. A review that found problems is a WARNING, not a stage failure:
@@ -135,6 +143,19 @@ export function badgeInfo(card: QueueCard): BadgeInfo | null {
       cls: "running",
       text: RUNNING_LABELS[card.stage] ?? "working…",
       title: "Agent running",
+      spinner: true,
+    };
+  }
+  // A recorded decision has (re)queued the chosen stage but the relaunched
+  // agent has not posted its started marker yet — or the launch was deferred to
+  // a healthy daemon. An in-progress, non-failing signal: never red, never a
+  // blank card, so the user always sees the choice re-queued the work (SC-1320).
+  if (card.state === "queued") {
+    const verb = QUEUED_LABELS[card.stage] ?? "work";
+    return {
+      cls: "queued",
+      text: `decision recorded — ${verb} picked up`,
+      title: "A direction was chosen — a fresh agent will pick up the work",
       spinner: true,
     };
   }

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -749,6 +749,13 @@ body {
   font-weight: 600;
 }
 
+/* A recorded decision that has (re)queued the chosen stage (SC-1320): in-play,
+   accent-colored like the running/decision states — never red. */
+.badge.queued {
+  color: var(--running);
+  font-weight: 600;
+}
+
 /* Age of a finished plan sitting in the Engineering backlog. Muted while
    fresh; escalates amber then red as the plan's code context rots, so stale
    work is visible without reading the number. */

--- a/internal/daemon/board_markers.go
+++ b/internal/daemon/board_markers.go
@@ -35,6 +35,14 @@ const (
 	// triage concluded no fix is warranted (not-a-bug or undetermined). It
 	// neither reds the card, chains a review, nor offers a deploy (ticket 405).
 	BoardResolved BoardState = "resolved"
+	// BoardQueued marks a stage that a recorded decision ([human:option-chosen])
+	// has (re)queued but whose relaunched agent has not yet posted its started
+	// marker — either the fresh agent is spinning up, or the launch was deferred
+	// to a healthy daemon (SC-1320). A non-failing in-progress state: it never
+	// reds the card and is superseded the moment the real started marker lands
+	// (latest-wins). [human:option-chosen] is not a classified marker, so this
+	// state is synthesized in DeriveBoardCard, not mapped from a marker.
+	BoardQueued BoardState = "queued"
 )
 
 // Board marker headers. These mirror the existing review-handoff headers in

--- a/internal/daemon/board_options.go
+++ b/internal/daemon/board_options.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/gethuman-sh/human/errors"
 	"github.com/gethuman-sh/human/internal/tracker"
@@ -101,6 +102,78 @@ func openOptionsBlock(comments []tracker.Comment) (tracker.Comment, bool) {
 		}
 	}
 	return latest, true
+}
+
+// optionChosenQueued reports the stage a recorded decision has (re)queued, when
+// the newest board-relevant signal is an [human:option-chosen] comment with no
+// later started/terminal marker. It returns the chosen stage (parsed from the
+// [human:options] block the decision consumed) and the choice comment, so
+// DeriveBoardCard can synthesize a BoardQueued state for the window before the
+// relaunch's started marker lands — or, when the launch is deferred to a healthy
+// daemon, indefinitely (SC-1320). Any classified marker strictly newer than the
+// choice supersedes it (latest-wins).
+func optionChosenQueued(comments []tracker.Comment) (BoardStage, tracker.Comment, bool) {
+	chosen, ok := latestOptionChosen(comments)
+	if !ok {
+		return "", tracker.Comment{}, false
+	}
+	if hasLaterMarker(comments, chosen.Created) {
+		return "", tracker.Comment{}, false
+	}
+	block, ok := latestOptionsBlockAtOrBefore(comments, chosen.Created)
+	if !ok {
+		return "", tracker.Comment{}, false
+	}
+	stage, _, opts := parseOptionsBlock(block.Body)
+	if len(opts) == 0 {
+		return "", tracker.Comment{}, false
+	}
+	return stage, chosen, true
+}
+
+// latestOptionChosen returns the newest [human:option-chosen] comment.
+func latestOptionChosen(comments []tracker.Comment) (tracker.Comment, bool) {
+	var chosen tracker.Comment
+	var have bool
+	for _, c := range comments {
+		if strings.HasPrefix(strings.TrimSpace(c.Body), OptionChosenHeader) &&
+			(!have || c.Created.After(chosen.Created)) {
+			chosen, have = c, true
+		}
+	}
+	return chosen, have
+}
+
+// hasLaterMarker reports whether any classified board marker lands strictly
+// after since — used to detect a started/terminal marker that supersedes a
+// recorded decision (latest-wins).
+func hasLaterMarker(comments []tracker.Comment, since time.Time) bool {
+	for _, c := range comments {
+		if !c.Created.After(since) {
+			continue
+		}
+		if _, _, ok := ClassifyMarker(c.Body); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// latestOptionsBlockAtOrBefore returns the newest [human:options] block posted
+// at or before until — the block a decision at that time would have consumed.
+func latestOptionsBlockAtOrBefore(comments []tracker.Comment, until time.Time) (tracker.Comment, bool) {
+	var block tracker.Comment
+	var have bool
+	for _, c := range comments {
+		if c.Created.After(until) {
+			continue
+		}
+		if strings.HasPrefix(strings.TrimSpace(c.Body), OptionsHeader) &&
+			(!have || c.Created.After(block.Created)) {
+			block, have = c, true
+		}
+	}
+	return block, have
 }
 
 // BoardOptionRequest is the wire request for choosing one option from a

--- a/internal/daemon/board_reconcile_test.go
+++ b/internal/daemon/board_reconcile_test.go
@@ -362,3 +362,25 @@ func TestReconcileStuckRunning_NilListerDisables(t *testing.T) {
 	assert.Equal(t, 0, n)
 	assert.Empty(t, posted)
 }
+
+// SC-1320 regression: a card whose newest signal is a recorded decision
+// ([human:option-chosen]) with a deferred relaunch derives to BoardQueued, not
+// BoardRunning — the stuck-running pass must leave it alone rather than red it
+// "Stuck in planning…" (the exact false red from the report).
+func TestReconcileStuckRunning_SkipsJustDecidedCard(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	old := now.Add(-StuckRunningGrace - time.Minute)
+	cards := []ReconcileCard{{
+		Key: "SC-1",
+		Comments: []tracker.Comment{
+			cmt(PlanningStartedHeader, old),
+			cmt("[human:options]\nstage: planning\n1: A\n2: B", old.Add(time.Second)),
+			cmt(OptionChosenHeader+" 2: B", old.Add(2*time.Second)),
+		},
+	}}
+	var posted []struct{ Key, Body string }
+	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+
+	assert.Equal(t, 0, n, "a just-decided card must never be reddened")
+	assert.Empty(t, posted)
+}

--- a/internal/daemon/board_state.go
+++ b/internal/daemon/board_state.go
@@ -93,23 +93,37 @@ func DeriveBoardCard(comments []tracker.Comment, statusType tracker.Category, is
 
 	_, hasPlan := latestPlanComment(comments)
 
+	var state BoardState
+	var latest tracker.Comment
+	if anyMarker {
+		// Second pass: within the furthest stage, the latest marker decides state.
+		state, latest = latestStateInStage(comments, furthest)
+
+		// A furthest-stage failure is authoritative only while it is the ticket's
+		// newest marker. A strictly-newer marker anywhere — a re-implementation
+		// restarting from an earlier stage (ticket 881) or a later deploy — retires
+		// the stale red; the card follows the ticket's current activity rather than a
+		// terminal failure the pipeline already moved past (SC-910).
+		if state == BoardFailed {
+			if newest, newestStage, newestState, ok := latestMarkerOverall(comments); ok && newest.Created.After(latest.Created) {
+				furthest, state, latest = newestStage, newestState, newest
+			}
+		}
+	}
+
+	// A recorded decision ([human:option-chosen]) that no started/terminal marker
+	// has yet superseded: the chosen stage is (re)queued while the relaunch's
+	// started marker is pending or its launch was deferred to a healthy daemon.
+	// Without this the card collapses to the pre-decision running marker and the
+	// stuck-running pass falsely reds it (SC-1320). Placed after the SC-910
+	// supersede so a decision strictly newer than a stale failure still wins.
+	if qStage, qChosen, ok := optionChosenQueued(comments); ok {
+		furthest, state, latest, anyMarker = qStage, BoardQueued, qChosen, true
+	}
+
 	if !anyMarker {
 		// No pipeline activity yet: the open ticket waits in Backlog.
 		return BoardCard{Stage: BoardBacklog, HasPlan: hasPlan}
-	}
-
-	// Second pass: within the furthest stage, the latest marker decides state.
-	state, latest := latestStateInStage(comments, furthest)
-
-	// A furthest-stage failure is authoritative only while it is the ticket's
-	// newest marker. A strictly-newer marker anywhere — a re-implementation
-	// restarting from an earlier stage (ticket 881) or a later deploy — retires
-	// the stale red; the card follows the ticket's current activity rather than a
-	// terminal failure the pipeline already moved past (SC-910).
-	if state == BoardFailed {
-		if newest, newestStage, newestState, ok := latestMarkerOverall(comments); ok && newest.Created.After(latest.Created) {
-			furthest, state, latest = newestStage, newestState, newest
-		}
 	}
 
 	card := BoardCard{Stage: furthest, State: state, HasPlan: hasPlan, StageEnteredAt: latest.Created}
@@ -117,23 +131,27 @@ func DeriveBoardCard(comments []tracker.Comment, statusType tracker.Category, is
 	card.Branch = latestPrefixedLine(comments, ReadyForReviewHeader, "branch:")
 	card.Commits = latestPrefixedLine(comments, ReadyForReviewHeader, "commits:")
 	card.Verdict = latestPrefixedLine(comments, ReviewCompleteHeader, "verdict:")
-	card.PRURL = latestPrefixedLine(comments, DeployedHeader, "pr:")
-	if card.PRURL == "" {
-		// Threads written before the deploy pipeline carry the URL on the old
-		// pr-pushed marker.
-		card.PRURL = latestPrefixedLine(comments, PRPushedHeader, "pr:")
-	}
-	if card.PRURL == "" {
-		// A deploy that failed AFTER opening the PR (the 695 merge-conflict case)
-		// records the PR on its deploy-failed marker. Surface it so the reconcile
-		// pass can confirm-shipped an out-of-band manual merge (SC-910).
-		card.PRURL = latestPrefixedLine(comments, DeployFailedHeader, "pr:")
-	}
+	card.PRURL = derivePRURL(comments)
 	if state == BoardFailed {
 		card.Error = failureReason(latest.Body)
 	}
 	attachOpenOptions(&card, comments)
 	return card
+}
+
+// derivePRURL resolves the card's PR link, newest-marker-first: a deployed
+// ticket's own pr: line, falling back to the pre-deploy-pipeline pr-pushed
+// marker, and finally to a deploy-failed marker's pr: line (the 695
+// merge-conflict case, where the PR opened before the deploy step failed) so
+// the reconcile pass can confirm-shipped an out-of-band manual merge (SC-910).
+func derivePRURL(comments []tracker.Comment) string {
+	if url := latestPrefixedLine(comments, DeployedHeader, "pr:"); url != "" {
+		return url
+	}
+	if url := latestPrefixedLine(comments, PRPushedHeader, "pr:"); url != "" {
+		return url
+	}
+	return latestPrefixedLine(comments, DeployFailedHeader, "pr:")
 }
 
 // failureReason extracts the human-readable reason from a *-failed marker: the

--- a/internal/daemon/board_state_test.go
+++ b/internal/daemon/board_state_test.go
@@ -283,3 +283,40 @@ func TestDeriveBoardCard_stageEnteredAt(t *testing.T) {
 	backlog := DeriveBoardCard(nil, tracker.CategoryUnstarted, false)
 	assert.True(t, backlog.StageEnteredAt.IsZero(), "a no-marker backlog card carries no stage time")
 }
+
+// SC-1320 regression: after a decision is recorded ([human:option-chosen]) and
+// the relaunch is deferred (launch gate blockers → no fresh started marker), the
+// card must read as queued for the chosen stage — never collapse to the stale
+// pre-decision running marker (which the stuck-running pass would then red).
+func TestDeriveBoardCard_OptionChosenQueuesChosenStage(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	comments := []tracker.Comment{
+		cmt(PlanningStartedHeader, base),
+		cmt("[human:options]\nstage: planning\ncontext: two directions\n1: A\n2: B", base.Add(1*time.Minute)),
+		cmt(OptionChosenHeader+" 2: B", base.Add(2*time.Minute)),
+	}
+
+	card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
+
+	assert.Equal(t, BoardPlanning, card.Stage)
+	assert.Equal(t, BoardQueued, card.State, "a recorded decision with no later started marker must read as queued")
+	assert.Empty(t, card.Options, "the chosen block is consumed")
+	assert.Empty(t, card.Error, "a queued card is not a failure")
+}
+
+// SC-1320 regression: the fresh started marker supersedes the queued state
+// (latest-wins) — once ApplyOption's relaunch posts planning-started the card
+// reads running again, exactly as before.
+func TestDeriveBoardCard_StartedMarkerSupersedesQueued(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	comments := []tracker.Comment{
+		cmt("[human:options]\nstage: planning\n1: A\n2: B", base),
+		cmt(OptionChosenHeader+" 2: B", base.Add(1*time.Minute)),
+		cmt(PlanningStartedHeader, base.Add(2*time.Minute)),
+	}
+
+	card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
+
+	assert.Equal(t, BoardPlanning, card.Stage)
+	assert.Equal(t, BoardRunning, card.State)
+}


### PR DESCRIPTION
PM ticket: 1320
Branch: autofix/sc-1320
