### PR TITLE
[SC-1450] Gate the stuck-card takeover on a fact, not a clock

### DIFF
--- a/internal/daemon/board_reconcile.go
+++ b/internal/daemon/board_reconcile.go
@@ -160,7 +160,7 @@ func reconcileOnce(ctx context.Context, listCards ReconcileLister, reachable Bra
 	if n := reconcilePRLoops(ctx, cards, liveAgents, driveLoop, logger); n > 0 {
 		logger.Info().Int("redriven", n).Msg("board reconcile: re-drove stalled PR review→fix loops")
 	}
-	if n := reconcileStuckRunning(ctx, cards, liveAgents, postFailed, retry, progress, stopAgent, daemonID, time.Now(), logger); n > 0 {
+	if n := reconcileStuckRunning(ctx, cards, liveAgents, postFailed, reachable, retry, progress, stopAgent, daemonID, time.Now(), logger); n > 0 {
 		logger.Info().Int("reddened", n).Msg("board reconcile: reddened stuck-running cards with no live agent")
 	}
 	// Last: the passes above all act on cards that are still ON the board, while
@@ -270,7 +270,7 @@ func stuckRunningCandidate(derived BoardCard, comments []tracker.Comment) bool {
 // once the *-failed marker lands the card derives BoardFailed, so the next tick
 // skips it and never double-posts. Reuses DeriveBoardCard verbatim so detection
 // can never disagree with the board's rendered state. Returns the number reddened.
-func reconcileStuckRunning(ctx context.Context, cards []ReconcileCard, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, retry StageRetry, progress AgentProgressProbe, stopAgent func(agentName string) error, daemonID string, now time.Time, logger zerolog.Logger) int {
+func reconcileStuckRunning(ctx context.Context, cards []ReconcileCard, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, reachable BranchReachable, retry StageRetry, progress AgentProgressProbe, stopAgent func(agentName string) error, daemonID string, now time.Time, logger zerolog.Logger) int {
 	if liveAgents == nil || postFailed == nil {
 		return 0
 	}
@@ -289,20 +289,7 @@ func reconcileStuckRunning(ctx context.Context, cards []ReconcileCard, liveAgent
 	reddened := 0
 	for _, card := range cards {
 		derived := DeriveBoardCard(card.Comments, tracker.CategoryUnstarted, false)
-		// Only a running card with no active PR loop is a stuck-running candidate.
-		// A mid-flight review→fix loop is owned by reconcilePRLoops, not this hang
-		// detector: its half-agents come and go between rounds, so the absence of a
-		// live agent here is normal rather than a dead-end.
-		if !stuckRunningCandidate(derived, card.Comments) {
-			continue
-		}
-		// An open [human:options] block for the card's OWN running stage is a
-		// deliberate human pause, not a hang — the live failure path already
-		// treats it as a clean pause (stagePausedOnOptions). [human:options] is
-		// not a state marker, so the card stays BoardRunning; without this twin
-		// guard the durable reconcile pass reddens the pause and loops
-		// re-planning forever (1290, the planning twin of SC-751).
-		if cardPausedOnOwnStage(derived) {
+		if !stuckCardIsOursToRed(derived, card, reachable, logger) {
 			continue
 		}
 		header := failedHeaderFor(derived.Stage)
@@ -377,6 +364,61 @@ func stuckRunningGraceFor(stageDaemonID, daemonID string) time.Duration {
 // board card rather than raw comments (1290).
 func cardPausedOnOwnStage(derived BoardCard) bool {
 	return len(derived.Options) > 0 && derived.OptionsStage == derived.Stage
+}
+
+// stuckCardIsOursToRed collects the three reasons a card must be left alone
+// before any hang judgement is made: it is not a stuck-running candidate, it is
+// deliberately paused on a human decision, or its work lives on another machine.
+// Kept together so the "leave it alone" cases read as one unit and the caller
+// stays a decision about hangs rather than a wall of guards.
+func stuckCardIsOursToRed(derived BoardCard, card ReconcileCard, reachable BranchReachable, logger zerolog.Logger) bool {
+	// Only a running card with no active PR loop is a stuck-running candidate.
+	// A mid-flight review→fix loop is owned by reconcilePRLoops, not this hang
+	// detector: its half-agents come and go between rounds, so the absence of a
+	// live agent here is normal rather than a dead-end.
+	if !stuckRunningCandidate(derived, card.Comments) {
+		return false
+	}
+	// An open [human:options] block for the card's OWN running stage is a
+	// deliberate human pause, not a hang — the live failure path already
+	// treats it as a clean pause (stagePausedOnOptions). [human:options] is
+	// not a state marker, so the card stays BoardRunning; without this twin
+	// guard the durable reconcile pass reddens the pause and loops
+	// re-planning forever (1290, the planning twin of SC-751).
+	if cardPausedOnOwnStage(derived) {
+		return false
+	}
+	// A card whose branch this machine cannot resolve is not this machine's to
+	// declare dead. Reddening it retries the stage HERE, against work that lives
+	// somewhere else — the peer's run is killed off mid-flight and the retry then
+	// fails on a branch it cannot check out (SC-1450).
+	//
+	// This is the hard half of that guard. StuckRunningForeignGrace is a clock:
+	// it delays a wrong takeover, it cannot prevent one, and it only helps when
+	// the deciding marker happens to carry a peer's id. Reachability is a fact
+	// about this disk that no elapsed time changes.
+	if !branchActionableHere(derived, reachable) {
+		logger.Debug().Str("pm", card.Key).Str("branch", derived.Branch).
+			Msg("board reconcile: stuck card's branch is unreachable here, leaving it for the machine that owns it")
+		return false
+	}
+	return true
+}
+
+// branchActionableHere reports whether THIS machine could actually act on the
+// card, by the only test that is a fact rather than a judgement: can it resolve
+// the card's branch.
+//
+// A card with no branch yet — planning, or a build that has not handed off — is
+// treated as actionable, because there is no fact to consult and refusing would
+// disable the hang detector for every early stage. Those cards keep the older,
+// softer protection (the grace plus the liveness probe). A nil predicate
+// disables the gate, matching the package's "nil disables" convention.
+func branchActionableHere(derived BoardCard, reachable BranchReachable) bool {
+	if reachable == nil || derived.Branch == "" {
+		return true
+	}
+	return reachable(derived.Branch)
 }
 
 // stuckRunningReason is the one-line badge text for a card the stuck-running

--- a/internal/daemon/board_reconcile_hang_test.go
+++ b/internal/daemon/board_reconcile_hang_test.go
@@ -42,7 +42,7 @@ func TestReconcileStuckRunning_HungAgentIsStoppedReddenedAndRelaunched(t *testin
 	}
 
 	n := reconcileStuckRunning(context.Background(), runningCard(now),
-		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), retry,
+		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), alwaysReachable, retry,
 		progressAt(now.Add(-ThinkingIdleGrace-time.Minute), false, false),
 		func(name string) error { stopped = append(stopped, name); return nil },
 		"d1", now, zerolog.Nop())
@@ -61,7 +61,7 @@ func TestReconcileStuckRunning_ActiveAgentIsLeftAlone(t *testing.T) {
 	var stopped []string
 
 	n := reconcileStuckRunning(context.Background(), runningCard(now),
-		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), StageRetry{},
+		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), alwaysReachable, StageRetry{},
 		progressAt(now.Add(-10*time.Second), false, false),
 		func(name string) error { stopped = append(stopped, name); return nil },
 		"d1", now, zerolog.Nop())
@@ -79,7 +79,7 @@ func TestReconcileStuckRunning_LongToolCallIsNotAHang(t *testing.T) {
 	var stopped []string
 
 	n := reconcileStuckRunning(context.Background(), runningCard(now),
-		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), StageRetry{},
+		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), alwaysReachable, StageRetry{},
 		progressAt(now.Add(-10*time.Minute), true, false), // inside a tool call
 		func(name string) error { stopped = append(stopped, name); return nil },
 		"d1", now, zerolog.Nop())
@@ -95,7 +95,7 @@ func TestReconcileStuckRunning_BlockedAgentIsNotHung(t *testing.T) {
 	var stopped []string
 
 	n := reconcileStuckRunning(context.Background(), runningCard(now),
-		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), StageRetry{},
+		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), alwaysReachable, StageRetry{},
 		progressAt(now.Add(-time.Hour), false, true), // blocked on a human
 		func(name string) error { stopped = append(stopped, name); return nil },
 		"d1", now, zerolog.Nop())
@@ -112,14 +112,14 @@ func TestReconcileStuckRunning_UnknownProgressLeavesLiveWorkAlone(t *testing.T) 
 
 	unknown := func(string) (AgentProgress, bool) { return AgentProgress{}, false }
 	n := reconcileStuckRunning(context.Background(), runningCard(now),
-		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), StageRetry{},
+		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), alwaysReachable, StageRetry{},
 		unknown, func(string) error { return nil }, "d1", now, zerolog.Nop())
 
 	require.Equal(t, 0, n)
 
 	// Same when no probe is wired at all — previous behaviour, unchanged.
 	n = reconcileStuckRunning(context.Background(), runningCard(now),
-		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), StageRetry{},
+		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), alwaysReachable, StageRetry{},
 		nil, nil, "d1", now, zerolog.Nop())
 	require.Equal(t, 0, n)
 }
