### PR TITLE
[SC-2400] Judge the fetch the prune actually acts on

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -98,9 +98,12 @@ func (a *App) Cards() (BoardData, error) {
 	}
 	project := projectKeyOf(info)
 	data := applyLocal(view, a.ideas.Assignments(project), cardMockups(), a.prefs.Snapshot(project))
+	// The keep sets come from `results` — the same fetch CanPrune judges — not
+	// from the composed view, which is a separate request that can answer with
+	// an empty board while this one is healthy (SC-2400).
 	board.PrunePrefs(results, project,
-		board.PruneTarget{Store: a.prefs, Keep: boardPrefsKeep(data)},
-		board.PruneTarget{Store: a.ideas, Keep: ideaSpaceKeep(data)},
+		board.PruneTarget{Store: a.prefs, Keep: board.PrefsKeep(results)},
+		board.PruneTarget{Store: a.ideas, Keep: board.IdeaKeep(results)},
 	)
 	return data, nil
 }
@@ -161,19 +164,6 @@ func (a *App) GetIssueDetail(trackerKind, trackerName, key string) (IssueDetail,
 	}, nil
 }
 
-// ideaSpaceKeep is the set of ticket keys still occupying the idea space
-// (idea-stage cards). board.PrunePrefs drops idea placements outside it — but
-// only on a trustworthy fetch (see board.CanPrune).
-func ideaSpaceKeep(data BoardData) map[string]struct{} {
-	keys := make(map[string]struct{})
-	for _, card := range data.Cards {
-		if card.Stage == string(daemon.BoardIdeas) {
-			keys[card.Key] = struct{}{}
-		}
-	}
-	return keys
-}
-
 // SetIdeaColumn persists the idea-space placement for one ticket. Purely
 // local UI state — never a tracker write or a board transition.
 func (a *App) SetIdeaColumn(pmKey string, col int) error {
@@ -202,17 +192,6 @@ func (a *App) SetCardHidden(pmKey string, hidden bool) error {
 		return err
 	}
 	return a.prefs.SetHidden(projectKeyOf(info), pmKey, hidden)
-}
-
-// boardPrefsKeep is the set of every ticket key currently on the board.
-// board.PrunePrefs drops order slots and hidden flags outside it — but only on a
-// trustworthy fetch (see board.CanPrune).
-func boardPrefsKeep(data BoardData) map[string]struct{} {
-	keys := make(map[string]struct{}, len(data.Cards))
-	for _, card := range data.Cards {
-		keys[card.Key] = struct{}{}
-	}
-	return keys
 }
 
 // CardsQuick fetches issue titles only — skipping the per-ticket comment scan

--- a/internal/board/gate.go
+++ b/internal/board/gate.go
@@ -97,6 +97,47 @@ func TruncationNotice(results []daemon.TrackerIssuesResult) string {
 	return fmt.Sprintf("Showing the first %d tickets — more open tickets exist beyond the fetch cap and are not displayed. Saved order and hidden flags are preserved (pruning is paused) until the full list can be fetched.", len(pm.Issues))
 }
 
+// PrefsKeep is every PM ticket the fetch actually returned.
+//
+// It is derived from the SAME results CanPrune judges, and that is the whole
+// point. The keep set used to come from the composed board — a second, separate
+// request — so a healthy fetch could authorise a prune against a board that had
+// answered with nothing, and every hidden flag and hand-sorted column went at
+// once (SC-2400). A guard is only a guard if it is inspecting the thing it
+// guards.
+//
+// Broader than the board on purpose: a done ticket is still in the listing
+// though it has left the board, so its preference survives until the ticket
+// itself does. Keeping a stale line costs a line; dropping a live one costs
+// somebody's deliberate act.
+func PrefsKeep(results []daemon.TrackerIssuesResult) map[string]struct{} {
+	pm, ok := FirstPMResult(results)
+	if !ok {
+		return map[string]struct{}{}
+	}
+	keys := make(map[string]struct{}, len(pm.Issues))
+	for _, issue := range pm.Issues {
+		keys[issue.Key] = struct{}{}
+	}
+	return keys
+}
+
+// IdeaKeep is every PM ticket the fetch returned that is an idea — the same
+// source as PrefsKeep, for the same reason.
+func IdeaKeep(results []daemon.TrackerIssuesResult) map[string]struct{} {
+	pm, ok := FirstPMResult(results)
+	if !ok {
+		return map[string]struct{}{}
+	}
+	keys := make(map[string]struct{})
+	for _, issue := range pm.Issues {
+		if issue.IsIdea() {
+			keys[issue.Key] = struct{}{}
+		}
+	}
+	return keys
+}
+
 // PrunePrefs drops stale entries from each target store for project, but ONLY
 // when the fetch is trustworthy (CanPrune). A prune failure is ignored: a
 // stale entry is harmless — the board renders from current cards regardless —
@@ -107,6 +148,15 @@ func PrunePrefs(results []daemon.TrackerIssuesResult, project string, targets ..
 		return
 	}
 	for _, t := range targets {
+		// Never prune to nothing. An empty keep set says "no ticket exists",
+		// which a refresh is not entitled to conclude — and acting on it removes
+		// every preference at once rather than the stale ones it was asked for
+		// (SC-2400). A board that genuinely holds no tickets keeps its stored
+		// preferences until one does; that costs a few lines in a file, which is
+		// the cheaper of the two mistakes by a wide margin.
+		if len(t.Keep) == 0 {
+			continue
+		}
 		_ = t.Store.PruneExcept(project, t.Keep)
 	}
 }

