### PR TITLE
[SC-2302] Fix red main: pass the hook event name the exit handler now requires

### DIFF
--- a/internal/daemon/board_failure_test.go
+++ b/internal/daemon/board_failure_test.go
@@ -990,7 +990,7 @@ func assertTicketReviewVerdictIsCleanStop(t *testing.T, verdict string) {
 	var reclaimed string
 	onHandoff := func(agentName string) { reclaimed = agentName }
 
-	handleBoardAgentExit(context.Background(), "board-SC-1-planning", "crashed", commenterFor, chain, nil, nil, alwaysReachable, nil, nil, onHandoff, StageRetry{}, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), "board-SC-1-planning", "crashed", "", commenterFor, chain, nil, nil, alwaysReachable, nil, nil, onHandoff, StageRetry{}, "", zerolog.Nop())
 
 	c.mu.Lock()
 	assert.Empty(t, c.added, "a deliberate %s stop must post no failed marker", verdict)
@@ -1027,7 +1027,7 @@ func TestRunBoardFailureWatch_TicketReviewReadyThenCrashStillFails(t *testing.T)
 	}
 	commenterFor := func() (tracker.Commenter, error) { return c, nil }
 
-	handleBoardAgentExit(context.Background(), "board-SC-1-planning", "crashed", commenterFor, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), "board-SC-1-planning", "crashed", "", commenterFor, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, "", zerolog.Nop())
 
 	c.mu.Lock()
 	defer c.mu.Unlock()


### PR DESCRIPTION
**`main` does not compile its tests right now.** `go build ./...` passes; `go vet ./internal/daemon/` fails, so `make test` and `make check` are red on main.

Two PRs, each green in isolation, changed one function from opposite sides:

```
e90eba8  [SC-2133] Stop misreading a clean review handoff as a mid-review death
         → added `eventName` to handleBoardAgentExit

bde3174  [SC-2302] Treat a gate's deliberate stop verdict as a clean ending
         → added two calls (board_failure_test.go:993, :1030) without it
```

Whichever merged second was never built against the other, and the merge itself succeeded — so nothing went red until the suite was run locally. Found while rebasing #292, not by CI.

**The fix is the two missing arguments.** `""`, matching main's existing precedent for a crash arriving outside a `StopFailure` event, which leaves `cleanExit` true so the tests still exercise the path they were written for. All four deliberate-stop assertions pass unchanged, including the guard that a `ready` verdict followed by a crash still reds the card — so this is a missing argument, not a behaviour change wearing one.

`make test` 4788 green, `make lint` 0 issues.

**Worth noting for the pattern**, since this is the third time today the same shape cost something: two pieces of work touching one function, neither able to see the other. The dependency gate that shipped this morning holds work that has not started — it cannot help two branches that have already merged. What would have caught this is building `main` after each merge instead of trusting each PR's own green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