@@ -138,7 +138,7 @@ func TestReconcileStuckRunning_FailedStopDoesNotRelaunch(t *testing.T) {
 	}
 
 	n := reconcileStuckRunning(context.Background(), runningCard(now),
-		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), retry,
+		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), alwaysReachable, retry,
 		progressAt(now.Add(-time.Hour), false, false),
 		func(string) error { return errors.New("docker unavailable") },
 		"d1", now, zerolog.Nop())

--- a/internal/daemon/board_reconcile_ownership_test.go
+++ b/internal/daemon/board_reconcile_ownership_test.go
@@ -26,7 +26,7 @@ func TestReconcileStuckRunning_SparesForeignCardUnderForeignGrace(t *testing.T) 
 	}}
 	var posted []struct{ Key, Body string }
 	n := reconcileStuckRunning(context.Background(), cards, liveAgents(),
-		capturingPoster(&posted), StageRetry{}, nil, nil, "thisBBBB", now, zerolog.Nop())
+		capturingPoster(&posted), alwaysReachable, StageRetry{}, nil, nil, "thisBBBB", now, zerolog.Nop())
 
 	assert.Equal(t, 0, n, "a foreign-owned card under the foreign grace must not be reddened")
 	assert.Empty(t, posted)
@@ -45,7 +45,7 @@ func TestReconcileStuckRunning_RedsForeignCardPastForeignGrace(t *testing.T) {
 	}}
 	var posted []struct{ Key, Body string }
 	n := reconcileStuckRunning(context.Background(), cards, liveAgents(),
-		capturingPoster(&posted), StageRetry{}, nil, nil, "thisBBBB", now, zerolog.Nop())
+		capturingPoster(&posted), alwaysReachable, StageRetry{}, nil, nil, "thisBBBB", now, zerolog.Nop())
 
 	assert.Equal(t, 1, n)
 	assert.Len(t, posted, 1)
