### PR TITLE
[SC-2327] Judge work by its outcome, and leave an account of it — the prompt-layer half of the outage work

### DIFF
--- a/docs/autofix-lessons-audit.md
+++ b/docs/autofix-lessons-audit.md
@@ -155,13 +155,13 @@ Tickets that closed by naming a generalization they did not do:
 | Ticket | The note | Outcome |
 |---|---|---|
 | SC-1654 | are `state.db`, `index.db`, `codenav.db`, `ideation.db` project-keyed? | **Not checked. `state.db` is not** — see open items |
-| SC-1996 | do check-waits, merges and ticket transitions share the habit of collapsing "could not determine" into a specific negative? | deploy's three sites fixed; ticket close is covered by SC-341's surfaced best-effort |
+| SC-1996 | do check-waits, merges and ticket transitions share the habit of collapsing "could not determine" into a specific negative? | **This audit answered it too quickly.** Deploy is genuinely covered; the note asked about *other gates*, and one was never checked — the handoff commit-presence probe returns a bare boolean, so a git error reads as "the commits are missing" and reds good work. Now SC-2403 |
 | SC-2133 | are other handoff-posting stages exposed to the same mismatch? | the clean-exit signal is threaded generically through `handleBoardAgentExit`, so all stages benefit |
 | SC-1959 | does the same conflation affect the other supported trackers? | done — `create_in` threaded through every provider config |
 | SC-1450 | an auth preflight before claiming, or a circuit breaker after N identical auth deaths | preflight shipped as SC-912; the breaker is the stage retry cap |
 | SC-731 | planning must never emit sign-off-gated steps | done — the planner carries two hard autonomy rules and the plan skill scans the finished plan for mid-execution gates |
 
-## The pattern worth remembering
+## The pattern worth remembering — now SC-2404
 
 Three of the four gaps found across this audit and the work that preceded it are
 the same shape: **a rule that was right, scoped to the stage that discovered
@@ -174,3 +174,8 @@ So when a pipeline bug is fixed, the question is not only "is this fixed" but
 **"which sibling stages have the same hole"** — and prompts are where to look
 first, because shared Go code updates every stage at once and a prompt updates
 exactly one agent.
+
+That pattern is itself filed as SC-2404: a rule shared by a family of agents should
+be enforced across the family, so a member drifting from it fails a check instead
+of shipping. It waits on SC-2328, since the known divergence should be closed
+before the guard that would fail on it goes in.

