### PR TITLE
Board columns overflow the window on open — rightmost column is clipped

### DIFF
--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -204,10 +204,13 @@ body {
 .board {
   display: grid;
   /* The wide idea-space track (five loose→concrete sub-columns), four queue
-     columns, and the slim terminal Deploy drop zone; min-widths keep each
-     readable and the board scrolls horizontally on narrow windows instead of
-     squishing cards into slivers. */
-  grid-template-columns: minmax(540px, 2.4fr) repeat(4, minmax(170px, 1fr)) minmax(80px, 110px);
+     columns, and the slim terminal Deploy drop zone. The Ideas track has a
+     0 floor (not a px minimum) so it absorbs compression at the default
+     window size instead of forcing the deploy-side columns off-screen
+     (SC-1451); the four queue columns keep their 170px floors so they stay
+     readable, and the board still scrolls horizontally when even that is not
+     enough room. */
+  grid-template-columns: minmax(0, 2.4fr) repeat(4, minmax(170px, 1fr)) minmax(80px, 110px);
   /* Bound the single row to the board's own height so columns can never grow
      past the space below the header (the old 100vh-based column max-height did,
      which pushed the document 20px taller than the viewport). */
@@ -216,6 +219,19 @@ body {
   padding: 12px;
   height: 100%;
   overflow-x: auto;
+  /* Reserve the scrollbar's space up front so its later appearance (once
+     content genuinely overflows) never shifts the board layout (SC-1451). */
+  scrollbar-gutter: stable;
+}
+.board::-webkit-scrollbar {
+  height: 10px;
+}
+.board::-webkit-scrollbar-thumb {
+  background: var(--col-border);
+  border-radius: 5px;
+}
+.board::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 /* The idea space: the Ideas queue widened into five lanes spanning a
@@ -242,8 +258,11 @@ body {
   min-height: 0;
   display: grid;
   /* Sub-columns run narrower than regular queues: idea cards are title-only
-     captures, and five of them must share one board track. */
-  grid-template-columns: repeat(5, minmax(100px, 1fr));
+     captures, and five of them must share one board track. The 0 floor lets
+     the lanes shrink with the Ideas track itself rather than forcing a fixed
+     500px inner min-width that would clip inside the (now compressible)
+     outer track (SC-1451). */
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   grid-auto-rows: minmax(0, 1fr);
   gap: 0;
 }

--- a/desktop/frontend/scripts/style.test.mjs
+++ b/desktop/frontend/scripts/style.test.mjs
@@ -39,3 +39,86 @@ test("default-theme .card contains its overflow and resists shrinking", () => {
   // flex column, otherwise the fancy theme's overflow:hidden squishes them.
   assert.match(body, /flex-shrink:\s*0/, ".card must set flex-shrink:0 so it keeps full height when the column overflows (SC-155)");
 });
+
+// SC-1451 regression: the board grid's fixed track minimums must fit the
+// default window's board area so the rightmost (Ready to Deploy) column is
+// never clipped off-screen on cold open. There is no DOM test runner here, so
+// sum the CSS grid track floors (the board's intrinsic min-width) and assert it
+// fits: default window 1280px (desktop/main.go App.Width) minus the 60px rail.
+const WINDOW_WIDTH = 1280; // desktop/main.go: options.App.Width
+const RAIL_WIDTH = 60;     // .rail width in style.css
+const BOARD_AREA = WINDOW_WIDTH - RAIL_WIDTH; // 1220
+const BOARD_PADDING = 12 * 2; // .board padding: 12px (both sides)
+const GAP = 10;               // .board gap
+
+// ruleBody() matches the selector as a substring, so a bare ".board" would
+// wrongly match the compound ".app-main .board" rule that appears earlier in
+// the file. Require the selector to start a rule (preceded by the start of
+// the file, a prior rule's closing brace, or a selector-list comma) so it
+// targets the exact standalone rule.
+function exactRuleBody(selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp("(?:^|[}\\n,])\\s*" + escaped + "\\s*\\{([^}]*)\\}", "m");
+  const m = stripped.match(re);
+  return m ? m[1] : "";
+}
+
+// Extract the grid-template-columns value from a rule body.
+function gridTemplateColumns(selector) {
+  const m = exactRuleBody(selector).match(/grid-template-columns:\s*([^;]+);/);
+  return m ? m[1].trim() : "";
+}
+
+// Sum the px floors of a grid-template-columns value, expanding
+// repeat(N, minmax(...)). A minmax() min in px is a hard floor; 0/fr/auto mins
+// can shrink to nothing and count as 0 — exactly how an overflow:auto grid
+// computes its intrinsic min-width. Returns { sum, count }.
+function boardMinWidth(value) {
+  const expanded = value.replace(
+    /repeat\(\s*(\d+)\s*,\s*(minmax\([^)]*\))\s*\)/g,
+    (_, n, track) => (track + " ").repeat(Number(n)),
+  );
+  const tracks = expanded.match(/minmax\([^)]*\)/g) || [];
+  let sum = 0;
+  for (const t of tracks) {
+    const min = t.match(/minmax\(\s*([^,]+),/)[1].trim();
+    const px = min.match(/^(\d+)px$/);
+    sum += px ? Number(px[1]) : 0;
+  }
+  return { sum, count: tracks.length };
+}
+
+test("board grid fits the default window so the last column is not clipped (SC-1451)", () => {
+  const value = gridTemplateColumns(".board");
+  assert.ok(value, ".board must set grid-template-columns");
+  const { sum, count } = boardMinWidth(value);
+  const minWidth = sum + (count - 1) * GAP + BOARD_PADDING;
+  assert.ok(
+    minWidth <= BOARD_AREA,
+    `board intrinsic min-width ${minWidth}px must fit the ${BOARD_AREA}px board ` +
+      `area (window ${WINDOW_WIDTH} − ${RAIL_WIDTH}px rail) so 'Ready to Deploy' ` +
+      `is not clipped on cold open (SC-1451)`,
+  );
+});
+
+test("idea-space lanes are compressible so the Ideas track never clips inside (SC-1451)", () => {
+  const value = gridTemplateColumns(".idea-space-grid");
+  assert.ok(value, ".idea-space-grid must set grid-template-columns");
+  const { sum } = boardMinWidth(value);
+  assert.equal(
+    sum, 0,
+    "idea-space lanes must use minmax(0, …) floors so the five lanes shrink " +
+      "with the Ideas track instead of forcing a ~500px inner min-width (SC-1451)",
+  );
+});
+
+test("board exposes a persistent horizontal scroll affordance (SC-1451)", () => {
+  assert.match(
+    exactRuleBody(".board"), /scrollbar-gutter:\s*stable/,
+    ".board must reserve a stable scrollbar gutter so scroll is discoverable",
+  );
+  assert.match(
+    stripped, /\.board::-webkit-scrollbar\s*\{[^}]*height:\s*\d+px/,
+    ".board must style ::-webkit-scrollbar so WebKitGTK shows a visible bar",
+  );
+});

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -204,10 +204,13 @@ body {
 .board {
   display: grid;
   /* The wide idea-space track (five loose→concrete sub-columns), four queue
-     columns, and the slim terminal Deploy drop zone; min-widths keep each
-     readable and the board scrolls horizontally on narrow windows instead of
-     squishing cards into slivers. */
-  grid-template-columns: minmax(540px, 2.4fr) repeat(4, minmax(170px, 1fr)) minmax(80px, 110px);
+     columns, and the slim terminal Deploy drop zone. The Ideas track has a
+     0 floor (not a px minimum) so it absorbs compression at the default
+     window size instead of forcing the deploy-side columns off-screen
+     (SC-1451); the four queue columns keep their 170px floors so they stay
+     readable, and the board still scrolls horizontally when even that is not
+     enough room. */
+  grid-template-columns: minmax(0, 2.4fr) repeat(4, minmax(170px, 1fr)) minmax(80px, 110px);
   /* Bound the single row to the board's own height so columns can never grow
      past the space below the header (the old 100vh-based column max-height did,
      which pushed the document 20px taller than the viewport). */
@@ -216,6 +219,19 @@ body {
   padding: 12px;
   height: 100%;
   overflow-x: auto;
+  /* Reserve the scrollbar's space up front so its later appearance (once
+     content genuinely overflows) never shifts the board layout (SC-1451). */
+  scrollbar-gutter: stable;
+}
+.board::-webkit-scrollbar {
+  height: 10px;
+}
+.board::-webkit-scrollbar-thumb {
+  background: var(--col-border);
+  border-radius: 5px;
+}
+.board::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 /* The idea space: the Ideas queue widened into five lanes spanning a
@@ -242,8 +258,11 @@ body {
   min-height: 0;
   display: grid;
   /* Sub-columns run narrower than regular queues: idea cards are title-only
-     captures, and five of them must share one board track. */
-  grid-template-columns: repeat(5, minmax(100px, 1fr));
+     captures, and five of them must share one board track. The 0 floor lets
+     the lanes shrink with the Ideas track itself rather than forcing a fixed
+     500px inner min-width that would clip inside the (now compressible)
+     outer track (SC-1451). */
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   grid-auto-rows: minmax(0, 1fr);
   gap: 0;
 }


### PR DESCRIPTION
PM ticket: 1451
Branch: autofix/sc-1451
