### PR TITLE
[SC-2596] Plan a ticket that reaches implementation without one

### DIFF
--- a/internal/daemon/board_options.go
+++ b/internal/daemon/board_options.go
@@ -247,6 +247,16 @@ func (d BoardTransitionDeps) ApplyOption(ctx context.Context, req BoardOptionReq
 		return errors.WrapWithDetails(err, "recording option choice", "pm", req.PMKey)
 	}
 
+	// This is the route the reported failure came in by: a decision answered on
+	// an unplanned ticket relaunches implementation, which then discovers there
+	// is nothing to execute — and does so again on every subsequent answer
+	// (SC-2596). Planning is what the ticket needs, so it goes there instead.
+	// The choice stays recorded above either way: it was made, and the run that
+	// eventually executes must still see it.
+	if stage == BoardImplementation && !planAlreadyOwned(comments) {
+		return d.planFirst(ctx, req.PMKey, WaitCause(""))
+	}
+
 	card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
 	prompt := stagePrompt(stage, req.PMKey, card) +
 		" — a decision was made on this ticket: pursue the direction in the latest " +

--- a/internal/daemon/board_options_test.go
+++ b/internal/daemon/board_options_test.go
@@ -112,6 +112,10 @@ func TestDeriveBoardCard_StageStartConsumesOptions(t *testing.T) {
 func TestApplyOptionPostsChoiceAndRelaunches(t *testing.T) {
 	base := time.Now().Add(-time.Hour)
 	c := &fakeCommenter{comments: []tracker.Comment{
+		// A ticket that legitimately reached implementation carries a plan (or,
+		// for a bug, a triage verdict). Without one the executor has nothing to
+		// carry out and the board plans first instead (SC-2596).
+		cmt(PlanCommentHeader+"\nstep one", base.Add(-time.Minute)),
 		cmt(ImplementationStartedHeader, base),
 		cmt(ReviewCompleteHeader+"\nverdict: fail", base.Add(1*time.Minute)),
 		cmt(optionsBody, base.Add(2*time.Minute)),

--- a/internal/daemon/board_plangate_test.go
+++ b/internal/daemon/board_plangate_test.go
@@ -1,0 +1,88 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// planGateDeps builds a transition whose card is ready to move into
+// implementation, carrying whatever comments the case needs.
+func planGateDeps(t *testing.T, comments []tracker.Comment) (BoardTransitionDeps, *fakeCommenter, *fakeLauncher) {
+	t.Helper()
+	c := &fakeCommenter{comments: comments}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+	return deps, c, l
+}
+
+func moveToImplementation(deps BoardTransitionDeps) error {
+	return deps.ApplyTransition(context.Background(),
+		BoardTransitionRequest{PMKey: "SC-1", From: BoardPlanning, To: BoardImplementation})
+}
+
+// The route the reported failure came in by: a decision answered on an
+// unplanned ticket relaunched implementation, which then found nothing to
+// execute — and repeated that on every answer. Planning is what the ticket
+// needs, so the machine goes there instead of dispatching the executor again.
+func TestApplyOption_noPlanRunsPlanningInsteadOfTheExecutor(t *testing.T) {
+	deps, _, l := planGateDeps(t, []tracker.Comment{
+		cmt("[human:options]\nstage: implementation\ncontext: which way\n1: this way\n2: that way", time.Now().Add(-time.Minute)),
+	})
+
+	require.NoError(t, deps.ApplyOption(context.Background(),
+		BoardOptionRequest{PMKey: "SC-1", OptionID: "1"}))
+
+	require.Equal(t, 1, l.calls)
+	assert.Contains(t, l.prompt, "/human-plan", "an unplanned ticket is planned, not executed")
+	assert.NotContains(t, l.prompt, "/human-execute")
+}
+
+// The same decision on a planned ticket still resumes the executor, carrying
+// the choice — the guard must not swallow the ordinary path.
+func TestApplyOption_withAPlanStillResumesTheExecutor(t *testing.T) {
+	deps, _, l := planGateDeps(t, []tracker.Comment{
+		cmt("[human:plan]\nstep one", time.Now().Add(-2*time.Minute)),
+		cmt("[human:options]\nstage: implementation\ncontext: which way\n1: this way\n2: that way", time.Now().Add(-time.Minute)),
+	})
+
+	require.NoError(t, deps.ApplyOption(context.Background(),
+		BoardOptionRequest{PMKey: "SC-1", OptionID: "1"}))
+
+	assert.Contains(t, l.prompt, "/human-execute")
+	assert.Contains(t, l.prompt, "decision was made", "the choice must reach the run")
+}
+
+// The guard belongs to the executor, not the stage: the bug pipeline launches
+// this same stage with no plan on purpose, and a guard on the stage would
+// refuse every autofix run.
+func TestApplyFix_stillRunsWithoutAPlan(t *testing.T) {
+	deps, _, l := planGateDeps(t, []tracker.Comment{cmt("[human:bug-verdict] head=confirmed", time.Now().Add(-time.Minute))})
+
+	require.NoError(t, deps.ApplyFix(context.Background(), BoardFixRequest{PMKey: "SC-1", PMTitle: "a bug"}))
+
+	require.Equal(t, 1, l.calls, "autofix must not be gated on a plan it produces itself")
+	assert.Contains(t, l.prompt, "/human-autofix")
+}
+
+// hasPlan reads the whole thread, not just the latest comment.
+func TestHasPlan_findsAPlanAnywhereInTheThread(t *testing.T) {
+	comments := []tracker.Comment{
+		cmt("[human:plan]\nstep one", time.Now().Add(-time.Hour)),
+		cmt("[human:implementation-failed]", time.Now()),
+	}
+
+	assert.True(t, hasPlan(comments))
+	assert.False(t, hasPlan([]tracker.Comment{cmt("[human:claim]", time.Now())}))
+}
+
+// "[human:plan]" must not be satisfied by an unrelated marker that merely
+// starts with the same letters.
+func TestHasPlan_planningStartedIsNotAPlan(t *testing.T) {
+	assert.False(t, hasPlan([]tracker.Comment{cmt("[human:planning-started]", time.Now())}))
+}

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -263,7 +263,7 @@ func (d BoardTransitionDeps) ApplyTransition(ctx context.Context, req BoardTrans
 			"pm", req.PMKey, "verdict", card.Verdict)
 	}
 
-	return d.launchForwardStage(ctx, req, card)
+	return d.launchForwardStage(ctx, req, card, comments)
 }
 
 // dispatchNonForwardMove handles the sanctioned moves that are not a single
@@ -273,8 +273,76 @@ func (d BoardTransitionDeps) ApplyTransition(ctx context.Context, req BoardTrans
 // as a non-advance, so they are resolved here first. handled reports whether the
 // request matched one of them — when false, ApplyTransition falls through to the
 // forward-only path — and err carries that dispatch's own result.
+// bugVerdictHeader marks a ticket the bug pipeline triaged. Its runs plan for
+// themselves, so the absence of a plan on such a ticket is by design.
+const bugVerdictHeader = "[human:bug-verdict]"
+
+// planAlreadyOwned reports whether dispatching the executor is sensible: either
+// a plan exists, or this ticket belongs to a pipeline that plans for itself.
+//
+// The second half is not a courtesy — it is what keeps this guard from breaking
+// the bug pipeline. Autofix triages, plans and fixes in one run and never posts
+// a plan, so "no plan" on a bug is the normal state, and treating it as an
+// error would send every reworked bug back to planning it does not need. The
+// existing rework tests caught exactly that.
+func planAlreadyOwned(comments []tracker.Comment) bool {
+	for _, c := range comments {
+		if strings.HasPrefix(strings.TrimSpace(c.Body), bugVerdictHeader) {
+			return true
+		}
+	}
+	return hasPlan(comments)
+}
+
+// hasPlan reports whether a plan exists for this ticket — the thing the
+// executor is dispatched to carry out.
+//
+// Either marker is sufficient and both are needed as signals. The plan comment
+// is the plan itself in single-tracker topology; plan-ready is what advances
+// the card and is present in both topologies, including the split one where the
+// plan lives in an engineering ticket's description and never appears as a
+// comment here. Requiring the comment alone would refuse every split-topology
+// ticket.
+func hasPlan(comments []tracker.Comment) bool {
+	if _, ok := latestPlanComment(comments); ok {
+		return true
+	}
+	for _, c := range comments {
+		if strings.HasPrefix(strings.TrimSpace(c.Body), PlanReadyHeader) {
+			return true
+		}
+	}
+	return false
+}
+
+// planFirst launches planning instead of the executor, for a ticket that has no
+// plan to execute.
+//
+// The executor exists to carry out a plan. Dispatched without one it claims the
+// ticket, prepares, can interrupt a person with a decision, and only then
+// discovers there is nothing to do — and every later launch repeats that
+// exactly (SC-2596). Planning is what the ticket needs and what a person would
+// ask for, so the machine does it rather than reporting a problem and waiting.
+//
+// Deliberately NOT placed in startAgentStage. The bug and security pipelines
+// launch this same stage with no plan on purpose — they triage, plan and fix in
+// one run — so a guard on the stage would refuse every autofix. What
+// presupposes a plan is the executor prompt, so the guard sits with it.
+func (d BoardTransitionDeps) planFirst(ctx context.Context, pmKey string, cause WaitCause) error {
+	d.Logger.Info().Str("pm", pmKey).
+		Msg("board: implementation asked for with no plan on the ticket; planning first")
+	return d.startAgentStage(ctx, pmKey, BoardPlanning, PlanningStartedHeader, planPrompt(pmKey), cause)
+}
+
 func (d BoardTransitionDeps) dispatchNonForwardMove(ctx context.Context, req BoardTransitionRequest, card BoardCard) (handled bool, err error) {
 	switch {
+	// Rework and the build retry are deliberately NOT gated on a plan existing.
+	// A card only reaches either by having completed implementation once, which
+	// means a plan existed or the bug pipeline owned it — history already
+	// guarantees what a check would look for. Checking anyway would risk
+	// refusing a nearly finished ticket whose plan-ready has aged out of a
+	// capped comment fetch, and sending it back to planning (SC-2596).
+	//
 	// Rework loop: a build whose review failed may be rebuilt. This is the ONE
 	// sanctioned backward move — the executor is re-dispatched with the review
 	// findings, and the resulting handoff chains into a fresh review.
@@ -326,12 +394,15 @@ func (d BoardTransitionDeps) dispatchNonForwardMove(ctx context.Context, req Boa
 // launchForwardStage dispatches an already-sanctioned forward transition to
 // its stage launcher. Split from ApplyTransition so the gate chain and the
 // dispatch read (and count) as separate concerns.
-func (d BoardTransitionDeps) launchForwardStage(ctx context.Context, req BoardTransitionRequest, card BoardCard) error {
+func (d BoardTransitionDeps) launchForwardStage(ctx context.Context, req BoardTransitionRequest, card BoardCard, comments []tracker.Comment) error {
 	switch req.To {
 	case BoardPlanning:
 		return d.startAgentStage(ctx, req.PMKey, BoardPlanning, PlanningStartedHeader,
 			planPrompt(req.PMKey), req.Cause)
 	case BoardImplementation:
+		if !planAlreadyOwned(comments) {
+			return d.planFirst(ctx, req.PMKey, req.Cause)
+		}
 		return d.startAgentStage(ctx, req.PMKey, BoardImplementation, ImplementationStartedHeader,
 			executePrompt(dispatchKey(req.PMKey, card), ""), req.Cause)
 	case BoardVerification:


### PR DESCRIPTION
The executor exists to carry out a plan. Dispatched without one it claims the ticket, runs preparation, can stop to ask a person a question, and only then discovers there's nothing to execute — then repeats that on every relaunch. The reported ticket was launched **six times across twenty-two minutes**, every launch doomed identically.

The gate that should have stopped it lives in `desktop/frontend/src/board-queue.ts`, attached to the drag:

```ts
export function planReady(card) { return card.stage === "planning" && card.state === "done"; }
```

The daemon's `startAgentStage` gates on doctor checks, dependencies and the claim — never on a plan existing. **A check on the gesture is not a guard on the operation.**

**Implementation asked for with no plan now runs planning instead** — the outcome a person wants, without spending six launches and an interruption to reach it.

## The guard sits with the executor prompt, not with the stage

Putting it in `startAgentStage` — the natural reading of "check where the stage is launched" — would refuse **every autofix and security-fix run**. Those launch the same `BoardImplementation` stage with no plan by design: they triage, plan and fix in one pass. So the discriminator is "is a plan *owned*", which a bug's `[human:bug-verdict]` answers as surely as a feature's `[human:plan]` does.

## Two routes deliberately left ungated

Working out why was most of the work:

- **The forward move** can't reach implementation without `plan-ready` — the single-next-stage rule already refuses it. The guard there is defence, not function.
- **Rework and build retry** only apply to a card that has completed implementation once, so history already guarantees what a check would look for. Checking anyway risks refusing a nearly finished ticket whose `plan-ready` has aged out of a capped comment fetch — sending finished work back to planning. Two existing tests caught exactly that when I first wrote the guard too widely.

**The route the failure actually used is the decision relaunch** (`ApplyOption`): an answer on an unplanned ticket restarts implementation, and answering again restarts it again. That one is gated.

## One fixture changed rather than the code

`TestApplyOptionPostsChoiceAndRelaunches` asserted a ticket in implementation with neither a plan nor a triage verdict — a state the pipeline cannot legitimately produce, which is precisely the bug described here.

The ticket's third requirement — *"what the card says matches what was actually determined"* — is **SC-2447**, where a recorded verdict is discarded when a later launch is killed while quiet. Fixing it there fixes it here; duplicating it would create two answers to one question.

6 new tests, `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
