### PR TITLE
[SC-2135] Draw the dependency where both ends are visible

### DIFF
--- a/desktop/frontend/dist/board-arrows.js
+++ b/desktop/frontend/dist/board-arrows.js
@@ -1,0 +1,112 @@
+// Dependency arrows between cards, kept free of DOM and Wails bindings so the
+// geometry can be unit-tested directly (the rest of board.ts bootstraps against
+// document/window.go at import time and cannot).
+//
+// An arrow says the same thing as the "waits for SC-1234" badge, but says it
+// without being read. It can only be drawn when both ends are on screen
+// together, so the badge stays the statement of record and the arrow is what
+// you get when the layout happens to allow it.
+// linksWithin returns the dependencies whose BOTH ends are present.
+//
+// Board columns are pipeline stages, so a blocker and the card it holds are
+// usually in different ones. Drawing an arrow to a card that is not there would
+// mean drawing to the edge of the container and hoping the user infers the
+// rest, so those are left to the badge. A chain that IS all present draws
+// arrow-per-hop and comes out as the tree it is, with no code that knows about
+// chains.
+//
+// `blockers` maps a card key to the keys it waits for. The result is ordered by
+// (to, from) so a re-render produces byte-identical SVG and the browser has
+// nothing to repaint.
+export function linksWithin(blockers, present) {
+    const links = [];
+    for (const [to, keys] of blockers) {
+        if (!present.has(to))
+            continue;
+        for (const from of keys) {
+            if (present.has(from) && from !== to)
+                links.push({ from, to });
+        }
+    }
+    return links.sort((a, b) => a.to.localeCompare(b.to) || a.from.localeCompare(b.from));
+}
+// sides picks the pair of edges to connect: the ones that face each other.
+//
+// A vertical offset of more than half a card decides it, because the two
+// layouts this runs in differ: the bug grid flows cards left-to-right, the
+// workflow columns stack them top-to-bottom. Reading the actual offsets means
+// neither layout has to announce itself — cards sharing a row connect
+// sideways, cards on different rows connect up or down. That also handles a
+// grid that wrapped: the blocker ends a row and the card it holds starts the
+// next one, far to the LEFT of it, and connecting sideways there would drag an
+// arrow back across the whole row to arrive pointing the wrong way.
+export function sides(from, to) {
+    const dx = to.left + to.width / 2 - (from.left + from.width / 2);
+    const dy = to.top + to.height / 2 - (from.top + from.height / 2);
+    if (Math.abs(dy) > from.height / 2) {
+        return dy >= 0 ? { exit: "bottom", enter: "top" } : { exit: "top", enter: "bottom" };
+    }
+    return dx >= 0 ? { exit: "right", enter: "left" } : { exit: "left", enter: "right" };
+}
+// anchor returns the point on one edge of a card, at the middle of that edge.
+export function anchor(box, side) {
+    const midX = box.left + box.width / 2;
+    const midY = box.top + box.height / 2;
+    switch (side) {
+        case "left":
+            return { x: box.left, y: midY };
+        case "right":
+            return { x: box.left + box.width, y: midY };
+        case "top":
+            return { x: midX, y: box.top };
+        default:
+            return { x: midX, y: box.top + box.height };
+    }
+}
+// GAP is how far short of the target the arrow stops, leaving the head clear of
+// the card's border instead of touching it.
+const GAP = 4;
+// arrowPath builds the SVG path for one dependency.
+//
+// A cubic curve rather than a straight line: adjacent cards sit edge to edge,
+// and a straight segment between them is short enough to read as a border
+// artifact. The control points push out along the exit and entry axes, so the
+// curve leaves and arrives perpendicular to the cards and the direction is
+// legible even when the two are only a few pixels apart.
+export function arrowPath(from, to) {
+    const { exit, enter } = sides(from, to);
+    const start = anchor(from, exit);
+    const raw = anchor(to, enter);
+    const end = shortenBy(raw, enter, GAP);
+    const bend = Math.max(12, Math.min(48, distance(start, end) / 2));
+    const c1 = push(start, exit, bend);
+    const c2 = push(end, enter, bend);
+    return `M ${r(start.x)} ${r(start.y)} C ${r(c1.x)} ${r(c1.y)}, ${r(c2.x)} ${r(c2.y)}, ${r(end.x)} ${r(end.y)}`;
+}
+// push moves a point outward along the axis of the edge it sits on — away from
+// its own card for the start, back toward the arrow's approach for the end.
+function push(p, side, by) {
+    switch (side) {
+        case "left":
+            return { x: p.x - by, y: p.y };
+        case "right":
+            return { x: p.x + by, y: p.y };
+        case "top":
+            return { x: p.x, y: p.y - by };
+        default:
+            return { x: p.x, y: p.y + by };
+    }
+}
+// shortenBy pulls the endpoint out of the target card by `by` pixels, along the
+// edge it would have landed on.
+function shortenBy(p, side, by) {
+    return push(p, side, by);
+}
+function distance(a, b) {
+    return Math.hypot(b.x - a.x, b.y - a.y);
+}
+// r rounds to whole pixels: sub-pixel coordinates buy nothing at this scale and
+// keep a re-render from emitting a different string for an identical layout.
+function r(n) {
+    return Math.round(n);
+}

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -16,6 +16,7 @@ import { initSettingsView, showSettings, settingsIndex, saveSetting, setPaletteO
 import { initPalette, openPalette, isPaletteChord } from "./palette.js";
 import { initStatsView, showStats, startStatsPoll, stopStatsPoll, } from "./statsview.js";
 import { QUEUES, QUEUE_TRANSITION_TO, queueOf, isReworkable, isReviewRetryable, ageBadge, isReplannable, forwardDropAllowed, badgeInfo, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReadyToDeploy, deployableCards, deployControlView, safetyPollShouldReconcile, safetyReconcileError, } from "./board-queue.js";
+import { linksWithin, arrowPath } from "./board-arrows.js";
 import { buildDeployControl } from "./board-deploy.js";
 import { buildDetailSections, buildOptionsSection } from "./board-detail.js";
 import { ideationInputEnabled, shouldCloseIdeation } from "./board-ideation.js";
@@ -1590,6 +1591,85 @@ function render() {
     // it — it only needs its card data refreshed from the new board state.
     refreshTicketDetail();
     updateHideToggle();
+    // Arrows are measured from laid-out cards, so they wait for the frame the
+    // browser draws this rebuild in — reading offsets now would measure the DOM
+    // as it was before any of the above landed.
+    requestAnimationFrame(drawBlockerArrows);
+}
+// drawBlockerArrows connects each card to the work it waits for, wherever both
+// ends happen to share a column.
+//
+// Every column is swept on every render rather than tracking which cards moved:
+// a card changes column by being rebuilt somewhere else, so there is no move to
+// observe, and a stale arrow pointing at a card that left would be worse than
+// no arrow at all.
+function drawBlockerArrows() {
+    const blockers = new Map();
+    for (const card of current.cards) {
+        if (card.blockers?.length)
+            blockers.set(card.key, card.blockers);
+    }
+    document.querySelectorAll(".column-body").forEach((body, i) => {
+        body.querySelector(".blocker-arrows")?.remove();
+        if (blockers.size === 0)
+            return;
+        const cards = new Map();
+        body.querySelectorAll(".card[data-key]").forEach((el) => {
+            if (el.dataset.key)
+                cards.set(el.dataset.key, el);
+        });
+        const links = linksWithin(blockers, new Set(cards.keys()));
+        if (links.length === 0)
+            return;
+        const overlay = arrowOverlay(body, i);
+        for (const link of links) {
+            const path = document.createElementNS(SVG_NS, "path");
+            path.setAttribute("d", arrowPath(boxOf(cards.get(link.from)), boxOf(cards.get(link.to))));
+            path.setAttribute("class", "blocker-arrow");
+            path.setAttribute("marker-end", `url(#${overlay.dataset.head})`);
+            overlay.appendChild(path);
+        }
+        body.appendChild(overlay);
+    });
+}
+const SVG_NS = "http://www.w3.org/2000/svg";
+// boxOf measures a card in its column's own content coordinates. The column is
+// positioned, so offsetLeft/offsetTop are already relative to it and already
+// account for how far it is scrolled — which is what makes the overlay scroll
+// with the cards instead of sliding across them.
+function boxOf(el) {
+    return { left: el.offsetLeft, top: el.offsetTop, width: el.offsetWidth, height: el.offsetHeight };
+}
+// arrowOverlay builds the SVG layer for one column, sized to the column's whole
+// scrollable content so an arrow to a card below the fold is not clipped away.
+// It never takes pointer events: dragging a card is how the board works, and a
+// layer over every card would swallow it.
+function arrowOverlay(body, index) {
+    const svg = document.createElementNS(SVG_NS, "svg");
+    svg.setAttribute("class", "blocker-arrows");
+    svg.setAttribute("width", String(body.scrollWidth));
+    svg.setAttribute("height", String(body.scrollHeight));
+    // Marker ids are document-global, so each column defines its own — two
+    // columns sharing one id would leave every arrow pointing at whichever
+    // definition happened to render last.
+    const headID = `blocker-arrowhead-${index}`;
+    svg.dataset.head = headID;
+    const defs = document.createElementNS(SVG_NS, "defs");
+    const marker = document.createElementNS(SVG_NS, "marker");
+    marker.setAttribute("id", headID);
+    marker.setAttribute("viewBox", "0 0 8 8");
+    marker.setAttribute("refX", "7");
+    marker.setAttribute("refY", "4");
+    marker.setAttribute("markerWidth", "6");
+    marker.setAttribute("markerHeight", "6");
+    marker.setAttribute("orient", "auto-start-reverse");
+    const head = document.createElementNS(SVG_NS, "path");
+    head.setAttribute("d", "M 0 1 L 7 4 L 0 7 z");
+    head.setAttribute("class", "blocker-arrowhead");
+    marker.appendChild(head);
+    defs.appendChild(marker);
+    svg.appendChild(defs);
+    return svg;
 }
 function showError(msg) {
     current.error = msg;
@@ -3065,6 +3145,10 @@ function init() {
     });
     document.getElementById("ideation-draft-submit")?.addEventListener("click", () => void approveIdeation());
 }
