### PR TITLE
[SC-1387] PR review→fix loop foundation (inert)

### DIFF
--- a/internal/claude/embed/human-pr-fix-skill.md
+++ b/internal/claude/embed/human-pr-fix-skill.md
@@ -1,0 +1,15 @@
+---
+name: human-pr-fix
+description: Address a PR's review comments — dispatch the fixer to change the code and push to the branch
+argument-hint: <key> --pr=<number> --branch=<branch>
+---
+
+`$ARGUMENTS` is `<KEY> --pr=<number> --branch=<branch>` — the PM ticket key, the open pull request whose review comments need addressing, and its branch. Parse them, then delegate to the **human-pr-fixer** agent.
+
+Run the fixer at the `sonnet` tier: implementing a fix is visible-failure work — a red re-review or a failed check catches what it misses — so the expensive tier is not warranted here.
+
+```
+Task(subagent_type="human-pr-fixer", model="sonnet", prompt="Address review comments on PR <number> for ticket <KEY> --branch=<branch>")
+```
+
+The agent reads the PR's open review comments (the machine reviewer's **and any a human left out of band**), addresses them, pushes to the branch, and records its exit (`done | needs-input`) in `stage.pr-fix`. The daemon re-reviews after a `done` and escalates on `needs-input`, so you do **not** post board markers or decide the next step yourself: run the agent and report what it changed.

--- a/internal/claude/embed/human-pr-fixer-agent.md
+++ b/internal/claude/embed/human-pr-fixer-agent.md
@@ -1,0 +1,59 @@
+---
+name: human-pr-fixer
+description: Reads a pull request's open review comments (agent and human), addresses them with code changes, and pushes fixes to the branch
+tools: Bash, Read, Grep, Glob, Write, Edit
+model: inherit
+---
+
+# Human PR Fixer Agent
+
+You address the review comments on an **open pull request** — both the machine reviewer's and any a human left out of band — by changing the code and pushing to the PR's branch. You are the fix half of the pre-merge review→fix loop.
+
+## Dispatch
+
+```
+Address review comments on PR <PR_NUMBER_OR_URL> for ticket <WORK_KEY> --branch=<branch>
+```
+
+The PR, work key, and branch are your fixed binding. Push only to `--branch`; commit only against `<WORK_KEY>`.
+
+## Access — always use `gh`
+
+```bash
+gh pr view <PR> --json number,headRefName,headRefOid
+# Every review comment (inline), newest last:
+gh api repos/{owner}/{repo}/pulls/<PR>/comments --paginate \
+  --jq '.[] | {id, path, line, user: .user.login, body}'
+# The summary review bodies:
+gh pr view <PR> --json reviews --jq '.reviews[] | {author: .author.login, state, body}'
+```
+
+## Process
+
+1. **Bind & check out.** `gh pr view <PR>` must succeed with `headRefName == --branch`. Check out the branch: `git checkout <branch>` (board runs start detached at the default branch — the PR code is on this branch, not HEAD).
+2. **Collect the open comments.** Read every inline review comment and the summary review bodies. Treat **human** comments with the same weight as the machine reviewer's — a human dropping a comment on the PR is exactly the out-of-band review this loop must answer.
+3. **Address each comment** with the smallest correct change. If a comment asks for a behavior change, add or update a test that pins it. If you disagree with a comment, do not silently ignore it — reply on the thread explaining why (`gh api --method POST repos/{owner}/{repo}/pulls/<PR>/comments/<id>/replies -f body=...`), and leave the code as is; the next review decides.
+4. **Go green on the fast tier** (`make test` scope for the touched packages, plus `make lint`) — not the full `make check`; the deploy CI gate runs the full suite.
+5. **Commit** referencing the key (`human commits prefix <WORK_KEY>` for the subject prefix) and **push to the branch**: `git push origin HEAD:<branch>`. The push re-triggers the PR's CI and gives the reviewer a fresh head to re-review.
+6. **Reply/resolve** the comments you addressed so the PR thread reflects what changed.
+
+## Convergence
+
+The daemon bounds this loop with a per-stage budget. If you cannot address a comment — it needs a product decision, or the fix is out of the PR's scope — do NOT guess and do NOT push a hollow change. Record it and stop for escalation:
+
+```bash
+human state set <WORK_KEY> stage.pr-fix --json --body-file - <<'EOF'
+{"exit":"<done|needs-input>",
+ "pushed":<true|false>,
+ "addressed":"<what you changed / which comments>",
+ "deferred":"<comments you could not address and why — empty when done>",
+ "summary":"<one line>"}
+EOF
+```
+
+- `done` — every blocking comment addressed and pushed; the reviewer runs again.
+- `needs-input` — a comment names a decision only a human can make. State the question and stop; do not invent an answer to keep the loop moving.
+
+Do NOT use `AskUserQuestion` — you cannot interact with a human.
+
+<!-- human:include exit-contract -->

