### PR TITLE
[SC-1883] Stop a leaked global log mode from flaking the proxy suite

### DIFF
--- a/internal/proxy/mitm_test.go
+++ b/internal/proxy/mitm_test.go
@@ -61,6 +61,19 @@ func newInterceptTestEnv(t *testing.T) *interceptTestEnv {
 	}
 }
 
+// withLogMode pins the global traffic log mode for one test and restores
+// whatever was there before. The mode is process-global, so a test that
+// restores a hard-coded value instead of the previous one silently changes the
+// environment every later test runs in — and a test that leaks full logging
+// makes any subsequent MITM test write traffic files asynchronously into its
+// t.TempDir, racing Go's cleanup.
+func withLogMode(t *testing.T, mode LogMode) {
+	t.Helper()
+	prev := GetLogMode()
+	SetLogMode(mode)
+	t.Cleanup(func() { SetLogMode(prev) })
+}
+
 // startUpstreamTLS starts a mock TLS server that handles connections with handler.
 // Returns the listener address.
 func startUpstreamTLS(t *testing.T, env *interceptTestEnv, hostname string, handler func(net.Conn)) net.Listener {
@@ -210,9 +223,7 @@ func TestLogMode_MetaStripsBody(t *testing.T) {
 		},
 	}
 
-	// Set meta mode.
-	SetLogMode(LogModeMeta)
-	defer SetLogMode(LogModeFull) // restore
+	withLogMode(t, LogModeMeta)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -276,8 +287,7 @@ func TestLogMode_OffSkipsLogging(t *testing.T) {
 		},
 	}
 
-	SetLogMode(LogModeOff)
-	defer SetLogMode(LogModeFull)
+	withLogMode(t, LogModeOff)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -269,6 +269,13 @@ func TestServer_interceptedConnectionMITM(t *testing.T) {
 	env := newInterceptTestEnv(t)
 	hostname := "intercept.example.com"
 
+	// This test asserts routing, not logging. Pin logging off rather than
+	// inheriting the global mode: the interceptor logs on the serving
+	// goroutine, which outlives the request, so an inherited full mode would
+	// let a traffic write land in env.LogDir after the test returned and race
+	// the t.TempDir cleanup that is removing it.
+	withLogMode(t, LogModeOff)
+
 	policy, err := NewPolicy(ModeAllow, []string{hostname, "passthrough.example.com"})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Fixes the intermittent `internal/proxy` failure that redded PR #262 — a change touching only two compiled JS files — and can red any PR at random.

## Root cause

`TestLogMode_MetaStripsBody` and `TestLogMode_OffSkipsLogging` set the process-global traffic log mode and then restored it to `LogModeFull` instead of the value they inherited. Everything running after them therefore ran with full logging on. `TestServer_interceptedConnectionMITM` then wrote traffic logs into its `t.TempDir` from the serving goroutine, which outlives the request — racing Go's `RemoveAll` cleanup:

```
TempDir RemoveAll cleanup: unlinkat /tmp/TestServer_...287831701/002: directory not empty
```

Intermittent because the trigger is test ordering and write timing, never the change under test.

## Evidence

Probed both ways in a throwaway worktree:

| | inherited mode | files left in LogDir at cleanup |
|---|---|---|
| before | `full` | `[2026-07-30.jsonl]` |
| after | `off` | `[]` |

The race window is closed by construction — nothing is written to that directory any more.

## Fix

- `withLogMode(t, mode)` saves the inherited mode and restores it via `t.Cleanup`, so no test decides what mode another runs in.
- The MITM test pins logging off explicitly: it asserts routing, not logging, and should not depend on inherited state.

Coverage in `internal/proxy` is unchanged at 81.4%; the MITM test is fixed, not deleted or skipped.

## Verification

- `go test ./internal/proxy/ -count=3` — pass
- `go test ./internal/proxy/ -shuffle=on` — pass (this is what catches the leak)
- `go test ./internal/proxy/ -race` — pass
- `make check` — clean (gosec 0 issues, no vulnerabilities, no leaks)

Randomised-order runs in the gate would catch the next instance of this class automatically; noted on the ticket rather than done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)