### PR TITLE
[SC-2132] The daemon owns the board; the board reads it

### DIFF
--- a/cmd/cmddaemon/board_index_test.go
+++ b/cmd/cmddaemon/board_index_test.go
@@ -1,0 +1,106 @@
+package cmddaemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/daemon"
+	"github.com/gethuman-sh/human/internal/recall"
+)
+
+// searchIndex opens the index written by indexBoardView and queries it.
+func searchIndex(t *testing.T, dbPath, query string) []recall.Entry {
+	t.Helper()
+	store, err := recall.NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+	found, err := store.Search(context.Background(), query, 20)
+	require.NoError(t, err)
+	return found
+}
+
+// viewWith builds a composed board carrying one ticket.
+func viewWith(card daemon.BoardViewCard) daemon.BoardView {
+	return daemon.BoardView{Cards: []daemon.BoardViewCard{card}}
+}
+
+// The index is what agents consult to find out whether a problem is already
+// being worked on. It was fed only by a hand-run command and sat empty for
+// months while the board beside it stayed minutes-fresh — so a search that
+// should have found a sibling ticket confidently returned nothing (SC-2132).
+func TestIndexBoardView_MakesTheBoardSearchable(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "index.db")
+
+	indexBoardView(context.Background(), viewWith(daemon.BoardViewCard{
+		Key:         "SC-1",
+		Title:       "Deploy blames CI when it cannot read its credentials",
+		Description: "the vault session expired and the failure was misattributed",
+		Tracker:     "human",
+		TrackerKind: "shortcut",
+		URL:         "https://example/1",
+		Assignee:    "stephan",
+		Stage:       string(daemon.BoardBacklog),
+	}), db, zerolog.Nop())
+
+	found := searchIndex(t, db, "credentials")
+	require.Len(t, found, 1, "a composed card must be findable by its title")
+	assert.Equal(t, "SC-1", found[0].Key)
+	assert.Equal(t, "human", found[0].Source)
+	assert.Equal(t, "shortcut", found[0].Kind)
+	assert.Equal(t, "https://example/1", found[0].URL)
+}
+
+// The description is the FTS payload — the half of a ticket that carries the
+// words a sibling search actually matches on.
+func TestIndexBoardView_IndexesTheDescriptionNotJustTheTitle(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "index.db")
+
+	indexBoardView(context.Background(), viewWith(daemon.BoardViewCard{
+		Key:         "SC-2",
+		Title:       "unrelated wording",
+		Description: "the vault session expired and the failure was misattributed",
+		Tracker:     "human",
+	}), db, zerolog.Nop())
+
+	found := searchIndex(t, db, "misattributed")
+	require.Len(t, found, 1, "the description must be searchable, not only the title")
+	assert.Equal(t, "SC-2", found[0].Key)
+}
+
+// Re-indexing the same ticket must update it rather than accumulate duplicates:
+// this runs on every board fetch.
+func TestIndexBoardView_ReindexingUpdatesInPlace(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "index.db")
+	card := daemon.BoardViewCard{Key: "SC-3", Title: "first title", Tracker: "human"}
+
+	indexBoardView(context.Background(), viewWith(card), db, zerolog.Nop())
+	card.Title = "second title"
+	indexBoardView(context.Background(), viewWith(card), db, zerolog.Nop())
+
+	assert.Empty(t, searchIndex(t, db, "first"), "the stale title must not linger")
+	assert.Len(t, searchIndex(t, db, "second"), 1, "the ticket is updated, not duplicated")
+}
+
+// An index write must never fail a board fetch — the board is the user's, the
+// index is a convenience.
+func TestIndexBoardView_UnwritableIndexIsNotFatal(t *testing.T) {
+	unwritable := filepath.Join(t.TempDir(), "no-such-dir", "index.db")
+
+	assert.NotPanics(t, func() {
+		indexBoardView(context.Background(), viewWith(daemon.BoardViewCard{Key: "SC-4", Title: "one"}), unwritable, zerolog.Nop())
+	})
+}
+
+// An empty board writes nothing rather than opening the store to do no work.
+func TestIndexBoardView_EmptyViewIsANoop(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "index.db")
+
+	indexBoardView(context.Background(), daemon.BoardView{}, db, zerolog.Nop())
+
+	assert.NoFileExists(t, db, "an empty board must not even create the index file")
+}

--- a/cmd/cmddaemon/board_stale_view_test.go
+++ b/cmd/cmddaemon/board_stale_view_test.go
@@ -1,0 +1,98 @@
+package cmddaemon
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/boardcache"
+	"github.com/gethuman-sh/human/internal/daemon"
+)
+
+func tmpCache(t *testing.T) *boardcache.Store {
+	t.Helper()
+	return boardcache.NewStore(filepath.Join(t.TempDir(), "boardcache.json"))
+}
+
+func workingView() daemon.BoardView {
+	return daemon.BoardView{Cards: []daemon.BoardViewCard{{Key: "SC-1", Title: "one"}}}
+}
+
+// A refresh that cannot complete must not present as a clean, empty workspace:
+// an empty board is indistinguishable from having no work at all (SC-2132).
+func TestServeLastGoodView_FailedRefreshKeepsTheLastBoard(t *testing.T) {
+	cache := tmpCache(t)
+	rememberBoardView(cache, "/proj", workingView(), zerolog.Nop())
+
+	view, err := serveLastGoodView(cache, "/proj", errors.New("tracker unreachable"), zerolog.Nop())
+
+	require.NoError(t, err)
+	require.Len(t, view.Cards, 1)
+	assert.Equal(t, "SC-1", view.Cards[0].Key)
+}
+
+// Keeping the cards must not hide the failure — a silently stale board that
+// looks healthy trades a visible problem for an invisible one.
+func TestServeLastGoodView_SaysItIsStale(t *testing.T) {
+	cache := tmpCache(t)
+	rememberBoardView(cache, "/proj", workingView(), zerolog.Nop())
+
+	view, err := serveLastGoodView(cache, "/proj", errors.New("boom"), zerolog.Nop())
+
+	require.NoError(t, err)
+	assert.Contains(t, view.Error, "this refresh failed")
+	assert.Contains(t, view.Error, "boom", "the cause travels with the notice")
+}
+
+// With nothing remembered there is nothing truer to show than the failure.
+func TestServeLastGoodView_NothingRememberedSurfacesTheError(t *testing.T) {
+	cause := errors.New("boom")
+
+	view, err := serveLastGoodView(tmpCache(t), "/proj", cause, zerolog.Nop())
+
+	require.ErrorIs(t, err, cause)
+	assert.Empty(t, view.Cards)
+}
+
+// An empty board is never remembered: one bad refresh would otherwise become
+// the "last good" one and pin the board empty for good.
+func TestRememberBoardView_EmptyBoardIsNotRemembered(t *testing.T) {
+	cache := tmpCache(t)
+	rememberBoardView(cache, "/proj", workingView(), zerolog.Nop())
+	rememberBoardView(cache, "/proj", daemon.BoardView{}, zerolog.Nop())
+
+	view, err := serveLastGoodView(cache, "/proj", errors.New("boom"), zerolog.Nop())
+
+	require.NoError(t, err)
+	assert.Len(t, view.Cards, 1, "the last board with work survives an empty one")
+}
+
+// Snapshots are per project: a global key evicted another project's board on
+// every save (SC-1654/1692).
+func TestRememberBoardView_IsKeyedPerProject(t *testing.T) {
+	cache := tmpCache(t)
+	rememberBoardView(cache, "/proj-a", workingView(), zerolog.Nop())
+	rememberBoardView(cache, "/proj-b", daemon.BoardView{Cards: []daemon.BoardViewCard{{Key: "SC-9"}}}, zerolog.Nop())
+
+	a, err := serveLastGoodView(cache, "/proj-a", errors.New("boom"), zerolog.Nop())
+	require.NoError(t, err)
+	require.Len(t, a.Cards, 1)
+	assert.Equal(t, "SC-1", a.Cards[0].Key, "one project's board must not evict another's")
+}
+
+// The remembered snapshot must round-trip as real JSON, not merely be written.
+func TestRememberBoardView_RoundTripsThroughTheCache(t *testing.T) {
+	cache := tmpCache(t)
+	rememberBoardView(cache, "/proj", workingView(), zerolog.Nop())
+
+	raw, ok := cache.Load("/proj")
+	require.True(t, ok)
+	var view daemon.BoardView
+	require.NoError(t, json.Unmarshal(raw, &view))
+	assert.Equal(t, "one", view.Cards[0].Title)
+}

--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gethuman-sh/human/internal/agent"
 	"github.com/gethuman-sh/human/internal/agentstate"
 	"github.com/gethuman-sh/human/internal/audit"
+	"github.com/gethuman-sh/human/internal/board"
 	"github.com/gethuman-sh/human/internal/botidentity"
 	"github.com/gethuman-sh/human/internal/chrome"
 	"github.com/gethuman-sh/human/internal/claude"
@@ -331,6 +332,11 @@ func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, de
 	launchGate := func(ctx context.Context) []daemon.DoctorCheck {
 		return doctor.Blockers(ctx, daemon.LaunchCriticalChecks)
 	}
+	// One fetcher instance, shared by the raw-results route and the composed
+	// board: the closure carries the last-known cards and the last good listing
+	// (1700, SC-2005), so a second instance would split that memory in half and
+	// each route would degrade with only its own history.
+	issueFetcher := fetchTrackerIssuesFunc(projectRegistry, vaultResolver, logger)
 
 	srv := &daemon.Server{
 		Addr:               addr,
@@ -342,8 +348,9 @@ func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, de
 		ConnectedPIDs:      connTracker,
 		HookEvents:         hookStore,
 		NetworkEvents:      networkStore,
-		IssueFetcher:       fetchTrackerIssuesFunc(projectRegistry, vaultResolver, logger),
+		IssueFetcher:       issueFetcher,
 		LiteIssueFetcher:   fetchTrackerIssuesLiteFunc(projectRegistry, vaultResolver),
+		BoardViewFetcher:   boardViewFunc(issueFetcher, doctor),
 		IssueGetter:        daemon.NewCachedIssueGetter(issueGetterFunc(projectRegistry, vaultResolver)),
 		TrackerDiagnoser:   trackerDiagnoserFunc(projectRegistry, vaultResolver),
 		Doctor:             doctor,
@@ -1602,6 +1609,27 @@ func issueGetterFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver) func
 			extras = daemon.BuildIssueDetailExtras(comments)
 		}
 		return &daemon.IssueDetailFetch{Issue: *issue, Extras: extras}, nil