--- a/internal/claude/embed/human-pr-review-skill.md
+++ b/internal/claude/embed/human-pr-review-skill.md
@@ -1,0 +1,15 @@
+---
+name: human-pr-review
+description: Run the machine PR review — dispatch the adversarial reviewer on the open draft PR and record its verdict
+argument-hint: <key> --pr=<number> --branch=<branch>
+---
+
+`$ARGUMENTS` is `<KEY> --pr=<number> --branch=<branch>` — the PM ticket key, the open (draft) pull request to review, and its branch, all supplied by the daemon's deploy loop. Parse them, then delegate to the **human-pr-reviewer** agent.
+
+Run the reviewer at the `opus` tier: it is the adversarial gate before a merge, and a weaker model gets talked out of real objections, turning the check into a rubber stamp (never tier down an adversary).
+
+```
+Task(subagent_type="human-pr-reviewer", model="opus", prompt="Review PR <number> for ticket <KEY> --branch=<branch>")
+```
+
+The agent posts its findings as **inline comments on the PR itself** and records the machine verdict (`approved | changes-requested | unreviewable`) in `stage.pr-review`. The daemon's loop reads that verdict to decide the next step — another fix pass, or the merge — so you do **not** post board markers, dispatch a fixer, or merge anything yourself: run the agent and report its verdict. Human review of the PR happens out of band and never gates this run.