@@ -65,7 +65,7 @@ func TestReconcileStuckRunning_RedsOwnCardAtLocalGrace(t *testing.T) {
 	}}
 	var posted []struct{ Key, Body string }
 	n := reconcileStuckRunning(context.Background(), cards, liveAgents(),
-		capturingPoster(&posted), StageRetry{}, nil, nil, "thisBBBB", now, zerolog.Nop())
+		capturingPoster(&posted), alwaysReachable, StageRetry{}, nil, nil, "thisBBBB", now, zerolog.Nop())
 
 	assert.Equal(t, 1, n)
 	assert.Len(t, posted, 1)

--- a/internal/daemon/board_reconcile_reachability_test.go
+++ b/internal/daemon/board_reconcile_reachability_test.go
@@ -1,0 +1,126 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// peerCard is an aged, still-running implementation card that handed off a
+// branch — the shape a peer daemon's live run takes as seen from another
+// machine: no local container, so the liveness probe reports nothing.
+func peerCard(now time.Time) []ReconcileCard {
+	return []ReconcileCard{{
+		Key: "SC-1",
+		Comments: []tracker.Comment{
+			cmt("[human:ready-for-review]\nbranch: autofix/sc-1", now.Add(-StuckRunningGrace-2*time.Minute)),
+			cmt("[human:implementation-started]", now.Add(-StuckRunningGrace-time.Minute)),
+		},
+	}}
+}
+
+func neverReachable(string) bool { return false }
+
+// The defect: a daemon judged a peer's live run dead from a machine-local
+// container probe, reddened the card and retried the stage HERE — against work
+// that lives on another disk. The retry then failed on a branch it could not
+// check out (SC-1450).
+//
+// StuckRunningForeignGrace only delays that; reachability forbids it, because
+// it is a fact about this disk rather than a judgement about elapsed time.
+func TestReconcileStuckRunning_UnreachableBranchIsLeftToItsOwner(t *testing.T) {
+	now := time.Unix(100_000, 0)
+	var posted []struct{ Key, Body string }
+
+	n := reconcileStuckRunning(context.Background(), peerCard(now),
+		liveAgents(), capturingPoster(&posted), neverReachable,
+		StageRetry{}, nil, nil, "d1", now, zerolog.Nop())
+
+	require.Zero(t, n, "a card this machine cannot act on must not be reddened")
+	assert.Empty(t, posted, "no failed marker may be posted for another machine's work")
+}
+
+// The same card, reachable here, is still reddened: the gate must not disable
+// hang detection on the machine that actually owns the work.
+func TestReconcileStuckRunning_ReachableBranchIsStillReddened(t *testing.T) {
+	now := time.Unix(100_000, 0)
+	var posted []struct{ Key, Body string }
+
+	n := reconcileStuckRunning(context.Background(), peerCard(now),
+		liveAgents(), capturingPoster(&posted), alwaysReachable,
+		StageRetry{}, nil, nil, "d1", now, zerolog.Nop())
+
+	require.Equal(t, 1, n)
+	require.Len(t, posted, 1)
+	assert.Contains(t, posted[0].Body, "Stuck in")
+}
+
+// A card with no branch yet — planning, or a build that never handed off — has
+// no fact to consult. Refusing there would disable the hang detector for every
+// early stage, so those keep the older grace-plus-liveness protection.
+func TestReconcileStuckRunning_CardWithoutABranchIsUnaffectedByTheGate(t *testing.T) {
+	now := time.Unix(100_000, 0)
+	var posted []struct{ Key, Body string }
+	cards := []ReconcileCard{{
+		Key:      "SC-1",
+		Comments: []tracker.Comment{cmt("[human:implementation-started]", now.Add(-StuckRunningGrace-time.Minute))},
+	}}
+
+	n := reconcileStuckRunning(context.Background(), cards,
+		liveAgents(), capturingPoster(&posted), neverReachable,
+		StageRetry{}, nil, nil, "d1", now, zerolog.Nop())
+
+	assert.Equal(t, 1, n, "a branchless card has no reachability fact and keeps the old behaviour")
+}
+
+// A nil predicate disables the gate, matching the package's convention for
+// optional dependencies — a single-daemon board is unchanged.
+func TestReconcileStuckRunning_NilReachableDisablesTheGate(t *testing.T) {
+	now := time.Unix(100_000, 0)
+	var posted []struct{ Key, Body string }
+
+	n := reconcileStuckRunning(context.Background(), peerCard(now),
+		liveAgents(), capturingPoster(&posted), nil,
+		StageRetry{}, nil, nil, "d1", now, zerolog.Nop())
+
+	assert.Equal(t, 1, n)
+}
+
+// The gate must also stop the RETRY, not merely the marker: relaunching a peer's
+// stage here is the half that actually destroys their in-flight run.
+func TestReconcileStuckRunning_UnreachableBranchIsNeverRelaunched(t *testing.T) {
+	now := time.Unix(100_000, 0)
+	var posted []struct{ Key, Body string }
+	retry := StageRetry{
+		Max:      2,
+		Outcome:  func(string, BoardStage) (string, bool) { return "", false },
+		Attempts: func(string, BoardStage) (int, error) { return 1, nil },
+		Relaunch: func(string, BoardStage) error {
+			t.Fatal("a stage whose branch is unreachable here must never be relaunched here")
+			return nil
+		},
+	}
+
+	n := reconcileStuckRunning(context.Background(), peerCard(now),
+		liveAgents(), capturingPoster(&posted), neverReachable,
+		retry, nil, nil, "d1", now, zerolog.Nop())
+
+	assert.Zero(t, n)
+}
+
+// branchActionableHere is the whole gate, so its three inputs are pinned
+// directly: no predicate, no branch, and the predicate's own verdict.
+func TestBranchActionableHere(t *testing.T) {
+	withBranch := BoardCard{Branch: "autofix/sc-1"}
+
+	assert.True(t, branchActionableHere(withBranch, nil), "nil disables the gate")
+	assert.True(t, branchActionableHere(BoardCard{}, neverReachable), "no branch, no fact to consult")
+	assert.True(t, branchActionableHere(withBranch, alwaysReachable))
+	assert.False(t, branchActionableHere(withBranch, neverReachable))
+}

