### PR TITLE
[SC-2005] Stop one credential hiccup from blanking the board, and say what broke

### DIFF
--- a/cmd/cmddaemon/board_stale_test.go
+++ b/cmd/cmddaemon/board_stale_test.go
@@ -1,0 +1,78 @@
+package cmddaemon
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/daemon"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// goodListing is a listing that actually produced work.
+func goodListing() []daemon.TrackerIssuesResult {
+	return []daemon.TrackerIssuesResult{{
+		TrackerName: "human",
+		TrackerRole: "pm",
+		Project:     "board",
+		Issues:      []tracker.Issue{{Key: "SC-1", Title: "one"}},
+	}}
+}
+
+// The defect: a refresh that failed handed the board nothing, and an empty
+// board is indistinguishable from having no work at all (SC-2005).
+func TestStaleListing_FailedRefreshKeepsTheLastGoodCards(t *testing.T) {
+	served, err := staleListing(goodListing(), errors.New("resolving 1Password secret via CLI"))
+
+	require.NoError(t, err, "a failed refresh with a remembered listing must not blank the board")
+	require.Len(t, served, 2)
+	assert.Equal(t, "SC-1", served[0].Issues[0].Key, "the last good cards survive")
+}
+
+// Keeping the cards must not hide the failure: a silently stale board that
+// looks healthy trades a visible problem for an invisible one.
+func TestStaleListing_SaysItIsStale(t *testing.T) {
+	served, err := staleListing(goodListing(), errors.New("boom"))
+
+	require.NoError(t, err)
+	last := served[len(served)-1]
+	assert.Contains(t, last.Err, "this refresh failed")
+	assert.Contains(t, last.Err, "boom", "the underlying cause travels with the notice")
+	assert.Empty(t, last.Issues, "the staleness notice carries no cards of its own")
+}
+
+// With nothing ever fetched there is nothing truer to show than the failure.
+func TestStaleListing_NoRememberedListingSurfacesTheError(t *testing.T) {
+	served, err := staleListing(nil, errors.New("boom"))
+
+	require.Error(t, err)
+	assert.Nil(t, served)
+}
+
+// The remembered listing is shared across refreshes, so serving it must not
+// let a caller mutate it.
+func TestStaleListing_DoesNotMutateTheRememberedListing(t *testing.T) {
+	remembered := goodListing()
+
+	served, err := staleListing(remembered, errors.New("boom"))
+	require.NoError(t, err)
+	served[0].Project = "clobbered"
+
+	assert.Equal(t, "board", remembered[0].Project,
+		"the fallback later refreshes depend on must be untouched")
+	assert.Len(t, remembered, 1, "the staleness notice must not land in the remembered listing")
+}
+
+// Only a listing that produced issues is worth remembering — otherwise one bad
+// refresh becomes the "last good" one and pins the board empty for good.
+func TestAnyIssues_DistinguishesRealWorkFromAnAllErrorListing(t *testing.T) {
+	assert.True(t, anyIssues(goodListing()))
+
+	assert.False(t, anyIssues([]daemon.TrackerIssuesResult{
+		{Project: "credentials", Err: "resolving 1Password secret via CLI"},
+	}), "an all-error listing must never become the fallback")
+
+	assert.False(t, anyIssues(nil))
+}

--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -1468,10 +1468,24 @@ func fetchTrackerIssuesFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolve
 		c, ok := lastCards[key]
 		return c, ok
 	}