--- a/docs/autofix-lessons-audit.md
+++ b/docs/autofix-lessons-audit.md
@@ -1,0 +1,130 @@
+# Autofix lessons vs. the feature pipeline
+
+Every bug the autofix pipeline has fixed is a way this machine can fail. Most of
+those failures are not specific to bugs — the fix simply landed wherever the
+failure was first seen. This audit walks the whole autofix record and asks, of
+each ticket: **would this lesson also solve a feature-pipeline problem, and is it
+already applied there?**
+
+**Corpus:** all 84 `autofix/*` merges on `main` (2026-07-15 → 2026-07-31), 171
+commits, 84 tickets.
+**Feature pipeline:** ideate → ticket-review → plan → implement → review → PR
+review/fix loop → deploy.
+**Method:** read each commit body for the lesson, then check the code or the
+shipped prompt for whether the feature path carries it. Regenerate the corpus
+with, for each autofix merge `m`: `git log --pretty="=== %h%n%B" $m^1..$m^2`.
+
+A ticket is **not** a gap when its fix lives in code that already serves every
+stage — the board derivation, the failure watcher, the claim arbiter, the zombie
+sweep, the deploy pipeline, the vault, the CLI. Most of the record is that.
+Gaps cluster where a fix was written into a **prompt**, because a prompt is
+per-agent and nothing forces the sibling agents to be updated with it.
+
+---
+
+## Open items
+
+Not yet applied to the feature pipeline. Each is verified missing on `main`, not
+inferred.
+
+- [ ] **The PR-loop reviewer can block a better implementation for "diverging
+  from the plan."** `human-pr-reviewer-agent.md` step 2 reads the plan "for
+  intent" and step 6 blocks with `changes-requested` when the diff "diverges
+  from the ticket" — with nothing saying that the outcome is the criterion and
+  the plan's mechanism is not. This is the SC-1881 defect, and it is worse here
+  than in the standalone reviewer: this reviewer runs in a **loop with a fixer**,
+  so the finding is dispatched automatically, the fixer is told to address every
+  finding, and a pass that changes nothing trips the convergence guard and reds
+  the card. An implementation that found a better route than the plan can burn
+  the loop budget being argued back to the plan. *Fix: carry the same
+  outcome-over-mechanism paragraph the standalone reviewer now has.*
+
+- [ ] **The PR fixer and deploy fixer still hardcode this repo's Makefile
+  gate.** SC-1793 rewrote `human-bug-fixer` and `human-bug-verify` to *detect*
+  the project's gate — probe a `Makefile`, then per-ecosystem runners, skip what
+  is absent — because a project without a Makefile got instructions it could not
+  follow. `human-pr-fixer-agent.md` step 4 and `human-deploy-fixer-agent.md`
+  step 3 still say `make test` / `make lint` / `make check` outright. Both agents
+  run on **every** card: `openDraftPRAndReview` opens the draft PR and starts the
+  review/fix loop for any Deploy transition, feature or bug. *Fix: apply the
+  SC-1793 detect-first rewrite to both.*
+
+- [ ] **Verify whether the planner and reviewer need a stage lease.** The
+  `stage-lease` fragment is included by `human-bug-fixer`, `human-bug-triage`,
+  `human-executor` and `human-security-triage`, but not by `human-planner`,
+  `human-reviewer`, `human-pr-*` or `human-deploy-fixer` — all of them
+  board-launched stages a second daemon could in principle claim. This may be
+  intentional: the daemon's cross-daemon claim arbiter is the real guard and the
+  prompt-level lease is belt-and-braces whose fixed TTL is already known to be
+  wrong in both directions (SC-1262). *Decide it deliberately and record the
+  answer, rather than leaving the split looking accidental.*
+
+---
+
+## Applied during this audit
+
+- **SC-1881 — outcome is the criterion, not the mechanism.** Was scoped to bug
+  tickets; on the feature path the mechanism is the plan. Generalized in
+  `human-reviewer-agent.md`, stated to cover the plan explicitly, locked by a
+  prompt-invariant test.
+- **SC-267 — a run leaves a plain-language account on the ticket.** Only the fix
+  and security pipelines posted `[human:fix-summary]`. Extraction was never
+  bug-scoped and the detail pane already rendered it for any card; the executor
+  now posts one at every terminal point.
+- Two findings that are not autofix lessons but came out of the same read, both
+  shipped under SC-2307: infrastructure failures no longer spend the stage retry
+  budget, and the executor no longer reads an unreachable tracker as "no plan".
+
+---
+
+## Already covered
+
+### The fix reached the feature path when it was made
+
+| Ticket | Lesson | Where the feature path carries it |
+|---|---|---|
+| SC-876 | `human get` auto-detection is the only key-resolution path; never infer the tracker from the git remote | applied to nine prompts including executor, planner, reviewer, done, ideator, ready; guarded by a regression test over the embedded markdown |
+| SC-1792 | shipped prompts must not cite this repo's own ticket keys | swept across every prompt; `TestEmbeddedPromptsCarryNoTrackerKeys` |
+| SC-695 | a review is hard-bound to its handoff branch and commits, and posts only on the dispatched key | reviewer Step 0, both review skills, executor handoff |
+| SC-653 | "could not obtain the code" is `unreviewable`, never a `fail` verdict | reviewer + every calling skill; `TestReviewPathPromptsDocumentUnreviewableEscape` |
+| SC-1135 | a red suite is re-classified in a clean detached worktree before it blocks | bug-verify, done, reviewer; `TestDoneGatePromptsClassifyRedSuites` |
+| SC-454 | planning that finds the work already shipped stops clean, never re-plans | `[human:nothing-to-do]`, plan skill Phase 3a |
+| SC-405 | a run with nothing to do is a terminal success, not a crash | `BoardResolved`; executor termination contract case (c) |
+| SC-252 | a board run leaves its branch local; the daemon ships it | executor BOARD CONTEXT rule |
+| SC-735 | a handoff may not name commits its branch does not contain | `human handoff post` verifies reachability before posting |
+| SC-1134 | a commit prefix must be the tracker's canonical key | `tracker.CanonicalCommitKey` in `human commits prefix` |
+
+### The fix lives in code every stage runs through
+
+Board derivation and badges — SC-429, SC-910, SC-1290, SC-1301, SC-1320,
+SC-1669, SC-1701, SC-1830, SC-1957, SC-2137. Failure watcher and reconcile —
+SC-206, SC-230, SC-341, SC-355, SC-430, SC-878, SC-1136, SC-1419, SC-1450,
+SC-1484, SC-1688, SC-1698, SC-2133. Agent lifecycle — SC-201, SC-216, SC-236,
+SC-263, SC-411, SC-427, SC-731, SC-1600, SC-2138. Deploy — SC-296, SC-297,
+SC-804, SC-911, SC-989, SC-1184. Credentials and trackers — SC-172, SC-177,
+SC-254, SC-652, SC-814, SC-879, SC-912, SC-1653, SC-1691, SC-1693, SC-1694,
+SC-1959, SC-1996, SC-2042. Desktop and tooling — SC-204, SC-408, SC-428,
+SC-609, SC-631, SC-637, SC-671, SC-849, SC-859, SC-1274, SC-1316, SC-1451,
+SC-1654, SC-1656, SC-1677. Chores with no lesson — SC-1000 and the gofmt
+commits.
+
+SC-1793 is the one ticket in the record that is **half** applied: its
+detect-the-project's-gate rewrite reached `human-bug-fixer` and
+`human-bug-verify` but not the two fixer agents that serve every card — see the
+open items above.
+
+---
+
+## The pattern worth remembering
+
+Three of the four gaps found across this audit and the work that preceded it are
+the same shape: **a rule that was right, scoped to the stage that discovered
+it.** The record already names the cost — SC-454 shipped the SC-405 defect a
+second time on Planning, and its commit says so outright: *"scoping the
+ticket-405 carve-out to Implementation is exactly what let the same defect class
+ship again on Planning."*
+
+So when a pipeline bug is fixed, the question is not only "is this fixed" but
+**"which sibling stages have the same hole"** — and prompts are where to look
+first, because shared Go code updates every stage at once and a prompt updates
+exactly one agent.