--- a/internal/daemon/board_reconcile_retry_test.go
+++ b/internal/daemon/board_reconcile_retry_test.go
@@ -33,7 +33,7 @@ func TestReconcileStuckRunning_RelaunchesAfterReddening(t *testing.T) {
 	}
 
 	n := reconcileStuckRunning(context.Background(), cards, liveAgents(),
-		capturingPoster(&posted), retry, nil, nil, "d1", now, zerolog.Nop())
+		capturingPoster(&posted), alwaysReachable, retry, nil, nil, "d1", now, zerolog.Nop())
 
 	require.Equal(t, 1, n, "the card is reddened")
 	require.Len(t, posted, 1, "the failed marker is the trail record")
@@ -68,7 +68,7 @@ func TestReconcileStuckRunning_OpenSameStageOptionsIsCleanPause(t *testing.T) {
 	}
 
 	n := reconcileStuckRunning(context.Background(), cards, liveAgents(),
-		capturingPoster(&posted), retry, nil, nil, "d1", now, zerolog.Nop())
+		capturingPoster(&posted), alwaysReachable, retry, nil, nil, "d1", now, zerolog.Nop())
 
 	require.Equal(t, 0, n, "an open same-stage options block is a clean pause, not a hang")
 	require.Empty(t, posted, "no failed marker for a card parked on its own decision")