+	// lastResults is the newest listing that actually produced issues. A refresh
+	// that fails outright serves this instead of nothing: an empty board is
+	// indistinguishable from having no work at all, which is the false
+	// impression the whole board is built to avoid (SC-2005). The failure still
+	// rides along as an error result, so the board says it is stale rather than
+	// quietly presenting old cards as current.
+	var lastResults []daemon.TrackerIssuesResult
 	return func() ([]daemon.TrackerIssuesResult, error) {
 		jobs, results, err := listTrackerIssues(reg, resolver)
 		if err != nil {
-			return nil, err
+			mu.Lock()
+			stale := lastResults
+			mu.Unlock()
+			served, serveErr := staleListing(stale, err)
+			if serveErr == nil {
+				logger.Warn().Err(err).Msg("board fetch failed; serving the last good listing marked stale")
+			}
+			return served, serveErr
 		}
 
 		// Scan PM-tracker comments for [human:ready-for-review] handoffs and
@@ -1491,8 +1505,48 @@ func fetchTrackerIssuesFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolve
 		mu.Unlock()
 
 		applyScanResults(results, readyKeys, readyPRs, boardCards)
+		// Only a listing that actually produced issues is worth falling back to:
+		// remembering an all-error listing would let one bad refresh become the
+		// "last good" one and pin the board empty.
+		if anyIssues(results) {
+			mu.Lock()
+			lastResults = results
+			mu.Unlock()
+		}
 		return results, nil
 	}