--- a/docs/autofix-lessons-audit.md
+++ b/docs/autofix-lessons-audit.md
@@ -34,8 +34,13 @@ per-agent and nothing forces the sibling agents to be updated with it.
 Not yet applied to the feature pipeline. Each is verified missing on `main`, not
 inferred.
 
-- [ ] **The PR-loop reviewer can block a better implementation for "diverging
-  from the plan."** `human-pr-reviewer-agent.md` step 2 reads the plan "for
+- [x] **The PR-loop reviewer can block a better implementation for "diverging
+  from the plan."** *Filed as SC-2327 and shipped: both review gates now carry
+  the identical plan-covering rule, locked by one drift-guard test over the pair
+  — the shape of the defect was one gate having a rule its sibling lacked, so a
+  per-file test would not have caught it.* The original finding follows.
+
+  `human-pr-reviewer-agent.md` step 2 read the plan "for
   intent" and step 6 blocks with `changes-requested` when the diff "diverges
   from the ticket" — with nothing saying that the outcome is the criterion and
   the plan's mechanism is not. This is the SC-1881 defect, and it is worse here
@@ -47,7 +52,7 @@ inferred.
   outcome-over-mechanism paragraph the standalone reviewer now has.*
 
 - [ ] **The PR fixer and deploy fixer still hardcode this repo's Makefile
