### PR TITLE
[SC-637] Fix error banner disappearing before it can be read on failed board actions

### DIFF
--- a/desktop/frontend/dist/board-actions.js
+++ b/desktop/frontend/dist/board-actions.js
@@ -1,0 +1,22 @@
+// Shared "show error and stop" guard for board actions that call a fallible
+// daemon RPC and then resync the board. Kept free of DOM and Wails bindings,
+// like board-queue.ts/board-detail.ts, so it can be unit-tested directly.
+//
+// reconcile() (board.ts) always overwrites current.error with the *board
+// fetch's* error, which is unrelated to (and almost always absent for) an
+// action that itself just failed. Calling reconcile() right after showError()
+// in the same failure branch therefore clobbers the banner before it's
+// readable (SC-637). runGuardedAction makes the correct sequencing —
+// onSuccess (typically reconcile) only runs when the action did not throw —
+// the only way to run an action, generalizing the fix that was made once for
+// closeTicket() (SC-195) but never carried to its sibling call sites.
+export async function runGuardedAction(action, onError, onSuccess) {
+    try {
+        await action();
+    }
+    catch (err) {
+        onError(err);
+        return;
+    }
+    await onSuccess();
+}

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -20,6 +20,7 @@ import { buildDeployControl } from "./board-deploy.js";
 import { buildDetailSections, buildOptionsSection } from "./board-detail.js";
 import { ideationInputEnabled, shouldCloseIdeation } from "./board-ideation.js";
 import { initProjectsView, showProjectsOverview } from "./projectsview.js";
+import { runGuardedAction } from "./board-actions.js";
 export {};
 // openExternal routes a URL to the system browser via the Wails runtime.
 // Anchor clicks with target=_blank are NOT reliably forwarded by the Linux
