### PR TITLE
[SC-1419] Treat an already-running launch refusal as a board no-op

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -1776,6 +1776,22 @@ func (l dockerAgentLauncher) Launch(ctx context.Context, name, prompt, workspace
 		ConfigDir: configDir,
 		DaemonID:  l.daemonID,
 	})
+	return translateLaunchErr(err)
+}
+
+// translateLaunchErr bridges the agent package's single-flight sentinel to the
+// daemon's AgentLauncher-contract sentinel. This is the one place that imports
+// both packages, so the translation lives here rather than in either package
+// (agent imports daemon — the reverse would cycle). A benign already-running
+// refusal becomes daemon.ErrAgentAlreadyRunning so the board launcher swallows
+// it; every other error (and nil) passes through unchanged (SC-1419).
+func translateLaunchErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if goerrors.Is(err, agent.ErrAlreadyRunning) {
+		return daemon.ErrAgentAlreadyRunning
+	}
 	return err
 }
 

--- a/cmd/cmddaemon/stageretry_test.go
+++ b/cmd/cmddaemon/stageretry_test.go
@@ -2,11 +2,15 @@ package cmddaemon
 
 import (
 	"context"
+	stderrors "errors"
+	"fmt"
 	"testing"
 
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gethuman-sh/human/internal/agent"
 	"github.com/gethuman-sh/human/internal/agentstate"
 	"github.com/gethuman-sh/human/internal/daemon"
 )
