### PR TITLE
[SC-1438] Poll the tracker and poke the board for external ticket changes

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -652,6 +652,15 @@ func runDaemonForeground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string,
 		liveBoardAgents, postFailedMarkerFunc(ds.srv.Projects, ds.vaultResolver, ds.daemonID),
 		chainReview, stageRetry, agentProgress, stopHungAgent, ds.daemonID, daemon.BoardReconcileInterval, logger)
 
+	// Surface tickets created or edited outside the board (tracker web UI, CLI,
+	// another teammate or daemon) — none raise a board event — by polling the
+	// cheap titles-only listing and poking subscribers on any change. Gated on
+	// live subscribers so it costs nothing when no board is open.
+	go daemon.RunBoardFreshnessPoll(ctx,
+		ds.srv.LiteIssueFetcher, ds.srv.PokeBoard,
+		boardHasWatchers(ds.srv.HookEvents),
+		daemon.BoardFreshnessInterval, logger)
+
 	// Watch the binary so a rebuild re-execs into the new build, handing over the
 	// live sockets (no client sees a refused connection) and draining in-flight
 	// connections before the old process exits. A no-op on Windows.
@@ -2771,6 +2780,13 @@ func boardPMCommenterFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver)
 		entry := entries[0]
 		return resolvePMCommenter(entry.Dir, entry.EnvLookup(), resolver)
 	}
+}
+
+// boardHasWatchers reports whether any UI (board or TUI) is subscribed, so the
+// freshness poll can skip tracker work when no board is open. A nil store (hook
+// tracking disabled) reads as no watchers.
+func boardHasWatchers(events *daemon.HookEventStore) func() bool {
+	return func() bool { return events != nil && events.SubscriberCount() > 0 }
 }
 
 // boardReconcileListerFunc enumerates open PM cards with their comment threads

