### PR TITLE
[SC-1892] Give a ticket one identity and treat the key as opaque

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -569,21 +569,21 @@ func runDaemonForeground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string,
 			To:    daemon.BoardVerification,
 		})
 	}
-	// The pre-merge PR review→fix loop is driven off the reviewer/fixer Stop
-	// events, exactly like chainReview: on each loop-agent exit read the outcome
-	// it recorded (the reviewer's verdict, the fixer's exit) from the state store
-	// and hand it to the loop executor, which decides the next step.
-	advancePRLoop := advancePRLoopFunc(ctx, ds, reviewLaunchGate, logger)
-	// The deploy-fixer (SC-1557) is driven off its Stop event exactly like the PR
-	// loop: on exit read the exit it recorded in stage.deploy-fix and hand it to
-	// AdvanceDeployFix, which re-runs Deploy on `done` or reds the card otherwise.
-	advanceDeployFix := advanceDeployFixFunc(ctx, ds, reviewLaunchGate, logger)
 	// The diagnoser reads the dead run's persisted artifacts so the failed
 	// marker says what actually broke instead of the generic stage line.
 	diagnoseFailure := func(agentName, hookErrorType string) daemon.FailureDiagnosis {
 		d := agent.DiagnoseFailure(agentName, hookErrorType)
 		return daemon.FailureDiagnosis{Headline: d.Headline, Detail: d.Detail}
 	}
+	// The pre-merge PR review→fix loop is driven off the reviewer/fixer Stop
+	// events, exactly like chainReview: on each loop-agent exit read the outcome
+	// it recorded (the reviewer's verdict, the fixer's exit) from the state store
+	// and hand it to the loop executor, which decides the next step.
+	advancePRLoop := advancePRLoopFunc(ctx, ds, diagnoseFailure, reviewLaunchGate, logger)
+	// The deploy-fixer (SC-1557) is driven off its Stop event exactly like the PR
+	// loop: on exit read the exit it recorded in stage.deploy-fix and hand it to
+	// AdvanceDeployFix, which re-runs Deploy on `done` or reds the card otherwise.
+	advanceDeployFix := advanceDeployFixFunc(ctx, ds, reviewLaunchGate, logger)
 	// A daemon only chains a review for a handoff branch it can resolve on its
 	// own machine — a board-context fix leaves its branch local on the machine
 	// that produced it, so a daemon elsewhere leaves the handoff for one that can
@@ -663,7 +663,11 @@ func runDaemonForeground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string,
 		branchReachable, commitsPresent, prMerged, postDeployed,
 		liveBoardAgents, postFailedMarkerFunc(ds.srv.Projects, ds.vaultResolver, ds.daemonID),
 		closedTicketProbeFunc(ds.srv.Projects, ds.vaultResolver),
-		chainReview, advancePRLoop, stageRetry, agentProgress, stopHungAgent, ds.daemonID, daemon.BoardReconcileInterval, logger)
+		// The durable re-drive has no exiting agent to attribute — the run it is
+		// recovering from is long gone — so it drives the loop with no run identity
+		// and any escalation falls back to its generic line.
+		chainReview, func(pmKey string) error { return advancePRLoop(pmKey, "", "") },
+		stageRetry, agentProgress, stopHungAgent, ds.daemonID, daemon.BoardReconcileInterval, logger)
 
 	// Surface tickets created or edited outside the board (tracker web UI, CLI,
 	// another teammate or daemon) — none raise a board event — by polling the
@@ -2317,15 +2321,29 @@ func closeTicketerFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver, li
 // (the reviewer's verdict, the fixer's exit) and hands it to the loop executor,
 // which decides and runs the next step. Extracted from runDaemonForeground so
 // the state-read + error path lives in its own scope.
