### PR TITLE
[SC-1401] Fix codenav index Open on pre-file_id databases

### DIFF
--- a/internal/codenav/store/migrate_test.go
+++ b/internal/codenav/store/migrate_test.go
@@ -1,0 +1,65 @@
+package store_test
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/gethuman-sh/human/internal/codenav/store"
+)
+
+// legacyRouteSchema is the route table as it existed before SC-1274 added the
+// file_id column and its index — the exact shape found on databases in the
+// field that trip the migration path.
+// Only route is seeded: it is the table whose column moved. schema.sql creates
+// every other table fresh (with its full column set), so seeding a pre-file_id
+// route alone reproduces the exact "route exists but lacks file_id" state that
+// tripped idx_route_file, without hand-copying the whole legacy schema.
+const legacyRouteSchema = `
+CREATE TABLE route (
+  id         INTEGER PRIMARY KEY,
+  project_id INTEGER NOT NULL,
+  method     TEXT,
+  pattern    TEXT,
+  handler_id INTEGER,
+  framework  TEXT
+);
+CREATE INDEX idx_route_proj ON route(project_id);
+`
+
+// TestOpenMigratesPreFileIDDatabase guards the ordering bug that turned the
+// board's codenav LED red: schema.sql creates idx_route_file over route(file_id),
+// so applying it against a pre-file_id database must not fail before the column
+// migration runs. Open must heal such a database instead of erroring out.
+func TestOpenMigratesPreFileIDDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy.db")
+
+	// Seed a database with the old route table (no file_id, no idx_route_file).
+	seed, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := seed.Exec(legacyRouteSchema); err != nil {
+		t.Fatalf("seed legacy schema: %v", err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Open used to return "apply schema: no such column: file_id" here.
+	st, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("Open on pre-file_id database: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	// The migration must have added file_id so route is queryable through it.
+	if _, err := st.DB().Exec(`SELECT file_id FROM route LIMIT 1`); err != nil {
+		t.Fatalf("route.file_id still missing after Open: %v", err)
+	}
+	if _, err := st.ListProjects(); err != nil {
+		t.Fatalf("ListProjects after migration: %v", err)
+	}
+}

--- a/internal/codenav/store/store.go
+++ b/internal/codenav/store/store.go
@@ -44,17 +44,24 @@ func Open(path string) (*Store, error) {
 	// per-connection PRAGMA drift.
 	db.SetMaxOpenConns(1)
 	db.SetConnMaxLifetime(0)
+	// Additive column migrations run BEFORE schema.sql, not after: schema.sql
+	// creates indexes over these columns (e.g. idx_route_file ON route(file_id)),
+	// and applying it against a pre-migration database whose table still lacks
+	// the column fails the whole batch with "no such column", which used to abort
+	// Open entirely and leave the index unusable. On a fresh database the tables
+	// do not exist yet, so each ALTER is a harmless no-op (error ignored) and
+	// schema.sql then creates the tables with the columns already present; on an
+	// existing database the ALTER adds the missing column (ignoring the
+	// "duplicate column" error when it is already there) so schema.sql's indexes
+	// resolve. Ordering is the migration here — do not move these after the batch.
+	_, _ = db.Exec(`ALTER TABLE project ADD COLUMN source_sig TEXT`)
+	_, _ = db.Exec(`ALTER TABLE file  ADD COLUMN mtime INTEGER`)
+	_, _ = db.Exec(`ALTER TABLE file  ADD COLUMN size  INTEGER`)
+	_, _ = db.Exec(`ALTER TABLE route ADD COLUMN file_id INTEGER`)
 	if _, err := db.Exec(schemaSQL); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("apply schema: %w", err)
 	}
-	// Migrate databases created before source_sig existed (ignore "duplicate column").
-	_, _ = db.Exec(`ALTER TABLE project ADD COLUMN source_sig TEXT`)
-	// Migrate databases created before incremental refresh: cheap change-detection
-	// fingerprint on file, and route attribution to its registration file.
-	_, _ = db.Exec(`ALTER TABLE file  ADD COLUMN mtime INTEGER`)
-	_, _ = db.Exec(`ALTER TABLE file  ADD COLUMN size  INTEGER`)
-	_, _ = db.Exec(`ALTER TABLE route ADD COLUMN file_id INTEGER`)
 	return &Store{db: db, path: path}, nil
 }
 


### PR DESCRIPTION
## Problem

The board's code-navigation LED shows red with `cannot open codenav index … no such column file_id(1)` on any codenav database created before SC-1274 added the `route.file_id` column.

## Root cause

`store.Open` applied `schema.sql` — which creates `idx_route_file` over `route(file_id)` — **before** the `ALTER TABLE route ADD COLUMN file_id` migration. On an older database the `route` table lacks the column, so applying the schema failed with `no such column: file_id` and `Open` returned early, before the migration could run.

Because every `Open` failed identically, the index could never self-heal — neither the daemon's background refresh nor `human codenav index .` could recover it, so the LED stayed red permanently.

## Fix

Run the additive `ALTER TABLE` column migrations **before** applying `schema.sql`, so indexes over migrated columns resolve on both fresh and pre-existing databases. On a fresh DB the ALTERs are harmless no-ops (tables absent); on an old DB they add the missing column first.

## Verification

- Reproduced the exact error against a copy of a real pre-file_id `codenav.db`, then confirmed the fixed `Open` heals it in place (opens cleanly, `route.file_id` present, projects readable).
- New regression test `TestOpenMigratesPreFileIDDatabase` — fails before the fix (`no such column: file_id`), passes after.
- `make check` green (test, lint, gosec, govulncheck, gitleaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)