--- a/internal/daemon/board_freshness.go
+++ b/internal/daemon/board_freshness.go
@@ -1,0 +1,128 @@
+package daemon
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// BoardFreshnessInterval is how often the daemon re-lists open tickets to catch
+// changes made OUTSIDE the board — the tracker web UI, the CLI, a teammate, or
+// another daemon — none of which flow through a route handler and so raise no
+// board event. It is shorter than the desktop's own ~90s safety poll so such a
+// change surfaces in seconds rather than up to a minute and a half.
+var BoardFreshnessInterval = 30 * time.Second
+
+// BoardFreshnessJitter spreads the poll by up to ±this fraction of the interval
+// so several daemons watching one board do not list the tracker in lockstep.
+var BoardFreshnessJitter = 0.2
+
+// IssueLister enumerates the open tickets whose set the freshness poll
+// fingerprints. Its signature matches the server's LiteIssueFetcher so the
+// cheap titles-only listing is reused (no per-ticket comment scan).
+type IssueLister func() ([]TrackerIssuesResult, error)
+
+// RunBoardFreshnessPoll re-lists open tickets on an interval and pokes open
+// board subscribers whenever the ticket set changes — a new or removed ticket,
+// or an in-place edit reflected in a ticket's UpdatedAt. It is the daemon-side
+// counterpart to the board's event-driven refresh: mutations made THROUGH the
+// board already poke via the route handlers, so this exists solely to cover
+// everything made outside it.
+//
+// The poll only does tracker work while at least one UI is subscribed
+// (hasWatchers): the signal is meaningless with no board open, and gating on it
+// bounds tracker API load to the times a board is actually being watched. The
+// first list after watchers appear establishes the baseline silently — the UI's
+// own initial fetch already holds that state, so poking for it would trigger a
+// redundant refetch. A nil lister or poke disables the loop (tests, disabled
+// tracking).
+func RunBoardFreshnessPoll(ctx context.Context, list IssueLister, poke func(), hasWatchers func() bool, interval time.Duration, logger zerolog.Logger) {
+	if list == nil || poke == nil || hasWatchers == nil {
+		return
+	}
+	var st freshnessState
+	fingerprint := func() (string, error) { return fingerprintIssues(list) }
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(jitteredInterval(interval, BoardFreshnessJitter)):
+		}
+		if st.step(hasWatchers(), fingerprint, logger) {
+			poke()
+			logger.Debug().Msg("board freshness poll: ticket set changed outside the board; poking subscribers")
+		}
+	}
+}
+
+// freshnessState carries the last-seen fingerprint across poll ticks. Split from
+// the loop so the poke decision is unit-testable without timers.
+type freshnessState struct {
+	baseline     string
+	haveBaseline bool
+}
+
+// step evaluates one poll tick and reports whether subscribers should be poked.
+// With no watchers it drops any baseline so the next watcher re-baselines
+// against live state instead of poking for a change it never saw a "before"
+// for; the desktop's reconnect fetch and 90s safety poll cover that gap. A list
+// error is swallowed (best effort) — the next tick retries.
+func (st *freshnessState) step(hasWatchers bool, fingerprint func() (string, error), logger zerolog.Logger) bool {
+	if !hasWatchers {
+		st.haveBaseline = false
+		return false
+	}
+	fp, err := fingerprint()
+	if err != nil {
+		logger.Debug().Err(err).Msg("board freshness poll: listing tickets failed; retrying next tick")
+		return false
+	}
+	if !st.haveBaseline {
+		st.baseline = fp
+		st.haveBaseline = true
+		return false
+	}
+	if fp != st.baseline {
+		st.baseline = fp
+		return true
+	}
+	return false
+}
+
+// fingerprintIssues renders an order-independent digest of the open-ticket set.
+// It folds in every field a board card reflects — key, title, status, type and
+// labels (kind) — plus UpdatedAt, the tracker's own "something changed"
+// timestamp, so an in-place edit is caught even when set membership is
+// unchanged. Over-detecting is harmless (a redundant refetch); under-detecting
+// would leave the board stale, so the digest errs toward sensitivity.
+func fingerprintIssues(list IssueLister) (string, error) {
+	results, err := list()
+	if err != nil {
+		return "", err
+	}
+	var lines []string
+	for i := range results {
+		for j := range results[i].Issues {
+			is := results[i].Issues[j]
+			labels := append([]string(nil), is.Labels...)
+			sort.Strings(labels)
+			// \x1f (unit separator) cannot occur in these fields, so it delimits
+			// them unambiguously; keys are unique per issue.
+			fields := []string{
+				is.Key, is.Title, is.Status, is.Type,
+				strconv.FormatInt(is.UpdatedAt.UnixNano(), 10),
+				strings.Join(labels, ","),
+			}
+			lines = append(lines, strings.Join(fields, "\x1f"))
+		}
+	}
+	sort.Strings(lines)
+	sum := sha256.Sum256([]byte(strings.Join(lines, "\n")))
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/internal/daemon/board_freshness_test.go
+++ b/internal/daemon/board_freshness_test.go
@@ -1,0 +1,171 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// listerFor returns an IssueLister yielding one tracker result carrying issues.
+func listerFor(issues ...tracker.Issue) IssueLister {
+	return func() ([]TrackerIssuesResult, error) {
+		return []TrackerIssuesResult{{Project: "p", Issues: issues}}, nil
+	}
+}
+
+func TestFingerprintIssues_StableAndOrderIndependent(t *testing.T) {
+	a := tracker.Issue{Key: "SC-1", Title: "one", Status: "To Do", UpdatedAt: time.Unix(100, 0)}
+	b := tracker.Issue{Key: "SC-2", Title: "two", Status: "Done", UpdatedAt: time.Unix(200, 0)}
+
+	fp1, err := fingerprintIssues(listerFor(a, b))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Same set, reversed order → identical digest.
+	fp2, err := fingerprintIssues(listerFor(b, a))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fp1 != fp2 {
+		t.Fatalf("digest is order-dependent: %s != %s", fp1, fp2)
+	}
+}
+
+func TestFingerprintIssues_DetectsChanges(t *testing.T) {
+	base := tracker.Issue{Key: "SC-1", Title: "one", Status: "To Do", UpdatedAt: time.Unix(100, 0)}
+	fpBase, _ := fingerprintIssues(listerFor(base))
+
+	cases := map[string]tracker.Issue{
+		"new title":  {Key: "SC-1", Title: "renamed", Status: "To Do", UpdatedAt: time.Unix(100, 0)},
+		"new status": {Key: "SC-1", Title: "one", Status: "In Progress", UpdatedAt: time.Unix(100, 0)},
+		"new mtime":  {Key: "SC-1", Title: "one", Status: "To Do", UpdatedAt: time.Unix(101, 0)},
+	}
+	for name, edited := range cases {
+		t.Run(name, func(t *testing.T) {
+			fp, _ := fingerprintIssues(listerFor(edited))
+			if fp == fpBase {
+				t.Fatalf("edit %q not reflected in digest", name)
+			}
+		})
+	}
+
+	// A new ticket joining the set changes the digest.
+	fpAdded, _ := fingerprintIssues(listerFor(base, tracker.Issue{Key: "SC-2", Title: "two"}))
+	if fpAdded == fpBase {
+		t.Fatal("added ticket not reflected in digest")
+	}
+}
+
+func TestFingerprintIssues_PropagatesError(t *testing.T) {
+	boom := errors.New("tracker down")
+	if _, err := fingerprintIssues(func() ([]TrackerIssuesResult, error) { return nil, boom }); !errors.Is(err, boom) {
+		t.Fatalf("want propagated error, got %v", err)
+	}
+}
+
+// fp is a fingerprint stub returning canned values so step's decision logic is
+// tested without any real listing or timers.
+func fpSeq(values ...string) func() (string, error) {
+	i := 0
+	return func() (string, error) {
+		v := values[i]
+		if i < len(values)-1 {
+			i++
+		}
+		return v, nil
+	}
+}
+
+func TestFreshnessStep_BaselineThenChange(t *testing.T) {
+	var st freshnessState
+	fp := fpSeq("A", "A", "B")
+	log := zerolog.Nop()
+
+	if st.step(true, fp, log) {
+		t.Fatal("first watched poll must only baseline, not poke")
+	}
+	if st.step(true, fp, log) {
+		t.Fatal("unchanged fingerprint must not poke")
+	}
+	if !st.step(true, fp, log) {
+		t.Fatal("changed fingerprint must poke")
+	}
+}
+
+func TestFreshnessStep_NoWatchersNeverPokesAndResets(t *testing.T) {
+	var st freshnessState
+	log := zerolog.Nop()
+
+	// Establish a baseline while watched.
+	st.step(true, fpSeq("A"), log)
+	// Watchers gone: never poke, and the baseline is dropped.
+	if st.step(false, fpSeq("B"), log) {
+		t.Fatal("must not poke with no watchers")
+	}
+	if st.haveBaseline {
+		t.Fatal("baseline must reset when watchers drop")
+	}
+	// Watcher returns mid-change: re-baselines silently (the UI's reconnect
+	// fetch covers the gap), so the first poll back does not poke.
+	if st.step(true, fpSeq("C"), log) {
+		t.Fatal("first poll after watchers return must re-baseline, not poke")
+	}
+}
+
+func TestFreshnessStep_ListErrorDoesNotPoke(t *testing.T) {
+	var st freshnessState
+	log := zerolog.Nop()
+	st.step(true, fpSeq("A"), log) // baseline
+	errFn := func() (string, error) { return "", errors.New("boom") }
+	if st.step(true, errFn, log) {
+		t.Fatal("a list error must not poke")
+	}
+}
+
+func TestRunBoardFreshnessPoll_NilArgsReturn(t *testing.T) {
+	// Must not panic or block; a nil dependency disables the loop.
+	RunBoardFreshnessPoll(context.Background(), nil, func() {}, func() bool { return true }, time.Millisecond, zerolog.Nop())
+}
+
+func TestRunBoardFreshnessPoll_PokesOnChange(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Toggle the ticket set after the baseline tick so the loop observes a change.
+	changed := make(chan struct{})
+	list := func() ([]TrackerIssuesResult, error) {
+		select {
+		case <-changed:
+			return []TrackerIssuesResult{{Issues: []tracker.Issue{{Key: "SC-2"}}}}, nil
+		default:
+			return []TrackerIssuesResult{{Issues: []tracker.Issue{{Key: "SC-1"}}}}, nil
+		}
+	}
+	poked := make(chan struct{}, 1)
+	poke := func() {
+		select {
+		case poked <- struct{}{}:
+		default:
+		}
+	}
+
+	oldJitter := BoardFreshnessJitter
+	BoardFreshnessJitter = 0
+	defer func() { BoardFreshnessJitter = oldJitter }()
+
+	go RunBoardFreshnessPoll(ctx, list, poke, func() bool { return true }, 2*time.Millisecond, zerolog.Nop())
+
+	time.Sleep(10 * time.Millisecond) // let the baseline settle
+	close(changed)
+
+	select {
+	case <-poked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a poke after the ticket set changed")
+	}
+}

--- a/internal/daemon/hookstore.go
+++ b/internal/daemon/hookstore.go
@@ -148,6 +148,15 @@ func (s *HookEventStore) Unsubscribe(ch chan struct{}) {
 	}
 }
 