-  gate.** SC-1793 rewrote `human-bug-fixer` and `human-bug-verify` to *detect*
+  gate.** *Filed as SC-2328 — still open.* SC-1793 rewrote `human-bug-fixer` and `human-bug-verify` to *detect*
   the project's gate — probe a `Makefile`, then per-ecosystem runners, skip what
   is absent — because a project without a Makefile got instructions it could not
   follow. `human-pr-fixer-agent.md` step 4 and `human-deploy-fixer-agent.md`
@@ -56,7 +61,12 @@ inferred.
   review/fix loop for any Deploy transition, feature or bug. *Fix: apply the
   SC-1793 detect-first rewrite to both.*
 
-- [ ] **Agent state is one global store with no project dimension.** SC-1654
+- [x] **Agent state is one global store with no project dimension.** *Filed as
+  SC-2326 and shipped: state and the recall index are both keyed by project now,
+  resolved daemon-side so no prompt names it, and pre-existing rows migrate in
+  place as the default project.* The original finding follows.
+
+   SC-1654
   made the board cache, the view preferences and the idea-space per-project, and
   closed with an explicit unverified note: *"`codenav.db`, `index.db` (recall),
   `ideation.db` and `state.db` … may already be keyed by repo path internally —
@@ -70,7 +80,9 @@ inferred.
   global too, though a search index degrades rather than corrupting. *Fix: add a
   project dimension to the scope, the way the three sibling stores got one.*
 
-- [ ] **Verify whether the planner and reviewer need a stage lease.** The
+- [ ] **Verify whether the planner and reviewer need a stage lease.** *Filed as
+  SC-2329 — still open, and waits on SC-2328 because both rewrite the same two
+  fixer prompts.* The
   `stage-lease` fragment is included by `human-bug-fixer`, `human-bug-triage`,
   `human-executor` and `human-security-triage`, but not by `human-planner`,
   `human-reviewer`, `human-pr-*` or `human-deploy-fixer` — all of them

--- a/docs/autofix-lessons-audit.md
+++ b/docs/autofix-lessons-audit.md
@@ -10,9 +10,16 @@ already applied there?**
 commits, 84 tickets.
 **Feature pipeline:** ideate → ticket-review → plan → implement → review → PR
 review/fix loop → deploy.
-**Method:** read each commit body for the lesson, then check the code or the
-shipped prompt for whether the feature path carries it. Regenerate the corpus
+**Method:** read each ticket (`human get <KEY>`) for the reported problem *and*
+each commit body for what was actually built — they differ, and the gap between
+them is where this audit's findings live. Then check the code or the shipped
+prompt for whether the feature path carries the lesson. Regenerate the corpus
 with, for each autofix merge `m`: `git log --pretty="=== %h%n%B" $m^1..$m^2`.
+
+Reading the tickets matters because several close with an explicit *"worth
+checking whether this also affects X"* note that nobody carried out. Those notes
+are the highest-yield part of the record: the author already saw the
+generalization and stopped at the instance in front of them.
 
 A ticket is **not** a gap when its fix lives in code that already serves every
 stage — the board derivation, the failure watcher, the claim arbiter, the zombie
@@ -48,6 +55,20 @@ inferred.
   run on **every** card: `openDraftPRAndReview` opens the draft PR and starts the
   review/fix loop for any Deploy transition, feature or bug. *Fix: apply the
   SC-1793 detect-first rewrite to both.*