+// The bug grid reflows on width (auto-fill columns), so a resize moves cards
+// out from under arrows drawn for the old layout. Redrawing on the next frame
+// re-measures rather than trying to transform what was already drawn.
+window.addEventListener("resize", () => requestAnimationFrame(drawBlockerArrows));
 if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", init);
 }

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -341,6 +341,9 @@ body {
 
 .column-body {
   padding: 10px;
+  /* Anchors the dependency-arrow overlay, and makes every card's
+     offsetLeft/offsetTop read in this column's own content coordinates. */
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -849,6 +852,30 @@ body {
    asked of the user and nothing has failed (SC-1830). */
 .badge.degraded {
   color: var(--turn-machine);
+}
+
+/* The dependency arrow layer: one SVG per column, sized to the column's whole
+   scrollable content. It sits over the cards, so it must never take a pointer
+   event — dragging a card is how the board works. */
+.blocker-arrows {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: visible;
+}
+
+/* Same muted register as the "waits for" badge: the arrow states an ordering,
+   it does not raise an alarm. */
+.blocker-arrow {
+  fill: none;
+  stroke: var(--muted);
+  stroke-width: 1.5;
+  opacity: 0.85;
+}
+
+.blocker-arrowhead {
+  fill: var(--muted);
+  opacity: 0.85;
 }
 
 /* Work parked behind another ticket: nothing is running and nothing is wrong,

--- a/desktop/frontend/scripts/board-arrows.test.mjs
+++ b/desktop/frontend/scripts/board-arrows.test.mjs
@@ -1,0 +1,97 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { linksWithin, sides, anchor, arrowPath } from "../build/board-arrows.js";
+
+const box = (left, top, width = 100, height = 60) => ({ left, top, width, height });
+
+// An arrow can only be drawn between two cards that are both on screen. Drawing
+// to a card that is not in this column would mean drawing at the container's
+// edge and hoping the user infers the rest — those are left to the badge.
+test("only dependencies with both ends present are drawn", () => {
+  const blockers = new Map([
+    ["SC-2", ["SC-1"]],
+    ["SC-9", ["SC-8"]], // SC-8 sits in another column
+  ]);
+
+  const links = linksWithin(blockers, new Set(["SC-1", "SC-2", "SC-9"]));
+
+  assert.deepEqual(links, [{ from: "SC-1", to: "SC-2" }]);
+});
+
+// A chain draws one arrow per hop and comes out as the tree it is — no code
+// knows about chains.
+test("a chain becomes one arrow per hop", () => {
+  const blockers = new Map([
+    ["SC-2", ["SC-1"]],
+    ["SC-3", ["SC-2"]],
+  ]);
+
+  assert.deepEqual(linksWithin(blockers, new Set(["SC-1", "SC-2", "SC-3"])), [
+    { from: "SC-1", to: "SC-2" },
+    { from: "SC-2", to: "SC-3" },
+  ]);
+});
+
+// A card waiting for several tickets gets an arrow from each.
+test("several blockers each get their own arrow", () => {
+  const links = linksWithin(new Map([["SC-3", ["SC-2", "SC-1"]]]), new Set(["SC-1", "SC-2", "SC-3"]));
+
+  assert.deepEqual(links, [
+    { from: "SC-1", to: "SC-3" },
+    { from: "SC-2", to: "SC-3" },
+  ]);
+});
+
+// Ordering is fixed so an unchanged layout re-renders to identical SVG and the
+// browser has nothing to repaint.
+test("output order does not depend on map insertion order", () => {
+  const a = linksWithin(new Map([["SC-3", ["SC-1"]], ["SC-2", ["SC-1"]]]), new Set(["SC-1", "SC-2", "SC-3"]));
+  const b = linksWithin(new Map([["SC-2", ["SC-1"]], ["SC-3", ["SC-1"]]]), new Set(["SC-1", "SC-2", "SC-3"]));
+
+  assert.deepEqual(a, b);
+});
+
+// A ticket cannot wait for itself; a self-arrow would be a loop drawn on one
+// card, which says nothing.
+test("a card is never linked to itself", () => {
+  assert.deepEqual(linksWithin(new Map([["SC-1", ["SC-1"]]]), new Set(["SC-1"])), []);
+});
+
+// The two layouts this runs in differ — the bug grid flows cards across, the
+// workflow columns stack them down — and reading the offsets means neither has
+// to announce itself.
+test("the connected edges are the ones facing each other", () => {
+  assert.deepEqual(sides(box(0, 0), box(200, 0)), { exit: "right", enter: "left" });
+  assert.deepEqual(sides(box(200, 0), box(0, 0)), { exit: "left", enter: "right" });
+  assert.deepEqual(sides(box(0, 0), box(0, 200)), { exit: "bottom", enter: "top" });
+  assert.deepEqual(sides(box(0, 200), box(0, 0)), { exit: "top", enter: "bottom" });
+});
+
+// A grid that wraps puts the blocker above and to the right of what it blocks;
+// the dominant axis decides, so the wrapped pair connects vertically instead of
+// drawing an arrow that points backwards.
+test("a wrapped grid row connects vertically", () => {
+  assert.deepEqual(sides(box(600, 0), box(0, 300)), { exit: "bottom", enter: "top" });
+});
+
+test("anchors sit at the middle of the named edge", () => {
+  assert.deepEqual(anchor(box(10, 20), "right"), { x: 110, y: 50 });
+  assert.deepEqual(anchor(box(10, 20), "top"), { x: 60, y: 20 });
+});
+
+// The head has to stop short of the card, or it renders as part of the border.
+test("the arrow stops short of the card it points at", () => {
+  const d = arrowPath(box(0, 0), box(200, 0));
+  const end = d.split(",").pop().trim().split(" ");
+
+  assert.equal(Number(end[0]), 196, "ends before the target's left edge at x=200");
+});
+
+// Adjacent cards sit edge to edge: a straight segment between them would read
+// as a border artifact, so the path is always a curve with room to bend.
+test("touching cards still produce a curve, not a dot", () => {
+  const d = arrowPath(box(0, 0), box(108, 0));
+
+  assert.match(d, /^M \d+ \d+ C /);
+  assert.notEqual(d.split("C")[1].trim(), "");
+});

--- a/desktop/frontend/src/board-arrows.ts
+++ b/desktop/frontend/src/board-arrows.ts
@@ -1,0 +1,138 @@
+// Dependency arrows between cards, kept free of DOM and Wails bindings so the
+// geometry can be unit-tested directly (the rest of board.ts bootstraps against
+// document/window.go at import time and cannot).
+//
+// An arrow says the same thing as the "waits for SC-1234" badge, but says it
+// without being read. It can only be drawn when both ends are on screen
+// together, so the badge stays the statement of record and the arrow is what
+// you get when the layout happens to allow it.
+
+// Box is a card's position within its scrolling container, in that container's
+// own content coordinates (offsetLeft/offsetTop), so an arrow drawn from these
+// scrolls with the cards instead of sliding across them.
+export interface Box {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+// Link is one dependency to draw: the blocker points at the work it holds.
+export interface Link {
+  from: string; // the blocker — it must finish first
+  to: string; // the card waiting for it
+}
+
+// linksWithin returns the dependencies whose BOTH ends are present.
+//
+// Board columns are pipeline stages, so a blocker and the card it holds are
+// usually in different ones. Drawing an arrow to a card that is not there would
+// mean drawing to the edge of the container and hoping the user infers the
+// rest, so those are left to the badge. A chain that IS all present draws
+// arrow-per-hop and comes out as the tree it is, with no code that knows about
+// chains.
+//
+// `blockers` maps a card key to the keys it waits for. The result is ordered by
+// (to, from) so a re-render produces byte-identical SVG and the browser has
+// nothing to repaint.
+export function linksWithin(blockers: Map<string, string[]>, present: Set<string>): Link[] {
+  const links: Link[] = [];
+  for (const [to, keys] of blockers) {
+    if (!present.has(to)) continue;
+    for (const from of keys) {
+      if (present.has(from) && from !== to) links.push({ from, to });
+    }
+  }
+  return links.sort((a, b) => a.to.localeCompare(b.to) || a.from.localeCompare(b.from));
+}
+
+// Side names which edge of a card an arrow leaves from or arrives at.
+type Side = "left" | "right" | "top" | "bottom";
+
+// sides picks the pair of edges to connect: the ones that face each other.
+//
+// A vertical offset of more than half a card decides it, because the two
+// layouts this runs in differ: the bug grid flows cards left-to-right, the
+// workflow columns stack them top-to-bottom. Reading the actual offsets means
+// neither layout has to announce itself — cards sharing a row connect
+// sideways, cards on different rows connect up or down. That also handles a
+// grid that wrapped: the blocker ends a row and the card it holds starts the
+// next one, far to the LEFT of it, and connecting sideways there would drag an
+// arrow back across the whole row to arrive pointing the wrong way.
+export function sides(from: Box, to: Box): { exit: Side; enter: Side } {
+  const dx = to.left + to.width / 2 - (from.left + from.width / 2);
+  const dy = to.top + to.height / 2 - (from.top + from.height / 2);
+  if (Math.abs(dy) > from.height / 2) {
+    return dy >= 0 ? { exit: "bottom", enter: "top" } : { exit: "top", enter: "bottom" };
+  }
+  return dx >= 0 ? { exit: "right", enter: "left" } : { exit: "left", enter: "right" };
+}
+
+// anchor returns the point on one edge of a card, at the middle of that edge.
+export function anchor(box: Box, side: Side): { x: number; y: number } {
+  const midX = box.left + box.width / 2;
+  const midY = box.top + box.height / 2;
+  switch (side) {
+    case "left":
+      return { x: box.left, y: midY };
+    case "right":
+      return { x: box.left + box.width, y: midY };
+    case "top":
+      return { x: midX, y: box.top };
+    default:
+      return { x: midX, y: box.top + box.height };
+  }
+}
+
+// GAP is how far short of the target the arrow stops, leaving the head clear of
+// the card's border instead of touching it.
+const GAP = 4;
+
+// arrowPath builds the SVG path for one dependency.
+//
+// A cubic curve rather than a straight line: adjacent cards sit edge to edge,
+// and a straight segment between them is short enough to read as a border
+// artifact. The control points push out along the exit and entry axes, so the
+// curve leaves and arrives perpendicular to the cards and the direction is
+// legible even when the two are only a few pixels apart.
+export function arrowPath(from: Box, to: Box): string {
+  const { exit, enter } = sides(from, to);
+  const start = anchor(from, exit);
+  const raw = anchor(to, enter);
+  const end = shortenBy(raw, enter, GAP);
+  const bend = Math.max(12, Math.min(48, distance(start, end) / 2));
+  const c1 = push(start, exit, bend);
+  const c2 = push(end, enter, bend);
+  return `M ${r(start.x)} ${r(start.y)} C ${r(c1.x)} ${r(c1.y)}, ${r(c2.x)} ${r(c2.y)}, ${r(end.x)} ${r(end.y)}`;
+}
+
+// push moves a point outward along the axis of the edge it sits on — away from
+// its own card for the start, back toward the arrow's approach for the end.
+function push(p: { x: number; y: number }, side: Side, by: number): { x: number; y: number } {
+  switch (side) {
+    case "left":
+      return { x: p.x - by, y: p.y };
+    case "right":
+      return { x: p.x + by, y: p.y };
+    case "top":
+      return { x: p.x, y: p.y - by };
+    default:
+      return { x: p.x, y: p.y + by };
+  }
+}
+
+// shortenBy pulls the endpoint out of the target card by `by` pixels, along the
+// edge it would have landed on.
+function shortenBy(p: { x: number; y: number }, side: Side, by: number): { x: number; y: number } {
+  return push(p, side, by);
+}
+
+function distance(a: { x: number; y: number }, b: { x: number; y: number }): number {
+  return Math.hypot(b.x - a.x, b.y - a.y);
+}
+
+// r rounds to whole pixels: sub-pixel coordinates buy nothing at this scale and
+// keep a re-render from emitting a different string for an identical layout.
+function r(n: number): number {
+  return Math.round(n);
+}

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -64,6 +64,8 @@ import {
   safetyReconcileError,
 } from "./board-queue.js";
 import type { DeploySide } from "./board-queue.js";
+import { linksWithin, arrowPath } from "./board-arrows.js";
+import type { Box } from "./board-arrows.js";
 import { buildDeployControl } from "./board-deploy.js";
 import { buildDetailSections, buildOptionsSection } from "./board-detail.js";
 import { ideationInputEnabled, shouldCloseIdeation } from "./board-ideation.js";
@@ -2009,6 +2011,85 @@ function render(): void {
   // it — it only needs its card data refreshed from the new board state.
   refreshTicketDetail();
   updateHideToggle();
+  // Arrows are measured from laid-out cards, so they wait for the frame the
+  // browser draws this rebuild in — reading offsets now would measure the DOM
+  // as it was before any of the above landed.
+  requestAnimationFrame(drawBlockerArrows);
+}
+
+// drawBlockerArrows connects each card to the work it waits for, wherever both
+// ends happen to share a column.
+//
+// Every column is swept on every render rather than tracking which cards moved:
+// a card changes column by being rebuilt somewhere else, so there is no move to
+// observe, and a stale arrow pointing at a card that left would be worse than
+// no arrow at all.
+function drawBlockerArrows(): void {
+  const blockers = new Map<string, string[]>();
+  for (const card of current.cards) {
+    if (card.blockers?.length) blockers.set(card.key, card.blockers);
+  }
+  document.querySelectorAll<HTMLElement>(".column-body").forEach((body, i) => {
+    body.querySelector(".blocker-arrows")?.remove();
+    if (blockers.size === 0) return;
+    const cards = new Map<string, HTMLElement>();
+    body.querySelectorAll<HTMLElement>(".card[data-key]").forEach((el) => {
+      if (el.dataset.key) cards.set(el.dataset.key, el);
+    });
+    const links = linksWithin(blockers, new Set(cards.keys()));
+    if (links.length === 0) return;
+    const overlay = arrowOverlay(body, i);
+    for (const link of links) {
+      const path = document.createElementNS(SVG_NS, "path");
+      path.setAttribute("d", arrowPath(boxOf(cards.get(link.from)!), boxOf(cards.get(link.to)!)));
+      path.setAttribute("class", "blocker-arrow");
+      path.setAttribute("marker-end", `url(#${overlay.dataset.head})`);
+      overlay.appendChild(path);
+    }
+    body.appendChild(overlay);
+  });
+}
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+// boxOf measures a card in its column's own content coordinates. The column is
+// positioned, so offsetLeft/offsetTop are already relative to it and already
+// account for how far it is scrolled — which is what makes the overlay scroll
+// with the cards instead of sliding across them.
+function boxOf(el: HTMLElement): Box {
+  return { left: el.offsetLeft, top: el.offsetTop, width: el.offsetWidth, height: el.offsetHeight };
+}
+
+// arrowOverlay builds the SVG layer for one column, sized to the column's whole
+// scrollable content so an arrow to a card below the fold is not clipped away.
+// It never takes pointer events: dragging a card is how the board works, and a
+// layer over every card would swallow it.
+function arrowOverlay(body: HTMLElement, index: number): SVGSVGElement {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("class", "blocker-arrows");
+  svg.setAttribute("width", String(body.scrollWidth));
+  svg.setAttribute("height", String(body.scrollHeight));
+  // Marker ids are document-global, so each column defines its own — two
+  // columns sharing one id would leave every arrow pointing at whichever
+  // definition happened to render last.
+  const headID = `blocker-arrowhead-${index}`;
+  svg.dataset.head = headID;
+  const defs = document.createElementNS(SVG_NS, "defs");
+  const marker = document.createElementNS(SVG_NS, "marker");
+  marker.setAttribute("id", headID);
+  marker.setAttribute("viewBox", "0 0 8 8");
+  marker.setAttribute("refX", "7");
+  marker.setAttribute("refY", "4");
+  marker.setAttribute("markerWidth", "6");
+  marker.setAttribute("markerHeight", "6");
+  marker.setAttribute("orient", "auto-start-reverse");
+  const head = document.createElementNS(SVG_NS, "path");
+  head.setAttribute("d", "M 0 1 L 7 4 L 0 7 z");
+  head.setAttribute("class", "blocker-arrowhead");
+  marker.appendChild(head);
+  defs.appendChild(marker);
+  svg.appendChild(defs);
+  return svg;
 }
 
 function showError(msg: string): void {
@@ -3518,6 +3599,11 @@ function init(): void {
   });
   document.getElementById("ideation-draft-submit")?.addEventListener("click", () => void approveIdeation());
 }
+
+// The bug grid reflows on width (auto-fill columns), so a resize moves cards
+// out from under arrows drawn for the old layout. Redrawing on the next frame
+// re-measures rather than trying to transform what was already drawn.
+window.addEventListener("resize", () => requestAnimationFrame(drawBlockerArrows));
 
 if (document.readyState === "loading") {
   document.addEventListener("DOMContentLoaded", init);

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -341,6 +341,9 @@ body {
 
 .column-body {
   padding: 10px;
+  /* Anchors the dependency-arrow overlay, and makes every card's
+     offsetLeft/offsetTop read in this column's own content coordinates. */
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -849,6 +852,30 @@ body {
    asked of the user and nothing has failed (SC-1830). */
 .badge.degraded {
   color: var(--turn-machine);
+}
+
+/* The dependency arrow layer: one SVG per column, sized to the column's whole
+   scrollable content. It sits over the cards, so it must never take a pointer
+   event — dragging a card is how the board works. */
+.blocker-arrows {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: visible;
+}
+
+/* Same muted register as the "waits for" badge: the arrow states an ordering,
+   it does not raise an alarm. */
+.blocker-arrow {
+  fill: none;
+  stroke: var(--muted);
+  stroke-width: 1.5;
+  opacity: 0.85;
+}
+
+.blocker-arrowhead {
+  fill: var(--muted);
+  opacity: 0.85;
 }
 
 /* Work parked behind another ticket: nothing is running and nothing is wrong,


### PR DESCRIPTION
Same feature as SC-2135, one step further: where the badge names the ticket a card waits for, an arrow now shows it.

SC-1792 blocks SC-1793 and both sit in the Bugs grid, side by side. That is the common case in that pane, and the ordering is drawable there — so draw it, blocker pointing at the work it holds.

**Only when both ends are present.** Board columns are pipeline stages, so a blocker and the card it holds are usually in different ones; an arrow to a card that isn't there would stop at the container's edge and hope the user infers the rest. Those keep the badge alone. The badge stays either way — it is the statement of record, correct whether or not the layout allows a drawing.

**Chains fall out of it.** Each dependency is drawn independently, so A → B → C is two arrows that read as one path, and a card blocking several others fans out. No code knows what a chain is.

**Which edges connect is read from the cards, not from the view.** Cards sharing a row connect sideways, cards on different rows connect up or down — one rule covering the bug grid (flows across) and the workflow columns (stack down). It also covers a wrapped grid row, where the blocker ends one row and the card it holds starts the next, far to its left; connecting sideways there would drag the arrow back across the whole row to arrive pointing the wrong way.

The overlay takes no pointer events — a layer over every card would swallow the drag the board is built on — and it lives inside the scrolling content, so arrows scroll with the cards rather than sliding across them.

12 new geometry tests (106 frontend tests total, all passing); `make check` green; `dist` rebuilt in the same commit and `make desktop` verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
