### PR TITLE
[SC-1857] Gate a board drop on the derived card, not a raw stage scan

### DIFF
--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -199,12 +199,10 @@ func (d BoardTransitionDeps) ApplyTransition(ctx context.Context, req BoardTrans
 	}
 	card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
 
-	// Idempotency: if the target stage already has an open *-started marker, a
-	// duplicate drop (e.g. a quick re-drag before the board refetches) must not
-	// launch a second agent or re-post the marker. Checked first because a
-	// re-drop derives the card as already sitting in the target stage, which
-	// the forward-only rule below would otherwise reject as a non-advance.
-	if _, state := latestStageState(comments, req.To); state == BoardRunning {
+	// Idempotency, checked first because a re-drop derives the card as already
+	// sitting in the target stage, which the forward-only rule below would
+	// otherwise reject as a non-advance.
+	if isDuplicateDrop(req.To, card) {
 		return nil
 	}
 
@@ -328,8 +326,9 @@ func (d BoardTransitionDeps) ApplyFix(ctx context.Context, req BoardFixRequest) 
 	// into) rather than a whole-card check on purpose: DeriveBoardCard reports
 	// the FURTHEST stage's state, so a stale [human:deploy-failed] marker pins
 	// the card to done/failed and structurally hides a running re-fix from a
-	// whole-card guard (SC-230). latestStageState mirrors ApplyTransition's
-	// duplicate-drop guard and is immune to that masking.
+	// whole-card guard (SC-230). Deliberately NOT the derived-card guard
+	// ApplyTransition uses: these two stages carry no supersede semantics, so a
+	// raw scan is both accurate here and immune to that masking.
 	if _, state := latestStageState(comments, BoardImplementation); state == BoardRunning {
 		return nil
 	}
@@ -1060,6 +1059,24 @@ func isReviewRetry(to BoardStage, card BoardCard) bool {
 	return to == BoardVerification &&
 		card.Stage == BoardVerification &&
 		card.State == BoardFailed
+}
+
+// isDuplicateDrop reports a drop onto a stage the card is already working, so a
+// quick re-drag before the board refetches cannot launch a second agent.
+//
+// The DERIVED card — not a raw per-stage marker scan — is the authority, and the
+// two genuinely disagree: DeriveBoardCard retires a done-stage marker the
+// pipeline has moved past (supersededByNewerMarker), a raw scan never does. A PR
+// review→fix loop that escalates to a [human:options] block leaves
+// [human:pr-fix-started] as the newest done-stage marker forever — the
+// escalation posts its block against the implementation stage, and nothing ever
+// closes the done stage. Once the chosen rebuild lands and its review passes,
+// the board (deriving) offers the Deploy drop while a raw scan still reads
+// "running": every drop was swallowed by a nil return no human could see or
+// clear (SC-1857). Gating on the derivation the board itself renders keeps the
+// two answering the same question.
+func isDuplicateDrop(to BoardStage, card BoardCard) bool {
+	return card.Stage == to && card.State == BoardRunning
 }
 
 // isReworkTransition reports the one allowed backward move: re-running the

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -433,6 +433,71 @@ func TestApplyTransitionIdempotentDuplicate(t *testing.T) {
 	assert.Empty(t, c.added)
 }
 
+// escalatedLoopThenRebuilt is the marker thread SC-1857 stranded: the PR
+// review→fix loop escalated to a [human:options] block (which the escalation
+// posts against the IMPLEMENTATION stage), the chosen rebuild ran, and its
+// review passed. [human:pr-fix-started] is left as the newest done-stage marker
+// forever — nothing in the loop ever closes the done stage.
+func escalatedLoopThenRebuilt() []tracker.Comment {
+	return []tracker.Comment{
+		cmt("[human:pr-review-started]\nnumber: 257\nbranch: autofix/x", time.Unix(1, 0)),
+		cmt("[human:pr-fix-started]", time.Unix(2, 0)),
+		cmt("[human:options]\nstage: implementation\ncontext: the fixer needs a decision\n1: Rebuild the branch", time.Unix(3, 0)),
+		cmt("[human:option-chosen] 1: Rebuild the branch", time.Unix(4, 0)),
+		cmt("[human:implementation-started]", time.Unix(5, 0)),
+		cmt("[human:ready-for-review]\nbranch: autofix/x\ncommits: abc1234", time.Unix(6, 0)),
+		cmt("[human:review-started]", time.Unix(7, 0)),
+		cmt("[human:review-complete]\nverdict: pass", time.Unix(8, 0)),
+	}
+}
+
+func TestApplyTransitionDeployAfterEscalatedLoop(t *testing.T) {
+	// SC-1857: the board derives this card to verification/done and offers the
+	// Deploy drop, but the raw done stage still reads "running" off the stranded
+	// [human:pr-fix-started]. Gating on the raw scan swallowed every drop with a
+	// silent nil; gating on the derived card ships it.
+	comments := escalatedLoopThenRebuilt()
+	card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
+	require.Equal(t, BoardVerification, card.Stage, "board offers the Deploy drop")
+	require.Equal(t, BoardDone, card.State)
+	_, raw := latestStageState(comments, BoardDoneStage)
+	require.Equal(t, BoardRunning, raw, "raw done stage disagrees — the trap")
+
+	syncPRReview(t)
+	c := &fakeCommenter{comments: comments}
+	p := &fakeDeployer{res: PRResult{Number: 257, URL: "https://github.com/o/r/pull/257"}}
+	deps := newDeps(c, &fakeLauncher{}, p)
+
+	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{
+		PMKey: "SC-1", From: BoardVerification, To: BoardDoneStage})
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, c.added, "the drop must do something visible, not return a silent nil")
+}
+
+func TestApplyTransitionRunningDeployStillIdempotent(t *testing.T) {
+	// The other half of the contract: a genuinely in-flight loop — the same
+	// thread WITHOUT the rebuild that moved past it — still derives to
+	// done/running and must not launch a second deploy on a re-drop.
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:ready-for-review]\nbranch: autofix/x", time.Unix(1, 0)),
+		cmt("[human:review-complete]\nverdict: pass", time.Unix(2, 0)),
+		cmt("[human:pr-review-started]\nnumber: 257\nbranch: autofix/x", time.Unix(3, 0)),
+		cmt("[human:pr-fix-started]", time.Unix(4, 0)),
+	}}
+	l := &fakeLauncher{}
+	p := &fakeDeployer{}
+	deps := newDeps(c, l, p)
+
+	err := deps.ApplyTransition(context.Background(), BoardTransitionRequest{
+		PMKey: "SC-1", From: BoardVerification, To: BoardDoneStage})
+
+	require.NoError(t, err)
+	assert.Zero(t, l.calls)
+	assert.Zero(t, p.call)
+	assert.Empty(t, c.added)
+}
+
 func TestApplyTransitionDoneNoBranch(t *testing.T) {
 	c := &fakeCommenter{comments: []tracker.Comment{cmt("[human:review-complete]", time.Unix(1, 0))}}
 	p := &fakeDeployer{}


### PR DESCRIPTION
Fixes SC-1857 — the defect that made SC-1693 un-deployable through seven Deploy drops.

## The bug

`ApplyTransition`'s idempotency guard read the target stage **raw** (`latestStageState`), while the board renders `DeriveBoardCard`. The two disagree by design: the derivation retires a done-stage marker the pipeline has moved past (`supersededByNewerMarker`), a raw scan never does.

A PR review→fix loop that escalates to a `[human:options]` block posts that block against the *implementation* stage and never closes the done stage — so `[human:pr-fix-started]` stays the newest done-stage marker forever. Once the chosen rebuild lands and its review passes:

- `DeriveBoardCard` → **verification/done** → the board offers the Deploy drop.
- `latestStageState(done)` → **running** → the guard returns `nil`.

No marker, no agent, no error, no board feedback. Observed on SC-1693: seven `board-transition` requests, every one a silent no-op, with no way for a human to clear it.

## The fix

Gate on the derived card, extracted as `isDuplicateDrop` alongside its `is*Retry` siblings (also keeps `ApplyTransition` under the gocyclo bound).

Genuine in-flight work still derives to `running`, so duplicate drops stay idempotent. `ApplyFix`/`ApplySecurityFix` keep their deliberately stage-scoped raw scans — those two stages carry no supersede semantics and the scan dodges the SC-230 masking — and their now-stale cross-reference comment is corrected.

## Tests

Both halves of the contract, verified fails-before/passes-after:

- `TestApplyTransitionDeployAfterEscalatedLoop` — the escalated-then-rebuilt thread deploys. Fails on `main` with *"the drop must do something visible, not return a silent nil"*.
- `TestApplyTransitionRunningDeployStillIdempotent` — a live loop still refuses the second launch.

`make check` green: 3807 tests, 0 lint issues, gosec/govulncheck/gitleaks clean.

## Scope note

The ticket's third Wanted item — *"a refused drop must never be silent"* — turned out to rest on a wrong premise I wrote into it. Genuine refusals already surface: `handleBoardTransition` → `writeError` → `daemonCause` → `showError`, with `runGuardedAction` keeping the reconcile from clobbering the banner (SC-637). The only silent path was this guard's `nil`, which is correct for a real duplicate. Nothing to build there; the premise is corrected on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)