+}
+
+// anyIssues reports whether a listing carried at least one issue.
+func anyIssues(results []daemon.TrackerIssuesResult) bool {
+	for _, r := range results {
+		if len(r.Issues) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// staleListing decides what a failed refresh should serve. With a remembered
+// listing it serves that, plus an error result announcing the staleness — the
+// board keeps its cards AND says they are not current. With nothing remembered
+// it surfaces the failure, because there is nothing truer to show than "this
+// did not work".
+//
+// The announcement is not optional: trading a blank board for a silently stale
+// one that looks healthy would replace a visible problem with an invisible one.
+// The remembered listing is copied so a caller cannot mutate the fallback that
+// later refreshes still depend on.
+func staleListing(stale []daemon.TrackerIssuesResult, err error) ([]daemon.TrackerIssuesResult, error) {
+	if len(stale) == 0 {
+		return nil, err
+	}
+	out := make([]daemon.TrackerIssuesResult, len(stale), len(stale)+1)
+	copy(out, stale)
+	return append(out, daemon.TrackerIssuesResult{
+		Project: "refresh",
+		Err:     "showing the last successful fetch — this refresh failed: " + err.Error(),
+	}), nil
 }
 
 // fetchTrackerIssuesLiteFunc returns a fetcher that lists issue titles only,
@@ -1555,11 +1609,16 @@ func issueGetterFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver) func
 func listTrackerIssues(reg *daemon.ProjectRegistry, resolver *vault.Resolver) ([]fetchJob, []daemon.TrackerIssuesResult, error) {
 	// Collect all (instance, project) pairs first.
 	var jobs []fetchJob
+	// loadFailures are credential/config failures that cost us whole instances.
+	// They are carried to the end and appended as visible error results rather
+	// than aborting: one provider's momentary credential failure used to erase
+	// every OTHER provider's cards, blanking the board (SC-2005). Secrets are
+	// deliberately never cached, so this load runs on every refresh and any blip
+	// took the whole board down with it.
+	var loadFailures []error
 	for _, entry := range reg.Entries() {
-		instances, err := cmdutil.LoadAllInstancesWithResolver(entry.Dir, entry.EnvLookup(), resolver)
-		if err != nil {
-			return nil, nil, err
-		}
+		instances, failures := cmdutil.LoadAllInstancesTolerant(entry.Dir, entry.EnvLookup(), resolver)
+		loadFailures = append(loadFailures, failures...)
 		for _, inst := range instances {
 			projects := inst.Projects
 			if len(projects) == 0 {
@@ -1611,6 +1670,18 @@ func listTrackerIssues(reg *daemon.ProjectRegistry, resolver *vault.Resolver) ([
 		}(i, job)
 	}
 	wg.Wait()
+
+	// A tracker we could not even build carries no issues, so it appends as a
+	// pure error result: the board shows the failure without losing the
+	// trackers that did load. No fetchJob is added for it — jobs and results
+	// stay 1:1, and the comment-scan fan-out skips it on the empty role.
+	for _, err := range loadFailures {
+		results = append(results, daemon.TrackerIssuesResult{
+			Project: "credentials",
+			Err:     err.Error(),
+		})
+		jobs = append(jobs, fetchJob{})
+	}
 
 	// Record which project each PM-role key was fetched from so keyed
 	// board-action closures can route a request to its owning project

--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -1618,6 +1618,15 @@ func listTrackerIssues(reg *daemon.ProjectRegistry, resolver *vault.Resolver) ([
 	var loadFailures []error
 	for _, entry := range reg.Entries() {
 		instances, failures := cmdutil.LoadAllInstancesTolerant(entry.Dir, entry.EnvLookup(), resolver)
+		for _, failure := range failures {
+			// LogError renders the full cause chain AND the attached details (the
+			// secret reference, op's stderr, the exit code). Only the outermost
+			// message survives to the board banner, so the log is the one place
+			// the whole diagnosis lands — without it a recurring credential blip
+			// leaves nothing to debug after the fact (SC-2005).
+			errors.LogError(failure).Str("dir", entry.Dir).
+				Msg("board listing: tracker instances failed to load, continuing without them")
+		}
 		loadFailures = append(loadFailures, failures...)
 		for _, inst := range instances {
 			projects := inst.Projects

--- a/cmd/cmdutil/instances.go
+++ b/cmd/cmdutil/instances.go
@@ -114,6 +114,39 @@ func LoadAllInstancesWithResolver(dir string, lookup config.EnvLookup, resolver 
 	return all, nil
 }
 
+// LoadAllInstancesTolerant is LoadAllInstancesWithResolver for callers that
+// would rather render the trackers that DID load than nothing at all: it
+// returns every instance it could build plus the failures it hit, instead of
+// abandoning the whole set at the first one.
+//
+// The strict variant is right where a caller needs one specific tracker and a
+// missing credential means it cannot proceed. It is wrong for the board's
+// listing, where one provider's momentary credential failure erased every other
+// provider's cards too (SC-2005) — secrets are deliberately never cached, so
+// that lookup runs on every refresh and any blip took the board down with it.
+//
+// The failures are returned rather than logged so the caller can surface them:
+// a partial board must SAY it is partial, never quietly present fewer trackers
+// as if that were all there is.
+func LoadAllInstancesTolerant(dir string, lookup config.EnvLookup, resolver *vault.Resolver) ([]tracker.Instance, []error) {
+	dir = config.ResolveDir(dir)
+	var resolveFunc config.SecretResolveFunc
+	if resolver != nil {
+		resolveFunc = resolver.Resolve
+	}
+	var all []tracker.Instance
+	var failures []error
+	for _, load := range allLoadersWithResolver {
+		instances, err := load(dir, lookup, resolveFunc)
+		if err != nil {
+			failures = append(failures, err)
+			continue
+		}
+		all = append(all, instances...)
+	}
+	return all, failures
+}
+
 // InstanceFromFlags builds a tracker instance from root persistent flags,
 // returning nil when insufficient flags are provided.
 func InstanceFromFlags(cmd *cobra.Command) *tracker.Instance {

--- a/cmd/cmdutil/instances_tolerant_test.go
+++ b/cmd/cmdutil/instances_tolerant_test.go
@@ -1,0 +1,91 @@
+package cmdutil
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/vault"
+)
+
+// failingProvider stands in for a vault whose backing CLI is momentarily
+// unavailable — the real-world trigger — without shelling out to it.
+type failingProvider struct{}
+
+func (failingProvider) CanResolve(ref string) bool { return strings.HasPrefix(ref, "1pw://") }
+
+func (failingProvider) Resolve(string) (string, error) {
+	return "", errors.New("resolving 1Password secret via CLI")
+}
+
+// configDir writes a .humanconfig.yaml into a fresh temp dir.
+func configDir(t *testing.T, yaml string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".humanconfig.yaml"), []byte(yaml), 0o600))
+	return dir
+}
+
+// oneBadOneGood configures two trackers where only the first carries an
+// unresolvable secret reference.
+const oneBadOneGood = `
+vault:
+  provider: 1password
+  account: nonexistent-account-for-test
+githubs:
+  - name: broken
+    token: 1pw://NoSuchVault/NoSuchItem/token
+shortcuts:
+  - name: working
+    token: plain-token-value
+`
+
+// The defect: one provider's credential failure erased every OTHER provider's
+// instances, so a momentary vault hiccup blanked the whole board (SC-2005).
+func TestLoadAllInstancesTolerant_KeepsTheTrackersThatLoaded(t *testing.T) {
+	dir := configDir(t, oneBadOneGood)
+
+	instances, failures := LoadAllInstancesTolerant(dir, nil, vault.NewResolver(failingProvider{}))
+
+	require.NotEmpty(t, failures, "the unresolvable reference must be reported")
+	names := make([]string, 0, len(instances))
+	for _, inst := range instances {
+		names = append(names, inst.Name)
+	}
+	assert.Contains(t, names, "working",
+		"a working tracker must survive another tracker's credential failure")
+	assert.NotContains(t, names, "broken")
+}
+
+// The strict variant keeps its all-or-nothing contract: callers that need one
+// specific tracker must still be told the load failed rather than handed a
+// silently short list.
+func TestLoadAllInstancesWithResolver_StillFailsWholesale(t *testing.T) {
+	dir := configDir(t, oneBadOneGood)
+
+	instances, err := LoadAllInstancesWithResolver(dir, nil, vault.NewResolver(failingProvider{}))
+
+	require.Error(t, err, "the strict loader must keep aborting on a credential failure")
+	assert.Nil(t, instances)
+}
+
+// With every credential resolvable there is nothing to report, and the tolerant
+// loader must behave exactly like the strict one.
+func TestLoadAllInstancesTolerant_NoFailuresWhenAllLoad(t *testing.T) {
+	dir := configDir(t, `
+shortcuts:
+  - name: working
+    token: plain-token-value
+`)
+
+	instances, failures := LoadAllInstancesTolerant(dir, nil, vault.NewResolver())
+
+	assert.Empty(t, failures)
+	require.Len(t, instances, 1)
+	assert.Equal(t, "working", instances[0].Name)
+}

--- a/internal/vault/opcli.go
+++ b/internal/vault/opcli.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"context"
+	stderrors "errors"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -16,6 +17,11 @@ import (
 // and flag introducers so no value that slips past the prefix check
 // can reach the CLI as a rogue argument.
 var opRefPattern = regexp.MustCompile(`^op://[A-Za-z0-9 _./\-]+$`)
+
+// opTimeout bounds one op invocation. It must be generous enough for a cold
+// CLI start and an unlock round-trip, yet short enough that an unresponsive
+// CLI does not stall every caller waiting on a secret.
+const opTimeout = 30 * time.Second
 
 // OpCLI resolves 1pw:// secret references by shelling out to the 1Password CLI.
 // It is the fallback behind the in-process SDK on every platform: released
@@ -63,7 +69,7 @@ func (o *OpCLI) Resolve(ref string) (string, error) {
 			"ref", ref)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
 	defer cancel()
 
 	var out []byte
@@ -74,13 +80,53 @@ func (o *OpCLI) Resolve(ref string) (string, error) {
 		out, err = exec.CommandContext(ctx, o.Binary, "read", sdkRef).Output() // #nosec G204 -- binary is a static default, ref is from config
 	}
 	if err != nil {
-		// .Output() stashes the command's stderr on *exec.ExitError; surfacing
-		// it turns an opaque "exit status 1" into the actual op diagnostic.
-		if exitErr, ok := err.(*exec.ExitError); ok && len(exitErr.Stderr) > 0 {
-			return "", errors.WrapWithDetails(err, "resolving 1Password secret via CLI",
-				"ref", ref, "stderr", strings.TrimSpace(string(exitErr.Stderr)))
-		}
-		return "", errors.WrapWithDetails(err, "resolving 1Password secret via CLI", "ref", ref)
+		return "", opFailure(o.Binary, ref, err, ctx.Err())
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// opFailure builds the error for a failed op invocation.
+//
+// The MESSAGE has to carry the diagnosis, not just the attached details: only
+// err.Error() survives the daemon→client hops, so a board banner shows the
+// message alone. The old one — "resolving 1Password secret via CLI" — named no
+// secret, no cause and no remedy, so a transient blip and a permanently signed-out
+// CLI were indistinguishable, and with several references configured it did not
+// even say WHICH one failed (SC-2005).
+//
+// The reference is safe to show: it is a vault/item/field path that already sits
+// in .humanconfig, never the secret it points at. op's own stderr is included
+// because it is the line that actually tells you what to do ("not signed in",
+// "item not found"), and the distinct failure shapes — binary absent, timed out,
+// non-zero exit — are separated because their remedies are different.
+func opFailure(binary, ref string, err error, ctxErr error) error {
+	details := []any{"ref", ref, "binary", binary}
+	switch {
+	case ctxErr != nil:
+		return errors.WrapWithDetails(err,
+			"1Password CLI "+binary+" timed out after "+opTimeout.String()+" reading "+ref+
+				" — the CLI is unresponsive or waiting on an unlock prompt",
+			append(details, "timeout", opTimeout.String())...)
+
+	case stderrors.Is(err, exec.ErrNotFound):
+		return errors.WrapWithDetails(err,
+			"1Password CLI "+binary+" not found on PATH, needed to read "+ref+
+				" — install it, or use env vars instead of a 1pw:// reference",
+			details...)
+	}
+
+	// .Output() stashes the command's stderr on *exec.ExitError; surfacing it
+	// turns an opaque "exit status 1" into op's actual diagnostic.
+	var exitErr *exec.ExitError
+	if stderrors.As(err, &exitErr) {
+		diag := strings.TrimSpace(string(exitErr.Stderr))
+		if diag == "" {
+			diag = "no diagnostic on stderr"
+		}
+		return errors.WrapWithDetails(err,
+			"1Password CLI "+binary+" could not read "+ref+": "+diag,
+			append(details, "stderr", diag, "exit_code", exitErr.ExitCode())...)
+	}
+	return errors.WrapWithDetails(err,
+		"1Password CLI "+binary+" could not read "+ref+": "+err.Error(), details...)
 }

--- a/internal/vault/opcli_failure_test.go
+++ b/internal/vault/opcli_failure_test.go
@@ -1,0 +1,110 @@
+package vault
+
+import (
+	"context"
+	stderrors "errors"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/errors"
+)
+
+const testRef = "1pw://Private/Shortcut Token/notesPlain"
+
+// TestOpCLIHelperProcess is not a real test: it is re-executed as a child so
+// the suite can obtain a GENUINE *exec.ExitError (with a real ProcessState and
+// captured stderr) instead of a hand-built one, which cannot report an exit
+// code. The standard library uses the same idiom for exactly this reason.
+func TestOpCLIHelperProcess(t *testing.T) {
+	if os.Getenv("HUMAN_OPCLI_HELPER") != "1" {
+		return
+	}
+	if diag := os.Getenv("HUMAN_OPCLI_STDERR"); diag != "" {
+		_, _ = os.Stderr.WriteString(diag)
+	}
+	os.Exit(3)
+}
+
+// exitErrorWithStderr runs the helper process and returns the *exec.ExitError
+// its failure produced.
+func exitErrorWithStderr(t *testing.T, diag string) *exec.ExitError {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=TestOpCLIHelperProcess") // #nosec G204 -- re-executes this test binary
+	cmd.Env = append(os.Environ(), "HUMAN_OPCLI_HELPER=1", "HUMAN_OPCLI_STDERR="+diag)
+	_, err := cmd.Output()
+
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr, "the helper must fail with an ExitError")
+	return exitErr
+}
+
+// resolveWith runs Resolve against a stubbed op invocation.
+func resolveWith(t *testing.T, run func(ctx context.Context) ([]byte, error)) error {
+	t.Helper()
+	o := &OpCLI{
+		Binary: "op",
+		runner: func(ctx context.Context, _ string, _ ...string) ([]byte, error) { return run(ctx) },
+	}
+	_, err := o.Resolve(testRef)
+	require.Error(t, err)
+	return err
+}
+
+// The message is all the board banner ever shows, so it must name WHICH secret
+// failed — with several references configured the old message could not even
+// distinguish the Shortcut token from the GitHub one (SC-2005).
+func TestOpFailure_MessageNamesTheReference(t *testing.T) {
+	err := resolveWith(t, func(context.Context) ([]byte, error) {
+		return nil, stderrors.New("boom")
+	})
+
+	assert.Contains(t, err.Error(), testRef, "the failing reference must be in the message itself")
+	assert.Contains(t, err.Error(), "boom", "the underlying cause must be in the message itself")
+}
+
+// op's own stderr is the line that says what to do about it, so it belongs in
+// the message rather than only in the attached details.
+func TestOpFailure_SurfacesOpsDiagnostic(t *testing.T) {
+	err := resolveWith(t, func(context.Context) ([]byte, error) {
+		return nil, exitErrorWithStderr(t, "  [ERROR] not signed in\n")
+	})
+
+	assert.Contains(t, err.Error(), "not signed in")
+	details := errors.AllDetails(err)
+	assert.Equal(t, "[ERROR] not signed in", details["stderr"], "stderr is also attached for the log")
+	assert.Equal(t, testRef, details["ref"])
+}
+
+// A missing binary is a permanent misconfiguration, not a blip, and its remedy
+// is different — the message must say so instead of reading like a failed read.
+func TestOpFailure_MissingBinaryIsNamedAsSuch(t *testing.T) {
+	err := resolveWith(t, func(context.Context) ([]byte, error) {
+		return nil, exec.ErrNotFound
+	})
+
+	assert.Contains(t, err.Error(), "not found on PATH")
+	assert.Contains(t, err.Error(), testRef)
+}
+
+// An exit status with nothing on stderr must still say something better than a
+// bare exit code.
+func TestOpFailure_EmptyStderrStillExplains(t *testing.T) {
+	err := opFailure("op", testRef, exitErrorWithStderr(t, ""), nil)
+
+	assert.Contains(t, err.Error(), "no diagnostic on stderr")
+	assert.Contains(t, err.Error(), testRef)
+}
+
+// The timeout branch, exercised directly: a non-nil context error means the
+// invocation was cut short rather than answered.
+func TestOpFailure_ContextErrorReportsTimeout(t *testing.T) {
+	err := opFailure("op", testRef, context.DeadlineExceeded, context.DeadlineExceeded)
+
+	assert.Contains(t, err.Error(), "timed out")
+	assert.Contains(t, err.Error(), testRef)
+	assert.Contains(t, err.Error(), opTimeout.String())
+}

--- a/internal/vault/opcli_test.go
+++ b/internal/vault/opcli_test.go
@@ -54,7 +54,12 @@ func TestOpCLI_Resolve_error(t *testing.T) {
 
 	_, err := op.Resolve("1pw://vault/item/field")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "resolving 1Password secret via CLI")
+	// The message must identify the binary, the reference and the cause: it is
+	// the only part that survives to a board banner, and the old wording
+	// ("resolving 1Password secret via CLI") named none of the three (SC-2005).
+	assert.Contains(t, err.Error(), "op.exe")
+	assert.Contains(t, err.Error(), "1pw://vault/item/field")
+	assert.Contains(t, err.Error(), "command failed")
 }
 
 func TestOpCLI_Resolve_translatesPrefix(t *testing.T) {

--- a/internal/vault/opcli_test.go
+++ b/internal/vault/opcli_test.go
@@ -31,9 +31,9 @@ func TestNewOpCLI_binaryByPlatform(t *testing.T) {
 
 func TestOpCLI_Resolve_success(t *testing.T) {
 	op := &OpCLI{
-		Binary: "op.exe",
+		Binary: "op",
 		runner: func(_ context.Context, binary string, args ...string) ([]byte, error) {
-			assert.Equal(t, "op.exe", binary)
+			assert.Equal(t, "op", binary)
 			assert.Equal(t, []string{"read", "op://DevVault/GitHub PAT/token"}, args)
 			return []byte("my-secret-token\n"), nil
 		},
@@ -46,7 +46,7 @@ func TestOpCLI_Resolve_success(t *testing.T) {
 
 func TestOpCLI_Resolve_error(t *testing.T) {
 	op := &OpCLI{
-		Binary: "op.exe",
+		Binary: "op",
 		runner: func(_ context.Context, _ string, _ ...string) ([]byte, error) {
 			return nil, errors.WithDetails("command failed")
 		},
@@ -57,7 +57,7 @@ func TestOpCLI_Resolve_error(t *testing.T) {
 	// The message must identify the binary, the reference and the cause: it is
 	// the only part that survives to a board banner, and the old wording
 	// ("resolving 1Password secret via CLI") named none of the three (SC-2005).
-	assert.Contains(t, err.Error(), "op.exe")
+	assert.Contains(t, err.Error(), "1Password CLI op could not read")
 	assert.Contains(t, err.Error(), "1pw://vault/item/field")
 	assert.Contains(t, err.Error(), "command failed")
 }
@@ -65,7 +65,7 @@ func TestOpCLI_Resolve_error(t *testing.T) {
 func TestOpCLI_Resolve_translatesPrefix(t *testing.T) {
 	var capturedArgs []string
 	op := &OpCLI{
-		Binary: "op.exe",
+		Binary: "op",
 		runner: func(_ context.Context, _ string, args ...string) ([]byte, error) {
 			capturedArgs = args
 			return []byte("the-password"), nil


### PR DESCRIPTION
Closes SC-2005.

The board went completely blank whenever a single credential lookup failed for a moment, then filled back in on the next refresh — flapping blank/back — while the only diagnosis offered was `resolving 1Password secret via CLI`.

## Why it blanked

Preparing tracker access was all-or-nothing twice over:

- `LoadAllInstancesWithResolver` abandons every provider at the first one whose secret will not resolve.
- `listTrackerIssues` abandoned the whole listing at the first project that failed.

`fetchTrackerIssuesFunc` then returned the error, and the board drew an empty workspace — which reads as "there is no work", the exact false impression the "No PM-role tracker configured" notice exists to prevent.

Secrets are deliberately never cached (the right call — it keeps the vault the single source of truth), so this lookup runs on **every refresh**. Any transient failure of the tool holding the secret took the board down for that cycle.

What makes it worse is that every neighbouring failure was already tolerated: a tracker that cannot list its issues is recorded against that tracker, and a ticket whose details cannot be read keeps its last-known stage (SC-1700). The protection built for exactly this disappearance sat directly below the one step that had none.

## Changes

**`LoadAllInstancesTolerant`** — returns the instances it could build plus the failures it hit, so one provider's blip no longer erases the others' cards. Failures are returned rather than logged so the caller can surface them: a partial board must say it is partial. The strict loader keeps its contract for callers that need one named tracker.

**Never render an unverified emptiness** — a refresh that fails outright now serves the last listing that actually produced issues, with an error result announcing the staleness. Falling back silently would trade a visible problem for an invisible one. Only a listing that carried issues is remembered, so one bad refresh cannot become the "last good" one and pin the board empty.

**Say what actually broke** — the old message named no secret, no cause and no remedy, so with several references configured it did not even say *which* token failed. The detail existed but was unreachable: op's stderr was an error detail, and only `err.Error()` survives the daemon→client hops. The diagnosis now lives in the message:

```
1Password CLI op could not read 1pw://Private/Shortcut Token/notesPlain: [ERROR] not signed in
1Password CLI op not found on PATH, needed to read 1pw://… — install it, or use env vars instead
```

Failure shapes whose remedies differ (binary absent, timed out, non-zero exit) are separated. The reference is safe to print — a vault/item/field path already in `.humanconfig`, never the secret behind it.

**Log the full picture** — instance-load failures go through `errors.LogError`, which renders the whole cause chain plus details (reference, stderr, exit code). Without it a recurring blip left nothing to debug after the fact.

## Verification

`make check` green: 3848 tests, 0 lint issues, gosec 0, govulncheck and gitleaks clean.

Not verified live — reproducing needs a real credential failure against the running daemon, which is the user's to trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)