-func advancePRLoopFunc(ctx context.Context, ds *daemonState, reviewLaunchGate func(context.Context) []daemon.DoctorCheck, logger zerolog.Logger) func(pmKey string) error {
-	return func(pmKey string) error {
-		verdict := readPRReviewVerdict(ctx, pmKey, logger)
-		exit, options, summary := readPRFixReport(ctx, pmKey, logger)
+// The exiting run's name and error type travel with the call so a step that died
+// before recording an outcome can still be explained from its artifacts; both are
+// empty when the durable reconcile pass re-drives a stalled loop, where the agent
+// is long gone (SC-1892).
+func advancePRLoopFunc(ctx context.Context, ds *daemonState, diagnose daemon.BoardFailureDiagnoser, reviewLaunchGate func(context.Context) []daemon.DoctorCheck, logger zerolog.Logger) func(pmKey, agentName, errorType string) error {
+	return func(pmKey, agentName, errorType string) error {
+		verdict, verdictRecorded := readPRReviewVerdict(ctx, pmKey, logger)
+		exit, options, summary, exitRecorded := readPRFixReport(ctx, pmKey, logger)
 		deps, err := boardTransitionDepsFor(ds.srv.Projects, ds.vaultResolver, ds.daemonID, logger, reviewLaunchGate)
 		if err != nil {
 			return err
 		}
-		return deps.AdvancePRLoop(ctx, pmKey, verdict, exit, options, summary)
+		deps.Diagnose = diagnose
+		return deps.AdvancePRLoop(ctx, pmKey, daemon.PRLoopOutcome{
+			ReviewVerdict:  verdict,
+			ReviewRecorded: verdictRecorded,
+			FixExit:        exit,
+			FixRecorded:    exitRecorded,
+			FixOptions:     options,
+			FixSummary:     summary,
+			Agent:          agentName,
+			ErrorType:      errorType,
+		})
 	}
 }
 

--- a/cmd/cmddaemon/prloopstate.go
+++ b/cmd/cmddaemon/prloopstate.go
@@ -11,36 +11,41 @@ import (
 )
 
 // readPRReviewVerdict returns the machine reviewer's verdict recorded in
-// stage.pr-review ("" when absent — the loop driver treats that as escalate).
+// stage.pr-review, and whether a report was found at all. Absence is reported
+// separately from an empty verdict because they are different failures: a step
+// that recorded nothing died or never got that far, while a step that recorded
+// something unrecognized decided something the daemon cannot read. Both
+// escalate; only the message differs (SC-1892).
 //
 // The reviewer's report carries non-string fields (a blocking count), so it is
 // read into a typed struct with only the needed scalar rather than a
 // map[string]string, which json.Unmarshal rejects on the first non-string value.
-func readPRReviewVerdict(ctx context.Context, pmKey string, logger zerolog.Logger) string {
+func readPRReviewVerdict(ctx context.Context, pmKey string, logger zerolog.Logger) (verdict string, recorded bool) {
 	var v struct {
 		Verdict string `json:"verdict"`
 	}
-	readStageReport(ctx, pmKey, "stage.pr-review", &v, logger)
-	return v.Verdict
+	recorded = readStageReport(ctx, pmKey, "stage.pr-review", &v, logger)
+	return v.Verdict, recorded
 }
 
 // readPRFixReport loads the fixer's stage.pr-fix report: its exit, the optional
 // enumerated directions it recorded on needs-input, and a one-line context
-// (deferred comments, else the summary) for the options block. Absent fields
-// stay zero — the loop driver treats a missing exit as escalate.
-func readPRFixReport(ctx context.Context, pmKey string, logger zerolog.Logger) (exit string, options []daemon.BoardOption, summary string) {
+// (deferred comments, else the summary) for the options block, plus whether a
+// report was found at all. Absent fields stay zero — the loop driver treats a
+// missing exit as escalate.
+func readPRFixReport(ctx context.Context, pmKey string, logger zerolog.Logger) (exit string, options []daemon.BoardOption, summary string, recorded bool) {
 	var v struct {
 		Exit     string               `json:"exit"`
 		Options  []daemon.BoardOption `json:"options"`
 		Deferred string               `json:"deferred"`
 		Summary  string               `json:"summary"`
 	}
-	readStageReport(ctx, pmKey, "stage.pr-fix", &v, logger)
+	recorded = readStageReport(ctx, pmKey, "stage.pr-fix", &v, logger)
 	summary = v.Deferred
 	if summary == "" {
 		summary = v.Summary
 	}
-	return v.Exit, v.Options, summary
+	return v.Exit, v.Options, summary, recorded
 }
 
 // readDeployFixExit returns the deploy fixer's exit recorded in stage.deploy-fix
@@ -49,15 +54,17 @@ func readDeployFixExit(ctx context.Context, pmKey string, logger zerolog.Logger)
 	var v struct {
 		Exit string `json:"exit"`
 	}
-	readStageReport(ctx, pmKey, "stage.deploy-fix", &v, logger)
+	_ = readStageReport(ctx, pmKey, "stage.deploy-fix", &v, logger)
 	return v.Exit
 }
 
 // readStageReport loads one loop step's JSON report from the agent state store
-// into out. A missing or unreadable report is not an error the loop can act on
-// — it is logged and out is left at its zero value, which the decider treats as
-// escalate (never merge on a state it cannot read).
-func readStageReport(ctx context.Context, pmKey, name string, out any, logger zerolog.Logger) {
+// into out, and reports whether it found one. A missing or unreadable report is
+// not an error the loop can act on — it is logged and out is left at its zero
+// value, which the decider treats as escalate (never merge on a state it cannot
+// read) — but the caller still needs to know it was MISSING rather than empty,
+// so the escalation can say which.
+func readStageReport(ctx context.Context, pmKey, name string, out any, logger zerolog.Logger) bool {
 	err := withStateStore(func(store agentstate.Store) error {
 		entry, err := store.Get(ctx, pmKey, name)
 		if err != nil {
@@ -67,5 +74,7 @@ func readStageReport(ctx context.Context, pmKey, name string, out any, logger ze
 	})
 	if err != nil {
 		logger.Debug().Err(err).Str("pm", pmKey).Str("name", name).Msg("PR loop: no readable stage report")
+		return false
 	}
+	return true
 }

--- a/cmd/cmddaemon/prloopstate_test.go
+++ b/cmd/cmddaemon/prloopstate_test.go
@@ -29,20 +29,24 @@ func TestReadPRReviewVerdict_readsField(t *testing.T) {
 	isolateState(t)
 	writeRawReport(t, "SC-1", "stage.pr-review", `{"verdict":"approved","blocking":0,"summary":"clean"}`)
 
-	assert.Equal(t, "approved", readPRReviewVerdict(context.Background(), "SC-1", zerolog.Nop()))
+	verdict, recorded := readPRReviewVerdict(context.Background(), "SC-1", zerolog.Nop())
+	assert.Equal(t, "approved", verdict)
+	assert.True(t, recorded)
 }
 
 // A missing report is not an error the loop can act on — it reads as "".
 func TestReadPRReviewVerdict_missingIsEmpty(t *testing.T) {
 	isolateState(t)
-	assert.Equal(t, "", readPRReviewVerdict(context.Background(), "SC-1", zerolog.Nop()))
+	verdict, recorded := readPRReviewVerdict(context.Background(), "SC-1", zerolog.Nop())
+	assert.Equal(t, "", verdict)
+	assert.False(t, recorded, "absence must be distinguishable from an empty verdict")
 }
 
 func TestReadPRFixReport_readsField(t *testing.T) {
 	isolateState(t)
 	writeRawReport(t, "SC-1", "stage.pr-fix", `{"exit":"done","pushed":true}`)
 
-	exit, options, summary := readPRFixReport(context.Background(), "SC-1", zerolog.Nop())
+	exit, options, summary, _ := readPRFixReport(context.Background(), "SC-1", zerolog.Nop())
 	assert.Equal(t, "done", exit)
 	assert.Empty(t, options)
 	assert.Empty(t, summary)
@@ -52,7 +56,7 @@ func TestReadPRFixReport_needsInput(t *testing.T) {
 	isolateState(t)
 	writeRawReport(t, "SC-1", "stage.pr-fix", `{"exit":"needs-input","pushed":false}`)
 
-	exit, _, _ := readPRFixReport(context.Background(), "SC-1", zerolog.Nop())
+	exit, _, _, _ := readPRFixReport(context.Background(), "SC-1", zerolog.Nop())
 	assert.Equal(t, "needs-input", exit)
 }
 
@@ -63,7 +67,7 @@ func TestReadPRFixReport_optionsAndDeferredContext(t *testing.T) {
 	writeRawReport(t, "SC-1", "stage.pr-fix",
 		`{"exit":"needs-input","options":[{"id":"1","label":"A"},{"id":"2","label":"B"}],"deferred":"blocked on X","summary":"one line"}`)
 
-	exit, options, summary := readPRFixReport(context.Background(), "SC-1", zerolog.Nop())
+	exit, options, summary, _ := readPRFixReport(context.Background(), "SC-1", zerolog.Nop())
 	assert.Equal(t, "needs-input", exit)
 	require.Len(t, options, 2)
 	assert.Equal(t, "A", options[0].Label)
@@ -77,6 +81,6 @@ func TestReadPRFixReport_summaryContextFallback(t *testing.T) {
 	isolateState(t)
 	writeRawReport(t, "SC-1", "stage.pr-fix", `{"exit":"needs-input","summary":"one line"}`)
 
-	_, _, summary := readPRFixReport(context.Background(), "SC-1", zerolog.Nop())
+	_, _, summary, _ := readPRFixReport(context.Background(), "SC-1", zerolog.Nop())
 	assert.Equal(t, "one line", summary)
 }

--- a/internal/daemon/board_failure.go
+++ b/internal/daemon/board_failure.go
@@ -57,7 +57,7 @@ const genericStageFailure = "agent exited without completing the stage"
 // resolved marker). It is the success signal that authorizes reclaiming the
 // run's private worktree — every other exit KEEPS the worktree so uncommitted
 // work is never destroyed (SC-731). Best-effort/idempotent by contract.
-func RunBoardFailureWatch(ctx context.Context, store *HookEventStore, commenterFor func() (tracker.Commenter, error), chainReview func(pmKey string) error, advancePRLoop func(pmKey string) error, advanceDeployFix func(pmKey string) error, reachable BranchReachable, commitsPresent CommitsPresent, diagnose BoardFailureDiagnoser, onHandoff func(agentName string), retry StageRetry, daemonID string, logger zerolog.Logger) {
+func RunBoardFailureWatch(ctx context.Context, store *HookEventStore, commenterFor func() (tracker.Commenter, error), chainReview func(pmKey string) error, advancePRLoop func(pmKey, agentName, errorType string) error, advanceDeployFix func(pmKey string) error, reachable BranchReachable, commitsPresent CommitsPresent, diagnose BoardFailureDiagnoser, onHandoff func(agentName string), retry StageRetry, daemonID string, logger zerolog.Logger) {
 	if store == nil || commenterFor == nil {
 		return
 	}
@@ -97,7 +97,7 @@ func RunBoardFailureWatch(ctx context.Context, store *HookEventStore, commenterF
 // latest marker is already its done-marker (a clean finish). A cleanly
 // finished build chains into its review. Pulled out so the watch loop stays a
 // thin event dispatcher.
-func handleBoardAgentExit(ctx context.Context, agentName, errorType string, commenterFor func() (tracker.Commenter, error), chainReview func(pmKey string) error, advancePRLoop func(pmKey string) error, advanceDeployFix func(pmKey string) error, reachable BranchReachable, commitsPresent CommitsPresent, diagnose BoardFailureDiagnoser, onHandoff func(agentName string), retry StageRetry, daemonID string, logger zerolog.Logger) {
+func handleBoardAgentExit(ctx context.Context, agentName, errorType string, commenterFor func() (tracker.Commenter, error), chainReview func(pmKey string) error, advancePRLoop func(pmKey, agentName, errorType string) error, advanceDeployFix func(pmKey string) error, reachable BranchReachable, commitsPresent CommitsPresent, diagnose BoardFailureDiagnoser, onHandoff func(agentName string), retry StageRetry, daemonID string, logger zerolog.Logger) {
 	pmKey, stage, ok := parseAgentName(agentName)
 	if !ok {
 		return
@@ -109,7 +109,7 @@ func handleBoardAgentExit(ctx context.Context, agentName, errorType string, comm
 	}
 	// The PR review→fix loop steps are not board stages: their exits are driven
 	// by the loop executor, not the generic stage-failure path below.
-	if drivePRLoopExit(pmKey, stage, agentName, advancePRLoop, onHandoff, logger) {
+	if drivePRLoopExit(pmKey, stage, agentName, errorType, advancePRLoop, onHandoff, logger) {
 		return
 	}
 	commenter, err := commenterFor()
@@ -212,7 +212,11 @@ func chainReviewAfterCleanBuild(ctx context.Context, pmKey, agentName, errorType
 // reviewer is read-only, the fixer already pushed its work). It reports whether
 // the exit was a loop step and thus fully handled here. A non-loop stage returns
 // false so the caller falls through to the stage-failure handling.
-func drivePRLoopExit(pmKey string, stage BoardStage, agentName string, advancePRLoop func(pmKey string) error, onHandoff func(agentName string), logger zerolog.Logger) bool {
+//
+// The exiting run's identity travels with the call: a step that dies before
+// recording its outcome can only be explained from its artifacts, and dropping
+// the name here is what left the loop's escalation with nothing to say (SC-1892).
+func drivePRLoopExit(pmKey string, stage BoardStage, agentName, errorType string, advancePRLoop func(pmKey, agentName, errorType string) error, onHandoff func(agentName string), logger zerolog.Logger) bool {
 	if stage != prReviewAgentStage && stage != prFixAgentStage {
 		return false
 	}
@@ -220,7 +224,7 @@ func drivePRLoopExit(pmKey string, stage BoardStage, agentName string, advancePR
 		onHandoff(agentName)
 	}
 	if advancePRLoop != nil {
-		if err := advancePRLoop(pmKey); err != nil {
+		if err := advancePRLoop(pmKey, agentName, errorType); err != nil {
 			logger.Warn().Err(err).Str("pm", pmKey).Str("stage", string(stage)).Msg("board PR loop: advance failed")
 		}
 	}

--- a/internal/daemon/board_failure_test.go
+++ b/internal/daemon/board_failure_test.go
@@ -288,13 +288,22 @@ func TestHandleBoardAgentExit_prReviewStage_drivesLoop(t *testing.T) {
 	c := &syncCommenter{}
 	commenterFor := func() (tracker.Commenter, error) { return c, nil }
 	var advanced []string
-	advance := func(pmKey string) error { advanced = append(advanced, pmKey); return nil }
+	var gotAgent, gotErrorType string
+	advance := func(pmKey, agentName, errorType string) error {
+		advanced = append(advanced, pmKey)
+		gotAgent, gotErrorType = agentName, errorType
+		return nil
+	}
 	var reclaimed string
 	onHandoff := func(agentName string) { reclaimed = agentName }
 
-	handleBoardAgentExit(context.Background(), "board-SC-1-prreview", "", commenterFor, nil, advance, nil, alwaysReachable, nil, nil, onHandoff, StageRetry{}, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), "board-SC-1-prreview", "crashed", commenterFor, nil, advance, nil, alwaysReachable, nil, nil, onHandoff, StageRetry{}, "", zerolog.Nop())
 
 	assert.Equal(t, []string{"SC-1"}, advanced, "the PR loop driver must be invoked once")
+	// A step that dies before recording an outcome can only be explained from its
+	// artifacts, so its identity must reach the driver (SC-1892).
+	assert.Equal(t, "board-SC-1-prreview", gotAgent, "the exiting run's name must reach the loop driver")
+	assert.Equal(t, "crashed", gotErrorType, "the exit's error type must reach the loop driver")
 	assert.Equal(t, "board-SC-1-prreview", reclaimed, "the loop step's worktree must be reclaimed")
 	assert.Empty(t, c.added, "a PR loop exit must not post a generic stage-failed marker")
 }

--- a/internal/daemon/board_opaque_key_test.go
+++ b/internal/daemon/board_opaque_key_test.go
@@ -1,0 +1,58 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A ticket key is an opaque identifier: the daemon must carry whatever the
+// tracker handed it and never assume a shape. Keys differ per backend (SC-1892,
+// HUM-30, octocat/repo#42, Project/42) and a daemon that only survives one of
+// those shapes loses the ticket's identity somewhere in the pipeline — which is
+// exactly how a handover gets written under one spelling and read under another
+// (SC-1892).
+//
+// The agent name is where that identity is most at risk, because it is the one
+// place the key is encoded into another string and recovered from it. This locks
+// the round trip for every key shape the tool supports, plus shapes it does not
+// produce today, so the guarantee is about opacity rather than about the
+// backends that happen to be wired up now.
+func TestAgentNameRoundTripsAnyOpaqueKey(t *testing.T) {
+	stages := []BoardStage{BoardImplementation, BoardVerification, prReviewAgentStage, prFixAgentStage, deployFixAgentStage}
+	keys := []string{
+		"SC-1892",          // Shortcut, the form it now emits
+		"HUM-30",           // Linear / Jira
+		"Stephan-Is-Great", // no digits, several hyphens
+		"a",                // single character
+		"1892",             // bare numeric, still readable from older state
+	}
+	for _, key := range keys {
+		for _, stage := range stages {
+			got, gotStage, ok := parseAgentName(agentNameFor(key, stage))
+			require.True(t, ok, "agent name for %q/%q must parse back", key, stage)
+			require.Equal(t, key, got, "key must survive the agent-name round trip")
+			require.Equal(t, stage, gotStage, "stage must survive the agent-name round trip")
+		}
+	}
+}
+
+// Keys carrying characters the agent-name encoding replaces cannot round-trip
+// verbatim, so they must still be MATCHED through the same sanitize() the
+// launcher used — never by raw-key equality, which would silently fail to find
+// a live agent for the ticket.
+func TestOpaqueKeyWithEncodedCharactersStillMatchesItsAgent(t *testing.T) {
+	// Anything outside [a-zA-Z0-9] is replaced, so these keys are lossy through
+	// the encoding — including the underscore, which reads as name-safe but is not.
+	for _, key := range []string{"octocat/repo#42", "Project/42", "UPPER_snake-42"} {
+		name := agentNameFor(key, BoardImplementation)
+
+		require.Equal(t, []string{name}, AgentsForPMKey([]string{name}, key),
+			"a key whose characters the name encoding replaces must still match its own agent")
+
+		parsed, _, ok := parseAgentName(name)
+		require.True(t, ok)
+		require.NotEqual(t, key, parsed,
+			"guard the premise for %q: it is lossy through the encoding, which is why matching goes through sanitize()", key)
+	}
+}

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -130,6 +130,10 @@ type BoardTransitionDeps struct {
 	// close). The zero value is a safe no-op writer, so an un-wired path stays
 	// valid without a logger.
 	Logger zerolog.Logger
+	// Diagnose distills why a dead run died, so a loop step that escalated
+	// without recording an outcome reports the real cause instead of a generic
+	// line. nil disables diagnosis (the package's "nil disables" convention).
+	Diagnose BoardFailureDiagnoser
 	// LaunchGate reports the launch-critical doctor checks currently failing on
 	// this daemon's host (docker, agent-skills, claude-auth). When it returns a
 	// non-empty slice the stage launcher neither claims nor launches — it silently
@@ -556,14 +560,14 @@ func prLoopURL(comments []tracker.Comment) string {
 // decider for the next action, and executes it: launch the reviewer, launch the
 // fixer, un-draft + merge via the existing DeployBranch, or red the card for a
 // human. Human PR review runs out of band and never enters here.
-func (d BoardTransitionDeps) AdvancePRLoop(ctx context.Context, pmKey, reviewVerdict, fixExit string, fixOptions []BoardOption, fixSummary string) error {
+func (d BoardTransitionDeps) AdvancePRLoop(ctx context.Context, pmKey string, outcome PRLoopOutcome) error {
 	comments, err := d.Commenter.ListComments(ctx, pmKey)
 	if err != nil {
 		return errors.WrapWithDetails(err, "loading comments for PR loop", "pm", pmKey)
 	}
 	card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
 	number, url, branch := prLoopNumber(comments), prLoopURL(comments), card.Branch
-	switch EvaluatePRLoop(comments, reviewVerdict, fixExit) {
+	switch EvaluatePRLoop(comments, outcome.ReviewVerdict, outcome.FixExit) {
 	case PRActionReview:
 		if _, err := d.Commenter.AddComment(ctx, pmKey, StampDaemon(prReviewStartedBody(url, number, branch), d.DaemonID)); err != nil {
 			return errors.WrapWithDetails(err, "posting pr-review-started marker", "pm", pmKey)
@@ -583,7 +587,7 @@ func (d BoardTransitionDeps) AdvancePRLoop(ctx context.Context, pmKey, reviewVer
 		// (forge.AdoptOrCreatePullRequest), runs the CI gate, freshness rebase and merge.
 		return d.DeployBranch(ctx, pmKey, pmKey, doneBody(pmKey, card), branch)
 	default: // PRActionEscalate
-		return d.escalatePRLoop(ctx, pmKey, comments, reviewVerdict, fixExit, fixOptions, fixSummary)
+		return d.escalatePRLoop(ctx, pmKey, comments, outcome)
 	}
 }
 
@@ -594,19 +598,20 @@ func (d BoardTransitionDeps) AdvancePRLoop(ctx context.Context, pmKey, reviewVer
 // unreviewable PR, an outcome the daemon cannot classify — reds the done stage.
 // Idempotent: a durable re-drive must never re-post the block, so an already-open
 // options block short-circuits.
-func (d BoardTransitionDeps) escalatePRLoop(ctx context.Context, pmKey string, comments []tracker.Comment, reviewVerdict, fixExit string, fixOptions []BoardOption, fixSummary string) error {
+func (d BoardTransitionDeps) escalatePRLoop(ctx context.Context, pmKey string, comments []tracker.Comment, outcome PRLoopOutcome) error {
 	if _, open := openOptionsBlock(comments); open {
 		return nil
 	}
-	if latestPRLoopStage(comments) == PRStageFix && fixExit != PRFixDone {
+	stage := latestPRLoopStage(comments)
+	if stage == PRStageFix && outcome.FixExit != PRFixDone {
 		var b strings.Builder
 		b.WriteString(OptionsHeader + "\nstage: " + string(BoardImplementation) + "\n")
-		ctxLine := fixSummary
+		ctxLine := outcome.FixSummary
 		if ctxLine == "" {
 			ctxLine = "the PR review→fix loop needs a decision the fixer could not make"
 		}
 		b.WriteString("context: " + ctxLine + "\n")
-		opts := fixOptions
+		opts := outcome.FixOptions
 		if len(opts) == 0 {
 			// A generic single option keeps the block valid (parseOptionsBlock needs
 			// ≥1) so the human can always move the card off the loop.
@@ -619,22 +624,52 @@ func (d BoardTransitionDeps) escalatePRLoop(ctx context.Context, pmKey string, c
 		return err
 	}
 	_, _ = d.Commenter.AddComment(ctx, pmKey,
-		StampDaemon(PRReviewFailedHeader+"\n"+prEscalationReason(reviewVerdict, fixExit), d.DaemonID))
+		StampDaemon(PRReviewFailedHeader+"\n"+prEscalationReason(stage, outcome, d.Diagnose), d.DaemonID))
 	return nil
 }
 
-// prEscalationReason renders the actionable headline the failed marker's badge shows.
-func prEscalationReason(reviewVerdict, fixExit string) string {
+// prEscalationReason renders the actionable headline the failed marker's badge
+// shows.
+//
+// The unrecorded case is kept distinct from every recorded one. A step that
+// wrote nothing did not decide anything — it died, or never got far enough to
+// report — and saying "unreadable outcome" for it sent a human to read a review
+// that was never written. Where a diagnosis of the dead run is available it
+// replaces the generic line entirely, the same way an ordinary stage failure
+// reports its cause (SC-1688); without one — notably the durable reconcile
+// re-drive, which has no agent in hand — the line at least names what was
+// missing instead of implying something unparseable was found.
+func prEscalationReason(stage PRLoopStage, outcome PRLoopOutcome, diagnose BoardFailureDiagnoser) string {
 	switch {
-	case fixExit == ExitNeedsInput:
+	case outcome.FixExit == ExitNeedsInput:
 		return "the PR fixer needs a human decision — read the PR review comments, decide, then re-run Deploy"
-	case reviewVerdict == PRVerdictChanges:
+	case outcome.ReviewVerdict == PRVerdictChanges:
 		return "the machine review did not converge within the round budget — review the PR yourself, then re-run Deploy"
-	case reviewVerdict == PRVerdictUnreviewable:
+	case outcome.ReviewVerdict == PRVerdictUnreviewable:
 		return "the PR could not be reviewed (bad binding or empty diff) — check the PR, then re-run Deploy"
+	case !outcome.stepRecorded(stage):
+		return unrecordedStepReason(stage, outcome, diagnose)
 	default:
-		return "the PR review→fix loop stopped on an unreadable outcome — check the PR and its review, then re-run Deploy"
+		return "the PR review→fix loop stopped on an outcome it could not classify — check the PR and its review, then re-run Deploy"
 	}
+}
+
+// unrecordedStepReason explains a loop step that left no outcome behind.
+func unrecordedStepReason(stage PRLoopStage, outcome PRLoopOutcome, diagnose BoardFailureDiagnoser) string {
+	if outcome.Agent != "" && diagnose != nil {
+		if body := failureMarkerBody(diagnose, outcome.Agent, outcome.ErrorType); body != genericStageFailure {
+			return body
+		}
+	}
+	step, report := "review→fix loop step", "an outcome"
+	switch stage {
+	case PRStageReview:
+		step, report = "PR reviewer", "a verdict"
+	case PRStageFix:
+		step, report = "PR fixer", "an exit"
+	}
+	return "the " + step + " finished without recording " + report +
+		" — its run may have died before reporting; check its log and the PR, then re-run Deploy"
 }
 
 // AdvanceDeployFix is the deploy-fixer's Stop-event driver. On the fixer's exit the

--- a/internal/daemon/pr_loop_escalation_test.go
+++ b/internal/daemon/pr_loop_escalation_test.go
@@ -1,0 +1,111 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// escalationBody runs the loop to escalation and returns the failed marker body.
+func escalationBody(t *testing.T, outcome PRLoopOutcome, diagnose BoardFailureDiagnoser) string {
+	t.Helper()
+	return escalationBodyAfterRounds(t, 1, outcome, diagnose)
+}
+
+// escalationBodyAfterRounds is escalationBody with an explicit number of
+// completed review rounds, for the verdicts that only escalate once the round
+// budget is spent.
+func escalationBodyAfterRounds(t *testing.T, rounds int, outcome PRLoopOutcome, diagnose BoardFailureDiagnoser) string {
+	t.Helper()
+	c := &fakeCommenter{comments: reviewStartedComments(rounds, "https://example/pr/7", 7, "feat/x")}
+	deps := newDeps(c, &fakeLauncher{}, &fakeDeployer{})
+	deps.Diagnose = diagnose
+
+	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", outcome))
+
+	body, ok := posted(c, PRReviewFailedHeader)
+	require.True(t, ok, "the loop must escalate")
+	return body
+}
+
+// A step that recorded NOTHING did not decide anything — it died, or never got
+// far enough to report. Telling a human the outcome was "unreadable" sent them
+// to read a review that was never written; the marker must say what was missing
+// (SC-1892).
+func TestPREscalation_unrecordedVerdictSaysWhatWasMissing(t *testing.T) {
+	body := escalationBody(t, PRLoopOutcome{ReviewRecorded: false}, nil)
+
+	assert.Contains(t, body, "PR reviewer")
+	assert.Contains(t, body, "without recording a verdict")
+	assert.NotContains(t, body, "could not classify",
+		"nothing was found, so nothing failed to be classified")
+}
+
+// The other half: a step that DID record something the daemon cannot classify
+// decided something deliberate, and must not be reported as having died.
+func TestPREscalation_unclassifiableVerdictIsNotReportedAsMissing(t *testing.T) {
+	body := escalationBody(t, PRLoopOutcome{ReviewVerdict: "maybe?", ReviewRecorded: true}, nil)
+
+	assert.Contains(t, body, "could not classify")
+	assert.NotContains(t, body, "without recording",
+		"an outcome WAS recorded — reporting it as absent misdirects the reader")
+}
+
+// When the dead run can be diagnosed from its artifacts, the real cause replaces
+// the generic line — the same treatment an ordinary stage failure gets.
+func TestPREscalation_unrecordedVerdictCarriesTheDiagnosis(t *testing.T) {
+	diagnose := func(agentName, errorType string) FailureDiagnosis {
+		assert.Equal(t, "board-SC-1-prreview", agentName)
+		assert.Equal(t, "oom", errorType)
+		return FailureDiagnosis{Headline: "the container ran out of memory", Detail: "killed at 4.0GiB"}
+	}
+
+	body := escalationBody(t, PRLoopOutcome{
+		ReviewRecorded: false,
+		Agent:          "board-SC-1-prreview",
+		ErrorType:      "oom",
+	}, diagnose)
+
+	assert.Contains(t, body, "the container ran out of memory")
+	assert.Contains(t, body, "killed at 4.0GiB")
+}
+
+// The durable reconcile re-drive has no exiting agent to attribute, so it must
+// still produce the honest generic line rather than a diagnosis of nothing.
+func TestPREscalation_reDriveWithoutAnAgentStillExplainsItself(t *testing.T) {
+	diagnose := func(string, string) FailureDiagnosis {
+		t.Fatal("a re-drive has no run to diagnose and must not attempt one")
+		return FailureDiagnosis{}
+	}
+
+	body := escalationBody(t, PRLoopOutcome{ReviewRecorded: false}, diagnose)
+
+	assert.Contains(t, body, "without recording a verdict")
+}
+
+// An empty-handed diagnoser must not blank the marker: the fallback line still
+// names what was missing.
+func TestPREscalation_emptyDiagnosisFallsBackToTheMissingOutcome(t *testing.T) {
+	diagnose := func(string, string) FailureDiagnosis { return FailureDiagnosis{} }
+
+	body := escalationBody(t, PRLoopOutcome{
+		ReviewRecorded: false,
+		Agent:          "board-SC-1-prreview",
+	}, diagnose)
+
+	assert.Contains(t, body, "without recording a verdict")
+}
+
+// Recorded verdicts the daemon DOES understand keep their existing, more
+// specific headlines — the unrecorded case must not swallow them.
+func TestPREscalation_recognisedVerdictsKeepTheirHeadlines(t *testing.T) {
+	unreviewable := escalationBody(t, PRLoopOutcome{ReviewVerdict: PRVerdictUnreviewable, ReviewRecorded: true}, nil)
+	assert.Contains(t, unreviewable, "could not be reviewed")
+
+	// changes-requested reaches escalation only once the round budget is spent.
+	budgetSpent := escalationBodyAfterRounds(t, DefaultPRReviewRounds,
+		PRLoopOutcome{ReviewVerdict: PRVerdictChanges, ReviewRecorded: true}, nil)
+	assert.Contains(t, budgetSpent, "did not converge within the round budget")
+}

--- a/internal/daemon/pr_loop_exec_test.go
+++ b/internal/daemon/pr_loop_exec_test.go
@@ -42,7 +42,7 @@ func TestAdvancePRLoop_reviewApproved_merges(t *testing.T) {
 	var closed string
 	deps.CloseTicket = func(pmKey string) error { closed = pmKey; return nil }
 
-	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", PRVerdictApproved, "", nil, ""))
+	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", PRLoopOutcome{ReviewVerdict: PRVerdictApproved, ReviewRecorded: true, FixExit: "", FixRecorded: true}))
 
 	assert.Equal(t, 7, p.markedReady, "the approved PR must be un-drafted before merge")
 	assert.Equal(t, 1, p.merged, "the un-drafted PR must merge")
@@ -56,7 +56,7 @@ func TestAdvancePRLoop_changesRequested_launchesFixer(t *testing.T) {
 	l := &fakeLauncher{}
 	deps := newDeps(c, l, &fakeDeployer{})
 
-	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", PRVerdictChanges, "", nil, ""))
+	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", PRLoopOutcome{ReviewVerdict: PRVerdictChanges, ReviewRecorded: true, FixExit: "", FixRecorded: true}))
 
 	_, ok := posted(c, PRFixStartedHeader)
 	assert.True(t, ok, "a pr-fix-started marker must be posted")
@@ -73,7 +73,7 @@ func TestAdvancePRLoop_fixDone_launchesReviewer(t *testing.T) {
 	l := &fakeLauncher{}
 	deps := newDeps(c, l, &fakeDeployer{})
 
-	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", "", PRFixDone, nil, ""))
+	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", PRLoopOutcome{ReviewVerdict: "", ReviewRecorded: true, FixExit: PRFixDone, FixRecorded: true}))
 
 	_, ok := posted(c, PRReviewStartedHeader)
 	assert.True(t, ok, "a fresh pr-review-started marker must be posted")
@@ -87,7 +87,7 @@ func TestAdvancePRLoop_budgetExhausted_escalates(t *testing.T) {
 	p := &fakeDeployer{}
 	deps := newDeps(c, l, p)
 
-	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", PRVerdictChanges, "", nil, ""))
+	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", PRLoopOutcome{ReviewVerdict: PRVerdictChanges, ReviewRecorded: true, FixExit: "", FixRecorded: true}))
 
 	failed, ok := posted(c, PRReviewFailedHeader)
 	require.True(t, ok, "the budget-exhausted loop must escalate")
@@ -105,7 +105,7 @@ func TestAdvancePRLoop_fixNeedsInput_escalates(t *testing.T) {
 	l := &fakeLauncher{}
 	deps := newDeps(c, l, &fakeDeployer{})
 
-	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", "", ExitNeedsInput, nil, ""))
+	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", PRLoopOutcome{ReviewVerdict: "", ReviewRecorded: true, FixExit: ExitNeedsInput, FixRecorded: true}))
 
 	// A fixer needs-input is a DECISION: it escalates to a [human:options] block,
 	// not a red failed marker, so each direction is a clickable board choice.
@@ -129,8 +129,12 @@ func TestAdvancePRLoop_fixNeedsInput_withOptions(t *testing.T) {
 	l := &fakeLauncher{}
 	deps := newDeps(c, l, &fakeDeployer{})
 
-	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", "", ExitNeedsInput,
-		[]BoardOption{{ID: "1", Label: "A"}, {ID: "2", Label: "B"}}, "deferred X"))
+	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", PRLoopOutcome{
+		FixExit:     ExitNeedsInput,
+		FixRecorded: true,
+		FixOptions:  []BoardOption{{ID: "1", Label: "A"}, {ID: "2", Label: "B"}},
+		FixSummary:  "deferred X",
+	}))
 
 	block, ok := posted(c, OptionsHeader)
 	require.True(t, ok)
@@ -153,7 +157,7 @@ func TestAdvancePRLoop_escalateIdempotent(t *testing.T) {
 	l := &fakeLauncher{}
 	deps := newDeps(c, l, &fakeDeployer{})
 
-	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", "", ExitNeedsInput, nil, ""))
+	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", PRLoopOutcome{ReviewVerdict: "", ReviewRecorded: true, FixExit: ExitNeedsInput, FixRecorded: true}))
 
 	// A durable re-drive over a loop that already escalated must not double-post.
 	assert.Empty(t, c.added, "an already-open options block short-circuits the escalation")
@@ -165,7 +169,7 @@ func TestAdvancePRLoop_unreadableVerdict_escalates(t *testing.T) {
 	p := &fakeDeployer{}
 	deps := newDeps(c, &fakeLauncher{}, p)
 
-	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", "", "", nil, ""))
+	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", PRLoopOutcome{ReviewVerdict: "", ReviewRecorded: true, FixExit: "", FixRecorded: true}))
 
 	_, ok := posted(c, PRReviewFailedHeader)
 	assert.True(t, ok, "an unreadable verdict must escalate rather than merge")
@@ -178,7 +182,7 @@ func TestAdvancePRLoop_markReadyFails_deployFailed(t *testing.T) {
 	p := &fakeDeployer{markReadyErr: errors.New("graphql: could not un-draft")}
 	deps := newDeps(c, &fakeLauncher{}, p)
 
-	err := deps.AdvancePRLoop(context.Background(), "SC-1", PRVerdictApproved, "", nil, "")
+	err := deps.AdvancePRLoop(context.Background(), "SC-1", PRLoopOutcome{ReviewVerdict: PRVerdictApproved, ReviewRecorded: true, FixExit: "", FixRecorded: true})
 	require.Error(t, err)
 
 	failed, ok := posted(c, DeployFailedHeader)

--- a/internal/daemon/pr_review_loop.go
+++ b/internal/daemon/pr_review_loop.go
@@ -136,6 +136,44 @@ func prReviewRounds(comments []tracker.Comment) int {
 	return n
 }
 
+// PRLoopOutcome is what the loop step that just finished left behind: the
+// reviewer's verdict or the fixer's exit, plus whether either was RECORDED AT
+// ALL. That last distinction is the point of the type. An agent that crashed
+// before writing anything and an agent that deliberately reported something the
+// daemon cannot classify both escalate, but they are different failures and the
+// ticket must be able to say which — the same distinction mayRelaunch already
+// draws for ordinary stages (board_retry.go). Carried as one value rather than
+// six positional arguments, which is how the recorded/unrecorded pairs stayed
+// impossible to tell apart.
+//
+// Agent and ErrorType identify the exited run so the escalation can carry a real
+// diagnosis. Both are empty when the loop is re-driven by the durable reconcile
+// pass, where the agent is long gone — the marker then falls back to its generic
+// line, which is the honest answer there.
+type PRLoopOutcome struct {
+	ReviewVerdict  string
+	ReviewRecorded bool
+	FixExit        string
+	FixRecorded    bool
+	FixOptions     []BoardOption
+	FixSummary     string
+	Agent          string
+	ErrorType      string
+}
+
+// stepRecorded reports whether the step that just ran recorded its outcome.
+// PRStageNone has no step behind it, so nothing is missing.
+func (o PRLoopOutcome) stepRecorded(stage PRLoopStage) bool {
+	switch stage {
+	case PRStageReview:
+		return o.ReviewRecorded
+	case PRStageFix:
+		return o.FixRecorded
+	default:
+		return true
+	}
+}
+
 // EvaluatePRLoop bridges the recorded board state to the decider: it reads which
 // loop step last ran (from the markers) and how many review rounds have
 // completed, pairs the step with the outcome that step recorded — the reviewer's

--- a/internal/tracker/shortcut/client.go
+++ b/internal/tracker/shortcut/client.go
@@ -285,7 +285,7 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 	}
 
 	return &tracker.Issue{
-		Key:         strconv.FormatInt(story.ID, 10),
+		Key:         storyKey(story.ID),
 		Project:     issue.Project,
 		Title:       story.Name,
 		Description: story.Description,
@@ -810,15 +810,22 @@ func normalizeStoryType(t string) string {
 	return ""
 }
 
+// keyPrefix is Shortcut's fixed universal display prefix. Shortcut has no
+// per-workspace project prefix, so this is hardcoded rather than configured —
+// mirroring tracker.shortcutDisplayRe, which recognises the same form.
+const keyPrefix = "SC-"
+
 // parseStoryID parses a string story ID into an int64. It accepts both the bare
 // numeric key and the tool's own "SC-nnn" display form (case-insensitive), so
 // every entry point that funnels through here — Get/Edit/Comment/Link — resolves
-// keys copied out of commits, markers and PR titles. The original key is kept in
+// keys copied out of commits, markers and PR titles. Keys emitted by this client
+// always carry the prefix; the bare form is still accepted because it is what
+// older commits, markers and stored state contain. The original key is kept in
 // the error so a bad "SC-abc" still reports what the caller passed.
 func parseStoryID(key string) (int64, error) {
 	numeric := key
-	if len(key) > 3 && strings.EqualFold(key[:3], "sc-") {
-		numeric = key[3:]
+	if len(key) > len(keyPrefix) && strings.EqualFold(key[:len(keyPrefix)], keyPrefix) {
+		numeric = key[len(keyPrefix):]
 	}
 	id, err := strconv.ParseInt(numeric, 10, 64)
 	if err != nil || id <= 0 {
@@ -847,7 +854,7 @@ func (c *Client) toTrackerIssue(ctx context.Context, story scStory, project stri
 	reporter, _ := c.resolveMemberName(ctx, story.RequestedByID)
 
 	issue := tracker.Issue{
-		Key:         strconv.FormatInt(story.ID, 10),
+		Key:         storyKey(story.ID),
 		Project:     project,
 		Type:        story.StoryType,
 		Title:       story.Name,
@@ -866,13 +873,27 @@ func (c *Client) toTrackerIssue(ctx context.Context, story scStory, project stri
 	return issue, nil
 }
 
+// storyKey renders a story ID as this tracker's issue key: the prefixed display
+// form Shortcut itself prints, which is the ONLY form the rest of the tool sees.
+//
+// A bare story ID was previously handed out as the key, which made a ticket's
+// identity ambiguous: everything user- and agent-facing (commits, markers, the
+// ticket's own commands) uses "SC-nnn", so a bare "nnn" left two spellings of
+// one ticket in circulation and any handover that wrote one and read the other
+// was silently lost (SC-1892). Emitting the display form here — the one place a
+// story becomes an issue — leaves exactly one identity, and lets every consumer
+// treat the key as an opaque string rather than guessing at its syntax.
+func storyKey(id int64) string {
+	return keyPrefix + strconv.FormatInt(id, 10)
+}
+
 // parentStoryKey renders a parent story ID as a tracker issue key, or "" when
 // the story has no parent.
 func parentStoryKey(id *int64) string {
 	if id == nil {
 		return ""
 	}
-	return strconv.FormatInt(*id, 10)
+	return storyKey(*id)
 }
 
 // toTrackerComment converts a Shortcut comment to a tracker.Comment.

--- a/internal/tracker/shortcut/client_test.go
+++ b/internal/tracker/shortcut/client_test.go
@@ -62,7 +62,7 @@ func TestListIssues_happy(t *testing.T) {
 	// "Done" story filtered out by default
 	require.Len(t, issues, 2)
 
-	assert.Equal(t, "1", issues[0].Key)
+	assert.Equal(t, "SC-1", issues[0].Key)
 	assert.Equal(t, "Bug report", issues[0].Title)
 	assert.Equal(t, "To Do", issues[0].Status)
 	assert.Equal(t, tracker.CategoryUnstarted, issues[0].StatusType)
@@ -70,7 +70,7 @@ func TestListIssues_happy(t *testing.T) {
 	assert.Equal(t, "Alice", issues[0].Assignee)
 	assert.Equal(t, "Bob", issues[0].Reporter)
 
-	assert.Equal(t, "2", issues[1].Key)
+	assert.Equal(t, "SC-2", issues[1].Key)
 	assert.Equal(t, "Feature request", issues[1].Title)
 	assert.Equal(t, "In Progress", issues[1].Status)
 	assert.Equal(t, tracker.CategoryStarted, issues[1].StatusType)
@@ -224,7 +224,7 @@ func TestGetIssue_happy(t *testing.T) {
 	issue, err := client.GetIssue(context.Background(), "42")
 
 	require.NoError(t, err)
-	assert.Equal(t, "42", issue.Key)
+	assert.Equal(t, "SC-42", issue.Key)
 	assert.Equal(t, "The answer", issue.Title)
 	assert.Equal(t, "In Progress", issue.Status)
 	assert.Equal(t, "feature", issue.Type)
@@ -284,8 +284,28 @@ func TestGetIssue_shortcutDisplayKey(t *testing.T) {
 	issue, err := client.GetIssue(context.Background(), "SC-879")
 
 	require.NoError(t, err)
-	assert.Equal(t, "879", issue.Key)
+	assert.Equal(t, "SC-879", issue.Key)
 	assert.Equal(t, "Display key story", issue.Title)
+}
+
+// A ticket has ONE identity: the key this client emits must be a key it accepts
+// back, unchanged, with no translation step in between. When it emitted the bare
+// story ID while everything user- and agent-facing used the "SC-nnn" display
+// form, two spellings of one ticket were in circulation and any handover that
+// wrote one and read the other was silently lost (SC-1892).
+func TestStoryKeyRoundTripsThroughParseStoryID(t *testing.T) {
+	key := storyKey(1892)
+	assert.Equal(t, "SC-1892", key, "the emitted key is the display form Shortcut itself prints")
+
+	id, err := parseStoryID(key)
+	require.NoError(t, err, "a key this client emitted must be one it accepts")
+	assert.Equal(t, int64(1892), id)
+
+	// The bare form stays readable: older commits, markers and stored state
+	// contain it, and they must not become unresolvable.
+	bare, err := parseStoryID("1892")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1892), bare)
 }
 
 func TestCreateIssue_happy(t *testing.T) {
@@ -327,7 +347,7 @@ func TestCreateIssue_happy(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Equal(t, "99", issue.Key)
+	assert.Equal(t, "SC-99", issue.Key)
 	assert.Equal(t, "Human", issue.Project)
 	assert.Equal(t, "New story", issue.Title)
 	assert.Equal(t, "Some description", issue.Description)
@@ -371,7 +391,7 @@ func TestCreateIssue_withoutDescription(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Equal(t, "100", issue.Key)
+	assert.Equal(t, "SC-100", issue.Key)
 	// Only name, no description
 	assert.Equal(t, "No desc", gotBody["name"])
 	_, hasDesc := gotBody["description"]
@@ -901,7 +921,7 @@ func TestEditIssue_happy(t *testing.T) {
 	issue, err := client.EditIssue(context.Background(), "123", tracker.EditOptions{Title: &title})
 
 	require.NoError(t, err)
-	assert.Equal(t, "123", issue.Key)
+	assert.Equal(t, "SC-123", issue.Key)
 	assert.Equal(t, "Updated Title", issue.Title)
 }
 
@@ -1324,8 +1344,8 @@ func TestCreateIssue_withParent(t *testing.T) {
 		ParentKey: "42",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "99", issue.Key)
-	assert.Equal(t, "42", issue.ParentKey)
+	assert.Equal(t, "SC-99", issue.Key)
+	assert.Equal(t, "SC-42", issue.ParentKey)
 	assert.Equal(t, float64(42), gotBody["parent_story_id"])
 }
 
@@ -1356,7 +1376,7 @@ func TestGetIssue_withParent(t *testing.T) {
 	client := New(srv.URL, "tok-test")
 	issue, err := client.GetIssue(context.Background(), "99")
 	require.NoError(t, err)
-	assert.Equal(t, "42", issue.ParentKey)
+	assert.Equal(t, "SC-42", issue.ParentKey)
 }
 
 func TestListIssues_labelsMapped(t *testing.T) {


### PR DESCRIPTION
Closes SC-1892.

## The stall

SC-1701's fix was implemented, verified, reviewed and approved, its PR was green and mergeable — and the board dead-ended it with `[human:pr-review-failed] the PR review→fix loop stopped on an unreadable outcome`.

Nothing crashed. The reviewer ran 10.4 minutes, exited 0, and approved. It recorded that verdict under `SC-1701`; the daemon looked for it under `1701`, found nothing, and escalated.

```
$ human state get SC-1701 stage.pr-review --field verdict
approved
$ human state get 1701 stage.pr-review --field verdict     # what the daemon asked for
Error: state entry not found
```

## Root cause

The Shortcut client handed out the bare story ID as `tracker.Issue.Key`, while everything user- and agent-facing — commits, markers, the ticket's own related commands — uses the `SC-nnn` display form. Two spellings of one ticket were in circulation, so any handover that wrote one and read the other was lost. Silently: nothing was corrupted and nothing errored.

Intermittent rather than constant, which is why the pipeline usually worked — across recorded handovers roughly one in six used the other form (`stage.pr-review`: 18 bare vs 3 canonical in the live store).

Four daemon-side readers were exposed: the PR reviewer's verdict, the PR fixer's report, the deploy fixer's exit, and the stage-retry exit class.

## The fix

**One identity, produced at the source.** `storyKey()` emits the display form from the one place a story becomes an issue, so a ticket has exactly one key and every consumer can carry it as an opaque string instead of guessing at its syntax. `parseStoryID` still accepts the bare form — older commits, markers and stored state contain it and must stay resolvable — but nothing emits it any more.

This is deliberately not a translation layer at the point of use. The same bare-vs-prefixed gap was patched once before for commit references (`tracker.CanonicalCommitKey`) and never generalised; normalising downstream would have encoded "numeric means Shortcut" into yet another component instead of removing the ambiguity.

**Opacity is now tested, not assumed.** The agent name is the one place a key is encoded into another string and recovered, so the round trip is covered for key shapes the tool does not produce today — no digits, a single character, several hyphens — and the lossy shapes (`octocat/repo#42`, `Project/42`, and `UPPER_snake-42`, whose underscore reads as name-safe but is not) are pinned to matching via `sanitize()` rather than raw equality.

**An unreadable handover now says what was missing.** A step that recorded nothing and a step that recorded something unclassifiable shared one hardcoded sentence. They are different failures, and reporting a dead reviewer as "unreadable" sent a human to read a review that was never written. Both still escalate; the message now distinguishes them, and the exiting run's identity reaches the loop driver so a genuine crash carries its real diagnosis — the treatment SC-1688 gave the sibling branch-review path.

## Verification

`make check` green: 3833 tests, 0 lint issues, gosec 0, govulncheck and gitleaks clean.

Not verified live: exercising this against the real tracker would mean bypassing the running daemon and handling tracker tokens, which is the user's call. The Shortcut client tests drive the change end to end against an httptest backend.

## After merge

Rebuilding and restarting the daemon switches the board to the new key form. Nothing is in flight (no board containers running), so no run is orphaned, but note: pre-existing `state.db` rows under bare scopes become unreachable, so retry budgets reset; `boardprefs.json`'s hidden-card list is keyed by the old form, so hidden cards reappear once; and new agents/worktrees are named `board-SC-nnn-*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)