### PR TITLE
[SC-1698] Closing a ticket cancels its run — and the reconcile net reaches the orphans

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -361,7 +361,7 @@ func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, de
 		BoardOptioner:      boardOptionerFunc(projectRegistry, vaultResolver, daemonID, logger, launchGate),
 		BugCreator:         bugCreatorFunc(projectRegistry, vaultResolver),
 		SecurityCreator:    securityCreatorFunc(projectRegistry, vaultResolver),
-		CloseTicketer:      closeTicketerFunc(projectRegistry, vaultResolver),
+		CloseTicketer:      closeTicketerFunc(projectRegistry, vaultResolver, liveBoardAgents, (&dockerAgentCleaner{}).DeleteAgent, logger),
 		FeaturesGenerator:  featuresGeneratorFunc(projectRegistry),
 		FindbugsRunner:     findbugsRunnerFunc(projectRegistry),
 		SecurityRunner:     securityRunnerFunc(projectRegistry),
@@ -2224,12 +2224,20 @@ func resolvePMTransitioner(dir string, lookup config.EnvLookup, resolver *vault.
 	return nil, errors.WithDetails("no PM-role tracker with transition support configured", "dir", dir)
 }
 
-// closeTicketerFunc builds the daemon's CloseTicketer closure: it resolves the
-// PM transitioner by role per request and moves the ticket to its Done status.
-// "done" is the status CATEGORY, not a literal label — the tracker resolves it
-// to the workflow's done state, the same convention `issue start` uses with
-// "started", so no team-specific status name is hardcoded.
-func closeTicketerFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver) func(daemon.CloseTicketRequest) error {
+// closeTicketerFunc builds the daemon's CloseTicketer closure: it stops any live
+// run claiming the ticket, then resolves the PM transitioner by role per request
+// and moves the ticket to its Done status. "done" is the status CATEGORY, not a
+// literal label — the tracker resolves it to the workflow's done state, the same
+// convention `issue start` uses with "started", so no team-specific status name
+// is hardcoded.
+//
+// Closing IS cancellation (1698): the board close reads to the user as "stop
+// this", so it must actually stop the claiming agent and release its container
+// before the ticket leaves the board — otherwise the run keeps working invisibly
+// against a closed card. The stop precedes the transition so a stop failure
+// still leaves the card open (and thus reachable by the reconcile safety net)
+// rather than closing over a run that refused to die.
+func closeTicketerFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver, liveAgents func() ([]string, error), stopAgent func(context.Context, string) error, logger zerolog.Logger) func(daemon.CloseTicketRequest) error {
 	return func(req daemon.CloseTicketRequest) error {
 		entries := reg.Entries()
 		if len(entries) == 0 {
@@ -2237,6 +2245,11 @@ func closeTicketerFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver) fu
 		}
 		entry := entries[0]
 		lookup := entry.EnvLookup()
+
+		stopCtx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		daemon.StopAgentsForPMKey(stopCtx, req.PMKey, liveAgents, stopAgent, logger)
+		cancel()
+
 		transitioner, err := resolvePMTransitioner(entry.Dir, lookup, resolver)
 		if err != nil {
 			return err

--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -662,6 +662,7 @@ func runDaemonForeground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string,
 		boardReconcileListerFunc(ds.srv.Projects, ds.vaultResolver, logger),
 		branchReachable, commitsPresent, prMerged, postDeployed,
 		liveBoardAgents, postFailedMarkerFunc(ds.srv.Projects, ds.vaultResolver, ds.daemonID),
+		closedTicketProbeFunc(ds.srv.Projects, ds.vaultResolver),
 		chainReview, advancePRLoop, stageRetry, agentProgress, stopHungAgent, ds.daemonID, daemon.BoardReconcileInterval, logger)
 
 	// Surface tickets created or edited outside the board (tracker web UI, CLI,
@@ -2202,6 +2203,55 @@ func resolvePMCommenter(dir string, lookup config.EnvLookup, resolver *vault.Res
 		}
 	}
 	return nil, errors.WithDetails("no PM-role tracker with comment support configured", "dir", dir)
+}
+
+// resolvePMGetter resolves the PM-role tracker.Getter for a workspace.
+// Role-based selection (InferRole()=="pm"), never key prefix — mirrors
+// resolvePMCommenter. tracker.Provider embeds Getter, so the PM instance
+// satisfies it.
+func resolvePMGetter(dir string, lookup config.EnvLookup, resolver *vault.Resolver) (tracker.Getter, error) {
+	instances, err := cmdutil.LoadAllInstancesWithResolver(dir, lookup, resolver)
+	if err != nil {
+		return nil, err
+	}
+	for _, inst := range instances {
+		if inst.InferRole() != "pm" {
+			continue
+		}
+		if g, ok := inst.Provider.(tracker.Getter); ok {
+			return g, nil
+		}
+	}
+	return nil, errors.WithDetails("no PM-role tracker with fetch support configured", "dir", dir)
+}
+
+// closedTicketProbeFunc builds the reconcile pass's ClosedTicketProbe: it fetches
+// one PM ticket by key and reports whether its status has landed in the done or
+// closed category — the same categories DeriveBoardCard hides the card on.
+//
+// It is asked only about a key no open card matched, so it stays off the hot
+// path entirely on a healthy board. Every failure propagates as an error rather
+// than a false: the caller must be able to tell "confirmed closed" from "could
+// not tell", because only the former may stop a live run (1698).
+func closedTicketProbeFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver) daemon.ClosedTicketProbe {
+	return func(ctx context.Context, pmKey string) (bool, error) {
+		entries := reg.Entries()
+		if len(entries) == 0 {
+			return false, errors.WithDetails("no project registered for the closed-ticket probe", "pm", pmKey)
+		}
+		entry := entries[0]
+		getter, err := resolvePMGetter(entry.Dir, entry.EnvLookup(), resolver)
+		if err != nil {
+			return false, err
+		}
+		fetchCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+		issue, err := getter.GetIssue(fetchCtx, pmKey)
+		if err != nil {
+			return false, errors.WrapWithDetails(err, "fetching PM ticket to confirm it is closed", "pm", pmKey)
+		}
+		return issue.StatusType == tracker.CategoryDone || issue.StatusType == tracker.CategoryClosed, nil
+	}
 }
 
 // resolvePMTransitioner resolves the PM-role tracker.Transitioner for a

