### PR TITLE
[SC-2135] Give the arrow room by narrowing the cards it touches

### DIFF
--- a/desktop/frontend/dist/board-arrows.js
+++ b/desktop/frontend/dist/board-arrows.js
@@ -73,8 +73,8 @@ const GAP = 4;
 // artifact. The control points push out along the exit and entry axes, so the
 // curve leaves and arrives perpendicular to the cards and the direction is
 // legible even when the two are only a few pixels apart.
-export function arrowPath(from, to) {
-    const { exit, enter } = sides(from, to);
+export function arrowPath(from, to, edges = sides(from, to)) {
+    const { exit, enter } = edges;
     const start = anchor(from, exit);
     const raw = anchor(to, enter);
     const end = shortenBy(raw, enter, GAP);
@@ -109,4 +109,71 @@ function distance(a, b) {
 // keep a re-render from emitting a different string for an identical layout.
 function r(n) {
     return Math.round(n);
+}
+// plan settles which dependencies are actually drawable, and how.
+//
+// A pair whose corridor is blocked is dropped rather than drawn across whatever
+// sits between them: a line over a third card's face states a relationship
+// between the wrong two tickets. Those keep the badge, exactly like a pair split
+// across two columns — the rule is the same one, that an arrow is drawn only
+// where it reads.
+export function plan(links, boxes) {
+    const drawn = [];
+    for (const link of links) {
+        const from = boxes.get(link.from);
+        const to = boxes.get(link.to);
+        if (!from || !to)
+            continue;
+        const others = [...boxes.entries()]
+            .filter(([key]) => key !== link.from && key !== link.to)
+            .map(([, box]) => box);
+        if (!corridorClear(from, to, others))
+            continue;
+        drawn.push({ ...link, ...sides(from, to) });
+    }
+    return drawn;
+}
+// corridorClear reports whether the space an arrow would cross holds no other
+// card. The corridor is the box spanning the two facing edges — for neighbours
+// that is the gap between them, and for a pair with a card in between it is a
+// box that card sits inside.
+export function corridorClear(from, to, others) {
+    const { exit, enter } = sides(from, to);
+    const a = anchor(from, exit);
+    const b = anchor(to, enter);
+    const corridor = {
+        left: Math.min(a.x, b.x),
+        top: Math.min(a.y, b.y),
+        width: Math.abs(b.x - a.x),
+        height: Math.abs(b.y - a.y),
+    };
+    return !others.some((o) => overlaps(corridor, o));
+}
+// overlaps is a strict rectangle intersection: two boxes that merely touch
+// edges do not overlap, so a neighbour flush against the corridor's boundary
+// does not count as standing in it.
+function overlaps(a, b) {
+    return (a.left < b.left + b.width &&
+        b.left < a.left + a.width &&
+        a.top < b.top + b.height &&
+        b.top < a.top + a.height);
+}
+// gapsBySide reports, per card, which of its edges an arrow attaches to — the
+// sides that must be narrowed to make room.
+//
+// A card in the middle of a chain is waited on from one side and waits on the
+// other, so it narrows on both; that is not a case in the code, it is what
+// collecting sides per card rather than per arrow produces.
+export function gapsBySide(drawn) {
+    const gaps = new Map();
+    const add = (key, side) => {
+        const sides = gaps.get(key) ?? new Set();
+        sides.add(side);
+        gaps.set(key, sides);
+    };
+    for (const d of drawn) {
+        add(d.from, d.exit);
+        add(d.to, d.enter);
+    }
+    return new Map([...gaps].map(([key, sides]) => [key, [...sides].sort()]));
 }

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -16,7 +16,7 @@ import { initSettingsView, showSettings, settingsIndex, saveSetting, setPaletteO
 import { initPalette, openPalette, isPaletteChord } from "./palette.js";
 import { initStatsView, showStats, startStatsPoll, stopStatsPoll, } from "./statsview.js";
 import { QUEUES, QUEUE_TRANSITION_TO, queueOf, isReworkable, isReviewRetryable, ageBadge, isReplannable, forwardDropAllowed, badgeInfo, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReadyToDeploy, deployableCards, deployControlView, safetyPollShouldReconcile, safetyReconcileError, } from "./board-queue.js";
-import { linksWithin, arrowPath } from "./board-arrows.js";
+import { linksWithin, arrowPath, plan, gapsBySide } from "./board-arrows.js";
 import { buildDeployControl } from "./board-deploy.js";
 import { buildDetailSections, buildOptionsSection } from "./board-detail.js";
 import { ideationInputEnabled, shouldCloseIdeation } from "./board-ideation.js";
@@ -1603,34 +1603,80 @@ function render() {
 // a card changes column by being rebuilt somewhere else, so there is no move to
 // observe, and a stale arrow pointing at a card that left would be worse than
 // no arrow at all.
+//
+// Three passes, all inside one frame so the user sees a single painted result:
+// decide what is drawable from the untouched layout, narrow the cards those
+// arrows attach to, then measure the settled layout and draw. The order is
+// forced — which edge an arrow uses is read from the cards' positions, and
+// narrowing moves them. Deciding first is safe because narrowing only ever
+// opens space, so a corridor that was clear stays clear.
 function drawBlockerArrows() {
     const blockers = new Map();
     for (const card of current.cards) {
         if (card.blockers?.length)
             blockers.set(card.key, card.blockers);
     }
-    document.querySelectorAll(".column-body").forEach((body, i) => {
-        body.querySelector(".blocker-arrows")?.remove();
-        if (blockers.size === 0)
-            return;
-        const cards = new Map();
-        body.querySelectorAll(".card[data-key]").forEach((el) => {
-            if (el.dataset.key)
-                cards.set(el.dataset.key, el);
-        });
-        const links = linksWithin(blockers, new Set(cards.keys()));
-        if (links.length === 0)
-            return;
-        const overlay = arrowOverlay(body, i);
-        for (const link of links) {
-            const path = document.createElementNS(SVG_NS, "path");
-            path.setAttribute("d", arrowPath(boxOf(cards.get(link.from)), boxOf(cards.get(link.to))));
-            path.setAttribute("class", "blocker-arrow");
-            path.setAttribute("marker-end", `url(#${overlay.dataset.head})`);
-            overlay.appendChild(path);
-        }
-        body.appendChild(overlay);
+    // Cleared unconditionally: a resize redraws without rebuilding the DOM, so
+    // last layout's gaps would otherwise linger beside arrows that have moved.
+    document.querySelectorAll(".card").forEach(clearArrowGaps);
+    const bodies = [...document.querySelectorAll(".column-body")];
+    bodies.forEach((body) => body.querySelector(".blocker-arrows")?.remove());
+    if (blockers.size === 0)
+        return;
+    const work = bodies.map((body) => {
+        const cards = cardsIn(body);
+        const boxes = new Map([...cards].map(([key, el]) => [key, boxOf(el)]));
+        return { body, cards, drawn: plan(linksWithin(blockers, new Set(cards.keys())), boxes) };
     });
+    for (const { cards, drawn } of work) {
+        for (const [key, sides] of gapsBySide(drawn)) {
+            const el = cards.get(key);
+            if (el)
+                for (const side of sides)
+                    el.classList.add(`arrow-gap-${side}`);
+        }
+    }
+    for (const { body, cards, drawn } of work) {
+        if (drawn.length === 0)
+            continue;
+        // Re-measured AFTER the gaps land: these are the positions the arrows are
+        // drawn between, and they are not the ones the plan was made from.
+        const boxes = new Map([...cards].map(([key, el]) => [key, boxOf(el)]));
+        body.appendChild(arrowLayer(body, bodies.indexOf(body), drawn, boxes));
+    }
+}
+const ARROW_GAP_SIDES = ["left", "right", "top", "bottom"];
+function clearArrowGaps(el) {
+    for (const side of ARROW_GAP_SIDES)
+        el.classList.remove(`arrow-gap-${side}`);
+}
+// cardsIn indexes one column's cards by ticket key.
+function cardsIn(body) {
+    const cards = new Map();
+    body.querySelectorAll(".card[data-key]").forEach((el) => {
+        if (el.dataset.key)
+            cards.set(el.dataset.key, el);
+    });
+    return cards;
+}
+// arrowLayer builds one column's finished SVG, paths and all.
+function arrowLayer(body, index, drawn, boxes) {
+    const overlay = arrowOverlay(body, index);
+    for (const d of drawn) {
+        const from = boxes.get(d.from);
+        const to = boxes.get(d.to);
+        if (!from || !to)
+            continue;
+        const path = document.createElementNS(SVG_NS, "path");
+        // The sides come from the plan, not from a fresh reading of the narrowed
+        // boxes: the gap was opened on those edges, and an arrow that picked
+        // different ones would leave through a side with no room for it.
+        path.setAttribute("d", arrowPath(from, to, { exit: d.exit, enter: d.enter }));
+        path.setAttribute("class", "blocker-arrow");
+        path.setAttribute("marker-end", `url(#${overlay.dataset.head})`);
+        overlay.appendChild(path);
+    }
+    return overlay;
 }
 const SVG_NS = "http://www.w3.org/2000/svg";
 // boxOf measures a card in its column's own content coordinates. The column is

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -854,6 +854,23 @@ body {
   color: var(--turn-machine);
 }
 
+/* Room for an arrow, taken from the card rather than from the layout: a margin
+   inside the grid cell leaves every track boundary where it was, so the row
+   stays a row. Only the edge an arrow actually attaches to gives up space, and
+   a card in the middle of a chain gives up both. */
+.card.arrow-gap-left {
+  margin-left: 12px;
+}
+.card.arrow-gap-right {
+  margin-right: 12px;
+}
+.card.arrow-gap-top {
+  margin-top: 12px;
+}
+.card.arrow-gap-bottom {
+  margin-bottom: 12px;
+}
+
 /* The dependency arrow layer: one SVG per column, sized to the column's whole
    scrollable content. It sits over the cards, so it must never take a pointer
    event — dragging a card is how the board works. */

--- a/desktop/frontend/scripts/board-arrows.test.mjs
+++ b/desktop/frontend/scripts/board-arrows.test.mjs
@@ -95,3 +95,73 @@ test("touching cards still produce a curve, not a dot", () => {
   assert.match(d, /^M \d+ \d+ C /);
   assert.notEqual(d.split("C")[1].trim(), "");
 });
+
+import { plan, corridorClear, gapsBySide } from "../build/board-arrows.js";
+
+// A row of three: SC-1 and SC-3 are linked, SC-2 sits between them. A straight
+// line would cross SC-2's face and state a relationship between the wrong two
+// tickets, so that pair keeps the badge — the same rule as a pair split across
+// two columns.
+test("a card in the way means no arrow, not an arrow through it", () => {
+  const boxes = new Map([
+    ["SC-1", box(0, 0)],
+    ["SC-2", box(140, 0)],
+    ["SC-3", box(280, 0)],
+  ]);
+
+  assert.deepEqual(plan([{ from: "SC-1", to: "SC-3" }], boxes), []);
+  assert.equal(plan([{ from: "SC-1", to: "SC-2" }], boxes).length, 1, "neighbours still draw");
+});
+
+// The corridor between neighbours is just the gap, and a card flush against it
+// is beside the arrow, not in its way.
+test("touching the corridor is not standing in it", () => {
+  assert.equal(corridorClear(box(0, 0), box(140, 0), [box(140, 0)]), true);
+});
+
+// A wrapped grid row: the blocker ends one row, the card it holds starts the
+// next. The corridor is the space between the rows, which no card occupies.
+test("a wrapped row still draws", () => {
+  const boxes = new Map([
+    ["SC-1", box(500, 0)],
+    ["SC-2", box(0, 100)],
+    ["SC-9", box(140, 0)],
+  ]);
+
+  const drawn = plan([{ from: "SC-1", to: "SC-2" }], boxes);
+  assert.deepEqual(drawn, [{ from: "SC-1", to: "SC-2", exit: "bottom", enter: "top" }]);
+});
+
+// The sides are settled before any card is narrowed, so the gap that gets
+// opened is always the one the arrow uses.
+test("the plan records which edges the arrow will use", () => {
+  const drawn = plan([{ from: "SC-1", to: "SC-2" }], new Map([["SC-1", box(0, 0)], ["SC-2", box(140, 0)]]));
+
+  assert.deepEqual(drawn, [{ from: "SC-1", to: "SC-2", exit: "right", enter: "left" }]);
+});
+
+// Only the edge an arrow attaches to gives up space.
+test("each card narrows only on the side an arrow uses", () => {
+  const drawn = plan([{ from: "SC-1", to: "SC-2" }], new Map([["SC-1", box(0, 0)], ["SC-2", box(140, 0)]]));
+
+  assert.deepEqual([...gapsBySide(drawn)], [
+    ["SC-1", ["right"]],
+    ["SC-2", ["left"]],
+  ]);
+});
+
+// A card in the middle of a chain is waited on from one side and waits on the
+// other, so it narrows on both — which is what collecting sides per card rather
+// than per arrow produces, with no case for it in the code.
+test("a card mid-chain narrows on both sides", () => {
+  const boxes = new Map([["SC-1", box(0, 0)], ["SC-2", box(140, 0)], ["SC-3", box(280, 0)]]);
+  const drawn = plan(
+    [
+      { from: "SC-1", to: "SC-2" },
+      { from: "SC-2", to: "SC-3" },
+    ],
+    boxes,
+  );
+
+  assert.deepEqual(gapsBySide(drawn).get("SC-2"), ["left", "right"]);
+});

--- a/desktop/frontend/src/board-arrows.ts
+++ b/desktop/frontend/src/board-arrows.ts
@@ -47,7 +47,15 @@ export function linksWithin(blockers: Map<string, string[]>, present: Set<string
 }
 
 // Side names which edge of a card an arrow leaves from or arrives at.
-type Side = "left" | "right" | "top" | "bottom";
+export type Side = "left" | "right" | "top" | "bottom";
+
+// Drawn is a dependency that survived the corridor test, with the edges it
+// connects settled. The sides are decided once, before any card is narrowed, so
+// the gap opened for an arrow is always the gap it actually uses.
+export interface Drawn extends Link {
+  exit: Side;
+  enter: Side;
+}
 
 // sides picks the pair of edges to connect: the ones that face each other.
 //
@@ -95,8 +103,8 @@ const GAP = 4;
 // artifact. The control points push out along the exit and entry axes, so the
 // curve leaves and arrives perpendicular to the cards and the direction is
 // legible even when the two are only a few pixels apart.
-export function arrowPath(from: Box, to: Box): string {
-  const { exit, enter } = sides(from, to);
+export function arrowPath(from: Box, to: Box, edges: { exit: Side; enter: Side } = sides(from, to)): string {
+  const { exit, enter } = edges;
   const start = anchor(from, exit);
   const raw = anchor(to, enter);
   const end = shortenBy(raw, enter, GAP);
@@ -135,4 +143,75 @@ function distance(a: { x: number; y: number }, b: { x: number; y: number }): num
 // keep a re-render from emitting a different string for an identical layout.
 function r(n: number): number {
   return Math.round(n);
+}
+
+// plan settles which dependencies are actually drawable, and how.
+//
+// A pair whose corridor is blocked is dropped rather than drawn across whatever
+// sits between them: a line over a third card's face states a relationship
+// between the wrong two tickets. Those keep the badge, exactly like a pair split
+// across two columns — the rule is the same one, that an arrow is drawn only
+// where it reads.
+export function plan(links: Link[], boxes: Map<string, Box>): Drawn[] {
+  const drawn: Drawn[] = [];
+  for (const link of links) {
+    const from = boxes.get(link.from);
+    const to = boxes.get(link.to);
+    if (!from || !to) continue;
+    const others = [...boxes.entries()]
+      .filter(([key]) => key !== link.from && key !== link.to)
+      .map(([, box]) => box);
+    if (!corridorClear(from, to, others)) continue;
+    drawn.push({ ...link, ...sides(from, to) });
+  }
+  return drawn;
+}
+
+// corridorClear reports whether the space an arrow would cross holds no other
+// card. The corridor is the box spanning the two facing edges — for neighbours
+// that is the gap between them, and for a pair with a card in between it is a
+// box that card sits inside.
+export function corridorClear(from: Box, to: Box, others: Box[]): boolean {
+  const { exit, enter } = sides(from, to);
+  const a = anchor(from, exit);
+  const b = anchor(to, enter);
+  const corridor: Box = {
+    left: Math.min(a.x, b.x),
+    top: Math.min(a.y, b.y),
+    width: Math.abs(b.x - a.x),
+    height: Math.abs(b.y - a.y),
+  };
+  return !others.some((o) => overlaps(corridor, o));
+}
+
+// overlaps is a strict rectangle intersection: two boxes that merely touch
+// edges do not overlap, so a neighbour flush against the corridor's boundary
+// does not count as standing in it.
+function overlaps(a: Box, b: Box): boolean {
+  return (
+    a.left < b.left + b.width &&
+    b.left < a.left + a.width &&
+    a.top < b.top + b.height &&
+    b.top < a.top + a.height
+  );
+}
+
+// gapsBySide reports, per card, which of its edges an arrow attaches to — the
+// sides that must be narrowed to make room.
+//
+// A card in the middle of a chain is waited on from one side and waits on the
+// other, so it narrows on both; that is not a case in the code, it is what
+// collecting sides per card rather than per arrow produces.
+export function gapsBySide(drawn: Drawn[]): Map<string, Side[]> {
+  const gaps = new Map<string, Set<Side>>();
+  const add = (key: string, side: Side) => {
+    const sides = gaps.get(key) ?? new Set<Side>();
+    sides.add(side);
+    gaps.set(key, sides);
+  };
+  for (const d of drawn) {
+    add(d.from, d.exit);
+    add(d.to, d.enter);
+  }
+  return new Map([...gaps].map(([key, sides]) => [key, [...sides].sort()]));
 }

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -64,8 +64,8 @@ import {
   safetyReconcileError,
 } from "./board-queue.js";
 import type { DeploySide } from "./board-queue.js";
-import { linksWithin, arrowPath } from "./board-arrows.js";
-import type { Box } from "./board-arrows.js";
+import { linksWithin, arrowPath, plan, gapsBySide } from "./board-arrows.js";
+import type { Box, Drawn, Side } from "./board-arrows.js";
 import { buildDeployControl } from "./board-deploy.js";
 import { buildDetailSections, buildOptionsSection } from "./board-detail.js";
 import { ideationInputEnabled, shouldCloseIdeation } from "./board-ideation.js";
@@ -2024,30 +2024,79 @@ function render(): void {
 // a card changes column by being rebuilt somewhere else, so there is no move to
 // observe, and a stale arrow pointing at a card that left would be worse than
 // no arrow at all.
+//
+// Three passes, all inside one frame so the user sees a single painted result:
+// decide what is drawable from the untouched layout, narrow the cards those
+// arrows attach to, then measure the settled layout and draw. The order is
+// forced — which edge an arrow uses is read from the cards' positions, and
+// narrowing moves them. Deciding first is safe because narrowing only ever
+// opens space, so a corridor that was clear stays clear.
 function drawBlockerArrows(): void {
   const blockers = new Map<string, string[]>();
   for (const card of current.cards) {
     if (card.blockers?.length) blockers.set(card.key, card.blockers);
   }
-  document.querySelectorAll<HTMLElement>(".column-body").forEach((body, i) => {
-    body.querySelector(".blocker-arrows")?.remove();
-    if (blockers.size === 0) return;
-    const cards = new Map<string, HTMLElement>();
-    body.querySelectorAll<HTMLElement>(".card[data-key]").forEach((el) => {
-      if (el.dataset.key) cards.set(el.dataset.key, el);
-    });
-    const links = linksWithin(blockers, new Set(cards.keys()));
-    if (links.length === 0) return;
-    const overlay = arrowOverlay(body, i);
-    for (const link of links) {
-      const path = document.createElementNS(SVG_NS, "path");
-      path.setAttribute("d", arrowPath(boxOf(cards.get(link.from)!), boxOf(cards.get(link.to)!)));
-      path.setAttribute("class", "blocker-arrow");
-      path.setAttribute("marker-end", `url(#${overlay.dataset.head})`);
-      overlay.appendChild(path);
-    }
-    body.appendChild(overlay);
+  // Cleared unconditionally: a resize redraws without rebuilding the DOM, so
+  // last layout's gaps would otherwise linger beside arrows that have moved.
+  document.querySelectorAll<HTMLElement>(".card").forEach(clearArrowGaps);
+  const bodies = [...document.querySelectorAll<HTMLElement>(".column-body")];
+  bodies.forEach((body) => body.querySelector(".blocker-arrows")?.remove());
+  if (blockers.size === 0) return;
+
+  const work = bodies.map((body) => {
+    const cards = cardsIn(body);
+    const boxes = new Map([...cards].map(([key, el]) => [key, boxOf(el)]));
+    return { body, cards, drawn: plan(linksWithin(blockers, new Set(cards.keys())), boxes) };
   });
+
+  for (const { cards, drawn } of work) {
+    for (const [key, sides] of gapsBySide(drawn)) {
+      const el = cards.get(key);
+      if (el) for (const side of sides) el.classList.add(`arrow-gap-${side}`);
+    }
+  }
+
+  for (const { body, cards, drawn } of work) {
+    if (drawn.length === 0) continue;
+    // Re-measured AFTER the gaps land: these are the positions the arrows are
+    // drawn between, and they are not the ones the plan was made from.
+    const boxes = new Map([...cards].map(([key, el]) => [key, boxOf(el)]));
+    body.appendChild(arrowLayer(body, bodies.indexOf(body), drawn, boxes));
+  }
+}
+
+const ARROW_GAP_SIDES: Side[] = ["left", "right", "top", "bottom"];
+
+function clearArrowGaps(el: HTMLElement): void {
+  for (const side of ARROW_GAP_SIDES) el.classList.remove(`arrow-gap-${side}`);
+}
+
+// cardsIn indexes one column's cards by ticket key.
+function cardsIn(body: HTMLElement): Map<string, HTMLElement> {
+  const cards = new Map<string, HTMLElement>();
+  body.querySelectorAll<HTMLElement>(".card[data-key]").forEach((el) => {
+    if (el.dataset.key) cards.set(el.dataset.key, el);
+  });
+  return cards;
+}
+
+// arrowLayer builds one column's finished SVG, paths and all.
+function arrowLayer(body: HTMLElement, index: number, drawn: Drawn[], boxes: Map<string, Box>): SVGSVGElement {
+  const overlay = arrowOverlay(body, index);
+  for (const d of drawn) {
+    const from = boxes.get(d.from);
+    const to = boxes.get(d.to);
+    if (!from || !to) continue;
+    const path = document.createElementNS(SVG_NS, "path");
+    // The sides come from the plan, not from a fresh reading of the narrowed
+    // boxes: the gap was opened on those edges, and an arrow that picked
+    // different ones would leave through a side with no room for it.
+    path.setAttribute("d", arrowPath(from, to, { exit: d.exit, enter: d.enter }));
+    path.setAttribute("class", "blocker-arrow");
+    path.setAttribute("marker-end", `url(#${overlay.dataset.head})`);
+    overlay.appendChild(path);
+  }
+  return overlay;
 }
 
 const SVG_NS = "http://www.w3.org/2000/svg";

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -854,6 +854,23 @@ body {
   color: var(--turn-machine);
 }
 
+/* Room for an arrow, taken from the card rather than from the layout: a margin
+   inside the grid cell leaves every track boundary where it was, so the row
+   stays a row. Only the edge an arrow actually attaches to gives up space, and
+   a card in the middle of a chain gives up both. */
+.card.arrow-gap-left {
+  margin-left: 12px;
+}
+.card.arrow-gap-right {
+  margin-right: 12px;
+}
+.card.arrow-gap-top {
+  margin-top: 12px;
+}
+.card.arrow-gap-bottom {
+  margin-bottom: 12px;
+}
+
 /* The dependency arrow layer: one SVG per column, sized to the column's whole
    scrollable content. It sits over the cards, so it must never take a pointer
    event — dragging a card is how the board works. */


### PR DESCRIPTION
The arrow was drawn correctly and was still unreadable: cards sit 8px apart, an arrowhead is 6px wide, so all that showed was a grey nub in the gutter with no line to say which way it pointed.

**The room comes out of the cards, not the layout.** A margin inside the grid cell leaves every track boundary where it was — the row still reads as a row, no card moves to a different column — and only the edge an arrow actually attaches to gives up 12px. A card mid-chain gives up both, which is what collecting sides per card rather than per arrow produces, with no case for it in the code.

**That forces the order of work**, all in one frame so it paints once:

1. decide what is drawable, from the untouched layout;
2. narrow the cards those arrows attach to;
3. re-measure the settled layout and draw.

Deciding first is safe precisely because narrowing only ever opens space, so a corridor that was clear stays clear. The sides are carried from step 1 into step 3 rather than re-derived, so an arrow can never leave through an edge that was not widened for it.

**Widening the gap surfaced a case narrowing cannot fix.** Two linked cards in the same row with a third between them were being connected by a line straight across that card's face — which states a relationship between the wrong two tickets. A pair is now drawn only when the corridor between their facing edges holds no other card. Neighbours pass; a wrapped row passes (the corridor is the space between rows); a blocked pair keeps its badge, exactly like a pair split across two columns. Nothing is narrowed for an arrow that will not be drawn.

6 new tests (112 frontend total, all passing); `make check` green; `dist` rebuilt in the same commit and `make desktop` verified to embed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
