### PR TITLE
[SC-2803] Declare the two fix pipelines as a rule family

### DIFF
--- a/internal/claude/families.go
+++ b/internal/claude/families.go
@@ -57,4 +57,24 @@ var ruleFamilies = []ruleFamily{
 			"human-pr-reviewer-agent.md",
 		},
 	},
+	{
+		// The two fix pipelines — bug and vulnerability — run the same shape of
+		// work and dispatch the same stages, so which model tier each stage gets
+		// has to read identically in both. They share that rule today only
+		// because the security skill was made by copying the autofix one, which
+		// is the share-by-copy this registry exists to end: nothing fails if one
+		// drops the include, and a third fix pipeline would start without it.
+		//
+		// Registered as prevention rather than repair. The two have not drifted
+		// (SC-2803) — the single change since the security skill was added
+		// reached both — and no prose is folded together to hold them here.
+		// Where the pipelines legitimately differ they keep their own words;
+		// only the tier rule is one rule.
+		name:    "fix-skill-model-tiers",
+		include: "model-tiers",
+		members: []string{
+			"human-autofix-skill.md",
+			"human-security-fix-skill.md",
+		},
+	},
 }


### PR DESCRIPTION
The bug and vulnerability pipelines dispatch the same stages, so which model tier each stage gets has to read the same way in both. They share that rule today only because one was made by copying the other — nothing fails if either drops it, and a third fix pipeline would start without it. That is the share-by-copy the family registry exists to end.

Prevention, not repair. The two have not drifted: since the security skill was added on 2026-07-24 there has been exactly one change to either of them, and it reached both, while 26 commits landed on other prompts in the same window. No prose is folded together — where the pipelines legitimately differ they keep their own words; only the tier rule is one rule.

Guard verified rather than assumed: removing the include from the security skill turns `TestRuleFamiliesShareTheirContract/fix-skill-model-tiers` red, naming the member and the missing directive; restoring it goes green. `make check` green.