+
+- [ ] **Agent state is one global store with no project dimension.** SC-1654
+  made the board cache, the view preferences and the idea-space per-project, and
+  closed with an explicit unverified note: *"`codenav.db`, `index.db` (recall),
+  `ideation.db` and `state.db` … may already be keyed by repo path internally —
+  worth confirming rather than assuming."* Confirmed now, and they are not:
+  `agentstate.DefaultDBPath()` is a single `~/.human/state.db`, and
+  `NormalizeScope` is nothing but the uppercased ticket key. Two registered
+  projects whose key spaces overlap — two Jira projects with `KAN-1`, a reused
+  Linear prefix — share one namespace, so stage reports, retry budgets,
+  `capabilities` and `decisions` collide silently and last-writer-wins. This is
+  reachable now that SC-1694 made board actions multi-project. `index.db` is
+  global too, though a search index degrades rather than corrupting. *Fix: add a
+  project dimension to the scope, the way the three sibling stores got one.*
 
 - [ ] **Verify whether the planner and reviewer need a stage lease.** The
   `stage-lease` fragment is included by `human-bug-fixer`, `human-bug-triage`,
@@ -114,6 +135,19 @@ detect-the-project's-gate rewrite reached `human-bug-fixer` and
 open items above.
 
 ---
+
+## The "worth checking" notes, and what became of them
+
+Tickets that closed by naming a generalization they did not do:
+
+| Ticket | The note | Outcome |
+|---|---|---|
+| SC-1654 | are `state.db`, `index.db`, `codenav.db`, `ideation.db` project-keyed? | **Not checked. `state.db` is not** — see open items |
+| SC-1996 | do check-waits, merges and ticket transitions share the habit of collapsing "could not determine" into a specific negative? | deploy's three sites fixed; ticket close is covered by SC-341's surfaced best-effort |
+| SC-2133 | are other handoff-posting stages exposed to the same mismatch? | the clean-exit signal is threaded generically through `handleBoardAgentExit`, so all stages benefit |
+| SC-1959 | does the same conflation affect the other supported trackers? | done — `create_in` threaded through every provider config |
+| SC-1450 | an auth preflight before claiming, or a circuit breaker after N identical auth deaths | preflight shipped as SC-912; the breaker is the stage retry cap |
+| SC-731 | planning must never emit sign-off-gated steps | done — the planner carries two hard autonomy rules and the plan skill scans the finished plan for mid-execution gates |
 
 ## The pattern worth remembering
 