+	}
+}
+
+// boardViewFunc builds the daemon's composed-board fetcher: the same listing the
+// raw route serves, run through board.Compose so every consumer reads one
+// picture instead of assembling its own.
+//
+// Docker availability is read from THIS host's doctor check rather than probed
+// by whoever renders the board. Docker matters because it is where agents
+// launch, which is this machine — a client probing its own engine answers a
+// question about the wrong computer (SC-2132).
+func boardViewFunc(fetch func() ([]daemon.TrackerIssuesResult, error), doctor *daemon.DoctorRunner) func() (daemon.BoardView, error) {
+	return func() (daemon.BoardView, error) {
+		results, err := fetch()
+		if err != nil {
+			return daemon.BoardView{}, err
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		dockerOK := len(doctor.Blockers(ctx, []string{"docker"})) == 0
+		return board.Compose(results, dockerOK), nil
 	}
 }
 

--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gethuman-sh/human/internal/agentstate"
 	"github.com/gethuman-sh/human/internal/audit"
 	"github.com/gethuman-sh/human/internal/board"
+	"github.com/gethuman-sh/human/internal/boardcache"
 	"github.com/gethuman-sh/human/internal/botidentity"
 	"github.com/gethuman-sh/human/internal/chrome"
 	"github.com/gethuman-sh/human/internal/claude"
@@ -351,7 +352,7 @@ func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, de
 		NetworkEvents:      networkStore,
 		IssueFetcher:       issueFetcher,
 		LiteIssueFetcher:   fetchTrackerIssuesLiteFunc(projectRegistry, vaultResolver),
-		BoardViewFetcher:   boardViewFunc(issueFetcher, doctor, logger),
+		BoardViewFetcher:   boardViewFunc(issueFetcher, doctor, projectRegistry, boardcache.NewStore(boardcache.DefaultPath()), logger),
 		IssueGetter:        daemon.NewCachedIssueGetter(issueGetterFunc(projectRegistry, vaultResolver)),
 		TrackerDiagnoser:   trackerDiagnoserFunc(projectRegistry, vaultResolver),
 		Doctor:             doctor,
@@ -1621,18 +1622,72 @@ func issueGetterFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver) func
 // by whoever renders the board. Docker matters because it is where agents
 // launch, which is this machine — a client probing its own engine answers a
 // question about the wrong computer (SC-2132).