--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -2234,9 +2234,10 @@ func resolvePMTransitioner(dir string, lookup config.EnvLookup, resolver *vault.
 // Closing IS cancellation (1698): the board close reads to the user as "stop
 // this", so it must actually stop the claiming agent and release its container
 // before the ticket leaves the board — otherwise the run keeps working invisibly
-// against a closed card. The stop precedes the transition so a stop failure
-// still leaves the card open (and thus reachable by the reconcile safety net)
-// rather than closing over a run that refused to die.
+// against a closed card. The transition is GATED on a confirmed stop: if the run
+// could not be stopped (or could not even be enumerated to stop it), the ticket
+// is left open — and thus reachable by the reconcile safety net, which lists open
+// cards only — rather than closing over a run that refused to die.
 func closeTicketerFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver, liveAgents func() ([]string, error), stopAgent func(context.Context, string) error, logger zerolog.Logger) func(daemon.CloseTicketRequest) error {
 	return func(req daemon.CloseTicketRequest) error {
 		entries := reg.Entries()
@@ -2247,8 +2248,11 @@ func closeTicketerFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver, li
 		lookup := entry.EnvLookup()
 
 		stopCtx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
-		daemon.StopAgentsForPMKey(stopCtx, req.PMKey, liveAgents, stopAgent, logger)
+		_, stopErr := daemon.StopAgentsForPMKey(stopCtx, req.PMKey, liveAgents, stopAgent, logger)
 		cancel()
+		if stopErr != nil {
+			return stopErr
+		}
 
 		transitioner, err := resolvePMTransitioner(entry.Dir, lookup, resolver)
 		if err != nil {

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -418,7 +418,7 @@ function showCardMenu(card, x, y) {
     closeItem.textContent = "Close ticket";
     closeItem.addEventListener("click", () => {
         menu.remove();
-        void requestClose(card.key, card.title);
+        void requestClose(card.key, card.title, card.state === "running");
     });
     menu.appendChild(closeItem);
     menu.style.left = `${x}px`;
@@ -1408,9 +1408,14 @@ async function transition(key, title, from, to) {
     }, reconcile);
 }
 // requestClose confirms in-app (never the OS dialog) before closing, so a stray
-// drop cannot silently close a ticket.
-async function requestClose(key, title) {
-    const ok = await confirmDialog(`Close ticket ${key}?`, `“${title}” will be marked Done and removed from the board.`, "Close ticket");
+// drop cannot silently close a ticket. When a run is live, the dialog says so
+// explicitly: closing IS cancellation (1698), so the confirm must not read as a
+// harmless "mark Done" when it will actually stop work in progress.
+async function requestClose(key, title, running) {
+    const body = running
+        ? `“${title}” has a live run. Closing will stop the run — its container is released and any uncommitted work is discarded — and mark the ticket Done.`
+        : `“${title}” will be marked Done and removed from the board.`;
+    const ok = await confirmDialog(`Close ticket ${key}?`, body, "Close ticket");
     if (ok)
         await closeTicket(key);
 }

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -767,7 +767,7 @@ function showCardMenu(card: Card, x: number, y: number): void {
   closeItem.textContent = "Close ticket";
   closeItem.addEventListener("click", () => {
     menu.remove();
-    void requestClose(card.key, card.title);
+    void requestClose(card.key, card.title, card.state === "running");
   });
   menu.appendChild(closeItem);
 
@@ -1808,13 +1808,18 @@ async function transition(key: string, title: string, from: string, to: string):
 }
 
 // requestClose confirms in-app (never the OS dialog) before closing, so a stray
-// drop cannot silently close a ticket.
-async function requestClose(key: string, title: string): Promise<void> {
-  const ok = await confirmDialog(
-    `Close ticket ${key}?`,
-    `“${title}” will be marked Done and removed from the board.`,
-    "Close ticket",
-  );
+// drop cannot silently close a ticket. When a run is live, the dialog says so
+// explicitly: closing IS cancellation (1698), so the confirm must not read as a
+// harmless "mark Done" when it will actually stop work in progress.
+async function requestClose(
+  key: string,
+  title: string,
+  running: boolean,
+): Promise<void> {
+  const body = running
+    ? `“${title}” has a live run. Closing will stop the run — its container is released and any uncommitted work is discarded — and mark the ticket Done.`
+    : `“${title}” will be marked Done and removed from the board.`;
+  const ok = await confirmDialog(`Close ticket ${key}?`, body, "Close ticket");
   if (ok) await closeTicket(key);
 }
 

--- a/internal/daemon/board_reconcile.go
+++ b/internal/daemon/board_reconcile.go
@@ -102,7 +102,7 @@ type FailedMarkerPoster func(ctx context.Context, pmKey, body string) error
 // It runs one pass immediately at start (recovers a restart-orphaned handoff
 // without waiting a full interval) then on a ticker, mirroring
 // RunAgentZombieSweep. nil deps disable it.
-func RunBoardReconcile(ctx context.Context, listCards ReconcileLister, reachable BranchReachable, commitsPresent CommitsPresent, mergedProbe PRMergedProbe, postDeployed DeployedPoster, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, chainReview func(pmKey string) error, driveLoop func(pmKey string) error, retry StageRetry, progress AgentProgressProbe, stopAgent func(agentName string) error, daemonID string, interval time.Duration, logger zerolog.Logger) {
+func RunBoardReconcile(ctx context.Context, listCards ReconcileLister, reachable BranchReachable, commitsPresent CommitsPresent, mergedProbe PRMergedProbe, postDeployed DeployedPoster, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, closedProbe ClosedTicketProbe, chainReview func(pmKey string) error, driveLoop func(pmKey string) error, retry StageRetry, progress AgentProgressProbe, stopAgent func(agentName string) error, daemonID string, interval time.Duration, logger zerolog.Logger) {
 	if listCards == nil || chainReview == nil {
 		return
 	}
@@ -112,14 +112,14 @@ func RunBoardReconcile(ctx context.Context, listCards ReconcileLister, reachable
 	// Recover a restart-orphaned handoff immediately, before the first wait. The
 	// jitter applies only to subsequent cycles, so a restart-orphan is never made
 	// to wait a full interval.
-	reconcileOnce(ctx, listCards, reachable, commitsPresent, mergedProbe, postDeployed, liveAgents, postFailed, chainReview, driveLoop, retry, progress, stopAgent, daemonID, logger)
+	reconcileOnce(ctx, listCards, reachable, commitsPresent, mergedProbe, postDeployed, liveAgents, postFailed, closedProbe, chainReview, driveLoop, retry, progress, stopAgent, daemonID, logger)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-time.After(jitteredInterval(interval, BoardReconcileJitter)):
-			reconcileOnce(ctx, listCards, reachable, commitsPresent, mergedProbe, postDeployed, liveAgents, postFailed, chainReview, driveLoop, retry, progress, stopAgent, daemonID, logger)
+			reconcileOnce(ctx, listCards, reachable, commitsPresent, mergedProbe, postDeployed, liveAgents, postFailed, closedProbe, chainReview, driveLoop, retry, progress, stopAgent, daemonID, logger)
 		}
 	}
 }
@@ -142,7 +142,7 @@ func jitteredInterval(d time.Duration, fraction float64) time.Duration {
 
 // reconcileOnce runs a single reconcile pass. A transient list error is logged
 // and skipped so a momentary tracker blip never kills the loop.
-func reconcileOnce(ctx context.Context, listCards ReconcileLister, reachable BranchReachable, commitsPresent CommitsPresent, mergedProbe PRMergedProbe, postDeployed DeployedPoster, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, chainReview func(pmKey string) error, driveLoop func(pmKey string) error, retry StageRetry, progress AgentProgressProbe, stopAgent func(agentName string) error, daemonID string, logger zerolog.Logger) {
+func reconcileOnce(ctx context.Context, listCards ReconcileLister, reachable BranchReachable, commitsPresent CommitsPresent, mergedProbe PRMergedProbe, postDeployed DeployedPoster, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, closedProbe ClosedTicketProbe, chainReview func(pmKey string) error, driveLoop func(pmKey string) error, retry StageRetry, progress AgentProgressProbe, stopAgent func(agentName string) error, daemonID string, logger zerolog.Logger) {
 	cards, err := listCards(ctx)
 	if err != nil {
 		logger.Warn().Err(err).Msg("board reconcile: cannot list PM cards")
@@ -162,6 +162,12 @@ func reconcileOnce(ctx context.Context, listCards ReconcileLister, reachable Bra
 	}
 	if n := reconcileStuckRunning(ctx, cards, liveAgents, postFailed, retry, progress, stopAgent, daemonID, time.Now(), logger); n > 0 {
 		logger.Info().Int("reddened", n).Msg("board reconcile: reddened stuck-running cards with no live agent")
+	}
+	// Last: the passes above all act on cards that are still ON the board, while
+	// this one reaches the runs whose card has left it — the orphan the close
+	// gate cannot cover because the ticket was closed outside the board (1698).
+	if n := reconcileOrphanedAgents(ctx, cards, liveAgents, closedProbe, stopAgent, logger); n > 0 {
+		logger.Info().Int("stopped", n).Msg("board reconcile: stopped agents orphaned on closed tickets")
 	}
 }
 

--- a/internal/daemon/board_reconcile_orphan.go
+++ b/internal/daemon/board_reconcile_orphan.go
@@ -1,0 +1,98 @@
+package daemon
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+)
+
+// ClosedTicketProbe reports whether pmKey's ticket has left the board as
+// done/closed. It is the authority the orphan sweep needs because the reconcile
+// lister enumerates OPEN cards only: absence from that list is not proof a
+// ticket was closed (a flaky per-ticket fetch drops it too), so the sweep never
+// stops a run on absence alone — it asks. A nil probe disables the sweep (the
+// package's "nil disables" convention).
+type ClosedTicketProbe func(ctx context.Context, pmKey string) (bool, error)
+
+// reconcileOrphanedAgents stops board agents still running against a ticket that
+// has left the board as done/closed — the orphan the close gate cannot cover
+// (1698). Closing FROM the board now stops the run before it transitions, but a
+// ticket closed anywhere else (the tracker's own web UI, `human close`, a
+// teammate, or a close that predates the gate) never passes through that path,
+// and the reconcile net that would otherwise recover the card enumerates open
+// cards only. Such an agent would keep working invisibly against a closed
+// ticket: holding its container and worktree, posting markers, even pushing
+// commits for work the user called off.
+//
+// It works from the AGENT side rather than the ticket side, so it costs nothing
+// on a healthy board: an agent whose key matches an open card is dismissed
+// without a tracker call, and only a key with no open card is probed. Every
+// uncertainty resolves to "leave it running" — an unparseable name, a probe
+// error, or a ticket that is merely absent rather than confirmed closed — because
+// killing live work on absent evidence is the one failure this must never risk.
+func reconcileOrphanedAgents(ctx context.Context, cards []ReconcileCard, liveAgents LiveAgentLister, closed ClosedTicketProbe, stopAgent func(agentName string) error, logger zerolog.Logger) int {
+	if liveAgents == nil || closed == nil || stopAgent == nil {
+		return 0
+	}
+	names, err := liveAgents()
+	if err != nil {
+		logger.Warn().Err(err).Msg("board reconcile: cannot list live agents for orphan sweep")
+		return 0
+	}
+	// Agent names embed the SANITIZED key, so open cards are matched through the
+	// same sanitize() the launcher used — raw-key equality would miss any key
+	// carrying characters the name encoding replaced.
+	open := make(map[string]struct{}, len(cards))
+	for _, card := range cards {
+		open[sanitize(card.Key)] = struct{}{}
+	}
+	candidates, order := orphanCandidates(names, open)
+
+	stopped := 0
+	for _, key := range order {
+		isClosed, probeErr := closed(ctx, key)
+		if probeErr != nil {
+			logger.Warn().Err(probeErr).Str("pm", key).
+				Msg("board reconcile: cannot confirm ticket is closed, leaving its run alone")
+			continue
+		}
+		if !isClosed {
+			continue
+		}
+		for _, name := range candidates[key] {
+			if err := stopAgent(name); err != nil {
+				logger.Warn().Err(err).Str("pm", key).Str("agent", name).
+					Msg("board reconcile: cannot stop agent orphaned on a closed ticket")
+				continue
+			}
+			logger.Info().Str("pm", key).Str("agent", name).
+				Msg("board reconcile: stopped agent orphaned on a closed ticket")
+			stopped++
+		}
+	}
+	return stopped
+}
+
+// orphanCandidates groups the live board agents whose PM key matches no open
+// card, keyed by that PM key, plus the keys in encounter order so the probe
+// round-trips (and the log they produce) are deterministic rather than map-order.
+// One key can hold several agents — the stages of one card — and they share a
+// single probe.
+func orphanCandidates(names []string, open map[string]struct{}) (map[string][]string, []string) {
+	candidates := make(map[string][]string)
+	var order []string
+	for _, name := range names {
+		key, _, ok := parseAgentName(name)
+		if !ok {
+			continue
+		}
+		if _, isOpen := open[key]; isOpen {
+			continue
+		}
+		if _, seen := candidates[key]; !seen {
+			order = append(order, key)
+		}
+		candidates[key] = append(candidates[key], name)
+	}
+	return candidates, order
+}

--- a/internal/daemon/board_reconcile_orphan_test.go
+++ b/internal/daemon/board_reconcile_orphan_test.go
@@ -1,0 +1,185 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+// openCards builds the reconcile input for keys that are still on the board.
+func openCards(keys ...string) []ReconcileCard {
+	cards := make([]ReconcileCard, 0, len(keys))
+	for _, k := range keys {
+		cards = append(cards, ReconcileCard{Key: k})
+	}
+	return cards
+}
+
+// closedKeys builds a probe that confirms exactly the named keys as closed.
+func closedKeys(keys ...string) ClosedTicketProbe {
+	closed := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		closed[k] = struct{}{}
+	}
+	return func(_ context.Context, key string) (bool, error) {
+		_, ok := closed[key]
+		return ok, nil
+	}
+}
+
+// The defect this fixes: a ticket closed OUTSIDE the board (tracker web UI,
+// `human close`, a teammate) never passes through the close gate, and the
+// reconcile net enumerates open cards only — so its agent kept working
+// invisibly against a closed ticket forever.
+func TestReconcileOrphanedAgents_StopsAgentOnTicketClosedOutsideTheBoard(t *testing.T) {
+	var stopped []string
+
+	n := reconcileOrphanedAgents(context.Background(), openCards("SC-2"),
+		liveAgents("board-SC-1-implementation"), closedKeys("SC-1"),
+		func(name string) error { stopped = append(stopped, name); return nil },
+		zerolog.Nop())
+
+	require.Equal(t, 1, n)
+	require.Equal(t, []string{"board-SC-1-implementation"}, stopped,
+		"the run orphaned on the closed ticket must be stopped")
+}
+
+// One card can hold several stage agents; a single probe covers them all.
+func TestReconcileOrphanedAgents_StopsEveryStageOfTheClosedTicket(t *testing.T) {
+	var stopped []string
+	probes := 0
+	probe := func(_ context.Context, key string) (bool, error) {
+		probes++
+		return key == "SC-1", nil
+	}
+
+	n := reconcileOrphanedAgents(context.Background(), nil,
+		liveAgents("board-SC-1-implementation", "board-SC-1-verification"), probe,
+		func(name string) error { stopped = append(stopped, name); return nil },
+		zerolog.Nop())
+
+	require.Equal(t, 2, n)
+	require.ElementsMatch(t, []string{"board-SC-1-implementation", "board-SC-1-verification"}, stopped)
+	require.Equal(t, 1, probes, "the stages of one card share a single probe round-trip")
+}
+
+// An agent whose card is still on the board is dismissed without ever reaching
+// the tracker — the sweep must cost nothing on a healthy board.
+func TestReconcileOrphanedAgents_OpenCardIsNeverProbed(t *testing.T) {
+	probed := false
+	probe := func(context.Context, string) (bool, error) {
+		probed = true
+		return true, nil
+	}
+
+	n := reconcileOrphanedAgents(context.Background(), openCards("SC-1"),
+		liveAgents("board-SC-1-implementation"), probe,
+		func(string) error { t.Fatal("a live run on an open card must never be stopped"); return nil },
+		zerolog.Nop())
+
+	require.Zero(t, n)
+	require.False(t, probed, "an agent matching an open card needs no tracker call")
+}
+
+// Absence from the open-card list is NOT proof of a close: a flaky per-ticket
+// comment fetch drops a healthy card too, so only a confirmed close may kill.
+func TestReconcileOrphanedAgents_AbsentButOpenTicketIsLeftRunning(t *testing.T) {
+	n := reconcileOrphanedAgents(context.Background(), nil,
+		liveAgents("board-SC-1-implementation"), closedKeys(),
+		func(string) error { t.Fatal("a ticket that is merely absent must not stop its run"); return nil },
+		zerolog.Nop())
+
+	require.Zero(t, n)
+}
+
+// A probe that cannot answer resolves to "leave it running": killing live work
+// on absent evidence is the one failure this must never risk.
+func TestReconcileOrphanedAgents_ProbeErrorLeavesTheRunAlone(t *testing.T) {
+	probe := func(context.Context, string) (bool, error) {
+		return false, errors.New("tracker unreachable")
+	}
+
+	n := reconcileOrphanedAgents(context.Background(), nil,
+		liveAgents("board-SC-1-implementation"), probe,
+		func(string) error { t.Fatal("an unconfirmed close must not stop a run"); return nil },
+		zerolog.Nop())
+
+	require.Zero(t, n)
+}
+
+// A failed stop must not be counted as a stop, and must not abort the sweep for
+// the agents behind it.
+func TestReconcileOrphanedAgents_FailedStopIsNotCountedAndDoesNotAbort(t *testing.T) {
+	var attempted []string
+	stop := func(name string) error {
+		attempted = append(attempted, name)
+		if name == "board-SC-1-implementation" {
+			return errors.New("container refused to die")
+		}
+		return nil
+	}
+
+	n := reconcileOrphanedAgents(context.Background(), nil,
+		liveAgents("board-SC-1-implementation", "board-SC-1-verification"),
+		closedKeys("SC-1"), stop, zerolog.Nop())
+
+	require.Equal(t, 1, n, "only the confirmed stop counts")
+	require.Len(t, attempted, 2, "a failed stop must not abort the remaining agents")
+}
+
+// Names that are not board agents carry no PM key and must be ignored rather
+// than probed as if they were one.
+func TestReconcileOrphanedAgents_NonBoardAgentsAreIgnored(t *testing.T) {
+	probe := func(context.Context, string) (bool, error) {
+		t.Fatal("a non-board container must never be probed")
+		return false, nil
+	}
+
+	n := reconcileOrphanedAgents(context.Background(), nil,
+		liveAgents("some-other-container", "board-"), probe,
+		func(string) error { t.Fatal("a non-board container must never be stopped"); return nil },
+		zerolog.Nop())
+
+	require.Zero(t, n)
+}
+
+// A liveness probe that cannot enumerate the runs must not be read as "nothing
+// is running" — there is nothing to reconcile against.
+func TestReconcileOrphanedAgents_ListErrorIsNotAnEmptyFleet(t *testing.T) {
+	lister := func() ([]string, error) { return nil, errors.New("docker down") }
+
+	n := reconcileOrphanedAgents(context.Background(), nil, lister, closedKeys("SC-1"),
+		func(string) error { t.Fatal("nothing may be stopped without a live-agent list"); return nil },
+		zerolog.Nop())
+
+	require.Zero(t, n)
+}
+
+// nil deps disable the sweep, matching the package's convention for optional
+// dependencies.
+func TestReconcileOrphanedAgents_NilDepsDisableTheSweep(t *testing.T) {
+	stop := func(string) error { t.Fatal("a disabled sweep must stop nothing"); return nil }
+
+	require.Zero(t, reconcileOrphanedAgents(context.Background(), nil, nil, closedKeys("SC-1"), stop, zerolog.Nop()))
+	require.Zero(t, reconcileOrphanedAgents(context.Background(), nil, liveAgents("board-SC-1-implementation"), nil, stop, zerolog.Nop()))
+	require.Zero(t, reconcileOrphanedAgents(context.Background(), nil, liveAgents("board-SC-1-implementation"), closedKeys("SC-1"), nil, zerolog.Nop()))
+}
+
+// The open-card match runs through the same sanitize() the launcher used, so a
+// key carrying encoded characters still matches its own card.
+func TestReconcileOrphanedAgents_OpenCardMatchesThroughSanitizedKey(t *testing.T) {
+	probe := func(context.Context, string) (bool, error) {
+		t.Fatal("a sanitized key matching an open card needs no tracker call")
+		return false, nil
+	}
+
+	n := reconcileOrphanedAgents(context.Background(), openCards("proj_1"),
+		liveAgents(agentNameFor("proj_1", BoardImplementation)), probe,
+		func(string) error { t.Fatal("a live run on an open card must never be stopped"); return nil },
+		zerolog.Nop())
+
+	require.Zero(t, n)
+}

--- a/internal/daemon/board_reconcile_test.go
+++ b/internal/daemon/board_reconcile_test.go
@@ -171,7 +171,7 @@ func TestRunBoardReconcile_RecoversOrphanWithNoLiveEvent(t *testing.T) {
 	ctx := t.Context()
 	// A long interval proves the recovery comes from the immediate startup pass,
 	// not a ticker tick.
-	go RunBoardReconcile(ctx, lister, alwaysReachable, nil, nil, nil, nil, nil, chain, nil, StageRetry{}, nil, nil, "", time.Hour, zerolog.Nop())
+	go RunBoardReconcile(ctx, lister, alwaysReachable, nil, nil, nil, nil, nil, nil, chain, nil, StageRetry{}, nil, nil, "", time.Hour, zerolog.Nop())
 
 	select {
 	case pmKey := <-chained:

--- a/internal/daemon/close_cancel.go
+++ b/internal/daemon/close_cancel.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/rs/zerolog"
+
+	"github.com/gethuman-sh/human/errors"
 )
 
 // AgentsForPMKey returns the board-agent names in names that belong to pmKey,
@@ -28,39 +30,48 @@ func AgentsForPMKey(names []string, pmKey string) []string {
 }
 
 // StopAgentsForPMKey stops every live board agent claiming pmKey, releasing its
-// container and worktree, and returns how many it stopped. This is the
-// close-is-cancellation mechanism (1698): closing a ticket from the board must
-// stop the run it was cancelling, otherwise the agent keeps working invisibly
-// against a closed card — holding its container, posting markers to a closed
-// ticket, even pushing commits for work the user called off. The reconcile
-// safety net cannot reach it (it enumerates open cards only), so the stop has to
-// happen here, at the close.
+// container and worktree, and returns how many it stopped plus whether the stop
+// is fully confirmed. This is the close-is-cancellation mechanism (1698):
+// closing a ticket from the board must stop the run it was cancelling, otherwise
+// the agent keeps working invisibly against a closed card — holding its
+// container, posting markers to a closed ticket, even pushing commits for work
+// the user called off. The reconcile safety net cannot reach it (it enumerates
+// open cards only), so the stop has to happen here, at the close.
 //
-// Best-effort by design: a liveness probe that fails leaves the run alone (a
-// blip is not evidence of an agent to stop), and a stop that fails is logged and
-// the remaining agents are still attempted — mirroring the reconcile pass's
-// hung-agent stop. Stopping is idempotent, so a no-longer-present agent is
-// harmless.
-func StopAgentsForPMKey(ctx context.Context, pmKey string, liveAgents func() ([]string, error), stopAgent func(context.Context, string) error, logger zerolog.Logger) int {
+// The returned error is the close gate (1698 criterion 2): the caller must NOT
+// transition the ticket to done while it is non-nil, so the card stays open and
+// thus reachable by the reconcile safety net rather than closing over a run that
+// refused to die. It is non-nil when the stop could not be confirmed for every
+// agent — either the liveness probe failed (we cannot even enumerate the runs to
+// stop them) or a stop attempt itself failed. Every agent is still attempted
+// before returning, mirroring the reconcile pass's hung-agent stop, and stopping
+// is idempotent so a no-longer-present agent is harmless. A successful clean stop
+// (including the common "no agent claims this key") returns a nil error, which
+// lets the close proceed.
+func StopAgentsForPMKey(ctx context.Context, pmKey string, liveAgents func() ([]string, error), stopAgent func(context.Context, string) error, logger zerolog.Logger) (int, error) {
 	if liveAgents == nil || stopAgent == nil {
-		return 0
+		return 0, nil
 	}
 	names, err := liveAgents()
 	if err != nil {
 		logger.Warn().Err(err).Str("pm", pmKey).
-			Msg("close-cancel: cannot list live agents, leaving any run untouched")
-		return 0
+			Msg("close-cancel: cannot list live agents, keeping the card open so the reconcile net can reach any run")
+		return 0, errors.WithDetails("close-cancel: cannot list live agents to confirm the run is stopped", "pm", pmKey, "cause", err.Error())
 	}
-	stopped := 0
+	stopped, failed := 0, 0
 	for _, name := range AgentsForPMKey(names, pmKey) {
 		if err := stopAgent(ctx, name); err != nil {
 			logger.Warn().Err(err).Str("pm", pmKey).Str("agent", name).
-				Msg("close-cancel: cannot stop agent for closed ticket")
+				Msg("close-cancel: cannot stop agent for closed ticket, keeping the card open")
+			failed++
 			continue
 		}
 		logger.Info().Str("pm", pmKey).Str("agent", name).
 			Msg("close-cancel: stopped agent for closed ticket")
 		stopped++
 	}
-	return stopped
+	if failed > 0 {
+		return stopped, errors.WithDetails("close-cancel: could not stop every agent claiming the ticket", "pm", pmKey, "stopped", stopped, "failed", failed)
+	}
+	return stopped, nil
 }

--- a/internal/daemon/close_cancel.go
+++ b/internal/daemon/close_cancel.go
@@ -1,0 +1,66 @@
+package daemon
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+)
+
+// AgentsForPMKey returns the board-agent names in names that belong to pmKey,
+// across every stage. An agent name embeds the sanitized PM key (see
+// agentNameFor), so a live agent is matched by the same sanitize() the launcher
+// used — not by raw-key equality, which would miss keys carrying characters the
+// name-encoding replaced. Names that are not board agents (or are malformed) are
+// skipped.
+func AgentsForPMKey(names []string, pmKey string) []string {
+	want := sanitize(pmKey)
+	var out []string
+	for _, name := range names {
+		key, _, ok := parseAgentName(name)
+		if !ok {
+			continue
+		}
+		if key == want {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// StopAgentsForPMKey stops every live board agent claiming pmKey, releasing its
+// container and worktree, and returns how many it stopped. This is the
+// close-is-cancellation mechanism (1698): closing a ticket from the board must
+// stop the run it was cancelling, otherwise the agent keeps working invisibly
+// against a closed card — holding its container, posting markers to a closed
+// ticket, even pushing commits for work the user called off. The reconcile
+// safety net cannot reach it (it enumerates open cards only), so the stop has to
+// happen here, at the close.
+//
+// Best-effort by design: a liveness probe that fails leaves the run alone (a
+// blip is not evidence of an agent to stop), and a stop that fails is logged and
+// the remaining agents are still attempted — mirroring the reconcile pass's
+// hung-agent stop. Stopping is idempotent, so a no-longer-present agent is
+// harmless.
+func StopAgentsForPMKey(ctx context.Context, pmKey string, liveAgents func() ([]string, error), stopAgent func(context.Context, string) error, logger zerolog.Logger) int {
+	if liveAgents == nil || stopAgent == nil {
+		return 0
+	}
+	names, err := liveAgents()
+	if err != nil {
+		logger.Warn().Err(err).Str("pm", pmKey).
+			Msg("close-cancel: cannot list live agents, leaving any run untouched")
+		return 0
+	}
+	stopped := 0
+	for _, name := range AgentsForPMKey(names, pmKey) {
+		if err := stopAgent(ctx, name); err != nil {
+			logger.Warn().Err(err).Str("pm", pmKey).Str("agent", name).
+				Msg("close-cancel: cannot stop agent for closed ticket")
+			continue
+		}
+		logger.Info().Str("pm", pmKey).Str("agent", name).
+			Msg("close-cancel: stopped agent for closed ticket")
+		stopped++
+	}
+	return stopped
+}

--- a/internal/daemon/close_cancel_test.go
+++ b/internal/daemon/close_cancel_test.go
@@ -1,0 +1,104 @@
+package daemon
+
+import (
+	"context"
+	stderrors "errors"
+	"sort"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestAgentsForPMKey_MatchesEveryStageOfTheKey(t *testing.T) {
+	names := []string{
+		agentNameFor("SC-1698", BoardImplementation),
+		agentNameFor("SC-1698", BoardVerification),
+		agentNameFor("SC-99", BoardImplementation),
+		"not-a-board-agent",
+		"board-malformed",
+	}
+	got := AgentsForPMKey(names, "SC-1698")
+	sort.Strings(got)
+	want := []string{
+		agentNameFor("SC-1698", BoardImplementation),
+		agentNameFor("SC-1698", BoardVerification),
+	}
+	sort.Strings(want)
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestAgentsForPMKey_MatchesViaSanitizedKey(t *testing.T) {
+	// The raw key carries a character the name-encoding replaces; matching must
+	// go through the same sanitize() the launcher used, not raw equality.
+	name := agentNameFor("SC/1698", BoardImplementation)
+	if got := AgentsForPMKey([]string{name}, "SC/1698"); len(got) != 1 || got[0] != name {
+		t.Fatalf("sanitized match failed: got %v", got)
+	}
+}
+
+func TestStopAgentsForPMKey_StopsOnlyTheKeysAgents(t *testing.T) {
+	names := []string{
+		agentNameFor("SC-1698", BoardImplementation),
+		agentNameFor("SC-1698", BoardVerification),
+		agentNameFor("SC-99", BoardImplementation),
+	}
+	var stopped []string
+	n := StopAgentsForPMKey(context.Background(), "SC-1698",
+		func() ([]string, error) { return names, nil },
+		func(_ context.Context, name string) error { stopped = append(stopped, name); return nil },
+		zerolog.Nop())
+	if n != 2 {
+		t.Fatalf("stopped count = %d, want 2", n)
+	}
+	if len(stopped) != 2 {
+		t.Fatalf("stopped %v, want the two SC-1698 agents", stopped)
+	}
+}
+
+func TestStopAgentsForPMKey_ContinuesPastAStopFailure(t *testing.T) {
+	names := []string{
+		agentNameFor("SC-1698", BoardImplementation),
+		agentNameFor("SC-1698", BoardVerification),
+	}
+	var stopped []string
+	n := StopAgentsForPMKey(context.Background(), "SC-1698",
+		func() ([]string, error) { return names, nil },
+		func(_ context.Context, name string) error {
+			stopped = append(stopped, name)
+			if name == names[0] {
+				return stderrors.New("boom")
+			}
+			return nil
+		},
+		zerolog.Nop())
+	if n != 1 {
+		t.Fatalf("stopped count = %d, want 1 (one failed, one succeeded)", n)
+	}
+	if len(stopped) != 2 {
+		t.Fatalf("attempted %v, want both agents attempted despite the failure", stopped)
+	}
+}
+
+func TestStopAgentsForPMKey_LeavesRunsAloneWhenLivenessProbeFails(t *testing.T) {
+	stopCalled := false
+	n := StopAgentsForPMKey(context.Background(), "SC-1698",
+		func() ([]string, error) { return nil, stderrors.New("probe blip") },
+		func(_ context.Context, _ string) error { stopCalled = true; return nil },
+		zerolog.Nop())
+	if n != 0 || stopCalled {
+		t.Fatalf("a liveness-probe failure must stop nothing (n=%d stopCalled=%v)", n, stopCalled)
+	}
+}
+
+func TestStopAgentsForPMKey_NilDepsAreNoOp(t *testing.T) {
+	if n := StopAgentsForPMKey(context.Background(), "SC-1698", nil, nil, zerolog.Nop()); n != 0 {
+		t.Fatalf("nil deps must be a no-op, got %d", n)
+	}
+}

--- a/internal/daemon/close_cancel_test.go
+++ b/internal/daemon/close_cancel_test.go
@@ -50,15 +50,31 @@ func TestStopAgentsForPMKey_StopsOnlyTheKeysAgents(t *testing.T) {
 		agentNameFor("SC-99", BoardImplementation),
 	}
 	var stopped []string
-	n := StopAgentsForPMKey(context.Background(), "SC-1698",
+	n, err := StopAgentsForPMKey(context.Background(), "SC-1698",
 		func() ([]string, error) { return names, nil },
 		func(_ context.Context, name string) error { stopped = append(stopped, name); return nil },
 		zerolog.Nop())
+	if err != nil {
+		t.Fatalf("a clean stop must report no error, got %v", err)
+	}
 	if n != 2 {
 		t.Fatalf("stopped count = %d, want 2", n)
 	}
 	if len(stopped) != 2 {
 		t.Fatalf("stopped %v, want the two SC-1698 agents", stopped)
+	}
+}
+
+func TestStopAgentsForPMKey_NoAgentClaimingKeyIsACleanNilError(t *testing.T) {
+	// The common case: closing a ticket with no live run must report success so
+	// the caller's transition is allowed to proceed.
+	names := []string{agentNameFor("SC-99", BoardImplementation)}
+	n, err := StopAgentsForPMKey(context.Background(), "SC-1698",
+		func() ([]string, error) { return names, nil },
+		func(_ context.Context, _ string) error { return nil },
+		zerolog.Nop())
+	if n != 0 || err != nil {
+		t.Fatalf("no matching agent must be a clean no-op (n=%d err=%v)", n, err)
 	}
 }
 
@@ -68,7 +84,7 @@ func TestStopAgentsForPMKey_ContinuesPastAStopFailure(t *testing.T) {
 		agentNameFor("SC-1698", BoardVerification),
 	}
 	var stopped []string
-	n := StopAgentsForPMKey(context.Background(), "SC-1698",
+	n, err := StopAgentsForPMKey(context.Background(), "SC-1698",
 		func() ([]string, error) { return names, nil },
 		func(_ context.Context, name string) error {
 			stopped = append(stopped, name)
@@ -81,6 +97,11 @@ func TestStopAgentsForPMKey_ContinuesPastAStopFailure(t *testing.T) {
 	if n != 1 {
 		t.Fatalf("stopped count = %d, want 1 (one failed, one succeeded)", n)
 	}
+	// The failed stop is the "agent refuses to die" case: it must be reported so
+	// the caller leaves the card open rather than closing over the live run.
+	if err == nil {
+		t.Fatalf("a stop failure must be reported so the close is gated, got nil error")
+	}
 	if len(stopped) != 2 {
 		t.Fatalf("attempted %v, want both agents attempted despite the failure", stopped)
 	}
@@ -88,17 +109,23 @@ func TestStopAgentsForPMKey_ContinuesPastAStopFailure(t *testing.T) {
 
 func TestStopAgentsForPMKey_LeavesRunsAloneWhenLivenessProbeFails(t *testing.T) {
 	stopCalled := false
-	n := StopAgentsForPMKey(context.Background(), "SC-1698",
+	n, err := StopAgentsForPMKey(context.Background(), "SC-1698",
 		func() ([]string, error) { return nil, stderrors.New("probe blip") },
 		func(_ context.Context, _ string) error { stopCalled = true; return nil },
 		zerolog.Nop())
 	if n != 0 || stopCalled {
 		t.Fatalf("a liveness-probe failure must stop nothing (n=%d stopCalled=%v)", n, stopCalled)
 	}
+	// Unable to confirm the run is stopped: the close must be gated so the card
+	// stays open and the reconcile net can reach any orphaned agent.
+	if err == nil {
+		t.Fatalf("a liveness-probe failure must be reported so the close is gated, got nil error")
+	}
 }
 
 func TestStopAgentsForPMKey_NilDepsAreNoOp(t *testing.T) {
-	if n := StopAgentsForPMKey(context.Background(), "SC-1698", nil, nil, zerolog.Nop()); n != 0 {
-		t.Fatalf("nil deps must be a no-op, got %d", n)
+	n, err := StopAgentsForPMKey(context.Background(), "SC-1698", nil, nil, zerolog.Nop())
+	if n != 0 || err != nil {
+		t.Fatalf("nil deps must be a clean no-op (n=%d err=%v)", n, err)
 	}
 }


### PR DESCRIPTION
Closes SC-1698.

Closing a ticket from the board did not stop the agent working it. The card disappeared, the user reasonably read that as cancellation, and the run kept going — holding its container and worktree, posting markers to a closed ticket, potentially pushing commits for work that was called off. The reconcile safety net could never reach it either: its lister enumerates open cards only.

## What changed

**Close is cancellation.** `closeTicketerFunc` now stops every live board agent claiming the PM key (releasing container and worktree) before it transitions the ticket.

**The transition is gated on a confirmed stop.** `StopAgentsForPMKey` reports failure (liveness probe failed, or any per-agent stop failed) and the close returns that error instead of transitioning. A run that refuses to die leaves its card open — and thus still reachable by the reconcile net — rather than closing over it.

**The confirm dialog says so.** For a card with a live run the confirmation states the run will be stopped, its container released and uncommitted work discarded, instead of the old "marked Done and removed from the board", which read as harmless archival.

**An orphan sweep reaches the closes that never pass through that gate.** A ticket closed in the tracker's own web UI, via `human close`, by a teammate, or before this change never touches `closeTicketerFunc`. The new reconcile pass works from the agent side, so it costs nothing on a healthy board: an agent whose sanitized key matches an open card is dismissed without a tracker call, and only a key with no open card is probed. Absence is deliberately not treated as proof of a close — a flaky per-ticket comment fetch drops a healthy card from the set too — so a run is stopped only on a `ClosedTicketProbe` confirming done/closed. Every uncertainty (unparseable agent name, probe error, failed liveness list, nil dep) resolves to leaving the run alone.

## Verification

`make check` green: 3824 tests, lint, gosec, govulncheck, gitleaks. `cmd/` packages (excluded from the check gate) tested separately. The desktop bundle was rebuilt after the rebase and shows no drift against `desktop/frontend/src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)