### PR TITLE
[SC-2135] Draw the dependency arrow when the column can be measured

### DIFF
--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -1619,10 +1619,19 @@ function drawBlockerArrows() {
     // Cleared unconditionally: a resize redraws without rebuilding the DOM, so
     // last layout's gaps would otherwise linger beside arrows that have moved.
     document.querySelectorAll(".card").forEach(clearArrowGaps);
-    const bodies = [...document.querySelectorAll(".column-body")];
-    bodies.forEach((body) => body.querySelector(".blocker-arrows")?.remove());
+    const all = [...document.querySelectorAll(".column-body")];
+    all.forEach((body) => body.querySelector(".blocker-arrows")?.remove());
+    observeForSize(all);
     if (blockers.size === 0)
         return;
+    // A hidden column measures zero on every card, so an arrow computed here
+    // would be drawn at the origin and never seen. The Bugs pane is rebuilt on
+    // every render even while the workflow board is showing, which is exactly
+    // that case: the gaps land (they are CSS, and correct the moment the pane
+    // appears) while the arrow does not, and it only shows up whenever the next
+    // render happens to run with the pane open. Skipping here and redrawing when
+    // the column gains size is what keeps the two in step.
+    const bodies = all.filter(hasLayout);
     const work = bodies.map((body) => {
         const cards = cardsIn(body);
         const boxes = new Map([...cards].map(([key, el]) => [key, boxOf(el)]));
@@ -1644,6 +1653,29 @@ function drawBlockerArrows() {
         const boxes = new Map([...cards].map(([key, el]) => [key, boxOf(el)]));
         body.appendChild(arrowLayer(body, bodies.indexOf(body), drawn, boxes));
     }
+}
+// hasLayout reports whether an element is actually laid out — false inside a
+// `display: none` subtree, where every offset reads zero.
+function hasLayout(el) {
+    return el.offsetParent !== null && el.offsetWidth > 0 && el.offsetHeight > 0;
+}
+// sizeWatcher redraws when a column's size changes: when a hidden pane is
+// opened (zero → real), when a web font finishes loading and reflows the cards,
+// and when the window resizes. Watching the elements rather than the window
+// covers all three with one mechanism, including the pane switch, which fires
+// no resize event at all.
+const sizeWatcher = typeof ResizeObserver === "undefined"
+    ? null
+    : new ResizeObserver(() => requestAnimationFrame(drawBlockerArrows));
+// observeForSize points the watcher at the current columns. render() rebuilds
+// them, so the previous observations are dropped first — an observer holding
+// detached nodes would keep firing for elements nobody can see.
+function observeForSize(bodies) {
+    if (!sizeWatcher)
+        return;
+    sizeWatcher.disconnect();
+    for (const body of bodies)
+        sizeWatcher.observe(body);
 }
 const ARROW_GAP_SIDES = ["left", "right", "top", "bottom"];
 function clearArrowGaps(el) {
@@ -3198,10 +3230,8 @@ function init() {
     });
     document.getElementById("ideation-draft-submit")?.addEventListener("click", () => void approveIdeation());
 }
-// The bug grid reflows on width (auto-fill columns), so a resize moves cards
-// out from under arrows drawn for the old layout. Redrawing on the next frame
-// re-measures rather than trying to transform what was already drawn.
-window.addEventListener("resize", () => requestAnimationFrame(drawBlockerArrows));
+// Window resizes are covered by sizeWatcher (the columns resize with the
+// window), so no separate resize listener is needed.
 if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", init);
 }

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -2043,9 +2043,18 @@ function drawBlockerArrows(): void {
   // Cleared unconditionally: a resize redraws without rebuilding the DOM, so
   // last layout's gaps would otherwise linger beside arrows that have moved.
   document.querySelectorAll<HTMLElement>(".card").forEach(clearArrowGaps);
-  const bodies = [...document.querySelectorAll<HTMLElement>(".column-body")];
-  bodies.forEach((body) => body.querySelector(".blocker-arrows")?.remove());
+  const all = [...document.querySelectorAll<HTMLElement>(".column-body")];
+  all.forEach((body) => body.querySelector(".blocker-arrows")?.remove());
+  observeForSize(all);
   if (blockers.size === 0) return;
+  // A hidden column measures zero on every card, so an arrow computed here
+  // would be drawn at the origin and never seen. The Bugs pane is rebuilt on
+  // every render even while the workflow board is showing, which is exactly
+  // that case: the gaps land (they are CSS, and correct the moment the pane
+  // appears) while the arrow does not, and it only shows up whenever the next
+  // render happens to run with the pane open. Skipping here and redrawing when
+  // the column gains size is what keeps the two in step.
+  const bodies = all.filter(hasLayout);
 
   const work = bodies.map((body) => {
     const cards = cardsIn(body);
@@ -2067,6 +2076,31 @@ function drawBlockerArrows(): void {
     const boxes = new Map([...cards].map(([key, el]) => [key, boxOf(el)]));
     body.appendChild(arrowLayer(body, bodies.indexOf(body), drawn, boxes));
   }
+}
+
+// hasLayout reports whether an element is actually laid out — false inside a
+// `display: none` subtree, where every offset reads zero.
+function hasLayout(el: HTMLElement): boolean {
+  return el.offsetParent !== null && el.offsetWidth > 0 && el.offsetHeight > 0;
+}
+
+// sizeWatcher redraws when a column's size changes: when a hidden pane is
+// opened (zero → real), when a web font finishes loading and reflows the cards,
+// and when the window resizes. Watching the elements rather than the window
+// covers all three with one mechanism, including the pane switch, which fires
+// no resize event at all.
+const sizeWatcher =
+  typeof ResizeObserver === "undefined"
+    ? null
+    : new ResizeObserver(() => requestAnimationFrame(drawBlockerArrows));
+
+// observeForSize points the watcher at the current columns. render() rebuilds
+// them, so the previous observations are dropped first — an observer holding
+// detached nodes would keep firing for elements nobody can see.
+function observeForSize(bodies: HTMLElement[]): void {
+  if (!sizeWatcher) return;
+  sizeWatcher.disconnect();
+  for (const body of bodies) sizeWatcher.observe(body);
 }
 
 const ARROW_GAP_SIDES: Side[] = ["left", "right", "top", "bottom"];
@@ -3660,10 +3694,8 @@ function init(): void {
   document.getElementById("ideation-draft-submit")?.addEventListener("click", () => void approveIdeation());
 }
 
-// The bug grid reflows on width (auto-fill columns), so a resize moves cards
-// out from under arrows drawn for the old layout. Redrawing on the next frame
-// re-measures rather than trying to transform what was already drawn.
-window.addEventListener("resize", () => requestAnimationFrame(drawBlockerArrows));
+// Window resizes are covered by sizeWatcher (the columns resize with the
+// window), so no separate resize listener is needed.
 
 if (document.readyState === "loading") {
   document.addEventListener("DOMContentLoaded", init);


### PR DESCRIPTION
The card gaps appear immediately; the arrow follows about two seconds later. That reads as the board struggling rather than the board working.

**Cause.** The Bugs pane is rebuilt on every render — including while the workflow board is showing and the pane is `display: none`:

```css
.bugs-view.hidden { display: none; }
```

Everything inside a `display:none` subtree measures zero, so the arrow was computed from cards at the origin with no size and drawn where nobody can see it. The gaps didn't suffer that: they're CSS classes on elements that size themselves correctly the moment the pane appears. So the two halves of one feature came apart, and the arrow waited for whichever later render happened to run with the pane open — the reconcile, hence the two seconds.

Switching to the pane fires no redraw of its own, which is why the delay tracked the poll rather than the click.

**Fix.** A column that isn't laid out is skipped rather than drawn wrong, and the columns are watched for size so the arrow is drawn the moment they have one.

**Why a `ResizeObserver` replaces the window resize listener** rather than joining it: a pane becoming visible fires no resize event, and a web font finishing its load fires none either — yet both move the cards. One observer on the columns covers those *and* the window, because the columns resize with it. Observations are re-pointed on each render, since `render()` rebuilds the columns and an observer holding detached nodes would keep firing for elements nobody can see.

Frontend tests 112 green, `make check` green, `dist` rebuilt in the same commit, `make desktop` verified to embed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
