### PR TITLE
[SC-2521] Hold a dropped card until the machine confirms it

### DIFF
--- a/desktop/frontend/dist/board-pending.js
+++ b/desktop/frontend/dist/board-pending.js
@@ -9,3 +9,33 @@ export function reconcilePending(pending, fetchedKeys, fetchedTitles) {
 export function dropPending(pending, target) {
     return pending.filter((p) => p !== target);
 }
+// applyPendingMoves re-applies moves the fetch has not caught up with, and
+// returns the moves still worth holding.
+//
+// A move is held only while the fetch still shows the card exactly where it was
+// before the drop. Anything else ends it: the destination means the machine
+// agreed, a third stage means the machine has moved on (a failure, a stage that
+// advanced), and a card absent from the fetch has left the board. That rule is
+// what keeps this from becoming a lie — it suppresses precisely one answer, the
+// stale one, and yields to every other.
+//
+// Expiry is the backstop for a move that is never confirmed and never
+// contradicted: a launch that silently did nothing must return to the truth
+// rather than leave the board comfortable and wrong.
+export function applyPendingMoves(cards, moves, now) {
+    if (moves.length === 0)
+        return { cards, moves };
+    const byKey = new Map(cards.map((c) => [c.key, c]));
+    const held = [];
+    for (const move of moves) {
+        const card = byKey.get(move.key);
+        if (!card || now >= move.expiresAt)
+            continue;
+        if (card.stage !== move.from)
+            continue; // confirmed, or overtaken
+        card.stage = move.to;
+        card.state = move.state;
+        held.push(move);
+    }
+    return { cards, moves: held };
+}

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -22,7 +22,7 @@ import { buildDetailSections, buildOptionsSection } from "./board-detail.js";
 import { ideationInputEnabled, shouldCloseIdeation } from "./board-ideation.js";
 import { initProjectsView, showProjectsOverview } from "./projectsview.js";
 import { runGuardedAction } from "./board-actions.js";
-import { reconcilePending, dropPending } from "./board-pending.js";
+import { reconcilePending, dropPending, applyPendingMoves } from "./board-pending.js";
 export {};
 // openExternal routes a URL to the system browser via the Wails runtime.
 // Anchor clicks with target=_blank are NOT reliably forwarded by the Linux
@@ -730,6 +730,7 @@ async function fixBug(key, title) {
     const prevStage = card?.stage;
     const prevState = card?.state;
     if (card) {
+        holdMove(key, card.stage, "implementation", "running");
         card.stage = "implementation";
         card.state = "running";
         render();
@@ -741,6 +742,7 @@ async function fixBug(key, title) {
             card.stage = prevStage;
             card.state = prevState;
         }
+        releaseMove(key);
         showError(errMessage(err));
     }, reconcile);
 }
