### PR TITLE
[SC-1973] Classify every credential pointer as unverified, not just 1pw://

### DIFF
--- a/internal/tracker/creds.go
+++ b/internal/tracker/creds.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"sort"
 	"strings"
+
+	"github.com/gethuman-sh/human/internal/vault"
 )
 
 // CredSpec describes the credentials required for a tracker kind.
@@ -70,7 +72,7 @@ type TrackerStatus struct {
 	Kind     string   // tracker kind, e.g. "linear", "jira"
 	Label    string   // human-readable name, e.g. "Linear", "Jira"
 	Working  bool     // true when all required credentials are present (and not vault refs)
-	VaultRef bool     // true when credentials are vault references (e.g. 1pw://) — unverified
+	VaultRef bool     // true when credentials are vault references (1pw://, gh://, …) — unverified
 	Missing  []string // env var names for missing credentials (empty when Working)
 	// Role is the role DECLARED in .humanconfig ("pm", "engineering", or empty).
 	// Captured independently of credential resolution so topology divergence — a
@@ -187,15 +189,23 @@ func DiagnoseTrackers(dir string, unmarshal func(dir, section string, target any
 
 // diagnoseMissing returns env var names for credentials not provided by
 // the config file, per-instance env vars, or global env vars.
-// The second return value is true if any credential is a vault reference
-// (e.g. 1pw://) that cannot be verified without vault resolution.
+// The second return value is true if any credential is a vault REFERENCE (1pw://,
+// gh://, or any scheme the vault adds later) rather than a literal secret — a
+// pointer whose target nothing here has resolved, so it must never be reported
+// as verified.
 func diagnoseMissing(spec CredSpec, entry diagnoseEntry, getenv func(string) string) ([]string, bool) {
 	var missing []string
 	vaultRef := false
 	for _, suffix := range spec.Required {
 		val := entry.fieldValue(suffix)
 		if val != "" {
-			if strings.HasPrefix(val, "1pw://") {
+			// Ask the vault what counts as a reference rather than restating it: a
+			// hardcoded "1pw://" test missed gh:// entirely, so a credential that
+			// is only a POINTER at the GitHub CLI's keyring was classified as a
+			// present, verified secret. That is a false all-clear — the health
+			// report said the tracker was fine while nothing had resolved it — and
+			// it silently widened with every reference scheme added since (SC-1973).
+			if vault.IsSecretRef(val) {
 				vaultRef = true
 			}
 			continue

--- a/internal/tracker/creds_vaultref_test.go
+++ b/internal/tracker/creds_vaultref_test.go
@@ -1,0 +1,72 @@
+package tracker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// statusFor finds one tracker entry in a diagnosis result.
+func statusFor(t *testing.T, statuses []TrackerStatus, kind, name string) TrackerStatus {
+	t.Helper()
+	for _, st := range statuses {
+		if st.Kind == kind && st.Name == name {
+			return st
+		}
+	}
+	require.FailNowf(t, "not found", "expected %s/%s in results", kind, name)
+	return TrackerStatus{}
+}
+
+// diagnoseWithToken runs a diagnosis for a single entry in one config section.
+func diagnoseWithToken(section, name, token string) []TrackerStatus {
+	unmarshal := func(_, sec string, target any) error {
+		if sec == section {
+			entries := target.(*[]diagnoseEntry)
+			*entries = []diagnoseEntry{{Name: name, Token: token}}
+		}
+		return nil
+	}
+	return DiagnoseTrackers(".", unmarshal, func(string) string { return "" })
+}
+
+// The defect: the reference test was hardcoded to "1pw://", so a gh:// token —
+// a POINTER at the GitHub CLI's keyring, not a secret — fell through as a
+// present literal value and the entry was reported as verified working. That is
+// a false all-clear: the health report said the tracker was fine while nothing
+// had resolved it (SC-1973).
+func TestDiagnoseTrackers_ghRefIsAnUnverifiedReference(t *testing.T) {
+	st := statusFor(t, diagnoseWithToken("githubs", "personal", "gh://token"), "github", "personal")
+
+	assert.True(t, st.VaultRef, "a gh:// token is a reference, not a resolved secret")
+	assert.False(t, st.Working, "nothing resolved it, so it must not be reported as verified")
+	assert.Empty(t, st.Missing, "the value is present — it is unverified, not absent")
+}
+
+// The host-qualified form must classify the same way: the rule is the scheme,
+// not one exact string.
+func TestDiagnoseTrackers_ghRefWithHostIsAlsoAReference(t *testing.T) {
+	st := statusFor(t, diagnoseWithToken("githubs", "enterprise", "gh://ghe.corp.com/token"), "github", "enterprise")
+
+	assert.True(t, st.VaultRef)
+	assert.False(t, st.Working)
+}
+
+// The scheme that already worked must keep working.
+func TestDiagnoseTrackers_onePasswordRefStillClassifies(t *testing.T) {
+	st := statusFor(t, diagnoseWithToken("shortcuts", "human", "1pw://Private/Shortcut Token/notesPlain"), "shortcut", "human")
+
+	assert.True(t, st.VaultRef)
+	assert.False(t, st.Working)
+}
+
+// A literal secret is NOT a reference: it is present and verified, and must not
+// be demoted to unverified by a rule that over-matches.
+func TestDiagnoseTrackers_literalTokenIsVerified(t *testing.T) {
+	st := statusFor(t, diagnoseWithToken("githubs", "personal", "ghp_literalvalue"), "github", "personal")
+
+	assert.False(t, st.VaultRef)
+	assert.True(t, st.Working)
+	assert.Empty(t, st.Missing)
+}


### PR DESCRIPTION
Closes SC-1973.

The check deciding whether a tracker's credentials are usable restated the vault's own rule instead of asking it, and the copy was out of date:

```go
if strings.HasPrefix(val, "1pw://") {   // internal/tracker/creds.go:198
    vaultRef = true
}
```

A `gh://` token — a pointer at the GitHub CLI's keyring, not a secret — fell through as a present literal value. `Working = len(missing) == 0 && !vaultRef` then came out **true**, so the entry was reported as verified working although nothing had resolved it.

## Why it matters

This is a false all-clear, the worse direction. With the tool holding the secret signed out or unreachable, the health report still said the tracker was fine, and the real failure surfaced later somewhere further from its cause — the one place built to answer "are my credentials OK?" pointing away from the problem.

It also widened silently: every reference scheme added since was reported as verified unless someone remembered to teach this particular check about it, and forgetting produced no visible symptom until something broke.

## The change

Route the decision through `vault.IsSecretRef` — the single place that already knows what a reference is — so the classification cannot drift from the resolver again and a new scheme is covered the day it is added. No import cycle: `internal/vault` does not import `internal/tracker`.

The distinction between "verified" and "present but unverified" is unchanged. The fix is to classify correctly, not to collapse the two — a literal token stays `Working`, and only a genuine pointer becomes `VaultRef`.

Two doc comments that named `1pw://` as the only reference form are corrected alongside.

## Verification

Red before / green after, confirmed by reverting the line and the import: `TestDiagnoseTrackers_ghRefIsAnUnverifiedReference` and `..._ghRefWithHostIsAlsoAReference` both fail, then pass. Tests also pin the two directions that must NOT change — `1pw://` still classifies, and a literal token stays verified.

`make check` green: 3864 tests, 0 lint issues, gosec 0, govulncheck and gitleaks clean.

## Note

This fix was independently implemented on another machine earlier today (branch `fix/sc-1973-gh-vault-ref`, reviewed and passing) but that branch was never pushed and is unreachable from here — the situation described in SC-2047. This is a fresh local implementation of the same one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)