@@ -107,4 +111,28 @@ func TestBumpStageRetries_IsPerStage(t *testing.T) {
 func TestRetryCounterName_IsScopedToTheStage(t *testing.T) {
 	require.Equal(t, "relaunch.implementation.attempts", retryCounterName(daemon.BoardImplementation))
 	require.Equal(t, "stage.planning", stageReportName(daemon.BoardPlanning))
+}
+
+func TestTranslateLaunchErr(t *testing.T) {
+	// The launcher bridges the agent single-flight sentinel to the daemon
+	// AgentLauncher-contract sentinel so the board swallows a benign racing
+	// retry; every other error (and nil) passes through unchanged (SC-1419).
+	t.Run("nil passes through", func(t *testing.T) {
+		require.NoError(t, translateLaunchErr(nil))
+	})
+	t.Run("bare sentinel maps to daemon sentinel", func(t *testing.T) {
+		got := translateLaunchErr(agent.ErrAlreadyRunning)
+		assert.True(t, stderrors.Is(got, daemon.ErrAgentAlreadyRunning))
+	})
+	t.Run("wrapped sentinel maps to daemon sentinel", func(t *testing.T) {
+		wrapped := fmt.Errorf("start failed: %w", agent.ErrAlreadyRunning)
+		got := translateLaunchErr(wrapped)
+		assert.True(t, stderrors.Is(got, daemon.ErrAgentAlreadyRunning))
+	})
+	t.Run("unrelated error passes through", func(t *testing.T) {
+		down := stderrors.New("docker down")
+		got := translateLaunchErr(down)
+		assert.Same(t, down, got)
+		assert.False(t, stderrors.Is(got, daemon.ErrAgentAlreadyRunning))
+	})
 }

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"os"
 	osexec "os/exec"
@@ -20,6 +21,13 @@ import (
 	"github.com/gethuman-sh/human/internal/dockerhost"
 	"github.com/gethuman-sh/human/internal/gitrepo"
 )
+
+// ErrAlreadyRunning is the typed sentinel Start returns (wrapped, so the "name"
+// detail survives) when an agent of the same name is already running with a
+// live container. Callers — the board launcher and the `human agent start` CLI
+// — errors.Is it to treat the single-flight refusal as a benign no-op rather
+// than a hard failure (SC-1419).
+var ErrAlreadyRunning = stderrors.New("agent already running")
 
 // isDockerUnreachable reports whether err is (or wraps) a Docker daemon
 // connection failure. errors.As traverses the wrap chain, so SDK connection
@@ -75,7 +83,7 @@ func (m *Manager) Start(ctx context.Context, opts StartOpts) (Meta, error) {
 				// Interactive mode: reuse the running container.
 				return existing, nil
 			}
-			return Meta{}, errors.WithDetails("agent already running", "name", opts.Name)
+			return Meta{}, errors.WrapWithDetails(ErrAlreadyRunning, "agent already running", "name", opts.Name)
 		}
 		existing.Status = StatusStopped
 		existing.StoppedAt = time.Now()

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"strings"
@@ -271,6 +272,33 @@ func TestIsContainerAlive_InspectError(t *testing.T) {
 	mgr := &Manager{Docker: mock}
 	if mgr.isContainerAlive(context.Background(), "nonexistent") {
 		t.Error("expected isContainerAlive to return false when inspect fails")
+	}
+}
+
+func TestStart_AlreadyRunningReturnsSentinel(t *testing.T) {
+	// A non-interactive Start against a name whose container is already live is a
+	// single-flight refusal. It must return an error satisfying
+	// errors.Is(err, ErrAlreadyRunning) so callers can treat the racing retry as
+	// a benign no-op rather than a hard failure (SC-1419).
+	t.Setenv("HOME", t.TempDir())
+
+	if err := WriteMeta(Meta{
+		Name:          "busy",
+		ContainerID:   "live-container",
+		ContainerName: ContainerName("busy"),
+		Status:        StatusRunning,
+		CreatedAt:     time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteMeta: %v", err)
+	}
+
+	mgr := &Manager{Docker: &mockDockerClient{inspectRunning: true}}
+	_, err := mgr.Start(context.Background(), StartOpts{Name: "busy"})
+	if err == nil {
+		t.Fatal("expected an error when the agent is already running")
+	}
+	if !stderrors.Is(err, ErrAlreadyRunning) {
+		t.Errorf("expected errors.Is(err, ErrAlreadyRunning); got %v", err)
 	}
 }
 

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -15,8 +16,18 @@ import (
 	"github.com/gethuman-sh/human/internal/tracker"
 )
 
+// ErrAgentAlreadyRunning is the AgentLauncher-boundary sentinel for a benign
+// single-flight refusal: the stage's agent is already running, so a racing
+// retry must be a no-op rather than a failure. The daemon package cannot import
+// internal/agent (that would cycle — agent imports daemon), so the launcher
+// implementation in cmd/cmddaemon translates agent.ErrAlreadyRunning into this
+// contract sentinel at the boundary (SC-1419).
+var ErrAgentAlreadyRunning = stderrors.New("agent already running")
+
 // AgentLauncher launches a containerized agent for a board stage. It is an
-// interface so the transition engine is testable without Docker.
+// interface so the transition engine is testable without Docker. An
+// implementation returns ErrAgentAlreadyRunning when the stage's agent is
+// already running so the caller can treat the racing retry as a no-op.
 type AgentLauncher interface {
 	Launch(ctx context.Context, name, prompt, workspace, configDir string) error
 }
@@ -383,6 +394,13 @@ func (d BoardTransitionDeps) startAgentStage(ctx context.Context, pmKey string, 
 	}
 	name := agentNameFor(pmKey, stage)
 	if err := d.Launcher.Launch(ctx, name, prompt, d.WorkspaceDir, d.ConfigDir); err != nil {
+		// A single-flight refusal (the stage's agent is already running) is the
+		// launch-path analogue of ApplyTransition's idempotency guard: a retry
+		// raced the agent cleanup, only one agent ever ran, so leave the card
+		// running and post no failed marker (SC-1419).
+		if stderrors.Is(err, ErrAgentAlreadyRunning) {
+			return nil
+		}
 		failBody := failedHeaderFor(stage) + "\n" + errors.CauseChain(err)
 		_, _ = d.Commenter.AddComment(ctx, pmKey, StampDaemon(failBody, d.DaemonID))
 		return errors.WrapWithDetails(err, "launching agent", "pm", pmKey, "stage", string(stage))

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -723,6 +723,24 @@ func TestStartAgentStageLaunchFails(t *testing.T) {
 	assert.Contains(t, c.added[1], PlanningFailedHeader)
 }
 
+func TestStartAgentStageAlreadyRunningIsNoOp(t *testing.T) {
+	// A retry that races the daemon's agent cleanup hits the manager's
+	// single-flight guard, which refuses the second launch with
+	// ErrAgentAlreadyRunning. That benign refusal must leave the card running:
+	// no [human:*-failed] marker, nil return (SC-1419).
+	c := &fakeCommenter{}
+	l := &fakeLauncher{err: ErrAgentAlreadyRunning}
+	deps := newDeps(c, l, &fakeDeployer{})
+	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{PMKey: "SC-1", To: BoardPlanning})
+	require.NoError(t, err)
+	// exactly the started marker, and no failed marker.
+	require.Len(t, c.added, 1)
+	assert.Equal(t, PlanningStartedHeader, c.added[0])
+	for _, body := range c.added {
+		assert.NotContains(t, body, PlanningFailedHeader)
+	}
+}
+
 func TestAgentNameRoundTrip(t *testing.T) {
 	name := agentNameFor("SC-105", BoardImplementation)
 	assert.Equal(t, "board-SC-105-implementation", name)


### PR DESCRIPTION
## Problem

Dragging a card to retry a stage could leave it stuck red with **"agent already running"** and no pick-up — even though only one agent ever ran. A retry that races the daemon's post-run agent cleanup hits the manager's single-flight guard (`internal/agent/manager.go`), which correctly refuses a second launch. But `startAgentStage` treated that refusal as a launch failure and posted a `[human:<stage>-failed]` marker, wedging the card (observed on SC-1388).

"agent already running" is benign — the same "already in flight, do nothing" meaning as `ApplyTransition`'s idempotency guard.

## Fix

- Export a typed sentinel `agent.ErrAlreadyRunning`; `Start` now returns it wrapped (via `WrapWithDetails`, so the `name` detail survives) so callers can `errors.Is` it.
- Add a daemon-boundary sentinel `daemon.ErrAgentAlreadyRunning` — the daemon package can't import `internal/agent` (that would cycle, since agent imports daemon), so the launcher in `cmd/cmddaemon` translates one into the other at the boundary (`translateLaunchErr`).
- `startAgentStage` swallows `ErrAgentAlreadyRunning` as a no-op: leave the card running, post **no** failed marker.

## Provenance

Implemented by the `human-autofix` pipeline dispatched from the board's Fix column on SC-1419; reviewed and shipped by hand. The run completed and posted its handoff, but its container was reaped before a clean exit was recorded, so the card falsely showed a failure — tracked separately as the reap-false-failure bug.

## Verification

- Tests at all three layers: `agent.Start` returns the sentinel; `translateLaunchErr` bridges bare/wrapped/unrelated; `startAgentStage` posts no failed marker on the refusal.
- `make check` green (test, lint incl. gocyclo, gosec, govulncheck, gitleaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)