-func boardViewFunc(fetch func() ([]daemon.TrackerIssuesResult, error), doctor *daemon.DoctorRunner, logger zerolog.Logger) func() (daemon.BoardView, error) {
+func boardViewFunc(fetch func() ([]daemon.TrackerIssuesResult, error), doctor *daemon.DoctorRunner, reg *daemon.ProjectRegistry, cache *boardcache.Store, logger zerolog.Logger) func() (daemon.BoardView, error) {
 	return func() (daemon.BoardView, error) {
+		project := boardProjectKey(reg)
 		results, err := fetch()
 		if err != nil {
-			return daemon.BoardView{}, err
+			return serveLastGoodView(cache, project, err, logger)
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		dockerOK := len(doctor.Blockers(ctx, []string{"docker"})) == 0
 		view := board.Compose(results, dockerOK)
 		indexBoardView(ctx, view, recall.DefaultDBPath(), logger)
+		rememberBoardView(cache, project, view, logger)
 		return view, nil
+	}
+}
+
+// boardProjectKey names the project a board snapshot belongs to, keyed the same
+// way the desktop keyed it: the first registered project's directory. The
+// per-project key is load-bearing — a global one evicted another project's
+// snapshot on every save (SC-1654/1692).
+func boardProjectKey(reg *daemon.ProjectRegistry) string {
+	if entries := reg.Entries(); len(entries) > 0 {
+		return entries[0].Dir
+	}
+	return ""
+}
+
+// serveLastGoodView answers a failed compose with the last board that worked,
+// marked stale, rather than with nothing.
+//
+// An empty board is indistinguishable from having no work at all, which is the
+// impression the whole board exists to avoid — so a refresh that cannot complete
+// must not present as a clean, empty workspace. This supersedes the
+// results-level fallback (SC-2005) by sitting one layer up: it survives a
+// failure to COMPOSE, not only a failure to fetch.
+//
+// Nothing remembered means nothing truer to show than the failure itself.
+func serveLastGoodView(cache *boardcache.Store, project string, cause error, logger zerolog.Logger) (daemon.BoardView, error) {
+	raw, ok := cache.Load(project)
+	if !ok {
+		return daemon.BoardView{}, cause
+	}
+	var view daemon.BoardView
+	if err := json.Unmarshal(raw, &view); err != nil {
+		return daemon.BoardView{}, cause
+	}
+	logger.Warn().Err(cause).Msg("board view: refresh failed, serving the last good board marked stale")
+	view.Error = "showing the last board that loaded — this refresh failed: " + cause.Error()
+	return view, nil
+}
+
+// rememberBoardView keeps the last board that actually carried work, so a later
+// failure has something true to fall back on. A board with no cards is not
+// remembered: one bad refresh would otherwise become the "last good" one and pin
+// the board empty for good. Best-effort — a cache write must never fail a fetch.
+func rememberBoardView(cache *boardcache.Store, project string, view daemon.BoardView, logger zerolog.Logger) {
+	if len(view.Cards) == 0 {
+		return
+	}
+	raw, err := json.Marshal(view)
+	if err != nil {
+		return
+	}
+	if err := cache.Save(project, raw); err != nil {
+		logger.Debug().Err(err).Msg("board view: cannot persist the last good board")
 	}
 }
 

--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gethuman-sh/human/internal/messaging/telegram"
 	"github.com/gethuman-sh/human/internal/mockups"
 	"github.com/gethuman-sh/human/internal/proxy"
+	"github.com/gethuman-sh/human/internal/recall"
 	"github.com/gethuman-sh/human/internal/stats"
 	"github.com/gethuman-sh/human/internal/tracker"
 	"github.com/gethuman-sh/human/internal/vault"
@@ -350,7 +351,7 @@ func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, de
 		NetworkEvents:      networkStore,
 		IssueFetcher:       issueFetcher,
 		LiteIssueFetcher:   fetchTrackerIssuesLiteFunc(projectRegistry, vaultResolver),
-		BoardViewFetcher:   boardViewFunc(issueFetcher, doctor),
+		BoardViewFetcher:   boardViewFunc(issueFetcher, doctor, logger),
 		IssueGetter:        daemon.NewCachedIssueGetter(issueGetterFunc(projectRegistry, vaultResolver)),
 		TrackerDiagnoser:   trackerDiagnoserFunc(projectRegistry, vaultResolver),
 		Doctor:             doctor,
@@ -1620,7 +1621,7 @@ func issueGetterFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver) func
 // by whoever renders the board. Docker matters because it is where agents
 // launch, which is this machine — a client probing its own engine answers a
 // question about the wrong computer (SC-2132).
-func boardViewFunc(fetch func() ([]daemon.TrackerIssuesResult, error), doctor *daemon.DoctorRunner) func() (daemon.BoardView, error) {
+func boardViewFunc(fetch func() ([]daemon.TrackerIssuesResult, error), doctor *daemon.DoctorRunner, logger zerolog.Logger) func() (daemon.BoardView, error) {
 	return func() (daemon.BoardView, error) {
 		results, err := fetch()
 		if err != nil {
@@ -1629,7 +1630,50 @@ func boardViewFunc(fetch func() ([]daemon.TrackerIssuesResult, error), doctor *d
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		dockerOK := len(doctor.Blockers(ctx, []string{"docker"})) == 0
-		return board.Compose(results, dockerOK), nil
+		view := board.Compose(results, dockerOK)
+		indexBoardView(ctx, view, recall.DefaultDBPath(), logger)
+		return view, nil
+	}
+}
+
+// indexBoardView keeps the searchable ticket record current from a fetch that
+// has already happened.
+//
+// The index is what every agent consults to find out whether a problem is
+// already being worked on, and it was fed only by a hand-run command — so it sat
+// empty for months while the board beside it stayed minutes-fresh. Two copies of
+// one fetch, one of them nobody owned. Writing here costs no extra tracker calls
+// and makes the record as current as the board.
+//
+// Deliberately partial: this covers the open PM tickets the board shows, not
+// closed ones, and it carries no comment text — TrackerIssuesResult does not
+// include comments, they are consumed deriving stages and discarded. Closed
+// tickets and plan bodies still need their own path.
+//
+// Best-effort throughout: an index write must never fail a board fetch.
+func indexBoardView(ctx context.Context, view daemon.BoardView, dbPath string, logger zerolog.Logger) {
+	if len(view.Cards) == 0 {
+		return
+	}
+	store, err := recall.NewSQLiteStore(dbPath)
+	if err != nil {
+		logger.Debug().Err(err).Msg("board index: cannot open the recall store")
+		return
+	}
+	defer func() { _ = store.Close() }()
+	for _, c := range view.Cards {
+		entry := recall.Entry{
+			Key:      c.Key,
+			Source:   c.Tracker,
+			Kind:     c.TrackerKind,
+			Title:    c.Title,
+			Status:   c.Stage,
+			Assignee: c.Assignee,
+			URL:      c.URL,
+		}
+		if err := store.UpsertEntry(ctx, entry, c.Description); err != nil {
+			logger.Debug().Err(err).Str("key", c.Key).Msg("board index: cannot upsert entry")
+		}
 	}
 }
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gethuman-sh/human/internal/ideaspace"
 	"github.com/gethuman-sh/human/internal/pipeline"
 	"github.com/gethuman-sh/human/internal/recentprojects"
-	"github.com/gethuman-sh/human/internal/tracker"
 )
 
 // App is the Go backend bound into the webview via options.App.Bind. Every
@@ -77,109 +76,14 @@ func NewApp() *App {
 	}
 }
 
-// Card is the flat, frontend-facing shape of one board ticket: a PM issue joined
-// with its derived BoardCard. The frontend renders columns purely from these —
-// it never re-derives a stage from comments.
-type Card struct {
-	Key            string `json:"key"`
-	Title          string `json:"title"`
-	URL            string `json:"url"`
-	Stage          string `json:"stage"`
-	State          string `json:"state"`
-	EngineeringKey string `json:"engineeringKey,omitempty"`
-	Branch         string `json:"branch,omitempty"`
-	PRURL          string `json:"prURL,omitempty"`
-	Error          string `json:"error,omitempty"`
-	// Verdict is the latest review's verdict line; a failing verdict pins the
-	// card in the Code lane with a warning instead of letting it advance.
-	Verdict string `json:"verdict,omitempty"`
-	// StageEnteredAt is when the newest marker of the card's current stage
-	// landed (RFC3339); the board's age badge renders how long the card has
-	// been sitting. Empty when the card has no derived stage yet.
-	StageEnteredAt string `json:"stageEnteredAt,omitempty"`
-	// DeployPhase names the done-stage sub-phase ("pr-review" while the machine
-	// review→fix loop runs, empty for a plain deploy) so the badge reads "PR
-	// review…" instead of "deploying…". Populated by the explicit field copy
-	// below — the daemon→desktop hop is a Go copy, not a JSON re-tag.
-	DeployPhase string `json:"deployPhase,omitempty"`
-	// Degraded marks a card whose markers could not be read this scan (a
-	// ListComments error). The frontend renders it locked — non-draggable and
-	// non-launchable — so a transient fetch failure never presents as idle,
-	// actionable Backlog work (1700).
-	Degraded bool `json:"degraded,omitempty"`
-	// Labels and Description feed the Ideas→Backlog promotion: labels tell
-	// the evolve session which idea labels to remove, the description seeds
-	// the ideation conversation alongside the title.
-	Labels      []string `json:"labels,omitempty"`
-	Description string   `json:"description,omitempty"`
-	// Assignee is the ticket owner shown in the detail panel. Display-only:
-	// the board never assigns; empty renders as "Unassigned" in the frontend.
-	Assignee string `json:"assignee,omitempty"`
-	// Tracker/TrackerKind are the instance name and provider kind the issue
-	// was listed from. The detail panel passes them back to GetIssueDetail so
-	// the daemon resolves the exact instance — bare numeric keys are ambiguous
-	// across kinds, and names can repeat across provider sections.
-	Tracker     string `json:"tracker,omitempty"`
-	TrackerKind string `json:"trackerKind,omitempty"`
-	// IdeaColumn is the idea-space sub-column (0 loosest … 4 most concrete)
-	// for cards in the Ideas stage. Locally persisted preference, never
-	// tracker state; the zero value is the leftmost column, so an idea with
-	// no saved placement starts loose by default.
-	IdeaColumn int `json:"ideaColumn"`
-	// Bug marks a defect ticket (bug label or bug issue type, see
-	// tracker.Issue.IsBug). Bug cards render in the Bugs pane instead of the
-	// workflow board's columns.
-	Bug bool `json:"bug,omitempty"`
-	// Security marks a security ticket (security label or type, see
-	// tracker.Issue.IsSecurity). Security cards render in the Security half of
-	// the Bugs pane. A ticket is never both a bug and security — the tokens are
-	// disjoint — so the two flags are mutually exclusive.
-	Security bool `json:"security,omitempty"`
-	// Hidden marks a ticket the user parked off the board (right-click →
-	// Hide). Locally persisted view preference, never tracker state; the
-	// frontend filters hidden cards out unless the user reveals them.
-	Hidden bool `json:"hidden,omitempty"`
-	// Options carries the card's open decision block: a stage ended in a fork
-	// and a human must pick a direction. OptionsContext is the one-line why.
-	Options        []daemon.BoardOption `json:"options,omitempty"`
-	OptionsContext string               `json:"optionsContext,omitempty"`
-	// MockupSlug/MockupState link the card to a locally generated mockup set:
-	// "ready" once mockups/<slug>/index.json is valid, "creating" while a
-	// launched generation has not produced it yet. Local file state — never
-	// tracker state — so browsing or generating mocks leaves no trace on the
-	// ticket.
-	MockupSlug  string `json:"mockupSlug,omitempty"`
-	MockupState string `json:"mockupState,omitempty"`
-	// MockupChosenSlug/MockupChosenFile pin the ticket's chosen winner mockup
-	// (a leaf group's slug + option file) when one has been marked, so the card
-	// can surface that a design direction is selected and the viewer can
-	// highlight the root→winner path. Empty when no winner is chosen.
-	MockupChosenSlug string `json:"mockupChosenSlug,omitempty"`
-	MockupChosenFile string `json:"mockupChosenFile,omitempty"`
-}
+// Card and BoardData are the frontend-facing board shapes. They are ALIASES of
+// the daemon's wire types (moved there so the daemon can compose and return the
+// board; internal/board already imports internal/daemon, so the types could not
+// live alongside Compose without cycling). Aliases rather than new types so every
+// existing reference and the frontend's JSON shape stay byte-identical.
+type Card = daemon.BoardViewCard
 
-// BoardData is the full payload the frontend renders: the flat card list plus an
-// optional fetch error (surfaced as a banner) and a dockerAvailable flag the
-// frontend uses to disable the agent-launching drop targets.
-type BoardData struct {
-	Cards []Card `json:"cards"`
-	Error string `json:"error,omitempty"`
-	// Notice is a non-error explanation shown in place of the columns when the
-	// board has nothing to render for a structural reason — chiefly no PM-role
-	// tracker configured (SC-1655). Distinct from Error so the frontend can
-	// style it as guidance rather than a failure.
-	Notice string `json:"notice,omitempty"`
-	// Truncation is a non-error affordance shown alongside the columns when the
-	// fetch hit the backend's cap and more tickets exist than are displayed
-	// (SC-1693). Unlike Notice it accompanies a populated board rather than
-	// replacing empty columns, so the user knows the list is partial.
-	Truncation      string `json:"truncation,omitempty"`
-	DockerAvailable bool   `json:"dockerAvailable"`
-	// ColumnOrder is the hand-sorted ticket order per queue column (top
-	// first). The frontend sorts each column by it; cards absent from their
-	// queue's list render after it in fetch order.
-	ColumnOrder map[string][]string `json:"columnOrder,omitempty"`
-}
+type BoardData = daemon.BoardView
 
 // Cards fetches the current board state from the daemon and flattens the single
 // PM-role result into a card list, dropping hidden cards. v1 is single
@@ -380,136 +284,33 @@ func (a *App) CachedCards() CachedBoard {
 	return CachedBoard{Hit: true, Data: data}
 }
 
-// boardFromResults flattens the single PM-role result into the frontend card
-// list. It is shared by Cards() (results carry derived BoardCards) and
-// CardsQuick() (results carry titles only, so every non-hidden issue lands in
-// Backlog). A PM issue with no derived card is hidden when its status is
-// done/closed and placed in Backlog otherwise, mirroring daemon.DeriveBoardCard's
-// marker-less decision so the quick pass and full pass agree on what to show.
+// boardFromResults composes the shared board and then applies this viewer's own
+// overlay. The split is the point: Compose produces what is true of the project,
+// applyLocal adds what is true only of the person looking.
 func boardFromResults(results []daemon.TrackerIssuesResult, dockerAvailable bool, ideaCols map[string]int, mocks map[string]cardMockupInfo, prefs boardprefs.Prefs) BoardData {
-	data := BoardData{DockerAvailable: dockerAvailable, ColumnOrder: prefs.Columns}
-	pm, ok := board.FirstPMResult(results)
-	if !ok {
-		// No PM-role tracker resolved: rather than five silently empty columns
-		// that read as "no work" (SC-1655), surface an explicit notice telling
-		// the user a tracker needs role: pm to appear on the board.
-		data.Notice = board.PMRoleNotice(results)
-		return data
-	}
-	if pm.Err != "" {
-		data.Error = pm.Err
-	}
-	// A capped fetch renders a full board that silently omits the overflow; the
-	// affordance tells the user the list is partial (and that their saved state
-	// is preserved because pruning paused). See board.CanPrune / SC-1693.
-	data.Truncation = board.TruncationNotice(results)
+	return applyLocal(board.Compose(results, dockerAvailable), ideaCols, mocks, prefs)
+}
 
-	for _, issue := range pm.Issues {
-		card := pm.BoardCards[issue.Key]
-		if card.Degraded {
-			// Could not read this ticket's markers this scan: render it locked in
-			// its last-known column (or the Backlog position when we have no
-			// prior stage), never as a silent actionable Backlog card (1700).
-			stage := card.Stage
-			if stage == "" || stage == daemon.BoardHidden {
-				stage = daemon.BoardBacklog
-			}
-			ideaCol := 0
-			if stage == daemon.BoardIdeas {
-				ideaCol = ideaCols[issue.Key]
-			}
-			mock := mocks[issue.Key]
-			_, hidden := prefs.Hidden[issue.Key]
-			data.Cards = append(data.Cards, Card{
-				Key:              issue.Key,
-				Title:            issue.Title,
-				URL:              issue.URL,
-				Stage:            string(stage),
-				State:            string(card.State),
-				Degraded:         true,
-				EngineeringKey:   card.EngineeringKey,
-				Branch:           card.Branch,
-				PRURL:            card.PRURL,
-				Error:            card.Error,
-				Verdict:          card.Verdict,
-				StageEnteredAt:   formatStageTime(card.StageEnteredAt),
-				DeployPhase:      card.DeployPhase,
-				Labels:           issue.Labels,
-				Description:      issue.Description,
-				Assignee:         issue.Assignee,
-				Tracker:          pm.TrackerName,
-				TrackerKind:      pm.TrackerKind,
-				Bug:              issue.IsBug(),
-				Security:         issue.IsSecurity(),
-				Hidden:           hidden,
-				IdeaColumn:       ideaCol,
-				Options:          card.Options,
-				OptionsContext:   card.OptionsContext,
-				MockupSlug:       mock.Slug,
-				MockupState:      mock.State,
-				MockupChosenSlug: mock.ChosenSlug,
-				MockupChosenFile: mock.ChosenFile,
-			})
-			continue
-		}
-		stage := card.Stage
-		if stage == "" {
-			// No derived card (quick fetch, or a marker-less ticket): a
-			// done/closed ticket that never entered the pipeline is hidden;
-			// ideas sit in the Ideas column by their label alone; everything
-			// else sits in Backlog. Mirrors daemon.DeriveBoardCard so the
-			// quick pass and full pass agree.
-			if issue.StatusType == tracker.CategoryDone || issue.StatusType == tracker.CategoryClosed {
-				continue
-			}
-			if issue.IsIdea() {
-				stage = daemon.BoardIdeas
-			} else {
-				stage = daemon.BoardBacklog
-			}
-		}
-		if stage == daemon.BoardHidden {
-			// Closed PM ticket that never entered the pipeline — not shown.
-			continue
-		}
-		ideaCol := 0
-		if stage == daemon.BoardIdeas {
+// applyLocal fills the fields Compose deliberately leaves blank because they
+// belong to the viewer, not the project: the idea-space sub-column, the locally
+// generated mockup links, the hand-sorted column order, and the hide flag.
+//
+// Hidden cards are marked, not dropped — the frontend filters them so a user can
+// reveal them without a refetch, which is why Compose returns them at all.
+func applyLocal(view daemon.BoardView, ideaCols map[string]int, mocks map[string]cardMockupInfo, prefs boardprefs.Prefs) BoardData {
+	view.ColumnOrder = prefs.Columns
+	for i := range view.Cards {
+		c := &view.Cards[i]
+		if c.Stage == string(daemon.BoardIdeas) {
 			// Missing key → zero value → leftmost column, the loose default.
-			ideaCol = ideaCols[issue.Key]
+			c.IdeaColumn = ideaCols[c.Key]
 		}
-		mock := mocks[issue.Key]
-		_, hidden := prefs.Hidden[issue.Key]
-		data.Cards = append(data.Cards, Card{
-			Key:              issue.Key,
-			Title:            issue.Title,
-			URL:              issue.URL,
-			Stage:            string(stage),
-			State:            string(card.State),
-			EngineeringKey:   card.EngineeringKey,
-			Branch:           card.Branch,
-			PRURL:            card.PRURL,
-			Error:            card.Error,
-			Verdict:          card.Verdict,
-			StageEnteredAt:   formatStageTime(card.StageEnteredAt),
-			DeployPhase:      card.DeployPhase,
-			Labels:           issue.Labels,
-			Description:      issue.Description,
-			Assignee:         issue.Assignee,
-			Tracker:          pm.TrackerName,
-			TrackerKind:      pm.TrackerKind,
-			Bug:              issue.IsBug(),
-			Security:         issue.IsSecurity(),
-			Hidden:           hidden,
-			IdeaColumn:       ideaCol,
-			Options:          card.Options,
-			OptionsContext:   card.OptionsContext,
-			MockupSlug:       mock.Slug,
-			MockupState:      mock.State,
-			MockupChosenSlug: mock.ChosenSlug,
-			MockupChosenFile: mock.ChosenFile,
-		})
+		mock := mocks[c.Key]
+		c.MockupSlug, c.MockupState = mock.Slug, mock.State
+		c.MockupChosenSlug, c.MockupChosenFile = mock.ChosenSlug, mock.ChosenFile
+		_, c.Hidden = prefs.Hidden[c.Key]
 	}
-	return data
+	return view
 }
 
 // formatStageTime renders a marker time for the frontend, empty when the card

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -26,7 +25,6 @@ import (
 
 	"github.com/gethuman-sh/human/errors"
 	"github.com/gethuman-sh/human/internal/board"
-	"github.com/gethuman-sh/human/internal/boardcache"
 	"github.com/gethuman-sh/human/internal/boardprefs"
 	"github.com/gethuman-sh/human/internal/daemon"
 	"github.com/gethuman-sh/human/internal/ideaspace"
@@ -62,7 +60,6 @@ type App struct {
 	// cache holds the last-known full board snapshot, keyed by project, so a
 	// cold open paints instantly from it before the live fetch lands
 	// (stale-while-revalidate). Local UI acceleration only — never tracker state.
-	cache *boardcache.Store
 }
 
 // NewApp constructs the backend. Wails injects the lifecycle context via
@@ -72,7 +69,6 @@ func NewApp() *App {
 		ideas:   ideaspace.NewStore(ideaspace.DefaultPath()),
 		recents: recentprojects.NewStore(recentprojects.DefaultPath()),
 		prefs:   boardprefs.NewStore(boardprefs.DefaultPath()),
-		cache:   boardcache.NewStore(boardcache.DefaultPath()),
 	}
 }
 
@@ -106,12 +102,6 @@ func (a *App) Cards() (BoardData, error) {
 		board.PruneTarget{Store: a.prefs, Keep: boardPrefsKeep(data)},
 		board.PruneTarget{Store: a.ideas, Keep: ideaSpaceKeep(data)},
 	)
-	// Persist the freshly derived board as the instant-paint snapshot for the
-	// next cold open. Best-effort: a cache-write failure must never fail a live
-	// fetch, exactly as a lost recent-projects bump does not.
-	if raw, mErr := json.Marshal(data); mErr == nil {
-		_ = a.cache.Save(project, raw)
-	}
 	return data, nil
 }
 
@@ -253,35 +243,6 @@ func projectKeyOf(info daemon.DaemonInfo) string {
 		return info.Projects[0].Dir
 	}
 	return ""
-}
-
-// CachedBoard is the instant-paint payload: the last-known board plus whether a
-// snapshot for the active project actually existed. Hit=false tells the frontend
-// to fall back to its spinner + quick-titles load.
-type CachedBoard struct {
-	Hit  bool      `json:"hit"`
-	Data BoardData `json:"data"`
-}
-
-// CachedCards returns the last-known board snapshot for the active project from
-// the local cache file — a fast, network-free read (daemon.ReadInfo reads
-// ~/.human/daemon.json, no tracker call), so the board paints instantly on a cold
-// open. A missing daemon info file, a missing/other-project snapshot, or a corrupt
-// cache all return Hit=false, and the frontend then shows its normal load.
-func (a *App) CachedCards() CachedBoard {
-	info, err := daemon.ReadInfo()
-	if err != nil {
-		return CachedBoard{}
-	}
-	raw, ok := a.cache.Load(projectKeyOf(info))
-	if !ok {
-		return CachedBoard{}
-	}
-	var data BoardData
-	if json.Unmarshal(raw, &data) != nil {
-		return CachedBoard{}
-	}
-	return CachedBoard{Hit: true, Data: data}
 }
 
 // boardView gets the composed board from the daemon, which is the machine that

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -96,12 +96,12 @@ func (a *App) Cards() (BoardData, error) {
 		return BoardData{}, err
 	}
 
-	results, err := daemon.GetTrackerIssues(info.Addr, info.Token)
+	view, results, err := a.boardView(info)
 	if err != nil {
 		return BoardData{}, daemonCause(err)
 	}
 	project := projectKeyOf(info)
-	data := boardFromResults(results, dockerAvailable(), a.ideas.Assignments(project), cardMockups(), a.prefs.Snapshot(project))
+	data := applyLocal(view, a.ideas.Assignments(project), cardMockups(), a.prefs.Snapshot(project))
 	board.PrunePrefs(results, project,
 		board.PruneTarget{Store: a.prefs, Keep: boardPrefsKeep(data)},
 		board.PruneTarget{Store: a.ideas, Keep: ideaSpaceKeep(data)},
@@ -282,6 +282,25 @@ func (a *App) CachedCards() CachedBoard {
 		return CachedBoard{}
 	}
 	return CachedBoard{Hit: true, Data: data}
+}
+
+// boardView gets the composed board from the daemon, which is the machine that
+// should own it. It also returns the raw results, because pref pruning still
+// needs to see every tracker's outcome — the composed view is PM-only by design.
+//
+// The fallback covers a daemon older than the board-view route: compose locally
+// from the same raw results. Same function, same output — only the machine doing
+// the work differs, so a version-skewed pair still renders a correct board
+// rather than nothing.
+func (a *App) boardView(info daemon.DaemonInfo) (daemon.BoardView, []daemon.TrackerIssuesResult, error) {
+	results, err := daemon.GetTrackerIssues(info.Addr, info.Token)
+	if err != nil {
+		return daemon.BoardView{}, nil, err
+	}
+	if view, vErr := daemon.GetBoardView(info.Addr, info.Token); vErr == nil {
+		return view, results, nil
+	}
+	return board.Compose(results, dockerAvailable()), results, nil
 }
 
 // boardFromResults composes the shared board and then applies this viewer's own

--- a/desktop/frontend/dist/board-queue.js
+++ b/desktop/frontend/dist/board-queue.js
@@ -333,15 +333,6 @@ export function deployControlView(cards, side) {
         tooltip: count === 0 ? `No ${noun}s to deploy yet` : `Ship every ${noun}`,
     };
 }
-// initialLoadPhase decides the startup render path from whether a cached
-// snapshot was available. A hit paints the last-known board instantly and takes
-// the "cache" path, SKIPPING the titles-only quick pass — running it after a
-// cache paint would regress every card to Backlog and flicker. A miss takes the
-// "quick" path (spinner + titles). Either way the full reconcile runs afterward
-// and silently swaps in fresh data (stale-while-revalidate).
-export function initialLoadPhase(cacheHit) {
-    return cacheHit ? "cache" : "quick";
-}
 // safetyPollShouldReconcile decides whether the 90s safety poll runs its
 // reconcile on a given tick. It intentionally does NOT gate on daemon
 // reachability: the poll exists to bound staleness for tracker writes that emit

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -15,7 +15,7 @@ import { initMockupsView, showMockups, setPendingMockupSlug, setChosenMockup, } 
 import { initSettingsView, showSettings, settingsIndex, saveSetting, setPaletteOpener, setActiveSection, } from "./settingsview.js";
 import { initPalette, openPalette, isPaletteChord } from "./palette.js";
 import { initStatsView, showStats, startStatsPoll, stopStatsPoll, } from "./statsview.js";
-import { QUEUES, QUEUE_TRANSITION_TO, queueOf, isReworkable, isReviewRetryable, ageBadge, isReplannable, forwardDropAllowed, badgeInfo, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReadyToDeploy, deployableCards, deployControlView, initialLoadPhase, safetyPollShouldReconcile, safetyReconcileError, } from "./board-queue.js";
+import { QUEUES, QUEUE_TRANSITION_TO, queueOf, isReworkable, isReviewRetryable, ageBadge, isReplannable, forwardDropAllowed, badgeInfo, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReadyToDeploy, deployableCards, deployControlView, safetyPollShouldReconcile, safetyReconcileError, } from "./board-queue.js";
 import { buildDeployControl } from "./board-deploy.js";
 import { buildDetailSections, buildOptionsSection } from "./board-detail.js";
 import { ideationInputEnabled, shouldCloseIdeation } from "./board-ideation.js";
@@ -1691,31 +1691,16 @@ async function pollDoctor() {
         led.title = [header, ...lines].join("\n");
     }
 }