@@ -750,6 +752,7 @@ async function fixBug(key, title) {
 async function fixSecurity(key, title) {
     const card = current.cards.find((c) => c.key === key);
     if (card) {
+        holdMove(key, card.stage, "implementation", "running");
         card.stage = "implementation";
         card.state = "running";
         render();
@@ -758,6 +761,9 @@ async function fixSecurity(key, title) {
         await go().FixSecurity(key, title);
     }
     catch (err) {
+        // The launch never happened, so the optimistic placement must not be held
+        // against the next fetch — the reconcile below then puts the card back.
+        releaseMove(key);
         showError(errMessage(err));
     }
     await reconcile();
@@ -1403,6 +1409,7 @@ async function transition(key, title, from, to) {
     if (card) {
         card.stage = to;
         card.state = "running";
+        holdMove(key, prevStage ?? from, to, "running");
         render();
     }
     await runGuardedAction(() => go().Transition(key, title, from, to), (err) => {
@@ -1412,6 +1419,7 @@ async function transition(key, title, from, to) {
             card.stage = prevStage;
             card.state = prevState;
         }
+        releaseMove(key);
         showError(errMessage(err));
     }, reconcile);
 }
@@ -1897,6 +1905,24 @@ async function initialLoad() {
 // write `current` — a slower stale response would otherwise overwrite fresh
 // state and resurrect cards that already left the board. closeTicket also
 // bumps the epoch when it mutates `current` directly, for the same reason.
+// Moves the person made that no fetch has confirmed yet. A refresh answering
+// from before the drop would otherwise undo the action on screen (SC-2521).
+let pendingMoves = [];
+// PENDING_MOVE_GRACE bounds how long an unconfirmed move is held. Long enough
+// to cover a tracker that has not made the new marker readable yet; short
+// enough that a launch which silently did nothing returns to the truth while
+// the person is still looking at it.
+const PENDING_MOVE_GRACE = 30_000;
+// holdMove records an optimistic placement so the next fetch cannot undo it.
+function holdMove(key, from, to, state) {
+    pendingMoves = pendingMoves.filter((m) => m.key !== key);
+    pendingMoves.push({ key, from, to, state, expiresAt: Date.now() + PENDING_MOVE_GRACE });
+}
+// releaseMove drops the hold when the action itself failed: the card has
+// already been reverted, and holding would re-apply a move that never happened.
+function releaseMove(key) {
+    pendingMoves = pendingMoves.filter((m) => m.key !== key);
+}
 let reconcileEpoch = 0;
 // reconcile fetches the full board (including derived stages) and renders it. It
 // is the single source of truth after the initial load: board:changed events and
@@ -1908,6 +1934,12 @@ async function reconcile(opts = {}) {
         if (epoch !== reconcileEpoch)
             return;
         current = boardStateFromPayload(data);
+        // A fetch that predates the drop still shows the card where it was. Hold
+        // the move rather than letting it undo what the person just did; every
+        // other answer — the destination, a different stage, a card that left —
+        // ends the hold (SC-2521).
+        const settled = applyPendingMoves(current.cards, pendingMoves, Date.now());
+        pendingMoves = settled.moves;
         findbugsHunting = await go()
             .FindbugsHunting()
             .catch(() => false);

--- a/desktop/frontend/scripts/board-pending-moves.test.mjs
+++ b/desktop/frontend/scripts/board-pending-moves.test.mjs
@@ -1,0 +1,79 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { applyPendingMoves } from "../build/board-pending.js";
+
+const card = (key, stage, state = "idle") => ({ key, stage, state });
+const move = (key, from, to, expiresAt = 1000) => ({ key, from, to, state: "running", expiresAt });
+
+// The reported failure: the fetch answers from before the drop, still showing
+// the card where it came from, and replacing the card with that answer undoes
+// what the person just did.
+test("a fetch that has not caught up does not undo the move", () => {
+  const cards = [card("SC-1", "bugs:grid")];
+
+  const out = applyPendingMoves(cards, [move("SC-1", "bugs:grid", "implementation")], 0);
+
+  assert.equal(out.cards[0].stage, "implementation");
+  assert.equal(out.cards[0].state, "running");
+  assert.equal(out.moves.length, 1, "still unconfirmed, so still held");
+});
+
+// Confirmation ends the hold — nothing is suppressed after that.
+test("the destination confirms the move and releases the hold", () => {
+  const cards = [card("SC-1", "implementation", "running")];
+
+  const out = applyPendingMoves(cards, [move("SC-1", "bugs:grid", "implementation")], 0);
+
+  assert.equal(out.cards[0].stage, "implementation");
+  assert.deepEqual(out.moves, [], "confirmed moves are not held");
+});
+
+// The machine changing its mind must win. A failure, or any other stage, is a
+// real answer and not a stale one.
+test("the machine moving the card elsewhere ends the hold", () => {
+  const cards = [card("SC-1", "verification", "failed")];
+
+  const out = applyPendingMoves(cards, [move("SC-1", "bugs:grid", "implementation")], 0);
+
+  assert.equal(out.cards[0].stage, "verification", "the machine's answer stands");
+  assert.equal(out.cards[0].state, "failed");
+  assert.deepEqual(out.moves, []);
+});
+
+// A move nothing ever confirms must not persist as a comfortable lie.
+test("an unconfirmed move expires back to the truth", () => {
+  const cards = [card("SC-1", "bugs:grid")];
+
+  const out = applyPendingMoves(cards, [move("SC-1", "bugs:grid", "implementation", 1000)], 5000);
+
+  assert.equal(out.cards[0].stage, "bugs:grid", "expired: the fetch wins");
+  assert.deepEqual(out.moves, []);
+});
+
+// A card that left the board entirely is not resurrected by a held move.
+test("a card absent from the fetch ends the hold", () => {
+  const out = applyPendingMoves([card("SC-9", "backlog")], [move("SC-1", "bugs:grid", "implementation")], 0);
+
+  assert.equal(out.cards.length, 1);
+  assert.deepEqual(out.moves, []);
+});
+
+// Only the moved card is touched.
+test("other cards are left exactly as fetched", () => {
+  const cards = [card("SC-1", "bugs:grid"), card("SC-2", "bugs:grid")];
+
+  const out = applyPendingMoves(cards, [move("SC-1", "bugs:grid", "implementation")], 0);
+
+  assert.equal(out.cards[1].stage, "bugs:grid");
+  assert.equal(out.cards[1].state, "idle");
+});
+
+// No moves in flight is the common case and must cost nothing.
+test("no pending moves returns the fetch untouched", () => {
+  const cards = [card("SC-1", "bugs:grid")];
+
+  const out = applyPendingMoves(cards, [], 0);
+
+  assert.equal(out.cards[0].stage, "bugs:grid");
+  assert.deepEqual(out.moves, []);
+});

--- a/desktop/frontend/src/board-pending.ts
+++ b/desktop/frontend/src/board-pending.ts
@@ -32,3 +32,60 @@ export function reconcilePending<T extends Pending>(
 export function dropPending<T>(pending: T[], target: T): T[] {
   return pending.filter((p) => p !== target);
 }
+
+// A move the person made that the machine has not confirmed yet.
+//
+// Dropping a card moves it at once, which is right — an action must be visible
+// immediately. The refresh that follows can answer from before the drop,
+// because the record of it is not readable yet, and replacing the card with
+// that answer undoes what the person just did (SC-2521). Holding the move until
+// a fetch confirms it is the same contract already used for a newly created
+// ticket, whose placeholder survives a fetch until its key appears.
+export interface PendingMove {
+  key: string;
+  // from is where the card sat before the drop. It is the ONLY fetched value
+  // that counts as "not caught up yet" — see applyPendingMoves.
+  from: string;
+  to: string;
+  state: string;
+  expiresAt: number;
+}
+
+// MovableCard is the part of a card this reconciliation touches.
+export interface MovableCard {
+  key: string;
+  stage: string;
+  state: string;
+}
+
+// applyPendingMoves re-applies moves the fetch has not caught up with, and
+// returns the moves still worth holding.
+//
+// A move is held only while the fetch still shows the card exactly where it was
+// before the drop. Anything else ends it: the destination means the machine
+// agreed, a third stage means the machine has moved on (a failure, a stage that
+// advanced), and a card absent from the fetch has left the board. That rule is
+// what keeps this from becoming a lie — it suppresses precisely one answer, the
+// stale one, and yields to every other.
+//
+// Expiry is the backstop for a move that is never confirmed and never
+// contradicted: a launch that silently did nothing must return to the truth
+// rather than leave the board comfortable and wrong.
+export function applyPendingMoves<T extends MovableCard>(
+  cards: T[],
+  moves: PendingMove[],
+  now: number,
+): { cards: T[]; moves: PendingMove[] } {
+  if (moves.length === 0) return { cards, moves };
+  const byKey = new Map(cards.map((c) => [c.key, c]));
+  const held: PendingMove[] = [];
+  for (const move of moves) {
+    const card = byKey.get(move.key);
+    if (!card || now >= move.expiresAt) continue;
+    if (card.stage !== move.from) continue; // confirmed, or overtaken
+    card.stage = move.to;
+    card.state = move.state;
+    held.push(move);
+  }
+  return { cards, moves: held };
+}

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -71,7 +71,8 @@ import { buildDetailSections, buildOptionsSection } from "./board-detail.js";
 import { ideationInputEnabled, shouldCloseIdeation } from "./board-ideation.js";
 import { initProjectsView, showProjectsOverview, type RecentProject } from "./projectsview.js";
 import { runGuardedAction } from "./board-actions.js";
-import { reconcilePending, dropPending, type Pending } from "./board-pending.js";
+import { reconcilePending, dropPending, type Pending , applyPendingMoves } from "./board-pending.js";
+import type { PendingMove } from "./board-pending.js";
 
 interface Card {
   key: string;
@@ -1120,6 +1121,7 @@ async function fixBug(key: string, title: string): Promise<void> {
   const prevStage = card?.stage;
   const prevState = card?.state;
   if (card) {
+    holdMove(key, card.stage, "implementation", "running");
     card.stage = "implementation";
     card.state = "running";
     render();
@@ -1133,6 +1135,7 @@ async function fixBug(key: string, title: string): Promise<void> {
         card.stage = prevStage;
         card.state = prevState;
       }
+      releaseMove(key);
       showError(errMessage(err));
     },
     reconcile,
@@ -1145,6 +1148,7 @@ async function fixBug(key: string, title: string): Promise<void> {
 async function fixSecurity(key: string, title: string): Promise<void> {
   const card = current.cards.find((c) => c.key === key);
   if (card) {
+    holdMove(key, card.stage, "implementation", "running");
     card.stage = "implementation";
     card.state = "running";
     render();
@@ -1152,6 +1156,9 @@ async function fixSecurity(key: string, title: string): Promise<void> {
   try {
     await go().FixSecurity(key, title);
   } catch (err) {
+    // The launch never happened, so the optimistic placement must not be held
+    // against the next fetch — the reconcile below then puts the card back.
+    releaseMove(key);
     showError(errMessage(err));
   }
   await reconcile();
@@ -1807,6 +1814,7 @@ async function transition(key: string, title: string, from: string, to: string):
   if (card) {
     card.stage = to;
     card.state = "running";
+    holdMove(key, prevStage ?? from, to, "running");
     render();
   }
   await runGuardedAction(
@@ -1818,6 +1826,7 @@ async function transition(key: string, title: string, from: string, to: string):
         card.stage = prevStage;
         card.state = prevState;
       }
+      releaseMove(key);
       showError(errMessage(err));
     },
     reconcile,
@@ -2329,6 +2338,28 @@ async function initialLoad(): Promise<void> {
 // write `current` — a slower stale response would otherwise overwrite fresh
 // state and resurrect cards that already left the board. closeTicket also
 // bumps the epoch when it mutates `current` directly, for the same reason.
+// Moves the person made that no fetch has confirmed yet. A refresh answering
+// from before the drop would otherwise undo the action on screen (SC-2521).
+let pendingMoves: PendingMove[] = [];
+
+// PENDING_MOVE_GRACE bounds how long an unconfirmed move is held. Long enough
+// to cover a tracker that has not made the new marker readable yet; short
+// enough that a launch which silently did nothing returns to the truth while
+// the person is still looking at it.
+const PENDING_MOVE_GRACE = 30_000;
+
+// holdMove records an optimistic placement so the next fetch cannot undo it.
+function holdMove(key: string, from: string, to: string, state: string): void {
+  pendingMoves = pendingMoves.filter((m) => m.key !== key);
+  pendingMoves.push({ key, from, to, state, expiresAt: Date.now() + PENDING_MOVE_GRACE });
+}
+
+// releaseMove drops the hold when the action itself failed: the card has
+// already been reverted, and holding would re-apply a move that never happened.
+function releaseMove(key: string): void {
+  pendingMoves = pendingMoves.filter((m) => m.key !== key);
+}
+
 let reconcileEpoch = 0;
 
 // reconcile fetches the full board (including derived stages) and renders it. It
@@ -2340,6 +2371,12 @@ async function reconcile(opts: { safety?: boolean } = {}): Promise<void> {
     const data = await go().Cards();
     if (epoch !== reconcileEpoch) return;
     current = boardStateFromPayload(data);
+    // A fetch that predates the drop still shows the card where it was. Hold
+    // the move rather than letting it undo what the person just did; every
+    // other answer — the destination, a different stage, a card that left —
+    // ends the hold (SC-2521).
+    const settled = applyPendingMoves(current.cards, pendingMoves, Date.now());
+    pendingMoves = settled.moves;
     findbugsHunting = await go()
       .FindbugsHunting()
       .catch(() => false);


### PR DESCRIPTION
Drag a ticket to Fix: it lands there, sits ~2s, jumps back to Bugs, then returns to Fix a few seconds later. The work started correctly the first time — only the board disagreed, twice, before settling. Someone watching can't tell whether the drag worked, and the reasonable response (drag again) asks the machine to start the same work twice.

**Neither half was wrong.** Moving the card at once is right — an action must be visible immediately. Refreshing afterwards is right too. The gap is that the refresh can answer from *before* the drop: `board-fix` is handled synchronously and posts `[human:implementation-started]`, but the tracker doesn't return that comment on the very next listing. `boardViewFunc` composes fresh (no TTL cache), derives the stage from markers that don't include it yet, and `reconcile` replaces `current` wholesale — undoing the optimistic move. The next poll sees the marker and moves it back.

This lag is already known here: `listStageSettled` re-reads with bounded backoff precisely because "a just-posted hand-off comment [may not be] visible on the tracker (SC-1484's read-after-write race)". That protection lives on the daemon's failure path; nothing equivalent guarded the desktop's post-action reconcile. The same shape *is* solved for created tickets — a pending idea or bug survives a fetch until its key appears — but was never applied to a ticket that **moves**.

**The fix: a dropped card keeps its new place until a fetch confirms it.** The hold suppresses exactly one answer — the card still sitting where it started — and every other answer ends it:

| fetch says | result |
|---|---|
| the destination | machine agreed → hold released |
| a different stage | machine moved on (failure, advance) → shown immediately |
| card absent | left the board → hold released |
| still at origin | stale → hold applied |

That narrowness is what keeps it from being a lie told on the board's behalf. An unconfirmed move **expires after 30s**, so a launch that silently did nothing returns to the truth while the person is still watching.

Both drop paths hold; every revert path releases — including `fixSecurity`, which reverted through its refresh alone and would otherwise have held a move that never happened. It covers the workflow-board drag too, since `transition()` has the identical structure, and both reconcile routes (`board:changed` and the post-action call) go through the same replace.

7 new tests (119 frontend total), `make check` green, `go vet -tags wailsapp ./desktop/...` clean, `dist` rebuilt in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