+// SubscriberCount reports how many live subscribers (board/TUI subscribe
+// streams) are attached. The board-freshness poll reads it to skip tracker work
+// when no UI is watching.
+func (s *HookEventStore) SubscriberCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.subscribers)
+}
+
 // Snapshot returns the current per-session state derived from all stored events.
 func (s *HookEventStore) Snapshot() map[string]hookevents.SessionSnapshot {
 	s.mu.Lock()

--- a/internal/daemon/hookstore_test.go
+++ b/internal/daemon/hookstore_test.go
@@ -13,6 +13,21 @@ import (
 	"github.com/gethuman-sh/human/internal/claude/logparser"
 )
 
+func TestHookEventStore_SubscriberCount(t *testing.T) {
+	store := NewHookEventStore()
+	assert.Equal(t, 0, store.SubscriberCount())
+
+	a := store.Subscribe()
+	b := store.Subscribe()
+	assert.Equal(t, 2, store.SubscriberCount())
+
+	store.Unsubscribe(a)
+	assert.Equal(t, 1, store.SubscriberCount())
+
+	store.Unsubscribe(b)
+	assert.Equal(t, 0, store.SubscriberCount())
+}
+
 func TestHookEventStore_AppendAndSnapshot(t *testing.T) {
 	store := NewHookEventStore()
 

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1197,6 +1197,11 @@ func (s *Server) handleSubscribe(conn net.Conn) {
 	}
 }
 
+// PokeBoard is the exported entry to the same board-refresh signal the route
+// handlers raise via pokeBoard, for changes detected outside a handler — today
+// the board-freshness poll, which notices tickets mutated in the tracker web UI.
+func (s *Server) PokeBoard() { s.pokeBoard() }
+
 // pokeBoard notifies open board subscribers that a daemon-executed change
 // landed, so the board refreshes within a second or two instead of waiting for
 // an unrelated agent lifecycle event. It appends a lightweight session-less


### PR DESCRIPTION
## Problem

Tickets created or edited **outside** the workflow board — the tracker web UI, the CLI, a teammate, or another daemon — took up to **90s** to appear. The board refreshes on its own actions plus a 90s safety poll, but changes made outside it raise no board event, so the daemon never notified the desktop.

## Approach (Option A of the freshness design)

Add `RunBoardFreshnessPoll`, a daemon goroutine that:

1. On an interval (`BoardFreshnessInterval`, 30s) re-lists open tickets via the existing **cheap titles-only lister** (`LiteIssueFetcher` — no per-ticket comment scan).
2. Fingerprints the set — key, title, status, type, labels, and `UpdatedAt` (the tracker's own "something changed" timestamp, so in-place edits are caught even when membership is unchanged).
3. Calls the existing `pokeBoard` signal whenever the fingerprint changes. The desktop already refetches on that poke, so an external ticket now surfaces within one interval (~30s) instead of 90s.

No new client mechanism — it reuses the subscribe/push channel that daemon-executed mutations already use.

### Efficiency

The poll is **gated on there being ≥1 live subscriber** (new `HookEventStore.SubscriberCount`), so it does **zero tracker work when no board is open**.

### Testability

The poke decision is split into a timer-free `freshnessState.step`, unit-tested for baseline/change/no-watchers/list-error paths. `fingerprintIssues` is tested for order-independence and change detection.

## Verification

- New tests in `board_freshness_test.go` and `hookstore_test.go`; full daemon suite green.
- `make check` green (test, lint incl. gocyclo, gosec, govulncheck, gitleaks).

## Follow-up

Strict stepping stone to Option B (daemon-owned board snapshot that pushes the payload itself) — this poller becomes that snapshot's maintainer, no rework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)