--- a/internal/claude/embed/human-pr-reviewer-agent.md
+++ b/internal/claude/embed/human-pr-reviewer-agent.md
@@ -1,0 +1,70 @@
+---
+name: human-pr-reviewer
+description: Reviews an open pull request, posts inline review comments on the PR (via gh), and records a machine verdict for the deploy loop
+tools: Bash, Read, Grep, Glob
+model: inherit
+---
+
+# Human PR Reviewer Agent
+
+You review an **open pull request** and post your findings **as review comments on the PR itself** — the medium humans read to trust code. You are the machine reviewer in the pre-merge review→fix loop. Your GitHub comments are for humans; your recorded verdict is what the daemon reads to decide whether another fix pass is needed before merge.
+
+You are **adversarial by design**. You are reviewing code another agent wrote, in a pipeline that will merge on your verdict. A shallow "looks good" is worse than no review — it manufactures false confidence and teaches humans not to trust the pipeline. Default to skepticism: find the real problems, or state precisely why there are none. Never approve to be agreeable.
+
+## Dispatch
+
+You are called as:
+
+```
+Review PR <PR_NUMBER_OR_URL> for ticket <WORK_KEY> --branch=<branch>
+```
+
+The PR, the work key, and the branch are your fixed binding for the whole run. Post your comments on that PR and record your verdict under that key — never another.
+
+## Access — always use `gh`
+
+```bash
+gh pr view <PR> --json number,headRefOid,headRefName,baseRefName,title,url
+gh pr diff <PR>                                   # the diff under review
+HEAD_SHA=$(gh pr view <PR> --json headRefOid -q .headRefOid)
+```
+
+## Review process
+
+1. **Bind.** `gh pr view <PR>` must succeed and its `headRefName` must equal `--branch`. On mismatch, record `verdict: unreviewable` (reason: binding mismatch) and stop — never review a different PR/branch.
+2. **Context.** Fetch the ticket and its plan for intent: `human get <WORK_KEY>` and `human plan show <WORK_KEY>` (or the ticket description). The diff is judged against what the ticket intended, plus general correctness, security, and test adequacy.
+3. **Read the diff** (`gh pr diff <PR>`). Read surrounding code with Read/Grep where a hunk's correctness depends on context the diff does not show.
+4. **Post inline comments** for each concrete, line-anchored finding — the review lives on the PR:
+   ```bash
+   gh api --method POST repos/{owner}/{repo}/pulls/<PR>/comments \
+     -f body="<specific, actionable finding>" \
+     -f commit_id="$HEAD_SHA" -f path="<file>" -F line=<line> -f side=RIGHT
+   ```
+   (`{owner}/{repo}` auto-resolve from the worktree's origin remote.) Every finding cites file and line and says what to change and why.
+5. **Post the summary review** — one COMMENT-type review body (not APPROVE; approval belongs to humans and to your recorded verdict, not a bot self-approval):
+   ```bash
+   gh pr review <PR> --comment --body "<summary: verdict, the material findings, what must change>"
+   ```
+6. **Judge with teeth.** A finding blocks (`changes-requested`) when the diff is wrong, unsafe, under-tested for its risk, or diverges from the ticket. Cosmetic-only nits do not block — note them, verdict `approved`. Do not invent blockers to look thorough, and do not wave through real ones to look agreeable.
+
+## Verdict — what the orchestrator reads
+
+The daemon loops you against the fixer until you record `approved` (or the loop budget is spent). Record the machine verdict as the LAST thing you do — the orchestrator must never parse your prose:
+
+```bash
+human state set <WORK_KEY> stage.pr-review --json --body-file - <<'EOF'
+{"exit":"done",
+ "verdict":"<approved|changes-requested|unreviewable>",
+ "blocking":<count of blocking findings>,
+ "findings":"<the substance of what you found, or 'no blocking issues'>",
+ "summary":"<one line>"}
+EOF
+```
+
+- `approved` — nothing blocks; safe to proceed toward merge.
+- `changes-requested` — at least one blocking finding; the fixer runs next, then you review again.
+- `unreviewable` — the PR/diff could not be obtained (bad binding, no diff). Not a synonym for a clean review.
+
+Do NOT use `AskUserQuestion` — you cannot interact with a human. Humans review this PR out of band, on their own cadence; you never wait for them.
+
+<!-- human:include exit-contract -->

--- a/internal/claude/install.go
+++ b/internal/claude/install.go
@@ -40,6 +40,12 @@ var reviewSkillContent []byte
 //go:embed embed/human-reviewer-agent.md
 var reviewerAgentContent []byte
 
+//go:embed embed/human-pr-reviewer-agent.md
+var prReviewerAgentContent []byte
+
+//go:embed embed/human-pr-fixer-agent.md
+var prFixerAgentContent []byte
+
 //go:embed embed/human-done-agent.md
 var doneAgentContent []byte
 
@@ -233,6 +239,8 @@ func Install(w io.Writer, fw FileWriter, personal bool) error {
 		{content: bugAnalyzerAgentContent, relPath: filepath.Join("agents", "human-bug-analyzer.md")},
 		{content: reviewSkillContent, relPath: filepath.Join("skills", "human-review", "SKILL.md")},
 		{content: reviewerAgentContent, relPath: filepath.Join("agents", "human-reviewer.md")},
+		{content: prReviewerAgentContent, relPath: filepath.Join("agents", "human-pr-reviewer.md")},
+		{content: prFixerAgentContent, relPath: filepath.Join("agents", "human-pr-fixer.md")},
 		{content: doneAgentContent, relPath: filepath.Join("agents", "human-done.md")},
 		{content: executeSkillContent, relPath: filepath.Join("skills", "human-execute", "SKILL.md")},
 		{content: executorAgentContent, relPath: filepath.Join("agents", "human-executor.md")},

--- a/internal/claude/install.go
+++ b/internal/claude/install.go
@@ -46,6 +46,12 @@ var prReviewerAgentContent []byte
 //go:embed embed/human-pr-fixer-agent.md
 var prFixerAgentContent []byte
 
+//go:embed embed/human-pr-review-skill.md
+var prReviewSkillContent []byte
+
+//go:embed embed/human-pr-fix-skill.md
+var prFixSkillContent []byte
+
 //go:embed embed/human-done-agent.md
 var doneAgentContent []byte
 
@@ -241,6 +247,8 @@ func Install(w io.Writer, fw FileWriter, personal bool) error {
 		{content: reviewerAgentContent, relPath: filepath.Join("agents", "human-reviewer.md")},
 		{content: prReviewerAgentContent, relPath: filepath.Join("agents", "human-pr-reviewer.md")},
 		{content: prFixerAgentContent, relPath: filepath.Join("agents", "human-pr-fixer.md")},
+		{content: prReviewSkillContent, relPath: filepath.Join("skills", "human-pr-review", "SKILL.md")},
+		{content: prFixSkillContent, relPath: filepath.Join("skills", "human-pr-fix", "SKILL.md")},
 		{content: doneAgentContent, relPath: filepath.Join("agents", "human-done.md")},
 		{content: executeSkillContent, relPath: filepath.Join("skills", "human-execute", "SKILL.md")},
 		{content: executorAgentContent, relPath: filepath.Join("agents", "human-executor.md")},

--- a/internal/claude/statekeys_test.go
+++ b/internal/claude/statekeys_test.go
@@ -30,8 +30,10 @@ var writeOnlyStateKeys = map[string]string{
 	// stageExitClass), not by another prompt, so a prompt-only scan cannot see
 	// the reader. The stage-contract test covers the ones a prompt DOES read
 	// back; these are the stages whose only reader is the board.
-	"stage.planning": "read by the daemon's stage-retry policy, not by a prompt",
-	"stage.opinion":  "read by the orchestrator prompt AND the daemon; the read is in human-autofix-skill.md",
+	"stage.planning":  "read by the daemon's stage-retry policy, not by a prompt",
+	"stage.opinion":   "read by the orchestrator prompt AND the daemon; the read is in human-autofix-skill.md",
+	"stage.pr-review": "read by the daemon's PR review→fix deploy loop (SC-1387), not by a prompt",
+	"stage.pr-fix":    "read by the daemon's PR review→fix deploy loop (SC-1387), not by a prompt",
 }
 
 // collectStateKeys returns the concrete keys prompts write and read.

--- a/internal/daemon/board_markers.go
+++ b/internal/daemon/board_markers.go
@@ -86,6 +86,17 @@ const (
 	DeployStartedHeader = "[human:deploy-started]"
 	DeployedHeader      = "[human:deployed]"
 	DeployFailedHeader  = "[human:deploy-failed]"
+
+	// PR review→fix loop markers (SC-1387): the pre-merge sub-phase of the
+	// deploy (done) stage where the machine reviewer and fixer alternate on the
+	// open draft PR before the merge. Both launches read as the done stage
+	// running; an escalation (budget spent, unreviewable, or an unresolvable
+	// review) reds it like any other deploy-phase failure. They deliberately
+	// live in the done stage rather than a new pipeline stage, so the
+	// verification→done transition adjacency (board_transition.go) is unchanged.
+	PRReviewStartedHeader = "[human:pr-review-started]"
+	PRFixStartedHeader    = "[human:pr-fix-started]"
+	PRReviewFailedHeader  = "[human:pr-review-failed]"
 )
 
 // PlanCommentHeader marks a comment whose body IS the engineering plan for
@@ -132,6 +143,9 @@ var orderedMarkerSpecs = []markerSpec{
 	{DeployStartedHeader, BoardDoneStage, BoardRunning},
 	{DeployedHeader, BoardDoneStage, BoardDone},
 	{DeployFailedHeader, BoardDoneStage, BoardFailed},
+	{PRReviewStartedHeader, BoardDoneStage, BoardRunning},
+	{PRFixStartedHeader, BoardDoneStage, BoardRunning},
+	{PRReviewFailedHeader, BoardDoneStage, BoardFailed},
 }
 
 // stageRank orders the pipeline stages so derivation can pick the furthest

--- a/internal/daemon/board_state_test.go
+++ b/internal/daemon/board_state_test.go
@@ -13,6 +13,53 @@ func cmt(body string, t time.Time) tracker.Comment {
 	return tracker.Comment{Body: body, Created: t}
 }
 
+// The PR review→fix loop lives inside the done (deploy) stage: its markers must
+// derive the done stage — leaving the verification→done transition adjacency
+// untouched — while still exposing the loop's running/failed state (SC-1387).
+func TestDeriveBoardCard_prReviewLoop(t *testing.T) {
+	t0 := time.Unix(1000, 0)
+	t1 := time.Unix(2000, 0)
+
+	t.Run("pr-review-started is done stage running", func(t *testing.T) {
+		card := DeriveBoardCard([]tracker.Comment{cmt(PRReviewStartedHeader, t0)}, tracker.CategoryUnstarted, false)
+		assert.Equal(t, BoardDoneStage, card.Stage)
+		assert.Equal(t, BoardRunning, card.State)
+	})
+
+	t.Run("pr-fix-started is done stage running", func(t *testing.T) {
+		card := DeriveBoardCard([]tracker.Comment{cmt(PRFixStartedHeader, t0)}, tracker.CategoryUnstarted, false)
+		assert.Equal(t, BoardDoneStage, card.Stage)
+		assert.Equal(t, BoardRunning, card.State)
+	})
+
+	t.Run("pr-review-failed reds the card with a reason", func(t *testing.T) {
+		card := DeriveBoardCard(
+			[]tracker.Comment{cmt(PRReviewFailedHeader+"\nreview budget exhausted — needs a human", t0)},
+			tracker.CategoryUnstarted, false)
+		assert.Equal(t, BoardDoneStage, card.Stage)
+		assert.Equal(t, BoardFailed, card.State)
+		assert.NotEmpty(t, card.Error)
+	})
+
+	t.Run("pr-review supersedes a passed verification (furthest stage wins)", func(t *testing.T) {
+		card := DeriveBoardCard([]tracker.Comment{
+			cmt(ReviewCompleteHeader+"\nverdict: pass", t0),
+			cmt(PRReviewStartedHeader, t1),
+		}, tracker.CategoryUnstarted, false)
+		assert.Equal(t, BoardDoneStage, card.Stage)
+		assert.Equal(t, BoardRunning, card.State)
+	})
+
+	t.Run("a later deployed marker retires the loop state (latest wins)", func(t *testing.T) {
+		card := DeriveBoardCard([]tracker.Comment{
+			cmt(PRReviewStartedHeader, t0),
+			cmt(DeployedHeader, t1),
+		}, tracker.CategoryUnstarted, false)
+		assert.Equal(t, BoardDoneStage, card.Stage)
+		assert.Equal(t, BoardDone, card.State)
+	})
+}
+
 func TestDeriveBoardCard(t *testing.T) {
 	t0 := time.Unix(1000, 0)
 	t1 := time.Unix(2000, 0)

--- a/internal/daemon/pr_review_loop.go
+++ b/internal/daemon/pr_review_loop.go
@@ -1,5 +1,12 @@
 package daemon
 
+import (
+	"strings"
+	"time"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
 // The pre-merge PR review→fix loop. Once a deploy opens the PR, the daemon runs
 // the human-pr-reviewer and human-pr-fixer agents in alternation against it: the
 // reviewer posts its findings as PR comments and records a verdict, the fixer
@@ -88,4 +95,64 @@ func NextPRLoopAction(stage PRLoopStage, outcome string, round, budget int) PRLo
 	default:
 		return PRActionEscalate
 	}
+}
+
+// latestPRLoopStage reports which loop step most recently started — and so just
+// finished, when its agent's Stop fires the evaluation. It scans the comment
+// thread for the newest pr-review-started / pr-fix-started marker; PRStageNone
+// means the loop has not run yet (the draft PR is freshly opened). Deploy-stage
+// markers that share the done stage are ignored: only the loop's own markers
+// move the loop.
+func latestPRLoopStage(comments []tracker.Comment) PRLoopStage {
+	stage := PRStageNone
+	var latest time.Time
+	found := false
+	for _, c := range comments {
+		trimmed := strings.TrimSpace(c.Body)
+		var s PRLoopStage
+		switch {
+		case strings.HasPrefix(trimmed, PRReviewStartedHeader):
+			s = PRStageReview
+		case strings.HasPrefix(trimmed, PRFixStartedHeader):
+			s = PRStageFix
+		default:
+			continue
+		}
+		if !found || c.Created.After(latest) {
+			latest, stage, found = c.Created, s, true
+		}
+	}
+	return stage
+}
+
+// prReviewRounds counts completed review rounds — one per pr-review-started
+// marker — the value the decider bounds against DefaultPRReviewRounds.
+func prReviewRounds(comments []tracker.Comment) int {
+	n := 0
+	for _, c := range comments {
+		if strings.HasPrefix(strings.TrimSpace(c.Body), PRReviewStartedHeader) {
+			n++
+		}
+	}
+	return n
+}
+
+// EvaluatePRLoop bridges the recorded board state to the decider: it reads which
+// loop step last ran (from the markers) and how many review rounds have
+// completed, pairs the step with the outcome that step recorded — the reviewer's
+// verdict or the fixer's exit, which live in the state store, not the comment
+// thread, so the caller supplies them — and returns the next action. Keeping the
+// bridge pure lets the marker/state → action mapping be tested without a daemon;
+// the caller executes the action (launch an agent, mark-ready + merge, or red
+// the card).
+func EvaluatePRLoop(comments []tracker.Comment, reviewVerdict, fixExit string) PRLoopAction {
+	stage := latestPRLoopStage(comments)
+	var outcome string
+	switch stage {
+	case PRStageReview:
+		outcome = reviewVerdict
+	case PRStageFix:
+		outcome = fixExit
+	}
+	return NextPRLoopAction(stage, outcome, prReviewRounds(comments), DefaultPRReviewRounds)
 }

--- a/internal/daemon/pr_review_loop.go
+++ b/internal/daemon/pr_review_loop.go
@@ -1,0 +1,91 @@
+package daemon
+
+// The pre-merge PR review→fix loop. Once a deploy opens the PR, the daemon runs
+// the human-pr-reviewer and human-pr-fixer agents in alternation against it: the
+// reviewer posts its findings as PR comments and records a verdict, the fixer
+// addresses them and pushes, and the reviewer runs again — until the review is
+// clean, a human decision is needed, or the round budget is spent. Human review
+// happens out of band and never gates this loop.
+//
+// This file is the pure decider: given the step that just finished and its
+// recorded outcome, it names the next action. Reading the state and executing
+// the action live in the deploy path (Phase 3); keeping the decision pure lets
+// every transition — including the budget boundary and the defensive
+// escalations — be unit-tested without a daemon.
+
+// DefaultPRReviewRounds bounds the review→fix loop: at most this many review
+// rounds before a still-unresolved review escalates to a human. A budget is
+// mandatory — without it a reviewer and fixer that disagree would ping-pong
+// forever, and each round costs an agent run plus a fresh CI trigger.
+const DefaultPRReviewRounds = 3
+
+// PR review/fix outcomes the decider branches on. These mirror the vocabulary
+// the human-pr-reviewer and human-pr-fixer prompts record in state, kept here as
+// the single Go-side source of truth. The fixer's needs-input reuses the shared
+// ExitNeedsInput; only "done" advances, everything else is treated as escalate.
+const (
+	PRVerdictApproved     = "approved"
+	PRVerdictChanges      = "changes-requested"
+	PRVerdictUnreviewable = "unreviewable"
+	PRFixDone             = "done"
+)
+
+// PRLoopStage names the loop step that just completed (PRStageNone when none
+// has: the PR is freshly opened and no review has run).
+type PRLoopStage int
+
+const (
+	PRStageNone PRLoopStage = iota
+	PRStageReview
+	PRStageFix
+)
+
+// PRLoopAction is the next step the deploy path should take.
+type PRLoopAction int
+
+const (
+	PRActionReview   PRLoopAction = iota // run human-pr-reviewer
+	PRActionFix                          // run human-pr-fixer
+	PRActionMerge                        // review is clean — proceed to the CI gate + merge
+	PRActionEscalate                     // stop and leave the card for a human
+)
+
+// NextPRLoopAction is the loop's transition function. `stage` is the step that
+// just finished and `outcome` its recorded field — the reviewer's verdict
+// (approved | changes-requested | unreviewable) or the fixer's exit
+// (done | needs-input). `round` is the number of reviews completed so far and
+// `budget` the maximum (DefaultPRReviewRounds when non-positive).
+//
+// Two safety rules are baked in. An unrecognized outcome escalates rather than
+// proceeds: the loop must never merge on a state it cannot read. And a
+// changes-requested review at the round budget escalates instead of fixing
+// again, so a disagreement the fixer cannot close reaches a human in bounded
+// time rather than looping.
+func NextPRLoopAction(stage PRLoopStage, outcome string, round, budget int) PRLoopAction {
+	if budget <= 0 {
+		budget = DefaultPRReviewRounds
+	}
+	switch stage {
+	case PRStageNone:
+		return PRActionReview
+	case PRStageReview:
+		switch outcome {
+		case PRVerdictApproved:
+			return PRActionMerge
+		case PRVerdictChanges:
+			if round >= budget {
+				return PRActionEscalate
+			}
+			return PRActionFix
+		default: // unreviewable, or an outcome the daemon cannot classify
+			return PRActionEscalate
+		}
+	case PRStageFix:
+		if outcome == PRFixDone {
+			return PRActionReview
+		}
+		return PRActionEscalate // needs-input, or unclassifiable
+	default:
+		return PRActionEscalate
+	}
+}

--- a/internal/daemon/pr_review_loop_test.go
+++ b/internal/daemon/pr_review_loop_test.go
@@ -1,6 +1,11 @@
 package daemon
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
 
 func TestNextPRLoopAction(t *testing.T) {
 	cases := []struct {
@@ -51,6 +56,49 @@ func TestNextPRLoopAction(t *testing.T) {
 			if got != tc.want {
 				t.Fatalf("NextPRLoopAction(%v, %q, round=%d, budget=%d) = %d, want %d",
 					tc.stage, tc.outcome, tc.round, tc.budget, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvaluatePRLoop(t *testing.T) {
+	t0 := time.Unix(1000, 0)
+	t1 := time.Unix(2000, 0)
+	t2 := time.Unix(3000, 0)
+
+	rev := func(at time.Time) tracker.Comment { return cmt(PRReviewStartedHeader, at) }
+	fix := func(at time.Time) tracker.Comment { return cmt(PRFixStartedHeader, at) }
+
+	cases := []struct {
+		name     string
+		comments []tracker.Comment
+		verdict  string
+		fixExit  string
+		want     PRLoopAction
+	}{
+		{"no loop markers reviews first", nil, "", "", PRActionReview},
+		{"review approved merges", []tracker.Comment{rev(t0)}, PRVerdictApproved, "", PRActionMerge},
+		{"review changes below budget fixes", []tracker.Comment{rev(t0)}, PRVerdictChanges, "", PRActionFix},
+		{"review changes at budget escalates",
+			[]tracker.Comment{rev(t0), rev(t1), rev(t2)}, PRVerdictChanges, "", PRActionEscalate},
+		{"fix done re-reviews",
+			[]tracker.Comment{rev(t0), fix(t1)}, "", PRFixDone, PRActionReview},
+		{"fix needs-input escalates",
+			[]tracker.Comment{rev(t0), fix(t1)}, "", ExitNeedsInput, PRActionEscalate},
+		// The newest loop marker names the step that just finished, so a fix after
+		// a review is evaluated as a fix (its exit), not the stale review verdict.
+		{"latest marker decides the step",
+			[]tracker.Comment{rev(t1), fix(t2)}, PRVerdictApproved, PRFixDone, PRActionReview},
+		// Deploy-stage markers share the done stage but never move the loop.
+		{"deploy markers are ignored",
+			[]tracker.Comment{cmt(DeployStartedHeader, t0), rev(t1)}, PRVerdictApproved, "", PRActionMerge},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EvaluatePRLoop(tc.comments, tc.verdict, tc.fixExit)
+			if got != tc.want {
+				t.Fatalf("EvaluatePRLoop() = %d, want %d", got, tc.want)
 			}
 		})
 	}

--- a/internal/daemon/pr_review_loop_test.go
+++ b/internal/daemon/pr_review_loop_test.go
@@ -1,0 +1,57 @@
+package daemon
+
+import "testing"
+
+func TestNextPRLoopAction(t *testing.T) {
+	cases := []struct {
+		name    string
+		stage   PRLoopStage
+		outcome string
+		round   int
+		budget  int
+		want    PRLoopAction
+	}{
+		// The loop opens with a review of the freshly-opened PR.
+		{"fresh PR reviews first", PRStageNone, "", 0, 3, PRActionReview},
+
+		// A clean review is the only path to merge.
+		{"approved proceeds to merge", PRStageReview, PRVerdictApproved, 1, 3, PRActionMerge},
+
+		// Changes-requested with budget left runs the fixer.
+		{"changes below budget fixes", PRStageReview, PRVerdictChanges, 1, 3, PRActionFix},
+		{"changes one below budget fixes", PRStageReview, PRVerdictChanges, 2, 3, PRActionFix},
+
+		// At (or past) the budget, an unresolved review escalates instead of
+		// looping — the disagreement the fixer cannot close reaches a human.
+		{"changes at budget escalates", PRStageReview, PRVerdictChanges, 3, 3, PRActionEscalate},
+		{"changes past budget escalates", PRStageReview, PRVerdictChanges, 4, 3, PRActionEscalate},
+
+		// Unreviewable / unknown review outcomes never merge — they escalate.
+		{"unreviewable escalates", PRStageReview, PRVerdictUnreviewable, 1, 3, PRActionEscalate},
+		{"unknown review outcome escalates", PRStageReview, "garbage", 1, 3, PRActionEscalate},
+		{"empty review outcome escalates", PRStageReview, "", 1, 3, PRActionEscalate},
+
+		// A completed fix re-reviews the pushed changes; anything else escalates.
+		{"fix done re-reviews", PRStageFix, PRFixDone, 1, 3, PRActionReview},
+		{"fix needs-input escalates", PRStageFix, ExitNeedsInput, 1, 3, PRActionEscalate},
+		{"unknown fix outcome escalates", PRStageFix, "garbage", 1, 3, PRActionEscalate},
+		{"empty fix outcome escalates", PRStageFix, "", 1, 3, PRActionEscalate},
+
+		// A non-positive budget falls back to DefaultPRReviewRounds.
+		{"default budget still fixes below cap", PRStageReview, PRVerdictChanges, DefaultPRReviewRounds - 1, 0, PRActionFix},
+		{"default budget escalates at cap", PRStageReview, PRVerdictChanges, DefaultPRReviewRounds, 0, PRActionEscalate},
+
+		// An unrecognized stage escalates rather than guessing.
+		{"unknown stage escalates", PRLoopStage(99), PRVerdictApproved, 1, 3, PRActionEscalate},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NextPRLoopAction(tc.stage, tc.outcome, tc.round, tc.budget)
+			if got != tc.want {
+				t.Fatalf("NextPRLoopAction(%v, %q, round=%d, budget=%d) = %d, want %d",
+					tc.stage, tc.outcome, tc.round, tc.budget, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -24,6 +24,7 @@ type PullRequest struct {
 	Head  string // source branch holding the changes
 	Title string
 	Body  string
+	Draft bool // open the PR in the forge's draft (unmergeable) state
 
 	Number int    // populated on return
 	URL    string // populated on return
@@ -125,6 +126,16 @@ type MergedReader interface {
 // source branch after merging.
 type BranchDeleter interface {
 	DeleteBranch(ctx context.Context, repo, branch string) error
+}
+
+// ReadyForReviewMarker converts a draft pull request to ready-for-review. It is
+// the signal that the pre-merge machine review→fix loop has converged: the PR
+// was opened draft (unmergeable) and stays that way until the review approves,
+// so a half-reviewed change cannot be merged even if the daemon's own gate
+// failed. Separate capability because a forge may open PRs without supporting
+// the draft lifecycle — callers type-assert for it.
+type ReadyForReviewMarker interface {
+	MarkReadyForReview(ctx context.Context, repo string, number int) error
 }
 
 // Forge aggregates the code-forge operations every provider must support. The

--- a/internal/forge/github/client.go
+++ b/internal/forge/github/client.go
@@ -15,12 +15,13 @@ import (
 )
 
 var (
-	_ forge.Forge             = (*Client)(nil)
-	_ forge.ChecksReader      = (*Client)(nil)
-	_ forge.Merger            = (*Client)(nil)
-	_ forge.MergedReader      = (*Client)(nil)
-	_ forge.BranchDeleter     = (*Client)(nil)
-	_ forge.PullRequestFinder = (*Client)(nil)
+	_ forge.Forge                = (*Client)(nil)
+	_ forge.ChecksReader         = (*Client)(nil)
+	_ forge.Merger               = (*Client)(nil)
+	_ forge.MergedReader         = (*Client)(nil)
+	_ forge.BranchDeleter        = (*Client)(nil)
+	_ forge.PullRequestFinder    = (*Client)(nil)
+	_ forge.ReadyForReviewMarker = (*Client)(nil)
 )
 
 // Client is a GitHub REST API client scoped to code-forge (pull request)
@@ -59,6 +60,7 @@ func (c *Client) CreatePullRequest(ctx context.Context, pr *forge.PullRequest) (
 		Head:  pr.Head,
 		Base:  pr.Base,
 		Body:  pr.Body,
+		Draft: pr.Draft,
 	}
 
 	body, err := json.Marshal(payload)
@@ -83,9 +85,67 @@ func (c *Client) CreatePullRequest(ctx context.Context, pr *forge.PullRequest) (
 		Head:   pr.Head,
 		Title:  result.Title,
 		Body:   pr.Body,
+		Draft:  pr.Draft,
 		Number: result.Number,
 		URL:    result.HTMLURL,
 	}, nil
+}
+
+// MarkReadyForReview implements forge.ReadyForReviewMarker. Un-drafting a PR is
+// a GraphQL-only mutation on GitHub — the REST pulls endpoint cannot toggle the
+// draft flag — so it resolves the PR's GraphQL node id and runs
+// markPullRequestReadyForReview. GitHub returns HTTP 200 with an `errors` array
+// on a GraphQL-level failure, so the body is inspected rather than the status.
+func (c *Client) MarkReadyForReview(ctx context.Context, repoName string, number int) error {
+	owner, repo, err := splitProject(repoName)
+	if err != nil {
+		return err
+	}
+	nodeID, err := c.pullNodeID(ctx, owner, repo, number)
+	if err != nil {
+		return err
+	}
+	payload := graphQLRequest{
+		Query:     "mutation($id:ID!){markPullRequestReadyForReview(input:{pullRequestId:$id}){pullRequest{isDraft}}}",
+		Variables: map[string]any{"id": nodeID},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return errors.WrapWithDetails(err, "marshalling ready-for-review mutation", "repo", repoName, "number", number)
+	}
+	resp, err := c.api.Do(ctx, http.MethodPost, "/graphql", "", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	var result graphQLResponse
+	if err := apiclient.DecodeJSON(resp, &result, "repo", repoName, "number", number); err != nil {
+		return err
+	}
+	if len(result.Errors) > 0 {
+		// The reason goes into the message itself — the deploy pipeline surfaces
+		// err.Error() on the board card, where structured details are invisible.
+		return errors.WithDetails("marking pull request ready for review failed: "+result.Errors[0].Message,
+			"repo", repoName, "number", number)
+	}
+	return nil
+}
+
+// pullNodeID fetches a pull request's GraphQL global id, needed by mutations the
+// REST API cannot express.
+func (c *Client) pullNodeID(ctx context.Context, owner, repo string, number int) (string, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d", url.PathEscape(owner), url.PathEscape(repo), number)
+	resp, err := c.api.Do(ctx, http.MethodGet, path, "", nil)
+	if err != nil {
+		return "", err
+	}
+	var pull pullGetResponse
+	if err := apiclient.DecodeJSON(resp, &pull, "number", number); err != nil {
+		return "", err
+	}
+	if pull.NodeID == "" {
+		return "", errors.WithDetails("pull request has no node id", "number", number)
+	}
+	return pull.NodeID, nil
 }
 
 // FindOpenPullRequest implements forge.PullRequestFinder. GitHub's list-pulls

--- a/internal/forge/github/client_test.go
+++ b/internal/forge/github/client_test.go
@@ -63,6 +63,86 @@ func TestCreatePullRequest_invalidRepo(t *testing.T) {
 	assert.Contains(t, err.Error(), "owner/repo")
 }
 
+func TestCreatePullRequest_draft(t *testing.T) {
+	var gotBody pullCreateRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"number":7,"title":"WIP","html_url":"https://github.com/octocat/hello-world/pull/7"}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "ghp_test")
+	pr, err := client.CreatePullRequest(context.Background(), &forge.PullRequest{
+		Repo:  "octocat/hello-world",
+		Base:  "main",
+		Head:  "autofix/1387",
+		Title: "WIP",
+		Draft: true,
+	})
+	require.NoError(t, err)
+	assert.True(t, gotBody.Draft, "create payload must set draft:true")
+	assert.True(t, pr.Draft, "returned PR echoes the draft flag")
+}
+
+func TestMarkReadyForReview_happy(t *testing.T) {
+	var graphqlBody graphQLRequest
+	var sawGet bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/octocat/hello-world/pulls/42":
+			sawGet = true
+			_, _ = fmt.Fprint(w, `{"node_id":"PR_node_abc","head":{"sha":"deadbeef"}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &graphqlBody))
+			_, _ = fmt.Fprint(w, `{"data":{"markPullRequestReadyForReview":{"pullRequest":{"isDraft":false}}}}`)
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "ghp_test")
+	err := client.MarkReadyForReview(context.Background(), "octocat/hello-world", 42)
+	require.NoError(t, err)
+	assert.True(t, sawGet, "must resolve the PR node id via REST first")
+	assert.Contains(t, graphqlBody.Query, "markPullRequestReadyForReview")
+	assert.Equal(t, "PR_node_abc", graphqlBody.Variables["id"])
+}
+
+func TestMarkReadyForReview_graphQLError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = fmt.Fprint(w, `{"node_id":"PR_1"}`)
+			return
+		}
+		// GitHub returns HTTP 200 with an errors array on a GraphQL-level failure.
+		_, _ = fmt.Fprint(w, `{"errors":[{"message":"Pull request is not a draft"}]}`)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "ghp_test")
+	err := client.MarkReadyForReview(context.Background(), "octocat/hello-world", 9)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a draft")
+}
+
+func TestMarkReadyForReview_noNodeID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `{"head":{"sha":"x"}}`) // response carries no node_id
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "ghp_test")
+	err := client.MarkReadyForReview(context.Background(), "octocat/hello-world", 3)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "node id")
+}
+
 func TestFindOpenPullRequest_found(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)

--- a/internal/forge/github/types.go
+++ b/internal/forge/github/types.go
@@ -5,6 +5,10 @@ type pullCreateRequest struct {
 	Head  string `json:"head"`
 	Base  string `json:"base"`
 	Body  string `json:"body,omitempty"`
+	// Draft opens the PR in GitHub's draft state — unmergeable until marked
+	// ready. The review→fix loop opens draft so a half-reviewed PR cannot be
+	// merged even if the daemon's own gate had a bug.
+	Draft bool `json:"draft,omitempty"`
 }
 
 type pullCreateResponse struct {
@@ -22,6 +26,24 @@ type pullGetResponse struct {
 	Mergeable *bool `json:"mergeable"`
 	// Merged reports whether the PR has already been merged into its base.
 	Merged bool `json:"merged"`
+	// NodeID is the PR's GraphQL global id, needed by the ready-for-review
+	// mutation (which the REST API cannot express).
+	NodeID string `json:"node_id"`
+}
+
+// graphQLRequest is a GraphQL query/mutation POST body. Used for the operations
+// GitHub exposes only through GraphQL — marking a draft PR ready for review.
+type graphQLRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables,omitempty"`
+}
+
+// graphQLResponse carries the errors array a GraphQL endpoint returns with an
+// HTTP 200 even when the operation failed, so a caller must inspect it.
+type graphQLResponse struct {
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors,omitempty"`
 }
 
 type checkRunsResponse struct {


### PR DESCRIPTION
## What this is

The **inert foundation** for a pre-merge PR review→fix loop (SC-1387): before a change merges, an adversarial machine reviewer posts its findings **as comments on the PR itself** and a fixer addresses them — so the pipeline's review is visible in the medium humans trust, and the code answers it. Human review stays out-of-band and **never gates** the pipeline; a future PR loops in different AI engines as additional reviewers.

**Everything here is additive and dormant — nothing in the live deploy path calls it yet, so this PR changes no runtime behavior.** The activation (wiring into `DeployBranch` + the Stop-hook handler) is a deliberate follow-up so the risky live-path surgery lands on its own, on top of a proven, tested base.

## Contents (6 commits, each test-first)

| Piece | What |
|---|---|
| `human-pr-reviewer` / `human-pr-fixer` agents | review an open PR → inline comments + verdict; fix comments → push |
| `NextPRLoopAction` decider | pure transition rules; never merge on an unknown state; bounded rounds (`DefaultPRReviewRounds`) |
| forge `Draft` + `ReadyForReviewMarker` | open the PR draft (hard-unmergeable) until review approves; un-draft via GitHub GraphQL |
| pr-review markers | `pr-review-started` / `pr-fix-started` / `pr-review-failed` as a **done-stage sub-phase** (keeps the verification→done transition adjacency intact) |
| `EvaluatePRLoop` | pure bridge: marker history + state records → next action |
| `/human-pr-review` + `/human-pr-fix` skills | thin launchers that dispatch the agents at the right model tier (opus reviewer, sonnet fixer) |

## Follow-up (not in this PR)

- **3c-exec / 3e** — open the draft PR in `DeployBranch`, drive the loop event-driven off the reviewer/fixer Stop hooks (`EvaluatePRLoop` → launch next / mark-ready + merge / escalate), then the existing CI gate + `mergeWithRetry`.
- **Board badge** — a "PR review…" affordance for the done-stage sub-phase.

## Verification

- `golangci-lint` — 0 issues; `gosec` — 0 issues; new `internal/daemon` + `internal/forge` code fully unit-tested (decider 16 cases, evaluator 8, forge 6, derivation 5).
- Note: local `make check` fmt-check flags one **pre-existing, unrelated** file (`cmd/cmddaemon/mockups_variation_test.go`, unchanged from main — go 1.26.5 gofmt drift). It is not in CI's gate set (CI runs golangci-lint, not gofmt) and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