-// initialLoad renders the board on startup with stale-while-revalidate: it first
-// paints the last-known cached snapshot instantly (a cold open, including after a
-// restart, shows the previous board rather than a spinner), then the full
-// reconcile below silently swaps in fresh data. On a cache miss it falls back to
-// the original spinner → quick-titles → reconcile path. reconcile() persists each
-// full fetch as the next snapshot (App.Cards).
+// initialLoad renders the board on startup: spinner → quick titles → full
+// reconcile.
+//
+// The board no longer keeps its own snapshot to paint from. The daemon owns the
+// last-known board and serves it (stale-marked) when a refresh fails, so
+// instant-paint is answered by the machine that actually knows what the board
+// last looked like. Without a daemon there is nothing to show and the fetch
+// error says so — an empty board would read as "there is no work" (SC-2132).
 async function initialLoad() {
-    let painted = false;
-    try {
-        const cached = await go().CachedCards();
-        if (initialLoadPhase(cached.hit) === "cache") {
-            // Cached cards already carry real stages, so no spinner and no
-            // per-card resolving badge (stagesLoading stays false) — the paint must
-            // look identical to a live view, with no staleness cue.
-            current = boardStateFromPayload(cached.data, true);
-            boardLoading = false;
-            stagesLoading = false;
-            painted = true;
-            render();
-        }
-    }
-    catch {
-        // Cache read failed (e.g. bindings not ready): fall through to the live path.
-    }
-    if (!painted) {
+    {
         boardLoading = true;
         render();
         try {

--- a/desktop/frontend/scripts/board-queue.test.mjs
+++ b/desktop/frontend/scripts/board-queue.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { queueOf, forwardDropAllowed, planReady, badgeInfo, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReviewRetryable, initialLoadPhase } from "../build/board-queue.js";
+import { queueOf, forwardDropAllowed, planReady, badgeInfo, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReviewRetryable } from "../build/board-queue.js";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -360,14 +360,6 @@ test("isReplannable: planned feature cards only", async () => {
   assert.equal(isReplannable({ stage: "planning", state: "running" }), false);
   assert.equal(isReplannable({ stage: "implementation", state: "done" }), false);
   assert.equal(isReplannable({ stage: "planning", state: "done", bug: true }), false);
-});
-
-test("initialLoadPhase: a cache hit paints from cache and skips the quick pass", () => {
-  assert.equal(initialLoadPhase(true), "cache");
-});
-
-test("initialLoadPhase: a cache miss falls back to the spinner + quick-titles path", () => {
-  assert.equal(initialLoadPhase(false), "quick");
 });
 
 import { deploySideOf, deployControlView, deployableCards } from "../build/board-queue.js";

--- a/desktop/frontend/src/board-queue.ts
+++ b/desktop/frontend/src/board-queue.ts
@@ -418,16 +418,6 @@ export function deployControlView(cards: QueueCard[], side: DeploySide): DeployC
   };
 }
 
-// initialLoadPhase decides the startup render path from whether a cached
-// snapshot was available. A hit paints the last-known board instantly and takes
-// the "cache" path, SKIPPING the titles-only quick pass — running it after a
-// cache paint would regress every card to Backlog and flicker. A miss takes the
-// "quick" path (spinner + titles). Either way the full reconcile runs afterward
-// and silently swaps in fresh data (stale-while-revalidate).
-export function initialLoadPhase(cacheHit: boolean): "cache" | "quick" {
-  return cacheHit ? "cache" : "quick";
-}
-
 // safetyPollShouldReconcile decides whether the 90s safety poll runs its
 // reconcile on a given tick. It intentionally does NOT gate on daemon
 // reachability: the poll exists to bound staleness for tracker writes that emit

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -60,7 +60,6 @@ import {
   isReadyToDeploy,
   deployableCards,
   deployControlView,
-  initialLoadPhase,
   safetyPollShouldReconcile,
   safetyReconcileError,
 } from "./board-queue.js";
@@ -141,14 +140,6 @@ interface BoardData {
   // Hand-sorted ticket order per queue column (top first); cards absent from
   // their queue's list render after it in fetch order.
   columnOrder?: Record<string, string[]>;
-}
-
-// CachedBoard is App.CachedCards's payload: the last-known board snapshot plus
-// whether one existed for the active project. hit=false means paint nothing from
-// cache and run the normal spinner + quick-titles load.
-interface CachedBoard {
-  hit: boolean;
-  data: BoardData;
 }
 
 interface IdeationMsg {
@@ -302,7 +293,6 @@ interface AppBindings {
   Doctor(): Promise<DoctorData>;
   GetIssueDetail(trackerKind: string, trackerName: string, key: string): Promise<IssueDetailData>;
   CardsQuick(): Promise<BoardData>;
-  CachedCards(): Promise<CachedBoard>;
   Transition(pmKey: string, pmTitle: string, from: string, to: string): Promise<void>;
   FixBug(pmKey: string, pmTitle: string): Promise<void>;
   FixSecurity(pmKey: string, pmTitle: string): Promise<void>;
@@ -2117,30 +2107,16 @@ async function pollDoctor(): Promise<void> {
   }
 }
 
-// initialLoad renders the board on startup with stale-while-revalidate: it first
-// paints the last-known cached snapshot instantly (a cold open, including after a
-// restart, shows the previous board rather than a spinner), then the full
-// reconcile below silently swaps in fresh data. On a cache miss it falls back to
-// the original spinner → quick-titles → reconcile path. reconcile() persists each
-// full fetch as the next snapshot (App.Cards).
+// initialLoad renders the board on startup: spinner → quick titles → full
+// reconcile.
+//
+// The board no longer keeps its own snapshot to paint from. The daemon owns the
+// last-known board and serves it (stale-marked) when a refresh fails, so
+// instant-paint is answered by the machine that actually knows what the board
+// last looked like. Without a daemon there is nothing to show and the fetch
+// error says so — an empty board would read as "there is no work" (SC-2132).
 async function initialLoad(): Promise<void> {
-  let painted = false;
-  try {
-    const cached = await go().CachedCards();
-    if (initialLoadPhase(cached.hit) === "cache") {
-      // Cached cards already carry real stages, so no spinner and no
-      // per-card resolving badge (stagesLoading stays false) — the paint must
-      // look identical to a live view, with no staleness cue.
-      current = boardStateFromPayload(cached.data, true);
-      boardLoading = false;
-      stagesLoading = false;
-      painted = true;
-      render();
-    }
-  } catch {
-    // Cache read failed (e.g. bindings not ready): fall through to the live path.
-  }
-  if (!painted) {
+  {
     boardLoading = true;
     render();
     try {

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -110,10 +110,15 @@ func (a *App) backoff(ctx context.Context) {
 	}
 }
 
-// dockerAvailable reports whether a Docker engine is reachable. The frontend
-// uses this to disable the agent-launching drop targets (planning, impl,
-// verification) with a tooltip while leaving the Done drop zone enabled, since
-// Done only pushes a branch and opens a PR.
+// dockerAvailable reports whether a Docker engine is reachable ON THIS MACHINE.
+// The frontend uses the flag to disable the agent-launching drop targets
+// (planning, impl, verification) with a tooltip while leaving the Done drop zone
+// enabled, since Done only pushes a branch and opens a PR.
+//
+// This is the FALLBACK answer only. The flag describes the host that launches
+// agents, which is the daemon's — so the composed board carries the daemon's own
+// doctor verdict, and this local probe is used just when composing locally
+// against a daemon too old to serve one (SC-2132).
 func dockerAvailable() bool {
 	dc, err := devcontainer.NewDockerClient()
 	if err != nil {

--- a/internal/board/compose.go
+++ b/internal/board/compose.go
@@ -1,0 +1,120 @@
+package board
+
+import (
+	"time"
+
+	"github.com/gethuman-sh/human/internal/daemon"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// Compose flattens a tracker fetch into the board the frontend renders: the
+// single PM-role result joined with its derived BoardCards, plus the structural
+// notices that explain an empty or partial board.
+//
+// It deliberately produces only what is TRUE OF THE PROJECT — the same board for
+// anyone looking at it. Three per-card fields are left at their zero values
+// because they are true only of the person looking: IdeaColumn, Hidden, and the
+// Mockup* set. The viewer fills those in (desktop applyLocal), which is why this
+// can run on the daemon and be shared, and why hidden cards are still returned
+// here: hiding is a viewer's filter, not a property of the work.
+//
+// dockerAvailable belongs to the machine that launches agents, so the caller
+// supplies it rather than probing — on the daemon that is its own host, which is
+// the host that actually matters.
+func Compose(results []daemon.TrackerIssuesResult, dockerAvailable bool) daemon.BoardView {
+	view := daemon.BoardView{DockerAvailable: dockerAvailable}
+	pm, ok := FirstPMResult(results)
+	if !ok {
+		// No PM-role tracker resolved: rather than five silently empty columns
+		// that read as "no work" (SC-1655), surface an explicit notice telling
+		// the user a tracker needs role: pm to appear on the board.
+		view.Notice = PMRoleNotice(results)
+		return view
+	}
+	if pm.Err != "" {
+		view.Error = pm.Err
+	}
+	// A capped fetch renders a full board that silently omits the overflow; the
+	// affordance tells the user the list is partial (and that their saved state
+	// is preserved because pruning paused). See CanPrune / SC-1693.
+	view.Truncation = TruncationNotice(results)
+
+	for _, issue := range pm.Issues {
+		card := pm.BoardCards[issue.Key]
+		stage, include := composedStage(issue, card)
+		if !include {
+			continue
+		}
+		view.Cards = append(view.Cards, daemon.BoardViewCard{
+			Key:            issue.Key,
+			Title:          issue.Title,
+			URL:            issue.URL,
+			Stage:          string(stage),
+			State:          string(card.State),
+			Degraded:       card.Degraded,
+			EngineeringKey: card.EngineeringKey,
+			Branch:         card.Branch,
+			PRURL:          card.PRURL,
+			Error:          card.Error,
+			Verdict:        card.Verdict,
+			StageEnteredAt: formatStageTime(card.StageEnteredAt),
+			DeployPhase:    card.DeployPhase,
+			Labels:         issue.Labels,
+			Description:    issue.Description,
+			Assignee:       issue.Assignee,
+			Tracker:        pm.TrackerName,
+			TrackerKind:    pm.TrackerKind,
+			Bug:            issue.IsBug(),
+			Security:       issue.IsSecurity(),
+			Options:        card.Options,
+			OptionsContext: card.OptionsContext,
+		})
+	}
+	return view
+}
+
+// composedStage resolves the column a ticket sits in, and whether it belongs on
+// the board at all. It keeps the two placement rules that differ only in why
+// they exist:
+//
+//   - A DEGRADED card's markers could not be read this scan, so it is pinned to
+//     its last-known column (Backlog when there is no prior stage) rather than
+//     appearing as idle, actionable Backlog work (1700).
+//   - A card with no derived stage never entered the pipeline: a done/closed
+//     ticket is hidden, an idea sits in Ideas by its label alone, everything
+//     else lands in Backlog. Mirrors daemon.DeriveBoardCard so the quick pass
+//     and the full pass agree.
+func composedStage(issue tracker.Issue, card daemon.BoardCard) (daemon.BoardStage, bool) {
+	if card.Degraded {
+		stage := card.Stage
+		if stage == "" || stage == daemon.BoardHidden {
+			stage = daemon.BoardBacklog
+		}
+		return stage, true
+	}
+	stage := card.Stage
+	if stage == "" {
+		if issue.StatusType == tracker.CategoryDone || issue.StatusType == tracker.CategoryClosed {
+			return "", false
+		}
+		if issue.IsIdea() {
+			stage = daemon.BoardIdeas
+		} else {
+			stage = daemon.BoardBacklog
+		}
+	}
+	if stage == daemon.BoardHidden {
+		// Closed PM ticket that never entered the pipeline — not shown.
+		return "", false
+	}
+	return stage, true
+}
+
+// formatStageTime renders a marker time for the frontend, empty when the card
+// has no derived stage yet.
+func formatStageTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format(time.RFC3339)
+}

--- a/internal/board/compose_test.go
+++ b/internal/board/compose_test.go
@@ -1,0 +1,188 @@
+package board
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/daemon"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// pmResult builds a PM-role result carrying the given issues and derived cards.
+func pmResult(issues []tracker.Issue, cards map[string]daemon.BoardCard) daemon.TrackerIssuesResult {
+	return daemon.TrackerIssuesResult{
+		TrackerName: "human",
+		TrackerKind: "shortcut",
+		TrackerRole: "pm",
+		Project:     "board",
+		Issues:      issues,
+		BoardCards:  cards,
+	}
+}
+
+// cardByKey finds a composed card.
+func cardByKey(t *testing.T, view daemon.BoardView, key string) daemon.BoardViewCard {
+	t.Helper()
+	for _, c := range view.Cards {
+		if c.Key == key {
+			return c
+		}
+	}
+	require.FailNowf(t, "card not found", "expected %s in the composed view", key)
+	return daemon.BoardViewCard{}
+}
+
+// The whole point of the split: Compose produces what is true of the PROJECT and
+// must leave the viewer's own fields untouched, so the same composition can be
+// computed once (on the daemon) and rendered by anyone.
+func TestCompose_LeavesViewerOwnedFieldsZero(t *testing.T) {
+	view := Compose([]daemon.TrackerIssuesResult{pmResult(
+		[]tracker.Issue{{Key: "SC-1", Title: "one"}},
+		map[string]daemon.BoardCard{"SC-1": {Stage: daemon.BoardIdeas}},
+	)}, true)
+
+	c := cardByKey(t, view, "SC-1")
+	assert.Zero(t, c.IdeaColumn, "idea column is a viewer preference")
+	assert.False(t, c.Hidden, "hiding is a viewer filter")
+	assert.Empty(t, c.MockupSlug)
+	assert.Empty(t, c.MockupState)
+	assert.Empty(t, c.MockupChosenSlug)
+	assert.Empty(t, c.MockupChosenFile)
+	assert.Empty(t, view.ColumnOrder, "hand-sorted order is a viewer preference")
+}
+
+// Hidden cards must still be composed: the frontend filters them, so dropping
+// them here would make "reveal hidden" impossible without a refetch.
+func TestCompose_ReturnsCardsTheViewerMayHide(t *testing.T) {
+	view := Compose([]daemon.TrackerIssuesResult{pmResult(
+		[]tracker.Issue{{Key: "SC-1", Title: "one"}, {Key: "SC-2", Title: "two"}},
+		map[string]daemon.BoardCard{
+			"SC-1": {Stage: daemon.BoardBacklog},
+			"SC-2": {Stage: daemon.BoardBacklog},
+		},
+	)}, false)
+
+	assert.Len(t, view.Cards, 2, "Compose knows nothing about which cards a viewer hides")
+}
+
+// A card whose markers could not be read is pinned to its last-known column
+// rather than presenting as idle, actionable Backlog work (1700).
+func TestCompose_DegradedCardKeepsItsLastKnownStage(t *testing.T) {
+	view := Compose([]daemon.TrackerIssuesResult{pmResult(
+		[]tracker.Issue{{Key: "SC-1", Title: "one"}},
+		map[string]daemon.BoardCard{"SC-1": {Stage: daemon.BoardImplementation, State: daemon.BoardRunning, Degraded: true}},
+	)}, false)
+
+	c := cardByKey(t, view, "SC-1")
+	assert.Equal(t, string(daemon.BoardImplementation), c.Stage)
+	assert.True(t, c.Degraded)
+}
+
+// A degraded card with no prior stage falls back to Backlog rather than to the
+// hidden lane, so it stays visible while unreadable.
+func TestCompose_DegradedCardWithoutAStageFallsBackToBacklog(t *testing.T) {
+	for _, stage := range []daemon.BoardStage{"", daemon.BoardHidden} {
+		view := Compose([]daemon.TrackerIssuesResult{pmResult(
+			[]tracker.Issue{{Key: "SC-1", Title: "one"}},
+			map[string]daemon.BoardCard{"SC-1": {Stage: stage, Degraded: true}},
+		)}, false)
+
+		c := cardByKey(t, view, "SC-1")
+		assert.Equal(t, string(daemon.BoardBacklog), c.Stage, "degraded stage %q", stage)
+	}
+}
+
+// A ticket that never entered the pipeline is placed by its own nature: closed
+// work is not shown, an idea sits in Ideas by its label, everything else lands
+// in Backlog.
+func TestCompose_UnstartedTicketsArePlacedByNature(t *testing.T) {
+	issues := []tracker.Issue{
+		{Key: "SC-done", Title: "shipped", StatusType: tracker.CategoryDone},
+		{Key: "SC-closed", Title: "dropped", StatusType: tracker.CategoryClosed},
+		{Key: "SC-idea", Title: "a thought", Labels: []string{"human/idea"}},
+		{Key: "SC-plain", Title: "work"},
+	}
+	view := Compose([]daemon.TrackerIssuesResult{pmResult(issues, map[string]daemon.BoardCard{})}, false)
+
+	keys := make(map[string]string, len(view.Cards))
+	for _, c := range view.Cards {
+		keys[c.Key] = c.Stage
+	}
+	assert.NotContains(t, keys, "SC-done", "closed work that never started is not board work")
+	assert.NotContains(t, keys, "SC-closed")
+	assert.Equal(t, string(daemon.BoardIdeas), keys["SC-idea"])
+	assert.Equal(t, string(daemon.BoardBacklog), keys["SC-plain"])
+}
+
+// A derived hidden stage is a closed ticket that never entered the pipeline.
+func TestCompose_HiddenStageIsNotRendered(t *testing.T) {
+	view := Compose([]daemon.TrackerIssuesResult{pmResult(
+		[]tracker.Issue{{Key: "SC-1", Title: "one"}},
+		map[string]daemon.BoardCard{"SC-1": {Stage: daemon.BoardHidden}},
+	)}, false)
+
+	assert.Empty(t, view.Cards)
+}
+
+// With no PM-role tracker the board must say so rather than render five empty
+// columns that read as "no work" (SC-1655).
+func TestCompose_NoPMTrackerExplainsItself(t *testing.T) {
+	view := Compose([]daemon.TrackerIssuesResult{{
+		TrackerName: "human", TrackerKind: "linear", Project: "eng",
+	}}, false)
+
+	assert.Empty(t, view.Cards)
+	assert.NotEmpty(t, view.Notice, "an empty board must explain why it is empty")
+}
+
+// A fetch error on the PM result rides along with whatever did come back, so the
+// frontend can show a banner instead of a silently short board.
+func TestCompose_PMFetchErrorIsCarried(t *testing.T) {
+	res := pmResult([]tracker.Issue{{Key: "SC-1", Title: "one"}}, map[string]daemon.BoardCard{"SC-1": {Stage: daemon.BoardBacklog}})
+	res.Err = "tracker unreachable"
+
+	view := Compose([]daemon.TrackerIssuesResult{res}, false)
+
+	assert.Equal(t, "tracker unreachable", view.Error)
+	assert.Len(t, view.Cards, 1, "the error must not discard the cards that did arrive")
+}
+
+// Facts about the ticket and its derived run must survive composition intact —
+// this is the payload the whole board renders from.
+func TestCompose_CarriesTicketAndRunFacts(t *testing.T) {
+	entered := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	view := Compose([]daemon.TrackerIssuesResult{pmResult(
+		[]tracker.Issue{{
+			Key: "SC-1", Title: "one", URL: "https://example/1",
+			Description: "body", Assignee: "stephan", Labels: []string{"bug"},
+		}},
+		map[string]daemon.BoardCard{"SC-1": {
+			Stage: daemon.BoardImplementation, State: daemon.BoardRunning,
+			Branch: "autofix/sc-1", PRURL: "https://example/pr/1",
+			EngineeringKey: "HUM-1", Verdict: "pass", DeployPhase: "pr-review",
+			StageEnteredAt: entered,
+			Options:        []daemon.BoardOption{{ID: "1", Label: "A"}}, OptionsContext: "why",
+		}},
+	)}, true)
+
+	c := cardByKey(t, view, "SC-1")
+	assert.Equal(t, "one", c.Title)
+	assert.Equal(t, "https://example/1", c.URL)
+	assert.Equal(t, "body", c.Description)
+	assert.Equal(t, "stephan", c.Assignee)
+	assert.Equal(t, "autofix/sc-1", c.Branch)
+	assert.Equal(t, "https://example/pr/1", c.PRURL)
+	assert.Equal(t, "HUM-1", c.EngineeringKey)
+	assert.Equal(t, "pass", c.Verdict)
+	assert.Equal(t, "pr-review", c.DeployPhase)
+	assert.Equal(t, entered.Format(time.RFC3339), c.StageEnteredAt)
+	assert.Equal(t, "human", c.Tracker)
+	assert.Equal(t, "shortcut", c.TrackerKind)
+	assert.True(t, c.Bug, "a bug label must reach the Bugs pane")
+	require.Len(t, c.Options, 1)
+	assert.Equal(t, "why", c.OptionsContext)
+	assert.True(t, view.DockerAvailable, "docker availability is the launching host's, passed in")
+}

--- a/internal/daemon/board_view_route_test.go
+++ b/internal/daemon/board_view_route_test.go
@@ -1,0 +1,63 @@
+package daemon
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The board-view route exists so every consumer reads one composed picture
+// instead of assembling its own from raw results (SC-2132).
+func TestServer_HandleBoardView_ReturnsTheComposedBoard(t *testing.T) {
+	token := "test-token"
+	addr, _ := startTestServerCustom(t, token, func(s *Server) {
+		s.BoardViewFetcher = func() (BoardView, error) {
+			return BoardView{
+				DockerAvailable: true,
+				Cards: []BoardViewCard{
+					{Key: "SC-1", Title: "one", Stage: string(BoardBacklog)},
+				},
+			}, nil
+		}
+	})
+
+	resp := sendRequest(t, addr, Request{Token: token, Args: []string{"board-view"}})
+	require.Equal(t, 0, resp.ExitCode)
+
+	var view BoardView
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(resp.Stdout)), &view))
+	require.Len(t, view.Cards, 1)
+	assert.Equal(t, "SC-1", view.Cards[0].Key)
+	assert.True(t, view.DockerAvailable,
+		"docker availability is the daemon host's verdict, carried on the view")
+}
+
+// A daemon with no composer must say so rather than answer with an empty board:
+// "no cards" and "cannot compose" are different states, and an empty board reads
+// as "there is no work".
+func TestServer_HandleBoardView_NoComposerIsAnError(t *testing.T) {
+	token := "test-token"
+	addr, _ := startTestServerCustom(t, token, func(s *Server) { s.BoardViewFetcher = nil })
+
+	resp := sendRequest(t, addr, Request{Token: token, Args: []string{"board-view"}})
+
+	assert.NotEqual(t, 0, resp.ExitCode, "an unavailable board must not read as an empty one")
+}
+
+// A compose failure is reported, not swallowed into an empty board.
+func TestServer_HandleBoardView_ComposeFailureIsReported(t *testing.T) {
+	token := "test-token"
+	addr, _ := startTestServerCustom(t, token, func(s *Server) {
+		s.BoardViewFetcher = func() (BoardView, error) {
+			return BoardView{}, assert.AnError
+		}
+	})
+
+	resp := sendRequest(t, addr, Request{Token: token, Args: []string{"board-view"}})
+
+	assert.NotEqual(t, 0, resp.ExitCode)
+	assert.Contains(t, resp.Stderr+resp.Stdout, assert.AnError.Error())
+}

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -413,6 +413,31 @@ func getTrackerIssues(addr, token, command string) ([]TrackerIssuesResult, error
 	return results, nil
 }
 
+// GetBoardView fetches the composed board from the daemon — the project-wide
+// picture, with the caller's own overlay (hidden cards, column order, local
+// mockups) still to be applied.
+//
+// Any error means "this daemon did not give me a board", and the caller falls
+// back to fetching raw results and composing them itself. That covers version
+// skew — desktop and daemon are separate binaries and routinely run at different
+// versions, and a daemon predating this route answers with a command-not-found
+// from the CLI forwarder — without inspecting the message to decide.
+//
+// Classifying the cause by matching error text was the obvious alternative and
+// is deliberately not used: the fallback path re-runs the same fetch, so a
+// genuine failure surfaces there anyway and nothing is masked by trying it.
+func GetBoardView(addr, token string) (BoardView, error) {
+	out, err := RunRemoteCapture(addr, token, []string{"board-view"})
+	if err != nil {
+		return BoardView{}, err
+	}
+	var view BoardView
+	if err := json.Unmarshal(out, &view); err != nil {
+		return BoardView{}, errors.WrapWithDetails(err, "invalid board view JSON")
+	}
+	return view, nil
+}
+
 // BoardTransition asks the daemon to advance a card one pipeline stage. The
 // request is sent as a single JSON arg so multi-word PM titles survive arg
 // splitting on the daemon side.

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -132,3 +132,114 @@ type PendingConfirm struct {
 	CreatedAt string `json:"created_at"`
 	ClientPID int    `json:"client_pid"` // PID of the Claude instance that triggered the operation
 }
+
+// --- Board view (the composed, frontend-facing board) ---
+//
+// These live here, beside TrackerIssuesResult and BoardCard, because they are
+// WIRE types: the daemon composes the board and returns it. They cannot live in
+// internal/board, which already imports this package — that would cycle.
+// The desktop aliases them (BoardData/Card) so its code and the frontend's JSON
+// shape are unchanged.
+// Card is the flat, frontend-facing shape of one board ticket: a PM issue joined
+// with its derived BoardCard. The frontend renders columns purely from these —
+// it never re-derives a stage from comments.
+type BoardViewCard struct {
+	Key            string `json:"key"`
+	Title          string `json:"title"`
+	URL            string `json:"url"`
+	Stage          string `json:"stage"`
+	State          string `json:"state"`
+	EngineeringKey string `json:"engineeringKey,omitempty"`
+	Branch         string `json:"branch,omitempty"`
+	PRURL          string `json:"prURL,omitempty"`
+	Error          string `json:"error,omitempty"`
+	// Verdict is the latest review's verdict line; a failing verdict pins the
+	// card in the Code lane with a warning instead of letting it advance.
+	Verdict string `json:"verdict,omitempty"`
+	// StageEnteredAt is when the newest marker of the card's current stage
+	// landed (RFC3339); the board's age badge renders how long the card has
+	// been sitting. Empty when the card has no derived stage yet.
+	StageEnteredAt string `json:"stageEnteredAt,omitempty"`
+	// DeployPhase names the done-stage sub-phase ("pr-review" while the machine
+	// review→fix loop runs, empty for a plain deploy) so the badge reads "PR
+	// review…" instead of "deploying…". Populated by the explicit field copy
+	// below — the daemon→desktop hop is a Go copy, not a JSON re-tag.
+	DeployPhase string `json:"deployPhase,omitempty"`
+	// Degraded marks a card whose markers could not be read this scan (a
+	// ListComments error). The frontend renders it locked — non-draggable and
+	// non-launchable — so a transient fetch failure never presents as idle,
+	// actionable Backlog work (1700).
+	Degraded bool `json:"degraded,omitempty"`
+	// Labels and Description feed the Ideas→Backlog promotion: labels tell
+	// the evolve session which idea labels to remove, the description seeds
+	// the ideation conversation alongside the title.
+	Labels      []string `json:"labels,omitempty"`
+	Description string   `json:"description,omitempty"`
+	// Assignee is the ticket owner shown in the detail panel. Display-only:
+	// the board never assigns; empty renders as "Unassigned" in the frontend.
+	Assignee string `json:"assignee,omitempty"`
+	// Tracker/TrackerKind are the instance name and provider kind the issue
+	// was listed from. The detail panel passes them back to GetIssueDetail so
+	// the daemon resolves the exact instance — bare numeric keys are ambiguous
+	// across kinds, and names can repeat across provider sections.
+	Tracker     string `json:"tracker,omitempty"`
+	TrackerKind string `json:"trackerKind,omitempty"`
+	// IdeaColumn is the idea-space sub-column (0 loosest … 4 most concrete)
+	// for cards in the Ideas stage. Locally persisted preference, never
+	// tracker state; the zero value is the leftmost column, so an idea with
+	// no saved placement starts loose by default.
+	IdeaColumn int `json:"ideaColumn"`
+	// Bug marks a defect ticket (bug label or bug issue type, see
+	// tracker.Issue.IsBug). Bug cards render in the Bugs pane instead of the
+	// workflow board's columns.
+	Bug bool `json:"bug,omitempty"`
+	// Security marks a security ticket (security label or type, see
+	// tracker.Issue.IsSecurity). Security cards render in the Security half of
+	// the Bugs pane. A ticket is never both a bug and security — the tokens are
+	// disjoint — so the two flags are mutually exclusive.
+	Security bool `json:"security,omitempty"`
+	// Hidden marks a ticket the user parked off the board (right-click →
+	// Hide). Locally persisted view preference, never tracker state; the
+	// frontend filters hidden cards out unless the user reveals them.
+	Hidden bool `json:"hidden,omitempty"`
+	// Options carries the card's open decision block: a stage ended in a fork
+	// and a human must pick a direction. OptionsContext is the one-line why.
+	Options        []BoardOption `json:"options,omitempty"`
+	OptionsContext string        `json:"optionsContext,omitempty"`
+	// MockupSlug/MockupState link the card to a locally generated mockup set:
+	// "ready" once mockups/<slug>/index.json is valid, "creating" while a
+	// launched generation has not produced it yet. Local file state — never
+	// tracker state — so browsing or generating mocks leaves no trace on the
+	// ticket.
+	MockupSlug  string `json:"mockupSlug,omitempty"`
+	MockupState string `json:"mockupState,omitempty"`
+	// MockupChosenSlug/MockupChosenFile pin the ticket's chosen winner mockup
+	// (a leaf group's slug + option file) when one has been marked, so the card
+	// can surface that a design direction is selected and the viewer can
+	// highlight the root→winner path. Empty when no winner is chosen.
+	MockupChosenSlug string `json:"mockupChosenSlug,omitempty"`
+	MockupChosenFile string `json:"mockupChosenFile,omitempty"`
+}
+
+// BoardData is the full payload the frontend renders: the flat card list plus an
+// optional fetch error (surfaced as a banner) and a dockerAvailable flag the
+// frontend uses to disable the agent-launching drop targets.
+type BoardView struct {
+	Cards []BoardViewCard `json:"cards"`
+	Error string          `json:"error,omitempty"`
+	// Notice is a non-error explanation shown in place of the columns when the
+	// board has nothing to render for a structural reason — chiefly no PM-role
+	// tracker configured (SC-1655). Distinct from Error so the frontend can
+	// style it as guidance rather than a failure.
+	Notice string `json:"notice,omitempty"`
+	// Truncation is a non-error affordance shown alongside the columns when the
+	// fetch hit the backend's cap and more tickets exist than are displayed
+	// (SC-1693). Unlike Notice it accompanies a populated board rather than
+	// replacing empty columns, so the user knows the list is partial.
+	Truncation      string `json:"truncation,omitempty"`
+	DockerAvailable bool   `json:"dockerAvailable"`
+	// ColumnOrder is the hand-sorted ticket order per queue column (top
+	// first). The frontend sorts each column by it; cards absent from their
+	// queue's list render after it in fetch order.
+	ColumnOrder map[string][]string `json:"columnOrder,omitempty"`
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -57,6 +57,12 @@ type Server struct {
 	NetworkEvents    *NetworkEventStore                    // in-memory ambient network activity buffer; nil disables
 	IssueFetcher     func() ([]TrackerIssuesResult, error) // injected; fetches issues from configured trackers
 	LiteIssueFetcher func() ([]TrackerIssuesResult, error) // injected; fetches issue titles only (skips the per-ticket comment scan) so the board can render titles before stages resolve
+	// BoardViewFetcher returns the composed board: the project-wide picture with
+	// every viewer's personal overlay left off. Injected because the composer
+	// (internal/board) imports this package — calling it directly would cycle.
+	// nil disables the board-view route, which is what an older client falls
+	// back from.
+	BoardViewFetcher func() (BoardView, error)
 	// IssueGetter fetches one full issue for the board's detail panel plus its
 	// comment-sourced extras (review findings, failure reason, fix summary).
 	// List endpoints on some trackers (e.g. Shortcut) return slim payloads
@@ -452,6 +458,7 @@ func (s *Server) routeSimpleCommand(conn net.Conn, args []string, projectDir str
 		"network-events":      func() { s.handleNetworkEvents(conn) },
 		"tracker-diagnose":    func() { s.handleTrackerDiagnose(conn, projectDir) },
 		"tracker-issues":      func() { s.handleTrackerIssues(conn) },
+		"board-view":          func() { s.handleBoardView(conn) },
 		"tracker-issues-lite": func() { s.handleTrackerIssuesLite(conn) },
 		"tracker-issue":       func() { s.handleTrackerIssue(conn, args[1:]) },
 		"pending-confirms":    func() { s.handlePendingConfirms(conn) },
@@ -573,6 +580,33 @@ func (s *Server) handleTrackerDiagnose(conn net.Conn, projectDir string) {
 // including each PM ticket's derived board stage (the comment-scan phase).
 func (s *Server) handleTrackerIssues(conn net.Conn) {
 	s.writeIssueResults(conn, s.IssueFetcher)
+}
+
+// handleBoardView returns the composed board — the same picture for every
+// viewer, with each viewer's own overlay (hidden cards, column order, local
+// mockups) left to the client.
+//
+// Composing here rather than in the client is the point: the board is not the
+// only thing that needs the current picture, and a client that assembles its own
+// leaves every other consumer to rebuild it or go without. The composer itself
+// lives in internal/board, which imports this package, so it arrives as an
+// injected closure rather than a direct call.
+func (s *Server) handleBoardView(conn net.Conn) {
+	if s.BoardViewFetcher == nil {
+		s.writeError(conn, "board view not available", 1)
+		return
+	}
+	view, err := s.BoardViewFetcher()
+	if err != nil {
+		s.writeError(conn, err.Error(), 1)
+		return
+	}
+	data, err := json.Marshal(view)
+	if err != nil {
+		s.writeError(conn, err.Error(), 1)
+		return
+	}
+	_ = json.NewEncoder(conn).Encode(Response{Stdout: string(data) + "\n"})
 }
 
 // handleTrackerIssuesLite returns issue titles only, skipping the per-ticket


### PR DESCRIPTION
Closes SC-2132.

The desktop was not a view of the board — it was the board's fetcher, composer, cacher and pruner. It asked the daemon for raw tracker results, assembled the board itself, kept a private copy on disk, and decided how stale that copy could get.

Three consequences, all live:

- **Two independent caches of one fetch.** `internal/boardcache` was imported by exactly one file and stayed minutes-fresh; the recall index — what every agent consults to see whether a problem is already being worked on — was fed only by a hand-run `human index` and had **0 rows since May**. Same upstream, opposite freshness, so every sibling search returned a confident "nothing found".
- **`dockerAvailable` probed the wrong machine.** It opened a Docker client on whichever host rendered the board, but the flag describes where *agents launch* — the daemon's host.
- **The staleness rules lived in the view**, the one place least able to know the answer.

## Four commits, each independently shippable

**1. Split composition from overlay.** `board.Compose` produces what is true of the *project*; the desktop's `applyLocal` adds what is true only of the viewer (idea column, mockups, hide flag, column order). Hidden cards are marked, not dropped — the frontend reveals them without a refetch, so `Compose` must return them. View types moved to `internal/daemon/protocol.go` (they are wire types, and `internal/board` already imports `internal/daemon`, so they could not sit beside `Compose` without cycling); the desktop aliases them, keeping every reference and the frontend's JSON byte-identical.

**2. Serve it from the daemon.** New `board-view` route taking an injected `BoardViewFetcher` — the pattern the server already uses for `IssueFetcher` — rather than calling the composer directly and cycling. Docker availability now comes from the daemon's own doctor check. One fetcher instance is shared with the raw route, because that closure carries the last-known cards and last good listing (1700, SC-2005); a second would split that memory. Version skew falls back to composing locally, triggered by *any* board-view error rather than by matching the message — the fallback re-runs the same fetch, so nothing is masked.

**3. Keep the index current from that fetch.** Upsert composed cards into `internal/recall`: no extra tracker calls, and the record becomes as fresh as the board. Deliberately partial — open PM tickets only, and no comment text, because `TrackerIssuesResult` carries none. "Was this already fixed?" and "which ticket touches this file?" still need their own path.

**4. Move the snapshot to the daemon.** It remembers the last board that carried work and serves it stale-marked when a refresh fails — one layer above SC-2005's fallback, so it survives a failure to *compose*, not just to fetch. An empty board is never remembered. The desktop's cache, `CachedCards`, and `initialLoadPhase` are deleted; a daemon-less board is now an explicit error, because an empty one reads as "there is no work".

## Testing

`boardFromResults` had **zero coverage** — `desktop/` has no test files, and it sits behind the `wailsapp` tag that `make check` never compiles. Moving the logic into an untagged package took it from 0% to **100% statement coverage** in a package the gate actually runs. New tests also cover the route, the version-skew fallback, index round-trip (a composed card is findable by title *and* description), and the stale-serve including its per-project keying.

`make check` green: 3911 tests, 0 lint, gosec 0, govulncheck and gitleaks clean. Desktop vets under `-tags wailsapp`; frontend `tsc` clean and 96 frontend tests pass. `desktop/frontend/dist` rebuilt and committed (SC-1691).

## Not done

Closed tickets and `[human:plan]` comment bodies are still absent from the index — that is the half that would make "which other ticket touches this file" a fact rather than a keyword guess, and it needs a hook inside the comment scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)