@@ -98,7 +98,7 @@ func TestReconcileStuckRunning_OpenOptionsForOtherStageStillReddens(t *testing.T
 	}
 
 	n := reconcileStuckRunning(context.Background(), cards, liveAgents(),
-		capturingPoster(&posted), retry, nil, nil, "d1", now, zerolog.Nop())
+		capturingPoster(&posted), alwaysReachable, retry, nil, nil, "d1", now, zerolog.Nop())
 
 	require.Equal(t, 1, n, "an options block for a different stage does not excuse a genuine hang")
 	require.Len(t, posted, 1, "the failed marker is the trail record")
@@ -123,7 +123,7 @@ func TestReconcileStuckRunning_RelaunchRespectsTheBudget(t *testing.T) {
 	}
 
 	n := reconcileStuckRunning(context.Background(), cards, liveAgents(),
-		capturingPoster(&posted), retry, nil, nil, "d1", now, zerolog.Nop())
+		capturingPoster(&posted), alwaysReachable, retry, nil, nil, "d1", now, zerolog.Nop())
 
 	require.Equal(t, 1, n, "the card is still reddened for a human")
 	require.Empty(t, relaunched, "a spent budget stops the automatic relaunch")

--- a/internal/daemon/board_reconcile_test.go
+++ b/internal/daemon/board_reconcile_test.go
@@ -274,7 +274,7 @@ func TestReconcileStuckRunning_FailsAgedRunningOrphanWithNoAgent(t *testing.T) {
 		Comments: []tracker.Comment{cmt("[human:implementation-started]", now.Add(-StuckRunningGrace-time.Minute))},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), alwaysReachable, StageRetry{}, nil, nil, "", now, zerolog.Nop())
 
 	assert.Equal(t, 1, n)
 	assert.Len(t, posted, 1)
@@ -292,7 +292,7 @@ func TestReconcileStuckRunning_SkipsWithinGrace(t *testing.T) {
 		Comments: []tracker.Comment{cmt("[human:implementation-started]", now.Add(-time.Minute))},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), alwaysReachable, StageRetry{}, nil, nil, "", now, zerolog.Nop())
 
 	assert.Equal(t, 0, n)
 	assert.Empty(t, posted)
@@ -308,7 +308,7 @@ func TestReconcileStuckRunning_SkipsWhenAgentAlive(t *testing.T) {
 	}}
 	var posted []struct{ Key, Body string }
 	live := liveAgents(agentNameFor("SC-1", BoardImplementation))
-	n := reconcileStuckRunning(context.Background(), cards, live, capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), cards, live, capturingPoster(&posted), alwaysReachable, StageRetry{}, nil, nil, "", now, zerolog.Nop())
 
 	assert.Equal(t, 0, n)
 	assert.Empty(t, posted)
@@ -326,7 +326,7 @@ func TestReconcileStuckRunning_SkipsNonRunning(t *testing.T) {
 		},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), alwaysReachable, StageRetry{}, nil, nil, "", now, zerolog.Nop())
 
 	assert.Equal(t, 0, n)
 	assert.Empty(t, posted)
