### PR TITLE
[SC-2173] Stop asking for approval on every call, and let work wait instead of dying

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -564,7 +564,7 @@ func runDaemonForeground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string,
 	// cannot serve a review must leave the ready-for-review handoff unclaimed for
 	// one that can, not claim and fail it (SC-912). Doctor.Blockers is nil-safe.
 	reviewLaunchGate := func(ctx context.Context) []daemon.DoctorCheck {
-		return ds.srv.Doctor.Blockers(ctx, daemon.LaunchCriticalChecks)
+		return ds.srv.Doctor.Blockers(ctx, daemon.LaunchRefusalChecks())
 	}
 	boardTransition := boardTransitionerFunc(ds.srv.Projects, ds.vaultResolver, ds.daemonID, logger, reviewLaunchGate)
 	// A finished build chains straight into its review — the board's

--- a/cmd/cmddaemon/doctor_checks.go
+++ b/cmd/cmddaemon/doctor_checks.go
@@ -65,8 +65,16 @@ func buildDoctorChecks(reg *daemon.ProjectRegistry, resolver *vault.Resolver, pe
 	for _, id := range daemon.LaunchCriticalChecks {
 		gating[id] = true
 	}
+	// Holding is the quieter sibling: these hold work back without declaring the
+	// substrate broken, so the board can say "waiting on you" instead of the
+	// untrue "nothing is blocked" (SC-2173).
+	holding := make(map[string]bool, len(daemon.LaunchHeldChecks))
+	for _, id := range daemon.LaunchHeldChecks {
+		holding[id] = true
+	}
 	for i := range checks {
 		checks[i].Gating = gating[checks[i].ID]
+		checks[i].Holding = holding[checks[i].ID]
 	}
 	return checks
 }

--- a/cmd/cmddaemon/doctor_holding_test.go
+++ b/cmd/cmddaemon/doctor_holding_test.go
@@ -1,0 +1,41 @@
+package cmddaemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/daemon"
+)
+
+// findCheck returns the definition with the given id.
+func findCheck(t *testing.T, defs []daemon.DoctorCheckDef, id string) daemon.DoctorCheckDef {
+	t.Helper()
+	for _, d := range defs {
+		if d.ID == id {
+			return d
+		}
+	}
+	require.FailNowf(t, "check not found", "expected a %q check", id)
+	return daemon.DoctorCheckDef{}
+}
+
+// The tracker check holds work without alarming: an agent launched while the
+// tracker is unreachable spends its run rediscovering that, but a thirty-second
+// credential lapse is not a broken substrate (SC-1991 vs SC-2173).
+func TestDoctorChecks_trackerLapseHoldsWorkWithoutAlarming(t *testing.T) {
+	trackers := findCheck(t, buildDoctorChecks(nil, nil, doctorPersistence{}), "trackers")
+
+	assert.True(t, trackers.Holding, "work must not launch into an unreachable tracker")
+	assert.False(t, trackers.Gating, "a blip must not read as a broken substrate")
+}
+
+// A genuinely broken substrate still gates, so the quieter state did not
+// swallow the loud one.
+func TestDoctorChecks_brokenSubstrateStillGates(t *testing.T) {
+	docker := findCheck(t, buildDoctorChecks(nil, nil, doctorPersistence{}), "docker")
+
+	assert.True(t, docker.Gating)
+	assert.False(t, docker.Holding)
+}

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -1818,9 +1818,16 @@ async function pollDoctor() {
     }
     else {
         const lines = failing.map((c) => `${c.name}: ${c.detail || "failing"}`);
+        // Three states, not two. A held check stops work from starting without the
+        // substrate being broken — saying "nothing is blocked" there would be
+        // false, and it is the false half that leaves someone hunting a ticket
+        // failure whose real cause was an approval nobody answered.
+        const holding = !blocked && failing.some((c) => c.holding);
         const header = blocked
             ? "New work is blocked:"
-            : "Advisory — work can start, nothing is blocked:";
+            : holding
+                ? "New work is waiting — this needs you:"
+                : "Advisory — work can start, nothing is blocked:";
         led.title = [header, ...lines].join("\n");
     }
 }

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -272,6 +272,10 @@ interface DoctorCheck {
   name: string;
   ok: boolean;
   gating?: boolean;
+  // Set when this failure holds new work back without being a substrate
+  // failure (an unreachable tracker): the rail must say work is waiting rather
+  // than that nothing is blocked.
+  holding?: boolean;
   // "ok" | "blocking" | "degraded" | "transient" — a failing check's real
   // consequence (SC-1991). Absent on older daemons; treat as unclassified.
   severity?: string;
@@ -2243,9 +2247,16 @@ async function pollDoctor(): Promise<void> {
     led.title = "All systems go";
   } else {
     const lines = failing.map((c) => `${c.name}: ${c.detail || "failing"}`);
+    // Three states, not two. A held check stops work from starting without the
+    // substrate being broken — saying "nothing is blocked" there would be
+    // false, and it is the false half that leaves someone hunting a ticket
+    // failure whose real cause was an approval nobody answered.
+    const holding = !blocked && failing.some((c) => c.holding);
     const header = blocked
       ? "New work is blocked:"
-      : "Advisory — work can start, nothing is blocked:";
+      : holding
+        ? "New work is waiting — this needs you:"
+        : "Advisory — work can start, nothing is blocked:";
     led.title = [header, ...lines].join("\n");
   }
 }

