### PR TITLE
[SC-2804] Give every pipeline step its own stage lease name

### DIFF
--- a/internal/agentstate/inherit_test.go
+++ b/internal/agentstate/inherit_test.go
@@ -1,0 +1,72 @@
+package agentstate
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A displaced predecessor's inheritance is handed to the successor as "what it
+// had already worked out". While several pipeline steps shared one lease name,
+// that predecessor could be a different role entirely, and its records would be
+// read as the successor's own prior work. Stale rows from that era outlive the
+// naming fix, so the scoping is the durable guard.
+func TestLeaseInheritsOnlyItsOwnStageRecords(t *testing.T) {
+	ctx := context.Background()
+	s, clock := newTestStore(t)
+	prev := Meta{Agent: "board-SC-2405-prreview"}
+
+	// A PR reviewer that held the shared "fix" lease and left its records behind.
+	for _, kv := range [][2]string{
+		{"stage.pr-review", "reviewer findings"},
+		{"fix.evidence", "same-stage evidence"},
+		{"capabilities", "shared working memory"},
+	} {
+		_, err := s.Set(ctx, "", "SC-2405", kv[0], kv[1], FormatText, prev)
+		require.NoError(t, err)
+	}
+
+	_, err := s.Lease(ctx, LeaseRequest{
+		Scope: "SC-2405", Stage: "fix", TTL: time.Minute, Meta: prev,
+	})
+	require.NoError(t, err)
+
+	// The lease goes stale and a genuine fix-stage agent takes it over.
+	*clock = clock.Add(2 * time.Hour)
+	res, err := s.Lease(ctx, LeaseRequest{
+		Scope: "SC-2405", Stage: "fix", TTL: time.Minute,
+		Meta: Meta{Agent: "board-SC-2405-implementation"},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Granted)
+	require.NotNil(t, res.Displaced)
+
+	assert.NotContains(t, res.InheritedKeys, "stage.pr-review",
+		"another step's record must never be handed over as the successor's own work")
+	assert.Contains(t, res.InheritedKeys, "fix.evidence", "same-stage state is the whole point of inheritance")
+	assert.Contains(t, res.InheritedKeys, "capabilities",
+		"un-namespaced working memory is shared, not another step's — dropping it would lose real state")
+}
+
+func TestBelongsToOtherStage(t *testing.T) {
+	cases := []struct {
+		name, key, stage string
+		other            bool
+	}{
+		{"same stage record", "stage.fix", "fix", false},
+		{"other stage record", "stage.pr-review", "fix", true},
+		{"same stage sub-record", "stage.triage.exit", "triage", false},
+		{"other stage sub-record", "stage.triage.exit", "fix", true},
+		{"stage-prefixed evidence", "fix.evidence", "fix", false},
+		{"un-namespaced shared key", "capabilities", "fix", false},
+		{"orchestrator bookkeeping", "budget.fix.attempts", "review", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.other, belongsToOtherStage(c.key, c.stage))
+		})
+	}
+}

--- a/internal/agentstate/lease.go
+++ b/internal/agentstate/lease.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	stderrors "errors"
+	"strings"
 	"time"
 
 	"github.com/gethuman-sh/human/errors"
@@ -58,7 +59,7 @@ func (s *SQLiteStore) Lease(ctx context.Context, req LeaseRequest) (LeaseResult,
 	result := LeaseResult{Granted: true, Lease: granted}
 	if displaced, ok := displacedBy(existing, found, req.Meta.Agent); ok {
 		result.Displaced = &displaced
-		keys, err := inheritedKeys(ctx, tx, normProject, normScope, displaced.Agent)
+		keys, err := inheritedKeys(ctx, tx, normProject, normScope, displaced.Agent, req.Stage)
 		if err != nil {
 			return LeaseResult{}, err
 		}
@@ -127,6 +128,19 @@ func displacedBy(existing Lease, found bool, agent string) (Lease, bool) {
 		return Lease{}, false
 	}
 	return existing, true
+}
+
+// belongsToOtherStage reports whether a state key is filed under a stage other
+// than the one being leased. Only the `stage.<name>` namespace is read as a
+// claim of ownership; `stage.triage.exit` belongs to `triage`, so the
+// comparison is on the segment after the prefix, not the whole remainder.
+func belongsToOtherStage(name, stage string) bool {
+	rest, ok := strings.CutPrefix(name, "stage.")
+	if !ok {
+		return false
+	}
+	owner, _, _ := strings.Cut(rest, ".")
+	return owner != stage
 }
 
 // Release marks a stage lease as handed back. When agent is non-empty the
@@ -225,8 +239,20 @@ func writeLease(ctx context.Context, tx *sql.Tx, project string, c Lease) error 
 }
 
 // inheritedKeys lists the state a displaced agent left behind in the scope —