@@ -341,7 +341,7 @@ func TestReconcileStuckRunning_CoversVerificationStage(t *testing.T) {
 		Comments: []tracker.Comment{cmt("[human:review-started]", now.Add(-StuckRunningGrace-time.Minute))},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), alwaysReachable, StageRetry{}, nil, nil, "", now, zerolog.Nop())
 
 	assert.Equal(t, 1, n)
 	assert.Len(t, posted, 1)
@@ -357,7 +357,7 @@ func TestReconcileStuckRunning_NilListerDisables(t *testing.T) {
 		Comments: []tracker.Comment{cmt("[human:implementation-started]", now.Add(-StuckRunningGrace-time.Minute))},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), cards, nil, capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), cards, nil, capturingPoster(&posted), alwaysReachable, StageRetry{}, nil, nil, "", now, zerolog.Nop())
 
 	assert.Equal(t, 0, n)
 	assert.Empty(t, posted)
@@ -379,7 +379,7 @@ func TestReconcileStuckRunning_SkipsJustDecidedCard(t *testing.T) {
 		},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), alwaysReachable, StageRetry{}, nil, nil, "", now, zerolog.Nop())
 
 	assert.Equal(t, 0, n, "a just-decided card must never be reddened")
 	assert.Empty(t, posted)
@@ -454,7 +454,7 @@ func TestReconcileStuckRunning_SkipsActiveLoop(t *testing.T) {
 		},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), cards, liveAgents(), capturingPoster(&posted), alwaysReachable, StageRetry{}, nil, nil, "", now, zerolog.Nop())
 
 	assert.Equal(t, 0, n, "a mid-flight PR loop must never be reddened by the stuck pass")
 	assert.Empty(t, posted)


### PR DESCRIPTION
Hardens SC-1450, whose original fix was a grace period.

## The failure

A daemon decides a card has hung from a machine-local container probe. A peer's healthy run is invisible to that probe, so the card looks frozen with no owner: the daemon reds it and retries the stage **here**, against work that lives on another disk. The retry then fails resolving a branch it never had (`resolving revision: exit status 128`).

Observed today on a two-daemon board:

```
11:14:53  [claim]                   4f3add9a   ← machine A
11:14:54  [implementation-started]  4f3add9a
11:31:52  [implementation-failed]   be3b4ffb   ← machine B, 17 min later
11:31:53  [claim]                   be3b4ffb
11:31:53  [implementation-started]  be3b4ffb
```

The claim mechanism was not bypassed — B first declared the stage *failed*, which legitimately reopens it, then claimed the now-free stage. The claim worked; its input was wrong.

## Why the existing guard did not hold

`StuckRunningForeignGrace` is a clock. It applies only when the deciding marker happens to carry a peer's id, and even then it just postpones the takeover — a timer can delay a wrong decision, never prevent one. The 17 minutes above is the *local* 15-minute grace, so that peer's build predates the foreign grace entirely.

Meanwhile the hard test already existed one function away: the review chain has always refused to act on a branch it cannot resolve (SC-652). The takeover path — the one that kills another machine's in-flight run — never consulted it.

## The change

`reconcileStuckRunning` now refuses to red **or relaunch** a card whose branch this machine cannot resolve. That is a fact about this disk, not a judgement about elapsed time, so no amount of waiting turns it into permission.

Deliberately not universal:

- A card with **no branch yet** — planning, or a build that never handed off — has no such fact to consult. Refusing there would disable hang detection for every early stage, so those keep the grace-plus-liveness behaviour. That residual case is the soft one, and it stays soft.
- A **nil predicate** disables the gate, matching the package convention, so single-daemon boards are unchanged.
- `CommitsPresent` is deliberately *not* added here. A branch present but missing its handoff commits is a real failure that should red — gating on it would suppress a genuine one.

The three leave-it-alone cases move into `stuckCardIsOursToRed` so they read as one unit (also keeps `reconcileStuckRunning` under the gocyclo limit).

## Not covered

`reconcilePRLoops` re-drives a stalled loop and can launch agents against a branch this machine may equally not have. Same exposure, left alone rather than widened silently.

## Verification

`make check` green: 3852 tests, 0 lint issues, gosec 0, govulncheck and gitleaks clean. The new tests pin the gate both ways — an unreachable branch is neither reddened nor relaunched, the same card reachable here still reds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)