### PR TITLE
[SC-1542] Resolve agent workspace to an absolute path before use

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -168,14 +168,21 @@ func resolveDirectories(opts StartOpts) (workspace, configDir string) {
 	if workspace == "" {
 		workspace = "."
 	}
+	// Must be absolute: it becomes projectDir, which worktreeGitDir joins
+	// with ".git" to produce a Docker bind-mount source — Docker rejects a
+	// relative mount path outright ("invalid mount path: '.git' must be
+	// absolute") whenever a caller (e.g. the CLI's default "." workspace)
+	// leaves it relative.
+	if abs, err := filepath.Abs(workspace); err == nil {
+		workspace = abs
+	}
 	configDir = opts.ConfigDir
 	if configDir == "" {
 		// Check .humanconfig for devcontainer.configdir.
 		if hcfg, err := devcontainer.LoadHumanConfig(workspace); err == nil && hcfg.ConfigDir != "" {
 			configDir = hcfg.ConfigDir
 			if !filepath.IsAbs(configDir) {
-				abs, _ := filepath.Abs(workspace)
-				configDir = filepath.Join(abs, configDir)
+				configDir = filepath.Join(workspace, configDir)
 			}
 		} else {
 			configDir = workspace

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -5,6 +5,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -147,12 +148,19 @@ func TestBuildClaudeArgs(t *testing.T) {
 func TestResolveDirectories_DefaultWorkspace(t *testing.T) {
 	opts := StartOpts{}
 	workspace, configDir := resolveDirectories(opts)
-	if workspace != "." {
-		t.Errorf("workspace = %q, want %q", workspace, ".")
+	wantCwd, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("filepath.Abs(\".\") failed: %v", err)
+	}
+	// workspace must be absolute: it becomes projectDir, which worktreeGitDir
+	// joins with ".git" for a Docker bind-mount source, and Docker rejects a
+	// relative mount path outright.
+	if workspace != wantCwd {
+		t.Errorf("workspace = %q, want %q", workspace, wantCwd)
 	}
 	// When no ConfigDir and no .humanconfig, configDir falls back to workspace.
-	if configDir != "." {
-		t.Errorf("configDir = %q, want %q", configDir, ".")
+	if configDir != wantCwd {
+		t.Errorf("configDir = %q, want %q", configDir, wantCwd)
 	}
 }
 


### PR DESCRIPTION
## Summary
- An unset `--workspace` defaulted to the relative path `"."`, which flowed into `projectDir`. `worktreeGitDir` then joined that with `.git` to build a Docker bind-mount source, and Docker rejects relative bind-mount paths outright — `invalid mount path: '.git' must be absolute`.
- `resolveDirectories()` in `internal/agent/manager.go` now resolves `workspace` to an absolute path via `filepath.Abs` immediately after the `"."` default is applied, before it's used to derive `configDir` or the Docker mount path.
- Updated `TestResolveDirectories_DefaultWorkspace` to expect the absolute cwd instead of the literal `"."`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/agent/...`

Fixes SC-1542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)