-// the successor's inheritance.
-func inheritedKeys(ctx context.Context, tx *sql.Tx, project, scope, agent string) ([]string, error) {
+// the successor's inheritance — minus anything filed under a DIFFERENT stage.
+//
+// The successor is told to read these as "what it had already worked out", so a
+// key belonging to another step is not merely noise: it is another role's work
+// presented as the reader's own. That was reachable while several steps shared
+// one lease name (a PR reviewer displacing a planner), and stale rows from that
+// era outlive the naming fix, so the filter stays as the durable guard.
+//
+// Only `stage.<other>` records are excluded, because that prefix is the one
+// unambiguous statement of ownership a key makes. Keys carrying no stage
+// namespace at all — `capabilities`, `decisions` — are shared working memory
+// and are deliberately still inherited; dropping them would trade this defect
+// for a silent loss of the state the mechanism exists to preserve.
+func inheritedKeys(ctx context.Context, tx *sql.Tx, project, scope, agent, stage string) ([]string, error) {
 	rows, err := tx.QueryContext(ctx,
 		`SELECT name FROM agent_state WHERE project = ? AND scope = ? AND agent = ? ORDER BY name`, project, scope, agent)
 	if err != nil {
@@ -239,6 +265,9 @@ func inheritedKeys(ctx context.Context, tx *sql.Tx, project, scope, agent string
 		var name string
 		if err := rows.Scan(&name); err != nil {
 			return nil, errors.WrapWithDetails(err, "scan inherited key")
+		}
+		if belongsToOtherStage(name, stage) {
+			continue
 		}
 		names = append(names, name)
 	}

--- a/internal/claude/embed/human-bug-fixer-agent.md
+++ b/internal/claude/embed/human-bug-fixer-agent.md
@@ -63,7 +63,7 @@ human state get  <WORK_KEY> budget.fix.attempts --default 0
 
 Infrastructure trouble — a dead container, a network blip, a runner that never started — is never a real attempt; it is a `retryable` ending. Say so rather than spending the budget on it.
 
-<!-- human:include stage-lease -->
+<!-- human:include stage-lease stage=fix -->
 
 <!-- human:include exit-contract -->
 

--- a/internal/claude/embed/human-bug-triage-agent.md
+++ b/internal/claude/embed/human-bug-triage-agent.md
@@ -119,6 +119,6 @@ EOF
 
 `verdict` must be exactly one of the three words. A missing record reads as an incomplete stage and gets re-dispatched, so write it before you finish.
 
-<!-- human:include stage-lease -->
+<!-- human:include stage-lease stage=triage -->
 
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-deploy-fixer-agent.md
+++ b/internal/claude/embed/human-deploy-fixer-agent.md
@@ -53,6 +53,6 @@ EOF
 
 Do NOT use `AskUserQuestion` — you cannot interact with a human.
 
-<!-- human:include stage-lease -->
+<!-- human:include stage-lease stage=deploy-fix -->
 
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-executor-agent.md
+++ b/internal/claude/embed/human-executor-agent.md
@@ -135,7 +135,7 @@ human state get  <PM_KEY> budget.implementation.attempts --default 0
 
 Infrastructure trouble is never a real attempt — it is a `retryable` ending, not a spent budget.
 
-<!-- human:include stage-lease -->
+<!-- human:include stage-lease stage=implementation -->
 
 <!-- human:include exit-contract -->
 

--- a/internal/claude/embed/human-planner-agent.md
+++ b/internal/claude/embed/human-planner-agent.md
@@ -146,6 +146,6 @@ For each new or modified behavior:
 
 Do NOT use `AskUserQuestion` — you cannot interact with the user. Either return a complete, gate-free plan or, for a genuine human fork, the `DECISION REQUIRED:` terminal verdict. Then finish.
 
-<!-- human:include stage-lease -->
+<!-- human:include stage-lease stage=planning -->
 
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-pr-fixer-agent.md
+++ b/internal/claude/embed/human-pr-fixer-agent.md
@@ -62,6 +62,6 @@ EOF
 
 Do NOT use `AskUserQuestion` — you cannot interact with a human.
 
-<!-- human:include stage-lease -->
+<!-- human:include stage-lease stage=pr-fix -->
 
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-pr-reviewer-agent.md
+++ b/internal/claude/embed/human-pr-reviewer-agent.md
@@ -77,6 +77,6 @@ EOF
 
 Do NOT use `AskUserQuestion` — you cannot interact with a human. Humans review this PR out of band, on their own cadence; you never wait for them.
 
-<!-- human:include stage-lease -->
+<!-- human:include stage-lease stage=pr-review -->
 
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-reviewer-agent.md
+++ b/internal/claude/embed/human-reviewer-agent.md
@@ -141,6 +141,6 @@ EOF
 
 Use `unreviewable` only when the code itself could not be obtained (branch unreachable, no commits reference the key). It is not a synonym for `fail`: a review that examined code and found problems is `fail`.
 
-<!-- human:include stage-lease -->
+<!-- human:include stage-lease stage=review -->
 
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-security-triage-agent.md
+++ b/internal/claude/embed/human-security-triage-agent.md
@@ -130,6 +130,6 @@ EOF
 
 `verdict` must be exactly one of the three words. A missing record reads as an incomplete stage and gets re-dispatched, so write it before you finish.
 
-<!-- human:include stage-lease -->
+<!-- human:include stage-lease stage=triage -->
 
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/shared/stage-lease.md
+++ b/internal/claude/embed/shared/stage-lease.md
@@ -3,22 +3,25 @@
 Before doing any work, lease the stage. It is one command, and it is what makes a crashed run recoverable rather than repeated:
 
 ```bash
-human state lease <TICKET_KEY> --stage fix --agent "$HUMAN_AGENT_NAME" --json
+human state lease <TICKET_KEY> --stage <STAGE> --agent "$HUMAN_AGENT_NAME" --json
 ```
 
-Substitute your ticket key and your stage — `<TICKET_KEY>` and `fix` are examples.
+`<STAGE>` above is **your** stage — it is already filled in for you, and it identifies your step of the pipeline. Do not change it to anything else. A lease is held per (ticket, stage), so a stage name that belongs to another step would lock that step out of its own work and hand you its leftovers as if they were yours.
 
 Read the result:
 
-- **`granted: false`** — another agent holds this stage and is still alive. Stop; you are a duplicate. Do not work in parallel with it.
-- **`granted: true` with `displaced`** — the previous holder died. `inherited_keys` lists the state it left behind. **Read those keys before starting**: they are what it had already worked out, and redoing that work is the waste this exists to prevent.
+- **`granted: false`** — another agent holds this stage and is still alive. It is running the same step on the same ticket, so it is you. Stop immediately and end the run as a no-op: record `exit:"done"` with a summary saying a live holder already owns the stage, and stop. Do not work in parallel with it.
+
+  A refused lease is **scheduling, not a decision**. Never post a `[human:options]` block for it, never post a `*-failed` marker, and never leave the card waiting on a human — nobody can answer "another agent is already doing this", and a card parked on it stops the pipeline for a condition that resolves itself.
+
+- **`granted: true` with `displaced`** — the previous holder of *this same stage* died. `inherited_keys` lists the state it left behind. **Read those keys before starting**: they are what it had already worked out, and redoing that work is the waste this exists to prevent.
 
   ```bash
-  human state get <TICKET_KEY> fix.evidence   # whatever inherited_keys named
+  human state get <TICKET_KEY> <STAGE>.evidence   # whatever inherited_keys named
   ```
 
 - **`granted: true` with no `displaced`** — a clean start, nothing to inherit.
 
 While you work, re-run the same lease command roughly every ten minutes. Re-leasing as the same agent refreshes the heartbeat and keeps your original lease time; without it a long stage looks abandoned and a later agent may take it over while you are still working.
 
-Record what you learn as you go, not only at the end — state written before a crash is state your successor inherits, and state held only in your head is lost with the container.
+Record what you learn as you go, not only at the end — state written before a crash is state your successor inherits, and state held only in your head is lost with the container. Namespace every key you write under your own stage (`<STAGE>.…`), so what your successor inherits is unambiguously yours.

--- a/internal/claude/includes.go
+++ b/internal/claude/includes.go
@@ -1,8 +1,11 @@
 package claude
 
 import (
+	"bytes"
 	_ "embed"
 	"regexp"
+	"slices"
+	"strings"
 
 	"github.com/gethuman-sh/human/errors"
 )
@@ -19,7 +22,17 @@ var modelTiersFragment []byte
 // security-triage — hold a prompt-level lease as a uniform second line of
 // defence behind the daemon's cross-daemon claim arbiter. A new board-launched
 // stage inherits the rule rather than a precedent to guess at: add
-// `<!-- human:include stage-lease -->` to its prompt.
+// `<!-- human:include stage-lease stage=<its own stage> -->` to its prompt.
+//
+// The stage is a REQUIRED argument, and the fragment deliberately contains no
+// usable example name. It used to carry `--stage fix` as a worked example and
+// tell each agent to substitute its own; nine prompts copied the example
+// instead. Because a lease is keyed (project, scope, stage), that put the
+// planner, the executor, the PR reviewer and the fixers on ONE lease slot per
+// ticket, where they blocked each other — the PR reviewer holding the lease the
+// fixer needed is what surfaced as a bogus "decision needed" card. Naming the
+// stage at the include site, and rejecting an include that omits it, is what
+// makes the collision unrepresentable rather than merely discouraged.
 //
 //go:embed embed/shared/stage-lease.md
 var stageLeaseFragment []byte
@@ -42,33 +55,84 @@ var sharedFragments = map[string][]byte{
 	"outcome-not-mechanism": outcomeNotMechanismFragment,
 }
 
-// includePattern matches a whole-line include directive:
+// fragmentArgs names the arguments each shared fragment requires. A fragment
+// absent from this map takes none, which keeps every existing include
+// unchanged. An argument named here MUST be supplied at the include site and
+// MUST appear in the fragment as its upper-cased placeholder (`stage` →
+// `<STAGE>`), so a fragment can never ship a value a prompt was supposed to
+// choose for itself.
+var fragmentArgs = map[string][]string{
+	"stage-lease": {"stage"},
+}
+
+// includePattern matches a whole-line include directive, with optional
+// space-separated key=value arguments:
 //
 //	<!-- human:include exit-contract -->
+//	<!-- human:include stage-lease stage=pr-review -->
 //
 // It is an HTML comment so an un-expanded prompt still renders as valid
 // markdown rather than showing markup to the model.
-var includePattern = regexp.MustCompile(`(?m)^[ \t]*<!--[ \t]*human:include[ \t]+([a-z0-9-]+)[ \t]*-->[ \t]*$`)
+var includePattern = regexp.MustCompile(`(?m)^[ \t]*<!--[ \t]*human:include[ \t]+([a-z0-9-]+)((?:[ \t]+[a-z]+=[a-z0-9.-]+)*)[ \t]*-->[ \t]*$`)
+
+// argPattern splits the argument tail of an include directive into key/value
+// pairs.
+var argPattern = regexp.MustCompile(`([a-z]+)=([a-z0-9.-]+)`)
 
 // expandIncludes substitutes every shared fragment referenced by content.
 //
 // An unknown fragment name is an error rather than a silent pass-through: a
 // prompt that ships with a dangling directive would quietly lose a rule the
 // pipeline depends on, and that failure would only surface as an agent
-// behaving oddly much later.
+// behaving oddly much later. A missing or unknown argument is an error for the
+// same reason — an unbound placeholder reaching a model is a rule the agent
+// then has to guess at.
 func expandIncludes(content []byte) ([]byte, error) {
-	var unknown string
+	var failure error
 	expanded := includePattern.ReplaceAllFunc(content, func(match []byte) []byte {
-		name := string(includePattern.FindSubmatch(match)[1])
+		groups := includePattern.FindSubmatch(match)
+		name := string(groups[1])
 		fragment, ok := sharedFragments[name]
 		if !ok {
-			unknown = name
+			failure = errors.WithDetails("unknown shared prompt fragment", "fragment", name)
 			return match
 		}
-		return fragment
+		bound, err := bindFragmentArgs(name, fragment, string(groups[2]))
+		if err != nil {
+			failure = err
+			return match
+		}
+		return bound
 	})
-	if unknown != "" {
-		return nil, errors.WithDetails("unknown shared prompt fragment", "fragment", unknown)
+	if failure != nil {
+		return nil, failure
 	}
 	return expanded, nil
+}
+
+// bindFragmentArgs substitutes an include's key=value arguments into the
+// fragment's placeholders. Every argument the fragment declares must be
+// supplied, and nothing beyond them is accepted: a typo'd argument name is a
+// silent no-op otherwise, which would leave the placeholder in the shipped
+// prompt.
+func bindFragmentArgs(name string, fragment []byte, tail string) ([]byte, error) {
+	supplied := map[string]string{}
+	for _, m := range argPattern.FindAllStringSubmatch(tail, -1) {
+		supplied[m[1]] = m[2]
+	}
+	required := fragmentArgs[name]
+	for key := range supplied {
+		if !slices.Contains(required, key) {
+			return nil, errors.WithDetails("unknown argument for shared prompt fragment", "fragment", name, "argument", key)
+		}
+	}
+	bound := fragment
+	for _, key := range required {
+		value, ok := supplied[key]
+		if !ok {
+			return nil, errors.WithDetails("shared prompt fragment requires an argument", "fragment", name, "argument", key)
+		}
+		bound = bytes.ReplaceAll(bound, []byte("<"+strings.ToUpper(key)+">"), []byte(value))
+	}
+	return bound, nil
 }

--- a/internal/claude/leasecontract_test.go
+++ b/internal/claude/leasecontract_test.go
@@ -1,0 +1,125 @@
+package claude
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A stage lease is keyed (project, scope, stage), so the stage name IS the
+// identity of a pipeline step. When two steps name the same stage they share
+// one lock per ticket: they block each other while alive, and inherit each
+// other's leftovers when one dies. That is not a hypothetical — the shared
+// fragment used to carry `--stage fix` as a worked example and 58 leases were
+// taken under `fix` by three different roles, including the PR reviewer holding
+// the lease the PR fixer needed.
+//
+// This test is the lease-side twin of stagecontract_test.go, which already
+// enforces the same discipline for the `stage.<name>` records. The records half
+// had a test and stayed correct; the lease half had none and drifted.
+
+var (
+	leaseIncludePattern = regexp.MustCompile(`<!--\s*human:include\s+stage-lease\b([^>]*)-->`)
+	leaseStagePattern   = regexp.MustCompile(`\bstage=([a-z0-9.-]+)`)
+)
+
+// leaseStages maps every prompt carrying the stage-lease include to the stage
+// it declares, and fails a prompt that carries the include without one.
+func leaseStages(t *testing.T) map[string]string {
+	t.Helper()
+	entries, err := os.ReadDir("embed")
+	require.NoError(t, err)
+
+	stages := map[string]string{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join("embed", e.Name()))
+		require.NoError(t, err)
+		m := leaseIncludePattern.FindSubmatch(body)
+		if m == nil {
+			continue
+		}
+		arg := leaseStagePattern.FindSubmatch(m[1])
+		require.NotNil(t, arg,
+			"%s includes stage-lease without stage=<its own stage>; a lease with no owner name is how nine prompts ended up sharing one lock",
+			e.Name())
+		stages[e.Name()] = string(arg[1])
+	}
+	require.NotEmpty(t, stages, "no prompt carries the stage-lease include — the locator is wrong, not the prompts")
+	return stages
+}
+
+// Every board-launched stage must lease under a name that identifies it. Two
+// prompts may share a stage only when they are the same step of two pipelines
+// that never run on one ticket (autofix and security-fix triage) — the same
+// exemption stagecontract_test.go grants the record writers.
+func TestLeaseStagesIdentifyTheirStep(t *testing.T) {
+	sharedAcrossPipelines := map[string]bool{"triage": true}
+
+	byStage := map[string][]string{}
+	for prompt, stage := range leaseStages(t) {
+		byStage[stage] = append(byStage[stage], prompt)
+	}
+	for stage, prompts := range byStage {
+		if len(prompts) == 1 || sharedAcrossPipelines[stage] {
+			continue
+		}
+		require.Failf(t, "stage lease collision",
+			"prompts %v all lease stage %q, so they hold ONE lock per ticket and will block each other; give each its own stage",
+			prompts, stage)
+	}
+}
+
+// The lease stage and the stage a prompt records its handoff under must agree.
+// They are the same step by two names, and a disagreement means a successor
+// inherits state filed somewhere it will not look.
+func TestLeaseStageMatchesRecordedStage(t *testing.T) {
+	recordPattern := regexp.MustCompile(`human state set (?:<[A-Z_]+>|SC-\d+) stage\.([a-z-]+)\b`)
+
+	for prompt, stage := range leaseStages(t) {
+		body := readEmbed(t, prompt)
+		m := recordPattern.FindStringSubmatch(body)
+		if m == nil {
+			// A stage that records no handoff still needs a lease; there is
+			// simply nothing to cross-check it against.
+			continue
+		}
+		require.Equal(t, m[1], stage,
+			"%s leases stage %q but records its handoff under stage.%s — a successor would inherit nothing",
+			prompt, stage, m[1])
+	}
+}
+
+// The fragment must not ship a stage name of its own. A usable literal in the
+// shared text is exactly what nine prompts copied, and re-adding one would
+// reintroduce the collision without failing any other test.
+func TestStageLeaseFragmentCarriesNoLiteralStage(t *testing.T) {
+	body := string(stageLeaseFragment)
+	require.Contains(t, body, "--stage <STAGE>",
+		"the fragment's lease command must use the <STAGE> placeholder, never a real stage name")
+	require.NotContains(t, body, "--stage fix",
+		"the fragment must not carry a copyable stage name — that literal is the original defect")
+}
+
+// An include that omits a required argument must fail the install rather than
+// ship a prompt with an unbound placeholder in it.
+func TestExpandIncludesRequiresFragmentArgs(t *testing.T) {
+	_, err := expandIncludes([]byte("<!-- human:include stage-lease -->\n"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires an argument")
+
+	_, err = expandIncludes([]byte("<!-- human:include stage-lease stg=review -->\n"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown argument")
+
+	out, err := expandIncludes([]byte("<!-- human:include stage-lease stage=pr-review -->\n"))
+	require.NoError(t, err)
+	require.Contains(t, string(out), "--stage pr-review")
+	require.NotContains(t, string(out), "<STAGE>", "every placeholder must be bound before the prompt ships")
+}

--- a/internal/daemon/board_failure.go
+++ b/internal/daemon/board_failure.go
@@ -365,6 +365,12 @@ func stagePausedOnOptions(comments []tracker.Comment, stage BoardStage) bool {
 	if !optionStages[optStage] {
 		return true
 	}
+	// A block offering too few answers is malformed for the same reason and takes
+	// the same exit: attachOpenOptions reds the card with an explanation, and a
+	// relaunch here would fight that with a re-run of the stage that posted it.
+	if len(opts) < marker.MinDecisionOptions {
+		return true
+	}
 	return stageRank[optStage] <= stageRank[stage]
 }
 

--- a/internal/daemon/board_options.go
+++ b/internal/daemon/board_options.go
@@ -2,9 +2,11 @@ package daemon
 
 import (
 	"context"
+	"strconv"
 	"strings"
 
 	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/marker"
 	"github.com/gethuman-sh/human/internal/tracker"
 )
 
@@ -77,6 +79,11 @@ func parseOptionsBlock(body string) (BoardStage, string, []BoardOption) {
 			raw = BoardStage(strings.TrimSpace(strings.TrimPrefix(line, "stage:")))
 		case strings.HasPrefix(line, "context:"):
 			context = strings.TrimSpace(strings.TrimPrefix(line, "context:"))
+		case strings.HasPrefix(line, DaemonLinePrefix):
+			// Provenance, not a choice. Every marker body carries this stamp, and
+			// `daemon: <id>` matches the id:label shape below exactly — so without
+			// this case the board offered the daemon id as a selectable answer,
+			// and counted it toward the number of answers a block appears to have.
 		default:
 			id, label, ok := strings.Cut(line, ":")
 			if !ok || strings.TrimSpace(id) == "" || strings.ContainsAny(id, " \t") {
@@ -314,6 +321,17 @@ func attachOpenOptions(card *BoardCard, comments []tracker.Comment) {
 	}
 	stage, context, opts := parseOptionsBlock(block.Body)
 	if len(opts) == 0 {
+		return
+	}
+	// A block offering fewer answers than a choice needs is malformed in the same
+	// way as one naming an unresumable stage, and gets the same treatment: say
+	// what is wrong on the card rather than presenting a dead end as a decision.
+	// Posting is now rejected for this (marker.MinDecisionOptions), so this is
+	// the recovery path for blocks already on a ticket.
+	if len(opts) < marker.MinDecisionOptions {
+		card.State = BoardFailed
+		card.Error = "decision block offers only " + strconv.Itoa(len(opts)) + " answer; a decision needs at least " +
+			strconv.Itoa(marker.MinDecisionOptions) + " — the stage should have handled this itself"
 		return
 	}
 	if !optionStages[stage] {

--- a/internal/daemon/board_options_malformed_test.go
+++ b/internal/daemon/board_options_malformed_test.go
@@ -1,0 +1,69 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// sc2405Block is the decision block that shipped on SC-2405, verbatim: a refused
+// stage lease turned into a question for a human, offering one real answer, with
+// the daemon provenance stamp sitting underneath it in the same `id: label`
+// shape a real answer has.
+const sc2405Block = "[human:options]\n" +
+	"stage: implementation\n" +
+	"context: Could not acquire the fix-stage lease for SC-2405 (PR 345) — another agent " +
+	"(board-SC-2405-prreview) currently holds it and its heartbeat is live within TTL.\n" +
+	"\n" +
+	"1: Rebuild the branch to resolve the decision the fixer raised\n" +
+	"daemon: 4f3add9a"
+
+// The daemon stamp is provenance, not an answer. It was rendered as a second
+// selectable option on the card, so a reader could "decide" the daemon id and
+// resume the pipeline on a choice that means nothing.
+func TestParseOptionsBlockDropsDaemonStamp(t *testing.T) {
+	_, _, opts := parseOptionsBlock(sc2405Block)
+
+	require.Len(t, opts, 1, "the daemon stamp must not be offered as an answer")
+	assert.Equal(t, "1", opts[0].ID)
+	for _, o := range opts {
+		assert.NotEqual(t, "daemon", o.ID, "the provenance stamp is not a choice")
+	}
+}
+
+// A block with one real answer is a dead end: the card must say so rather than
+// present it as a decision a human can make.
+func TestAttachOpenOptionsRedsSingleAnswerBlock(t *testing.T) {
+	card := &BoardCard{}
+	attachOpenOptions(card, []tracker.Comment{cmt(sc2405Block, time.Unix(1, 0))})
+
+	assert.Equal(t, BoardFailed, card.State)
+	assert.Contains(t, card.Error, "at least")
+	assert.Empty(t, card.Options, "a malformed block offers no choices to the board")
+}
+
+// Reding the card must not also relaunch the stage that posted the block: that
+// pair is the loop SC-751 removed, and it would re-post the same bad block.
+func TestSingleAnswerBlockIsACleanStop(t *testing.T) {
+	comments := []tracker.Comment{cmt(sc2405Block, time.Unix(1, 0))}
+
+	assert.True(t, stagePausedOnOptions(comments, BoardImplementation),
+		"a malformed decision ends the stage cleanly; the card carries the error instead")
+}
+
+// A well-formed decision is untouched by the floor.
+func TestAttachOpenOptionsKeepsTwoAnswerBlock(t *testing.T) {
+	body := "[human:options]\nstage: implementation\ncontext: two defensible directions\n" +
+		"1: Narrow the fix to the reported path\n2: Fix the class across all callers\ndaemon: 4f3add9a"
+
+	card := &BoardCard{}
+	attachOpenOptions(card, []tracker.Comment{cmt(body, time.Unix(1, 0))})
+
+	assert.NotEqual(t, BoardFailed, card.State)
+	require.Len(t, card.Options, 2, "the daemon stamp is dropped, both real answers survive")
+	assert.Equal(t, "two defensible directions", card.OptionsContext)
+}

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -454,7 +454,7 @@ func escalatedLoopThenRebuilt() []tracker.Comment {
 	return []tracker.Comment{
 		cmt("[human:pr-review-started]\nnumber: 257\nbranch: autofix/x", time.Unix(1, 0)),
 		cmt("[human:pr-fix-started]", time.Unix(2, 0)),
-		cmt("[human:options]\nstage: implementation\ncontext: the fixer needs a decision\n1: Rebuild the branch", time.Unix(3, 0)),
+		cmt("[human:options]\nstage: implementation\ncontext: the fixer needs a decision\n1: Rebuild the branch\n2: Keep the branch and narrow the fix", time.Unix(3, 0)),
 		cmt("[human:option-chosen] 1: Rebuild the branch", time.Unix(4, 0)),
 		cmt("[human:implementation-started]", time.Unix(5, 0)),
 		cmt("[human:ready-for-review]\nbranch: autofix/x\ncommits: abc1234", time.Unix(6, 0)),
@@ -519,7 +519,7 @@ func escalatedLoopAwaitingDecision() []tracker.Comment {
 	return []tracker.Comment{
 		cmt("[human:pr-review-started]\nnumber: 257\nbranch: autofix/x", time.Unix(1, 0)),
 		cmt("[human:pr-fix-started]", time.Unix(2, 0)),
-		cmt("[human:options]\nstage: implementation\ncontext: the fixer needs a decision\n1: Rebuild the branch", time.Unix(3, 0)),
+		cmt("[human:options]\nstage: implementation\ncontext: the fixer needs a decision\n1: Rebuild the branch\n2: Keep the branch and narrow the fix", time.Unix(3, 0)),
 	}
 }
 

--- a/internal/marker/marker.go
+++ b/internal/marker/marker.go
@@ -7,6 +7,7 @@ package marker
 
 import (
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -37,6 +38,50 @@ type spec struct {
 	required  []string
 	headEnum  []string
 	needsHead bool
+	// validate carries a contract the required/head fields cannot express.
+	validate func(Marker) error
+}
+
+// MinDecisionOptions is the fewest answers a decision block may offer. A block
+// with one answer is not a decision: it parks the card until a human clicks the
+// only thing on offer, which is a dead end dressed as a choice. Rejecting it at
+// post time is what stops a stage from turning a condition it should have
+// handled itself into a question.
+const MinDecisionOptions = 2
+
+// reservedOptionKeys are the option-block lines that are metadata rather than
+// answers. `daemon` is the provenance stamp every marker body carries, and it
+// has the same `id: label` shape as a real answer — counting it is how a
+// one-answer block passed for a two-answer one.
+var reservedOptionKeys = map[string]bool{"stage": true, "context": true, "daemon": true}
+
+// validateOptions counts the answers a decision block actually offers. They
+// arrive as numbered fields when posted and as body lines when read back, so
+// both are counted.
+func validateOptions(m Marker) error {
+	ids := map[string]bool{}
+	for key, value := range m.Fields {
+		if !reservedOptionKeys[key] && strings.TrimSpace(value) != "" {
+			ids[key] = true
+		}
+	}
+	for _, line := range strings.Split(m.Body, "\n") {
+		line = strings.TrimSpace(line)
+		id, label, ok := strings.Cut(line, ":")
+		id = strings.TrimSpace(id)
+		if !ok || id == "" || strings.ContainsAny(id, " \t") || reservedOptionKeys[id] {
+			continue
+		}
+		if strings.TrimSpace(label) != "" {
+			ids[id] = true
+		}
+	}
+	if len(ids) < MinDecisionOptions {
+		return errors.WithDetails(
+			"a decision block must offer at least two answers",
+			"type", m.Type, "answers", len(ids), "minimum", MinDecisionOptions)
+	}
+	return nil
 }
 
 var specs = map[string]spec{
@@ -56,7 +101,7 @@ var specs = map[string]spec{
 	"deployed":              {required: []string{"pr"}},
 	"bug-verdict":           {needsHead: true, headEnum: []string{"confirmed", "not-a-bug", "undetermined"}},
 	"bug-verify":            {needsHead: true, headEnum: []string{"DONE", "NOT DONE"}},
-	"options":               {required: []string{"stage"}},
+	"options":               {required: []string{"stage"}, validate: validateOptions},
 	// The ticket-review gate's verdict. The head carries the outcome so a reader
 	// can classify it without parsing the body, exactly as bug-verdict does; the
 	// gate ACTS on every outcome, so these name what it did, not what it asks for.
@@ -99,13 +144,11 @@ func Validate(m Marker) error {
 	if s.needsHead && strings.TrimSpace(m.Head) == "" {
 		return errors.WithDetails("marker requires a head token", "type", m.Type, "allowed", strings.Join(s.headEnum, "|"))
 	}
-	if len(s.headEnum) > 0 && m.Head != "" {
-		for _, allowed := range s.headEnum {
-			if m.Head == allowed {
-				return nil
-			}
-		}
+	if len(s.headEnum) > 0 && m.Head != "" && !slices.Contains(s.headEnum, m.Head) {
 		return errors.WithDetails("marker head token not in allowed set", "type", m.Type, "head", m.Head, "allowed", strings.Join(s.headEnum, "|"))
+	}
+	if s.validate != nil {
+		return s.validate(m)
 	}
 	return nil
 }

--- a/internal/marker/options_test.go
+++ b/internal/marker/options_test.go
@@ -1,0 +1,75 @@
+package marker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A decision block is the pipeline's one sanctioned way to stop and ask a
+// human. Posting one with a single answer parks a card on a question that has
+// only one possible reply — which is what a stage does when it turns a
+// condition it should have handled itself into a question.
+func TestValidateRejectsSingleAnswerDecision(t *testing.T) {
+	m := Marker{
+		Type: "options",
+		Fields: map[string]string{
+			"stage":   "implementation",
+			"context": "could not acquire the fix-stage lease",
+			"1":       "Rebuild the branch",
+		},
+	}
+
+	err := Validate(m)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at least two answers")
+}
+
+// The daemon provenance stamp has the same shape as an answer, so counting it
+// would let a one-answer block pass the floor.
+func TestValidateDoesNotCountDaemonStampAsAnAnswer(t *testing.T) {
+	m := Marker{
+		Type:   "options",
+		Fields: map[string]string{"stage": "implementation", "1": "Rebuild the branch"},
+		Body:   "daemon: 4f3add9a",
+	}
+
+	require.Error(t, Validate(m), "stage, context and daemon are metadata, not answers")
+}
+
+func TestValidateAcceptsTwoAnswerDecision(t *testing.T) {
+	m := Marker{
+		Type: "options",
+		Fields: map[string]string{
+			"stage": "implementation",
+			"1":     "Narrow the fix to the reported path",
+			"2":     "Fix the class across all callers",
+		},
+	}
+
+	require.NoError(t, Validate(m))
+}
+
+// Answers survive a round trip through the rendered comment body, where they
+// arrive as body lines rather than fields — both shapes must count.
+func TestValidateCountsAnswersFromBody(t *testing.T) {
+	m := Marker{
+		Type:   "options",
+		Fields: map[string]string{"stage": "implementation"},
+		Body:   "1: Narrow the fix\n2: Fix the class\ndaemon: 4f3add9a",
+	}
+
+	require.NoError(t, Validate(m))
+}
+
+// The stage requirement predates the answer floor and must still bite.
+func TestValidateStillRequiresStage(t *testing.T) {
+	m := Marker{
+		Type:   "options",
+		Fields: map[string]string{"1": "a", "2": "b"},
+	}
+
+	err := Validate(m)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing a required field")
+}


### PR DESCRIPTION
Fixes SC-2804.

A stage lease is keyed `(project, scope, stage)`, so the stage name is the identity of a pipeline step. `shared/stage-lease.md` carried `--stage fix` as a worked example and told each agent to substitute its own; nine prompts copied the example instead.

Live evidence from `~/.human/state.db`:

```
fix    | 58 leases | board-*-implementation, board-*-prreview, board-*-planning
triage | 51        | board-*-implementation
review | 11        | board-*-verification, board-*-implementation
```

Three roles on one lock per ticket. On SC-2405 the PR reviewer held the `fix` lock the PR fixer needed — the two halves of one loop deadlocking by construction — and it surfaced as a card stuck on a "decision needed" with a single answer.

## What each commit does

1. **Give every pipeline step its own stage lease name.** The include now takes a required argument (`stage-lease stage=pr-review`), the fragment carries only the `<STAGE>` placeholder, and an include that omits or misnames it fails the install rather than shipping an unbound placeholder. The records half of this contract already had `stagecontract_test.go` and stayed correct; the lease half had no test and drifted — `leasecontract_test.go` is its twin.

2. **Reject a decision block offering fewer than two answers.** A one-answer block parks a card until someone clicks the only thing on offer. Answers are counted across both fields (post time) and body lines (read back).

3. **Stop rendering the daemon stamp as a choosable answer.** `parseOptionsBlock` split every unrecognised line on `:`, so the `daemon: <id>` provenance stamp became a second selectable option beside the real one — choosing it would resume the pipeline on a decision that means nothing. It also inflated the answer count, so a naive two-answer floor would not have caught the SC-2405 block.

4. **Never inherit another step's records on a lease takeover.** A successor displacing a dead holder is handed its state and told to read it as its own prior work, filtered by *agent* rather than stage. Naming the steps apart closes this for new runs, but leases taken under the shared name outlive the fix. Only `stage.<other>` records are excluded — `capabilities` (70 rows) and `decisions` (7) are deliberately un-namespaced shared memory, and dropping those would trade this defect for silent state loss.

## Verification

`make check` green — 0 lint issues, full suite passing, real exit 0.

Expansion verified end to end: pr-reviewer → `--stage pr-review`, pr-fixer → `--stage pr-fix`, planner → `--stage planning`.

The escalated-loop fixtures used single-answer blocks, the shape this makes invalid; they now carry two.

## Note for after merge

`.claude/` still ships `--stage fix` for every agent, so the collision stays live until `human install` regenerates it and the daemon is rebuilt and restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)