--- a/internal/daemon/doctor.go
+++ b/internal/daemon/doctor.go
@@ -45,6 +45,14 @@ type DoctorCheckDef struct {
 	ID      string
 	Name    string
 	Timeout time.Duration // zero means defaultCheckTimeout
+	// Holding marks a check whose failure makes new work WAIT without declaring
+	// the substrate broken. A tracker that cannot be reached right now is the
+	// case it exists for: launching into it spends an agent run on a credential
+	// that was unavailable for thirty seconds, but calling that a system failure
+	// alarms on a blip (SC-1991 vs SC-2173). Work waits, quietly, and the report
+	// says so rather than telling the user nothing is blocked.
+	Holding bool
+
 	// Gating marks a check whose failure genuinely prevents new work from
 	// starting. Only gating failures may be presented as a hard stop; a
 	// non-gating failure is advisory. Kept in lockstep with the launch gate's
@@ -66,6 +74,10 @@ type DoctorCheck struct {
 	// Gating echoes the def's Gating flag so UIs can render a failing check with
 	// its real weight without re-deriving the launch-critical set.
 	Gating bool `json:"gating,omitempty"`
+	// Holding echoes the def's Holding flag: this failure holds new work back
+	// without being a substrate failure, so a UI can say "waiting" rather than
+	// either "blocked" or the untrue "nothing is blocked".
+	Holding bool `json:"holding,omitempty"`
 	// Severity is the failure's classification (see the Severity* constants). A
 	// passing check is SeverityOK.
 	Severity string `json:"severity,omitempty"`
@@ -163,7 +175,7 @@ func (d *DoctorRunner) run(ctx context.Context) DoctorData {
 		}
 		data.Checks = append(data.Checks, DoctorCheck{
 			ID: def.ID, Name: def.Name, OK: ok,
-			Gating: def.Gating, Severity: severity, Detail: detail,
+			Gating: def.Gating, Holding: def.Holding, Severity: severity, Detail: detail,
 		})
 	}
 	data.Summary = summarizeDoctor(data.Checks)

--- a/internal/daemon/doctor_launch_test.go
+++ b/internal/daemon/doctor_launch_test.go
@@ -1,0 +1,41 @@
+package daemon
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// An agent launched while the tracker is unreachable cannot read its plan and
+// cannot post its handoff: it dies blaming the ticket for a credential that was
+// unavailable for thirty seconds. The work must wait instead (SC-2173).
+func TestLaunchRefusalChecks_holdsWorkWhenCredentialsAreUnavailable(t *testing.T) {
+	assert.Contains(t, LaunchRefusalChecks(), "trackers")
+}
+
+// Everything that already stopped a launch still does.
+func TestLaunchRefusalChecks_keepsTheCriticalSet(t *testing.T) {
+	refusal := LaunchRefusalChecks()
+	for _, id := range LaunchCriticalChecks {
+		assert.Contains(t, refusal, id)
+	}
+}
+
+// But a tracker blip must NOT be reported as gating: a momentary credential
+// lapse raising a system alarm is the SC-1991 failure, and holding a launch is
+// a quieter thing than declaring the substrate broken.
+func TestLaunchCriticalChecks_trackerBlipRaisesNoAlarm(t *testing.T) {
+	assert.False(t, slices.Contains(LaunchCriticalChecks, "trackers"),
+		"gating is derived from this list; adding trackers here would alarm on a blip")
+}
+
+// The union must not mutate the list it is derived from — a caller appending to
+// the returned slice must not quietly extend the alarm set.
+func TestLaunchRefusalChecks_doesNotAliasTheCriticalSet(t *testing.T) {
+	before := slices.Clone(LaunchCriticalChecks)
+	got := LaunchRefusalChecks()
+	got[0] = "mutated"
+
+	assert.Equal(t, before, LaunchCriticalChecks)
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1527,6 +1527,24 @@ const doctorCacheAge = 2 * time.Minute
 // from the same source of truth as the synchronous launch-refusal path.
 var LaunchCriticalChecks = []string{"docker", "agent-skills", "claude-auth"}
 
+// LaunchHeldChecks additionally refuse a launch WITHOUT marking the check as
+// gating in the report.
+//
+// The two lists differ because the two questions do. A tracker that cannot be
+// reached right now is a blip that must not raise a system alarm (SC-1991) —
+// but an agent launched into it cannot read its plan, cannot post its handoff,
+// and dies blaming the ticket for a credential that was unavailable for thirty
+// seconds (SC-2173). So the work waits, quietly, exactly as it waits for a
+// daemon that cannot serve it, and nothing is spent.
+var LaunchHeldChecks = []string{"trackers"}
+
+// LaunchRefusalChecks is every check that stops a launch — the single source
+// the gate builds its blocker set from, so a check can never be added to one
+// list and forgotten in the other.
+func LaunchRefusalChecks() []string {
+	return append(append([]string{}, LaunchCriticalChecks...), LaunchHeldChecks...)
+}
+
 // handleDoctor returns the substrate health checks as JSON. "refresh" as an
 // argument forces a live run instead of the poller cache.
 func (s *Server) handleDoctor(conn net.Conn, args []string) {

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -34,18 +34,30 @@ type SecretProvider interface {
 // command contexts via WithResolver so all requests share one provider
 // instance (avoiding repeated op.exe subprocesses on WSL2).
 //
-// Providers are always tried first, so a rotated secret is picked up
-// immediately while the store is reachable. A successful resolution is
-// remembered for a bounded TTL, and only surfaces as a fallback when every
-// claiming provider later fails — a credential lapse. This keeps a momentary
-// loss of access from invalidating a secret that already resolved in the same
-// run (SC-2039): the deploy step that reads a credential it read at push time
-// survives the lapse instead of failing on an unrelated stale read. The cache
-// lives only in daemon memory, never on disk. Every entry is TTL-bounded:
-// remember sweeps expired entries on each successful resolve (so a ref that
-// is never re-requested does not linger past its TTL just because nobody
-// asked for it again), and cached additionally drops its own entry on a
-// stale read.
+// A resolved secret is served from memory for a bounded TTL, and the provider
+// is consulted only on a miss. That is what keeps a human out of the machine's
+// loop: an interactive store (the 1Password desktop app) raises an approval
+// dialog per read, so reaching the provider on every request means approving
+// one prompt per command the pipeline runs — faster than anyone can clear
+// them, and a missed one fails an unrelated piece of work half a minute later
+// (SC-2173).
+//
+// The cost is the honest one for any cache: a rotated secret is picked up when
+// the entry ages out rather than instantly. The window is configurable, and a
+// non-positive `cache_ttl` disables caching entirely for anyone who wants the
+// provider consulted every time.
+//
+// Concurrent resolutions of the same reference are collapsed into one provider
+// call, so several pieces of work starting together raise one approval between
+// them instead of one each.
+//
+// A still-fresh entry is also served when every claiming provider fails — a
+// credential lapse. This keeps a momentary loss of access from invalidating a
+// secret that already resolved in the same run (SC-2039). The cache lives only
+// in daemon memory, never on disk. Every entry is TTL-bounded: remember sweeps
+// expired entries on each successful resolve (so a ref that is never
+// re-requested does not linger past its TTL just because nobody asked for it
+// again), and cached additionally drops its own entry on a stale read.
 type Resolver struct {
 	providers []SecretProvider
 
@@ -53,6 +65,18 @@ type Resolver struct {
 	now   func() time.Time
 	mu    sync.Mutex
 	cache map[string]cachedSecret
+	// inflight holds the resolution currently running for a reference, so
+	// callers that arrive while it runs wait for its result instead of raising
+	// a second approval prompt for the same secret.
+	inflight map[string]*resolveCall
+}
+
+// resolveCall is one in-progress resolution, shared by everyone who asked for
+// the same reference while it was running.
+type resolveCall struct {
+	done chan struct{}
+	val  string
+	err  error
 }
 
 // cachedSecret is a resolved plaintext value with the instant it stops being a
@@ -74,16 +98,59 @@ func NewResolver(providers ...SecretProvider) *Resolver {
 		ttl:       DefaultCacheTTL,
 		now:       time.Now,
 		cache:     make(map[string]cachedSecret),
+		inflight:  make(map[string]*resolveCall),
 	}
 }
 
 // Resolve looks up a secret reference. If the value is not a vault reference
 // (no provider claims it), the original value is returned unchanged.
+//
+// A still-fresh cached value is served without touching the provider. With an
+// interactive store that is the difference between one approval prompt and one
+// per command the pipeline runs.
 func (r *Resolver) Resolve(ref string) (string, error) {
 	if !IsSecretRef(ref) {
 		return ref, nil
 	}
+	if val, ok := r.cached(ref); ok {
+		return val, nil
+	}
+	return r.resolveOnce(ref)
+}
 
+// resolveOnce consults the providers, with concurrent callers asking for the
+// same reference sharing one call.
+//
+// Without this, ten pieces of work starting together raise ten prompts for one
+// secret — and a person cannot clear ten dialogs before the first times out, so
+// a burst of activity is precisely when resolution is most likely to fail.
+func (r *Resolver) resolveOnce(ref string) (string, error) {
+	r.mu.Lock()
+	if r.inflight == nil {
+		r.inflight = make(map[string]*resolveCall)
+	}
+	if call, running := r.inflight[ref]; running {
+		r.mu.Unlock()
+		<-call.done
+		return call.val, call.err
+	}
+	call := &resolveCall{done: make(chan struct{})}
+	r.inflight[ref] = call
+	r.mu.Unlock()
+
+	call.val, call.err = r.fromProviders(ref)
+
+	r.mu.Lock()
+	delete(r.inflight, ref)
+	r.mu.Unlock()
+	close(call.done)
+	return call.val, call.err
+}
+
+// fromProviders tries each claiming provider in order and remembers what one of
+// them returns. Providers are tried in order; the first claimant that succeeds
+// wins.
+func (r *Resolver) fromProviders(ref string) (string, error) {
 	var lastErr error
 	claimed := false
 	for _, p := range r.providers {
@@ -105,7 +172,9 @@ func (r *Resolver) Resolve(ref string) (string, error) {
 		// Every claimant failed — a credential lapse. Serve a still-fresh
 		// cached value so work whose secret already resolved this run is not
 		// failed by an unrelated stale read; only when nothing is cached does
-		// the lapse surface as the error it is.
+		// the lapse surface as the error it is. Reached when an entry landed
+		// while this call was running, or expired between the read above and
+		// the failure here.
 		if val, ok := r.cached(ref); ok {
 			return val, nil
 		}

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -2,6 +2,8 @@ package vault
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -228,15 +230,42 @@ func TestResolver_Resolve_cachingDisabledByZeroTTL(t *testing.T) {
 	require.Error(t, err)
 }
 
-// A successful resolution refreshes the cache: a value read again while the
-// store is up wins over an older cached one, and rotations are picked up.
-func TestResolver_Resolve_successRefreshesCache(t *testing.T) {
+// The contract that keeps a human out of the machine's loop: within the TTL the
+// stored value is served and the provider is never consulted. With an
+// interactive store, every provider call is an approval dialog, so "ask again
+// each time" means one prompt per command the pipeline runs (SC-2173).
+func TestResolver_Resolve_servesTheCachedValueWithoutAskingAgain(t *testing.T) {
+	calls := 0
+	provider := &fakeProvider{
+		canResolve: func(string) bool { return true },
+		resolve: func(string) (string, error) {
+			calls++
+			return "token", nil
+		},
+	}
+	r := NewResolver(provider)
+
+	for range 5 {
+		val, err := r.Resolve("1pw://vault/item/field")
+		require.NoError(t, err)
+		assert.Equal(t, "token", val)
+	}
+
+	assert.Equal(t, 1, calls, "five reads of one secret must raise one approval, not five")
+}
+
+// The trade-off, stated as a test rather than left implicit: a rotated secret
+// is picked up when the entry ages out, not instantly.
+func TestResolver_Resolve_rotationIsPickedUpWhenTheEntryAgesOut(t *testing.T) {
+	now := time.Now()
 	current := "first"
 	provider := &fakeProvider{
 		canResolve: func(string) bool { return true },
 		resolve:    func(string) (string, error) { return current, nil },
 	}
 	r := NewResolver(provider)
+	r.now = func() time.Time { return now }
+	r.ttl = time.Minute
 
 	val, err := r.Resolve("1pw://vault/item/field")
 	require.NoError(t, err)
@@ -245,7 +274,93 @@ func TestResolver_Resolve_successRefreshesCache(t *testing.T) {
 	current = "rotated"
 	val, err = r.Resolve("1pw://vault/item/field")
 	require.NoError(t, err)
-	assert.Equal(t, "rotated", val)
+	assert.Equal(t, "first", val, "within the window the stored value stands")
+
+	now = now.Add(time.Minute + time.Second)
+	val, err = r.Resolve("1pw://vault/item/field")
+	require.NoError(t, err)
+	assert.Equal(t, "rotated", val, "once it ages out the store is asked again")
+}
+
+// Disabling the cache restores asking every time, for anyone who wants that.
+func TestResolver_Resolve_disabledCacheAsksEveryTime(t *testing.T) {
+	calls := 0
+	provider := &fakeProvider{
+		canResolve: func(string) bool { return true },
+		resolve: func(string) (string, error) {
+			calls++
+			return "token", nil
+		},
+	}
+	r := NewResolver(provider)
+	r.ttl = 0
+
+	for range 3 {
+		_, err := r.Resolve("1pw://vault/item/field")
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 3, calls)
+}
+
+// Several pieces of work starting at once must raise ONE approval between them.
+// A person cannot clear ten dialogs before the first times out, so a burst is
+// exactly when asking separately fails.
+func TestResolver_Resolve_concurrentCallersShareOneApproval(t *testing.T) {
+	var calls atomic.Int32
+	release := make(chan struct{})
+	provider := &fakeProvider{
+		canResolve: func(string) bool { return true },
+		resolve: func(string) (string, error) {
+			calls.Add(1)
+			<-release // hold the "dialog" open while the others pile in
+			return "token", nil
+		},
+	}
+	r := NewResolver(provider)
+
+	var wg sync.WaitGroup
+	got := make([]string, 10)
+	for i := range got {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			val, err := r.Resolve("1pw://vault/item/field")
+			assert.NoError(t, err)
+			got[i] = val
+		}()
+	}
+	// Let the waiters reach the in-flight call before the first one returns.
+	assert.Eventually(t, func() bool { return calls.Load() == 1 }, time.Second, time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), calls.Load(), "ten concurrent readers, one approval")
+	for _, v := range got {
+		assert.Equal(t, "token", v, "every caller gets the resolved value")
+	}
+}
+
+// Distinct references are not collapsed — the single-flight is per secret.
+func TestResolver_Resolve_differentRefsAreNotShared(t *testing.T) {
+	calls := 0
+	provider := &fakeProvider{
+		canResolve: func(string) bool { return true },
+		resolve: func(ref string) (string, error) {
+			calls++
+			return ref, nil
+		},
+	}
+	r := NewResolver(provider)
+
+	a, err := r.Resolve("1pw://vault/item/one")
+	require.NoError(t, err)
+	b, err := r.Resolve("1pw://vault/item/two")
+	require.NoError(t, err)
+
+	assert.Equal(t, "1pw://vault/item/one", a)
+	assert.Equal(t, "1pw://vault/item/two", b)
+	assert.Equal(t, 2, calls)
 }
 
 func TestResolveField_nilResolver(t *testing.T) {


### PR DESCRIPTION
Working the board raised a 1Password approval for nearly every action the machine took. They arrive faster than anyone can clear them, and the one that goes unanswered doesn't fail what you're looking at — a ticket dies minutes later, elsewhere on the board, saying the tracker was unreachable. Nothing connects it to the dialog.

**The cache was already there and was never read.** `Resolver` keeps a resolved secret for 15 minutes and consults it *only after the provider has already failed* — `r.cached()` appeared exactly once in the file, inside the failure branch. On the ordinary path the value was written and never looked at, so every call shelled out to `op` and every call raised a dialog. Proved before fixing: five resolves of one reference, five provider calls. A test now pins one.

**Reading it first costs nothing we weren't already paying.** Same plaintext, same map, same 15 minutes, same daemon memory, never on disk. The retention is unchanged — we just stop ignoring it.

**The trade-off is a test, not a footnote.** A rotated secret is picked up when the entry ages out rather than instantly. That is what keeping a copy means; `cache_ttl` still tightens the window, and a non-positive value still disables caching entirely.

**Single-flight.** Concurrent readers of one reference share one resolution. Ten agents starting together used to raise ten dialogs for one secret — and nobody clears ten dialogs before the first times out, so a burst was precisely when resolution was most likely to fail.

**Work waits instead of dying.** An agent launched into an unreachable tracker cannot read its plan or post its handoff; it spends a full run rediscovering what the daemon already knew. Launches are now held while credentials are unresolvable — nothing claimed, nothing marked, the work left for when it can be done.

Holding is deliberately *not* alarming, so the lists are separate: a momentary lapse raising a system alarm is the failure SC-1991 fixed, and spending a run on that same lapse is this one. `LaunchRefusalChecks()` is the single place a refusal is derived from, so a check can't be added to one list and forgotten in the other.

**And the rail no longer lies.** A held check used to render "Advisory — work can start, nothing is blocked" while launches were being refused. Failing, holding and blocked are now three distinct states; a held one reads "New work is waiting — this needs you:" with the check's own message, which already names the unanswered prompt.

11 new tests (4723 Go + 112 frontend, all green), race-clean on the resolver, `make check` green, `dist` rebuilt in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