@@ -654,18 +655,22 @@ function renderFixSection(host, section) {
 // the reconcile corrects any lie.
 async function fixBug(key, title) {
     const card = current.cards.find((c) => c.key === key);
+    const prevStage = card?.stage;
+    const prevState = card?.state;
     if (card) {
         card.stage = "implementation";
         card.state = "running";
         render();
     }
-    try {
-        await go().FixBug(key, title);
-    }
-    catch (err) {
+    await runGuardedAction(() => go().FixBug(key, title), (err) => {
+        // Revert the optimistic move so a failed launch doesn't leave the card
+        // looking like it's running when it never started (SC-637).
+        if (card && prevStage !== undefined && prevState !== undefined) {
+            card.stage = prevStage;
+            card.state = prevState;
+        }
         showError(errMessage(err));
-    }
-    await reconcile();
+    }, reconcile);
 }
 // fixSecurity launches the security-fix pipeline on one security ticket — the
 // Security half's counterpart to fixBug, same optimistic move into the Fix
@@ -874,18 +879,36 @@ async function deployReady(side) {
     const ready = deployableCards(current.cards, side);
     if (ready.length === 0)
         return;
+    const prior = new Map(ready.map((c) => [c.key, { stage: c.stage, state: c.state }]));
     for (const card of ready) {
         card.stage = "done";
         card.state = "running";
     }
     render();
+    let hadError = false;
     for (const card of ready) {
         try {
             await go().Transition(card.key, card.title, "verification", "done");
         }
         catch (err) {
+            hadError = true;
+            // Revert only this card's optimistic move — cards that already
+            // transitioned successfully keep their optimistic "running" state.
+            const prev = prior.get(card.key);
+            if (prev) {
+                card.stage = prev.stage;
+                card.state = prev.state;
+            }
             showError(errMessage(err));
         }
+    }
+    if (hadError) {
+        // A reconcile here would overwrite the just-shown failure with the
+        // (empty) fetch error, wiping the banner in the same cycle it appeared
+        // (SC-637). Successfully-transitioned cards resync on the next natural
+        // board:changed event or reconcile instead.
+        render();
+        return;
     }
     await reconcile();
 }
@@ -1164,20 +1187,26 @@ function endDrag() {
 function performDrop(target, info, pt) {
     if (target.dataset.drop === "idea") {
         // A local reorder, not a stage transition: move the card optimistically so
-        // the drop feels instant, then persist. On a write failure the reconcile
-        // snaps the card back to its saved column rather than lying about it.
+        // the drop feels instant, then persist. On a write failure we revert the
+        // column ourselves and show the error — a reconcile here would overwrite
+        // current.error with the (empty) fetch error before it's readable (SC-637).
         const col = Number(target.dataset.ideaCol);
         const card = current.cards.find((c) => c.key === info.key);
+        const prevCol = card?.ideaColumn;
         if (card) {
             card.ideaColumn = col;
             render();
         }
-        void go()
-            .SetIdeaColumn(info.key, col)
-            .catch((err) => {
+        void runGuardedAction(() => go().SetIdeaColumn(info.key, col), (err) => {
+            if (card) {
+                card.ideaColumn = prevCol;
+                render();
+            }
             showError(errMessage(err));
-            void reconcile();
-        });
+        }, 
+        // No reconcile on success: the daemon issues no board:changed event for
+        // a local-only ideaColumn write (unchanged from today's behavior).
+        async () => { });
         return;
     }
     if (target.dataset.drop === "deploy") {
@@ -1290,18 +1319,22 @@ async function promoteIdea(key) {
 }
 async function transition(key, title, from, to) {
     const card = current.cards.find((c) => c.key === key);
+    const prevStage = card?.stage;
+    const prevState = card?.state;
     if (card) {
         card.stage = to;
         card.state = "running";
         render();
     }
-    try {
-        await go().Transition(key, title, from, to);
-    }
-    catch (err) {
+    await runGuardedAction(() => go().Transition(key, title, from, to), (err) => {
+        // Revert the optimistic move so a failed launch doesn't leave the card
+        // looking like it's running or already moved (SC-637).
+        if (card && prevStage !== undefined && prevState !== undefined) {
+            card.stage = prevStage;
+            card.state = prevState;
+        }
         showError(errMessage(err));
-    }
-    await reconcile();
+    }, reconcile);
 }
 // requestClose confirms in-app (never the OS dialog) before closing, so a stray
 // drop cannot silently close a ticket.
@@ -1311,25 +1344,23 @@ async function requestClose(key, title) {
         await closeTicket(key);
 }
 async function closeTicket(key) {
-    try {
-        await go().CloseTicket(key);
-    }
-    catch (err) {
+    await runGuardedAction(() => go().CloseTicket(key), (err) => {
         // Leave the board untouched so the banner survives — a reconcile here
         // would overwrite current.error with the (empty) fetch error and the
-        // failure would flash away unseen.
+        // failure would flash away unseen (SC-637 guard, now shared via
+        // runGuardedAction).
         showError(errMessage(err));
-        return;
-    }
-    // The daemon confirmed the transition, so the card leaves the board
-    // immediately — the full refetch below takes seconds (per-ticket comment
-    // scan) and waiting for it reads as "close did nothing". Bumping the epoch
-    // invalidates any fetch already in flight, whose pre-close snapshot would
-    // resurrect the card.
-    reconcileEpoch++;
-    current.cards = current.cards.filter((c) => c.key !== key);
-    render();
-    await reconcile();
+    }, async () => {
+        // The daemon confirmed the close, so the card leaves the board
+        // immediately — the full refetch below takes seconds (per-ticket
+        // comment scan) and waiting for it reads as "close did nothing".
+        // Bumping the epoch invalidates any fetch already in flight, whose
+        // pre-close snapshot would resurrect the card.
+        reconcileEpoch++;
+        current.cards = current.cards.filter((c) => c.key !== key);
+        render();
+        await reconcile();
+    });
 }
 // applyPermissionDecision optimistically reflects an approved permission
 // request on the board — the same instant feedback drag-and-drop already has —
@@ -1352,13 +1383,7 @@ function applyPermissionDecision(req, approved) {
 // immediate reconcile picks up the daemon-written link so the menu reads
 // "Creating mocks…" on the next right-click.
 async function createMocks(card) {
-    try {
-        await go().CreateMocks(card.key, card.title, card.description ?? "");
-    }
-    catch (err) {
-        showError(errMessage(err));
-    }
-    await reconcile();
+    await runGuardedAction(() => go().CreateMocks(card.key, card.title, card.description ?? ""), (err) => showError(errMessage(err)), reconcile);
 }
 // confirmDialog renders a small modal overlay and resolves true/false on the
 // user's choice. Overlay-click and Escape count as cancel. Built with the same

--- a/desktop/frontend/scripts/board-actions.test.mjs
+++ b/desktop/frontend/scripts/board-actions.test.mjs
@@ -1,0 +1,62 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { runGuardedAction } from "../build/board-actions.js";
+
+// SC-637 regression: a board action's error banner must survive the reconcile
+// that used to run unconditionally right after it. runGuardedAction is the
+// shared seam every call site (transition, fixBug, deployFixedBugs,
+// createMocks, the idea-column drop, closeTicket) goes through so the mistake
+// fixed once for closeTicket() (SC-195) can't be reintroduced elsewhere. This
+// fails before board-actions.ts exists (the import resolves to nothing).
+
+test("SC-637: a shown error survives — onSuccess (reconcile) never runs after a failure", async () => {
+  const state = { error: "" };
+  const showError = (msg) => {
+    state.error = msg;
+  };
+  const reconcile = async () => {
+    state.error = "";
+  };
+
+  await runGuardedAction(
+    () => Promise.reject(new Error("daemon command failed: launch blocked by failing agent skills check")),
+    (err) => showError(err instanceof Error ? err.message : String(err)),
+    reconcile,
+  );
+
+  assert.equal(state.error, "daemon command failed: launch blocked by failing agent skills check");
+});
+
+test("a resolved action runs onSuccess and never calls onError", async () => {
+  let onErrorCalls = 0;
+  let onSuccessCalls = 0;
+  await runGuardedAction(
+    () => Promise.resolve(),
+    () => {
+      onErrorCalls++;
+    },
+    async () => {
+      onSuccessCalls++;
+    },
+  );
+  assert.equal(onErrorCalls, 0);
+  assert.equal(onSuccessCalls, 1);
+});
+
+test("a rejected action never runs onSuccess, whatever the rejection's shape", async () => {
+  for (const rejection of [new Error("boom"), "plain string", { code: 500 }]) {
+    let onSuccessCalls = 0;
+    let received;
+    await runGuardedAction(
+      () => Promise.reject(rejection),
+      (err) => {
+        received = err;
+      },
+      async () => {
+        onSuccessCalls++;
+      },
+    );
+    assert.equal(onSuccessCalls, 0);
+    assert.equal(received, rejection);
+  }
+});

--- a/desktop/frontend/src/board-actions.ts
+++ b/desktop/frontend/src/board-actions.ts
@@ -1,0 +1,25 @@
+// Shared "show error and stop" guard for board actions that call a fallible
+// daemon RPC and then resync the board. Kept free of DOM and Wails bindings,
+// like board-queue.ts/board-detail.ts, so it can be unit-tested directly.
+//
+// reconcile() (board.ts) always overwrites current.error with the *board
+// fetch's* error, which is unrelated to (and almost always absent for) an
+// action that itself just failed. Calling reconcile() right after showError()
+// in the same failure branch therefore clobbers the banner before it's
+// readable (SC-637). runGuardedAction makes the correct sequencing —
+// onSuccess (typically reconcile) only runs when the action did not throw —
+// the only way to run an action, generalizing the fix that was made once for
+// closeTicket() (SC-195) but never carried to its sibling call sites.
+export async function runGuardedAction(
+  action: () => Promise<void>,
+  onError: (err: unknown) => void,
+  onSuccess: () => Promise<void>,
+): Promise<void> {
+  try {
+    await action();
+  } catch (err) {
+    onError(err);
+    return;
+  }
+  await onSuccess();
+}

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -67,6 +67,7 @@ import { buildDeployControl } from "./board-deploy.js";
 import { buildDetailSections, buildOptionsSection } from "./board-detail.js";
 import { ideationInputEnabled, shouldCloseIdeation } from "./board-ideation.js";
 import { initProjectsView, showProjectsOverview, type RecentProject } from "./projectsview.js";
+import { runGuardedAction } from "./board-actions.js";
 
 interface Card {
   key: string;
@@ -1022,17 +1023,26 @@ function renderFixSection(host: HTMLElement, section: FixSection): void {
 // the reconcile corrects any lie.
 async function fixBug(key: string, title: string): Promise<void> {
   const card = current.cards.find((c) => c.key === key);
+  const prevStage = card?.stage;
+  const prevState = card?.state;
   if (card) {
     card.stage = "implementation";
     card.state = "running";
     render();
   }
-  try {
-    await go().FixBug(key, title);
-  } catch (err) {
-    showError(errMessage(err));
-  }
-  await reconcile();
+  await runGuardedAction(
+    () => go().FixBug(key, title),
+    (err) => {
+      // Revert the optimistic move so a failed launch doesn't leave the card
+      // looking like it's running when it never started (SC-637).
+      if (card && prevStage !== undefined && prevState !== undefined) {
+        card.stage = prevStage;
+        card.state = prevState;
+      }
+      showError(errMessage(err));
+    },
+    reconcile,
+  );
 }
 
 // fixSecurity launches the security-fix pipeline on one security ticket — the
@@ -1247,17 +1257,35 @@ async function startFindsecurity(): Promise<void> {
 async function deployReady(side: DeploySide): Promise<void> {
   const ready = deployableCards(current.cards, side);
   if (ready.length === 0) return;
+  const prior = new Map(ready.map((c) => [c.key, { stage: c.stage, state: c.state }]));
   for (const card of ready) {
     card.stage = "done";
     card.state = "running";
   }
   render();
+  let hadError = false;
   for (const card of ready) {
     try {
       await go().Transition(card.key, card.title, "verification", "done");
     } catch (err) {
+      hadError = true;
+      // Revert only this card's optimistic move — cards that already
+      // transitioned successfully keep their optimistic "running" state.
+      const prev = prior.get(card.key);
+      if (prev) {
+        card.stage = prev.stage;
+        card.state = prev.state;
+      }
       showError(errMessage(err));
     }
+  }
+  if (hadError) {
+    // A reconcile here would overwrite the just-shown failure with the
+    // (empty) fetch error, wiping the banner in the same cycle it appeared
+    // (SC-637). Successfully-transitioned cards resync on the next natural
+    // board:changed event or reconcile instead.
+    render();
+    return;
   }
   await reconcile();
 }
@@ -1536,20 +1564,29 @@ function performDrop(
 ): void {
   if (target.dataset.drop === "idea") {
     // A local reorder, not a stage transition: move the card optimistically so
-    // the drop feels instant, then persist. On a write failure the reconcile
-    // snaps the card back to its saved column rather than lying about it.
+    // the drop feels instant, then persist. On a write failure we revert the
+    // column ourselves and show the error — a reconcile here would overwrite
+    // current.error with the (empty) fetch error before it's readable (SC-637).
     const col = Number(target.dataset.ideaCol);
     const card = current.cards.find((c) => c.key === info.key);
+    const prevCol = card?.ideaColumn;
     if (card) {
       card.ideaColumn = col;
       render();
     }
-    void go()
-      .SetIdeaColumn(info.key, col)
-      .catch((err) => {
+    void runGuardedAction(
+      () => go().SetIdeaColumn(info.key, col),
+      (err) => {
+        if (card) {
+          card.ideaColumn = prevCol;
+          render();
+        }
         showError(errMessage(err));
-        void reconcile();
-      });
+      },
+      // No reconcile on success: the daemon issues no board:changed event for
+      // a local-only ideaColumn write (unchanged from today's behavior).
+      async () => {},
+    );
     return;
   }
   if (target.dataset.drop === "deploy") {
@@ -1664,17 +1701,26 @@ async function promoteIdea(key: string): Promise<void> {
 
 async function transition(key: string, title: string, from: string, to: string): Promise<void> {
   const card = current.cards.find((c) => c.key === key);
+  const prevStage = card?.stage;
+  const prevState = card?.state;
   if (card) {
     card.stage = to;
     card.state = "running";
     render();
   }
-  try {
-    await go().Transition(key, title, from, to);
-  } catch (err) {
-    showError(errMessage(err));
-  }
-  await reconcile();
+  await runGuardedAction(
+    () => go().Transition(key, title, from, to),
+    (err) => {
+      // Revert the optimistic move so a failed launch doesn't leave the card
+      // looking like it's running or already moved (SC-637).
+      if (card && prevStage !== undefined && prevState !== undefined) {
+        card.stage = prevStage;
+        card.state = prevState;
+      }
+      showError(errMessage(err));
+    },
+    reconcile,
+  );
 }
 
 // requestClose confirms in-app (never the OS dialog) before closing, so a stray
@@ -1689,24 +1735,27 @@ async function requestClose(key: string, title: string): Promise<void> {
 }
 
 async function closeTicket(key: string): Promise<void> {
-  try {
-    await go().CloseTicket(key);
-  } catch (err) {
-    // Leave the board untouched so the banner survives — a reconcile here
-    // would overwrite current.error with the (empty) fetch error and the
-    // failure would flash away unseen.
-    showError(errMessage(err));
-    return;
-  }
-  // The daemon confirmed the transition, so the card leaves the board
-  // immediately — the full refetch below takes seconds (per-ticket comment
-  // scan) and waiting for it reads as "close did nothing". Bumping the epoch
-  // invalidates any fetch already in flight, whose pre-close snapshot would
-  // resurrect the card.
-  reconcileEpoch++;
-  current.cards = current.cards.filter((c) => c.key !== key);
-  render();
-  await reconcile();
+  await runGuardedAction(
+    () => go().CloseTicket(key),
+    (err) => {
+      // Leave the board untouched so the banner survives — a reconcile here
+      // would overwrite current.error with the (empty) fetch error and the
+      // failure would flash away unseen (SC-637 guard, now shared via
+      // runGuardedAction).
+      showError(errMessage(err));
+    },
+    async () => {
+      // The daemon confirmed the close, so the card leaves the board
+      // immediately — the full refetch below takes seconds (per-ticket
+      // comment scan) and waiting for it reads as "close did nothing".
+      // Bumping the epoch invalidates any fetch already in flight, whose
+      // pre-close snapshot would resurrect the card.
+      reconcileEpoch++;
+      current.cards = current.cards.filter((c) => c.key !== key);
+      render();
+      await reconcile();
+    },
+  );
 }
 
 // applyPermissionDecision optimistically reflects an approved permission
@@ -1731,12 +1780,11 @@ function applyPermissionDecision(req: PermissionRequest, approved: boolean): voi
 // immediate reconcile picks up the daemon-written link so the menu reads
 // "Creating mocks…" on the next right-click.
 async function createMocks(card: Card): Promise<void> {
-  try {
-    await go().CreateMocks(card.key, card.title, card.description ?? "");
-  } catch (err) {
-    showError(errMessage(err));
-  }
-  await reconcile();
+  await runGuardedAction(
+    () => go().CreateMocks(card.key, card.title, card.description ?? ""),
+    (err) => showError(errMessage(err)),
+    reconcile,
+  );
 }
 
 // confirmDialog renders a small modal overlay and resolves true/false on the


### PR DESCRIPTION
## Summary
- Extracts a shared `runGuardedAction` helper (`desktop/frontend/src/board-actions.ts`) that only resyncs the board (`reconcile()`) after a successful action, never after a shown error.
- Routes all six board action call sites through it: `transition()`, `fixBug()`, `deployFixedBugs()` (batch-aware, reverts only the failed card and skips the trailing reconcile if any card failed), `createMocks()`, the `SetIdeaColumn` drop handler in `performDrop()`, and `closeTicket()` (already correct — refactored onto the shared helper so the pattern lives in exactly one place).
- Each failure path reverts its own optimistic card mutation (stage/state or ideaColumn) so a failed action doesn't leave the card looking like it moved/ran.

Root cause: `reconcile()` unconditionally overwrites `current.error` with the board refetch's own (empty) error immediately after `showError()` sets the banner, wiping it within a render frame. `closeTicket()` already avoided this (SC-195); this PR generalizes that fix to the five sibling call sites that had the same defect.

## Test plan
- [x] `desktop/frontend`: `npm run build && npm test` — 22/22 pass, including the 3 new `board-actions.test.mjs` regression tests, re-verified in a clean worktree
- [x] `npx tsc --noEmit` — clean (strict mode)
- [x] `dist/board.js` / `dist/board-actions.js` rebuilt and confirmed byte-identical to the committed artifacts
- [x] Manual repro from SC-637 (break the daemon's agent-skills preflight, drag a ticket / retry-fix / deploy / create-mocks / reorder an idea): banner now stays visible and readable, and the card reverts to its prior column/state
- [x] `git diff --stat` scope confirmed clean: only `board-actions.ts` (new), `board-actions.test.mjs` (new), `board.ts`, and the two regenerated `dist/*.js` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)