--- a/internal/board/gate_prunekeep_test.go
+++ b/internal/board/gate_prunekeep_test.go
@@ -1,0 +1,89 @@
+package board
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gethuman-sh/human/internal/daemon"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// fakePruneStore records what it was asked to keep.
+type fakePruneStore struct {
+	calls []map[string]struct{}
+}
+
+func (f *fakePruneStore) PruneExcept(_ string, keys map[string]struct{}) error {
+	f.calls = append(f.calls, keys)
+	return nil
+}
+
+func pmResults(issues ...tracker.Issue) []daemon.TrackerIssuesResult {
+	return []daemon.TrackerIssuesResult{{
+		TrackerName: "human", TrackerKind: "shortcut", TrackerRole: "pm", Issues: issues,
+	}}
+}
+
+// The defect: the guard judged one fetch while the keep set came from another,
+// so a healthy listing could authorise a prune against a board that had
+// answered with nothing — taking every hidden flag and every hand-sorted column
+// with it. Deriving the keep set from the guarded results is what makes the
+// guard mean something.
+func TestPrefsKeep_comesFromTheFetchTheGuardJudges(t *testing.T) {
+	results := pmResults(tracker.Issue{Key: "SC-1"}, tracker.Issue{Key: "SC-2"})
+
+	assert.Equal(t, map[string]struct{}{"SC-1": {}, "SC-2": {}}, PrefsKeep(results))
+	assert.True(t, CanPrune(results), "the same results must satisfy the guard")
+}
+
+// A ticket that left the board but is still in the listing keeps its
+// preference: dropping it early is the expensive mistake.
+func TestPrefsKeep_keepsATicketThatLeftTheBoard(t *testing.T) {
+	done := tracker.Issue{Key: "SC-9", StatusType: tracker.CategoryDone}
+
+	assert.Contains(t, PrefsKeep(pmResults(done)), "SC-9")
+}
+
+func TestIdeaKeep_onlyIdeas(t *testing.T) {
+	idea := tracker.Issue{Key: "SC-3", Labels: []string{"human/idea"}}
+	plain := tracker.Issue{Key: "SC-4"}
+
+	keep := IdeaKeep(pmResults(idea, plain))
+
+	assert.Contains(t, keep, "SC-3")
+	assert.NotContains(t, keep, "SC-4")
+}
+
+// No PM tracker means nothing is known, and nothing known must never read as
+// "no ticket exists".
+func TestPrefsKeep_noPMResultKeepsNothingAndPrunesNothing(t *testing.T) {
+	results := []daemon.TrackerIssuesResult{{TrackerName: "x", TrackerKind: "github"}}
+	store := &fakePruneStore{}
+
+	PrunePrefs(results, "proj", PruneTarget{Store: store, Keep: PrefsKeep(results)})
+
+	assert.Empty(t, store.calls, "an unknown board must not prune")
+}
+
+// The safety net: even past the guard, an empty keep set is refused. Wiping
+// every preference is not a tidy-up, and it is what the reported failure looked
+// like from the outside.
+func TestPrunePrefs_neverPrunesEverythingAtOnce(t *testing.T) {
+	results := pmResults(tracker.Issue{Key: "SC-1"})
+	store := &fakePruneStore{}
+
+	PrunePrefs(results, "proj", PruneTarget{Store: store, Keep: map[string]struct{}{}})
+
+	assert.Empty(t, store.calls, "an empty keep set must not reach the store")
+}
+
+// A healthy fetch still prunes what genuinely went away.
+func TestPrunePrefs_stillPrunesStaleEntries(t *testing.T) {
+	results := pmResults(tracker.Issue{Key: "SC-1"})
+	store := &fakePruneStore{}
+
+	PrunePrefs(results, "proj", PruneTarget{Store: store, Keep: PrefsKeep(results)})
+
+	assert.Equal(t, []map[string]struct{}{{"SC-1": {}}}, store.calls)
+}


### PR DESCRIPTION
Hiding a ticket did not survive a restart, and neither did any column's hand-sorted order.

**Cause.** The refresh prunes preferences for tickets that no longer exist, and asks first whether the fetch can be trusted — a partial or failed listing must never read as "these tickets are gone". But the question and the answer came from two different requests:

```go
results, _ := daemon.GetTrackerIssues(...)   // fetch A → gates CanPrune
view,    _ := daemon.GetBoardView(...)       // fetch B → became the keep set
```

`CanPrune` is carefully guarded — PM result present, no error, not truncated, ≥1 issue — but it was guarding **the wrong data**. When fetch A is healthy and fetch B answers with an empty board (a daemon that has not composed yet, a compose that failed, instances that did not load on that route), the prune ran against zero keys and removed every hidden flag and every hand-sorted column at once. A restart is exactly when the two disagree.

The stored file showed it plainly: `hidden` and all four column orders emptied together, which no per-ticket prune can produce.

**Fix, in two parts.**

1. **Both keep sets come from `results`** — the same fetch the guard judges — so the guard is inspecting the thing it guards. This also makes the keep set broader than the board: a done ticket is still in the listing though it has left the board, so its preference survives until the ticket does. A stale line in a file costs a line; a dropped one costs somebody's deliberate act.

2. **An empty keep set is refused outright.** "No ticket exists" is not a conclusion a refresh may reach, and acting on it removes everything rather than the stale entries it was asked for. A board that genuinely holds no tickets keeps its preferences until one appears.

The logic moved into `internal/board`, where it is testable — `desktop/` is behind the `wailsapp` tag that `make check` does not compile, which is part of why this shipped unnoticed.

7 new tests. `make check` green, `go vet -tags wailsapp ./desktop/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