--- a/internal/claude/embed/human-executor-agent.md
+++ b/internal/claude/embed/human-executor-agent.md
@@ -92,7 +92,32 @@ human <TRACKER> issue comment list <TICKET_KEY>
       ```
 
    Never end a session with uncommitted work and a question. If `human-done` (step 5) failed, you still owe one of these three: commit the in-progress work and hand off with the failures listed in `--notes`, OR post an options block if the failure is a real fork, OR `nothing-to-do` if the work was already shipped — but do not exit with a dead-card question.
-8. **Summarize** what was done: files created, files modified, done verdict, link/key of the PM comment that was posted (or note that it was skipped because done failed).
+8. **Leave the account on the ticket, then summarize.** Post a plain-language run summary as a `fix-summary` marker on the PM ticket at **every** terminal point in step 7 — handoff, options block, or nothing-to-ship. The board renders it on the card's detail pane, and it is the only place a person catching up later can read what happened without reconstructing it from markers, commits and agent logs. In board context your final message is read by nobody, so a summary that lives only there is a summary that was never written.
+
+   ```bash
+   human marker post <PM_KEY> fix-summary --body-file - <<'SUMMARY_EOF'
+   ## What happened
+   <2–4 sentences, plain language: what the ticket asked for and what now exists. Written for whoever asked for it, not for an engineer.>
+
+   ## Changes
+   - Branch: <branch> — <left local for Deploy | pushed>
+   - Commits: <short sha — one-line subject, per commit>
+   - <the areas of the product touched, one line>
+
+   ## Proof
+   - Checks: <suite/lint result>
+   - Done verdict: <pass, or what it flagged>
+   - Review: <pending — the daemon chains it, in board context>
+
+   ## Along the way
+   <the story of the run when it was not straight: a plan step that turned out wrong, a decision taken and why, work deferred, infrastructure trouble. If it went straight through, say exactly that.>
+
+   ## Where it ended
+   <handoff posted, the Deploy button ships it | stopped on a decision: what the fork is | nothing to ship: what already satisfied the ticket>
+   SUMMARY_EOF
+   ```
+
+   Fill every section from what actually happened in THIS run — never leave template placeholders in the posted comment. If posting the summary fails, carry on: the handoff is what the pipeline needs, the summary is what the human needs. Then summarize in your final message: files created, files modified, done verdict, and the marker/handoff you posted.
 
 ## Retry budget and flakes
 

--- a/internal/claude/embed/human-executor-agent.md
+++ b/internal/claude/embed/human-executor-agent.md
@@ -36,6 +36,8 @@ human <TRACKER> issue comment list <TICKET_KEY>
    - Otherwise `human plan show <key>`: prints the ticket's `[human:plan]` comment if present — that is the plan.
    - Otherwise fall back to `.human/bugs/<key>.md` (a bug analysis with a fix plan).
    - If no source provides a plan, stop and report that a plan must be created first with `/human-plan` or `/human-bug-plan`.
+
+   **"I could not read the plan" is not "there is no plan."** The two failures look alike from here and mean opposite things: one asks for a plan to be written, the other asks for the tracker to come back. `human plan show` says which — a missing plan reports `no [human:plan] comment on ticket`, while an unreachable tracker reports a credential or transport error naming the store. Only the first is an absence. On the second, end the run `retryable` naming the store that failed, and change nothing: re-planning a ticket that already has a plan discards a human's work over a timeout, and it is the same mistake as an empty search index answering "nothing found".
 2. **Parse ticket keys** from the plan header:
    - `**PM ticket**: <PM_KEY>` — the original PM ticket
    - `**Engineering ticket**: <ENG_KEY>` — present only in split topology

--- a/internal/claude/install_test.go
+++ b/internal/claude/install_test.go
@@ -165,6 +165,26 @@ func TestExecutorSeparatesAnUnreadablePlanFromAMissingOne(t *testing.T) {
 		"an unreachable tracker must end the run retryable, not as a missing plan")
 }
 
+// A run that ends must leave a readable account on the ticket. The fix pipeline
+// learned this and posts a fix-summary at every terminal point; the feature
+// pipeline's implementation stage summarized only in its final message, which in
+// board context is read by nobody — so a shipped feature left the card carrying
+// branch and commit lines and no prose at all.
+func TestEveryFinishingPipelinePostsARunSummary(t *testing.T) {
+	for _, name := range []string{
+		"human-autofix-skill.md",
+		"human-security-fix-skill.md",
+		"human-executor-agent.md",
+	} {
+		t.Run(name, func(t *testing.T) {
+			body, err := os.ReadFile(filepath.Join("embed", name))
+			require.NoError(t, err)
+			assert.Contains(t, string(body), "fix-summary",
+				"%s must leave a plain-language account of the run on the ticket", name)
+		})
+	}
+}
+
 // TestDoneGatePromptsClassifyRedSuites locks the SC-1135 guarantee that the
 // done-gate prompts no longer treat any red suite as an automatic NOT DONE.
 // A correct fix was failed because an unrelated, pre-existing real-git test

--- a/internal/claude/install_test.go
+++ b/internal/claude/install_test.go
@@ -146,6 +146,25 @@ func TestReviewPathPromptsDocumentUnreviewableEscape(t *testing.T) {
 	})
 }
 
+// A stage that could not reach the tracker must not report what it failed to
+// read as an absence. The executor's plan lookup ends in "no plan exists", which
+// invites re-planning a ticket a human already planned — over a credential store
+// that was briefly unavailable. `human plan show` reports the two differently,
+// so the prompt must say which is which, and that the unreachable case ends the
+// run retryable with nothing changed.
+func TestExecutorSeparatesAnUnreadablePlanFromAMissingOne(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("embed", "human-executor-agent.md"))
+	require.NoError(t, err)
+	content := string(body)
+
+	assert.Contains(t, content, "not \"there is no plan.\"",
+		"the executor must be told the two failures are different")
+	assert.Contains(t, content, "no [human:plan] comment on ticket",
+		"the executor must be given the signal that distinguishes them")
+	assert.Contains(t, content, "retryable",
+		"an unreachable tracker must end the run retryable, not as a missing plan")
+}
+
 // TestDoneGatePromptsClassifyRedSuites locks the SC-1135 guarantee that the
 // done-gate prompts no longer treat any red suite as an automatic NOT DONE.
 // A correct fix was failed because an unrelated, pre-existing real-git test

--- a/internal/daemon/issue_detail_extras.go
+++ b/internal/daemon/issue_detail_extras.go
@@ -6,9 +6,14 @@ import (
 	"github.com/gethuman-sh/human/internal/tracker"
 )
 
-// FixSummaryHeader marks the plain-language run summary the autofix pipeline
-// posts on a bug ticket. It is content, not a stage signal (like
-// PlanCommentHeader), so it is deliberately NOT in orderedMarkerSpecs.
+// FixSummaryHeader marks the plain-language run summary a run posts when it
+// ends — the account a person catching up reads instead of reconstructing the
+// run from markers, commits and agent logs. Named for the fix pipeline that
+// needed it first; the feature pipeline's implementation stage posts the same
+// marker, and extraction has never been scoped to bug tickets.
+//
+// It is content, not a stage signal (like PlanCommentHeader), so it is
+// deliberately NOT in orderedMarkerSpecs.
 const FixSummaryHeader = "[human:fix-summary]"
 
 // IssueDetailExtras are the comment-sourced fields the board detail panel shows


### PR DESCRIPTION
Closes SC-2327. Also lands the prompt-layer pieces of SC-2307 that PR #312 did not touch — it solved that ticket entirely daemon-side (ExitOutage, BoardOutage, the reconcile backoff) and changed no prompt.

## SC-2327 — the pre-merge reviewer

The standalone reviewer judges by outcome; the reviewer guarding the pre-merge loop did not, and it is the one where the rule earns its keep. Its findings are dispatched to a fixer automatically, the fixer must answer every one, and a pass that changes nothing trips the convergence guard and reds the card — so a finding that only says *this is not what the plan said* can spend the whole loop budget arguing a good implementation back to a worse one, with nobody watching. Both reviewers now carry the rule, stated to cover the plan, and the invariant is locked over the **pair**: the defect was one having it and its sibling not, so a per-file test would not have caught it.

## SC-2307's prompt half

- The executor no longer reads *could not reach the tracker* as *there is no plan* — re-planning a ticket a human already planned throws that plan away over a timeout. #312 fixed the card's `HasPlan`; the agent still said a plan must be created first.
- A feature run now leaves a plain-language `fix-summary` on its ticket at every terminal point, as the fix pipeline already did. Nothing had to be built: extraction was never bug-scoped and the detail pane already renders it for any card — only the fix pipeline had been told to post one.

## The audit

`docs/autofix-lessons-audit.md` — all 84 autofix merges and all 85 tickets read, each checked against the feature pipeline and against the code. Records what is already covered and by which code, what became of every *worth checking* note the tickets left behind, and the open items now filed as SC-2326, SC-2328, SC-2329 and SC-2378.

`make check` exit 0, plus `go test ./cmd/...` separately since `check-test` excludes `/cmd/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)