### PR TITLE
[SC-2845] A deploy blocked by a conflict never recovers on its own

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -2529,6 +2529,56 @@ func (p forgeDeployer) EnsureMergeable(ctx context.Context, req daemon.PRRequest
 	return true, nil
 }
 
+// PublishResolvedBranch carries a deploy-fixer's conflict resolution from the
+// local branch ref to origin. The fixer runs in a board container, which holds
+// no push credentials by design — the daemon publishes on its behalf, the same
+// division of labour the pr-fixer already relies on. Without this the resolution
+// is unreachable: branchTip below reads the branch from origin, so the deploy
+// would rebase the unresolved origin tip again and hit the identical conflict,
+// discarding the finished work sitting on the local ref (SC-2845).
+//
+// It publishes ONLY a ref that is genuinely a resolution — present locally,
+// different from the origin tip, and already containing the base tip (the
+// property the fixer was dispatched to establish). Anything else is left
+// untouched for EnsureMergeable's own freshness rebase to handle, so a fixer
+// that reported done without moving the branch cannot make the deploy publish
+// something unexamined. The publish itself goes through pushBranch, inheriting
+// the never-publish-behind-origin guard and the lease against a concurrent push.
+func (p forgeDeployer) PublishResolvedBranch(ctx context.Context, dir, branch string) (bool, error) {
+	if !gitrepo.BranchExistsLocal(ctx, dir, branch) {
+		return false, nil
+	}
+	base := gitrepo.DefaultBranch(ctx, dir)
+	if err := gitrepo.Fetch(ctx, dir, base); err != nil {
+		return false, err
+	}
+	local, err := gitrepo.RevParse(ctx, dir, branch)
+	if err != nil {
+		return false, err
+	}
+	// Not yet current with the base: whatever the fixer did, it is not the
+	// resolution the deploy is waiting for.
+	if !gitrepo.IsAncestor(ctx, dir, "origin/"+base, local) {
+		return false, nil
+	}
+	if gitrepo.BranchExistsRemote(ctx, dir, branch) {
+		if err := gitrepo.Fetch(ctx, dir, branch); err != nil {
+			return false, err
+		}
+		remote, err := gitrepo.RevParse(ctx, dir, "origin/"+branch)
+		if err != nil {
+			return false, err
+		}
+		if local == remote {
+			return false, nil // already published — nothing to carry
+		}
+	}
+	if err := p.pushBranch(ctx, dir, branch); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // branchTip resolves the commit the freshness rebase starts from, preferring
 // the origin ref: the deploy serves the PR (which lives on origin), and the
 // local ref may lag a prior deploy's rebase — the ephemeral-worktree rebase

--- a/cmd/cmddaemon/deployer_publish_test.go
+++ b/cmd/cmddaemon/deployer_publish_test.go
@@ -1,0 +1,200 @@
+package cmddaemon
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// resolvedBranchRepo builds the exact state a deploy-fixer leaves behind: origin
+// carries the branch at a tip that conflicts with the advanced base, and the
+// LOCAL branch ref carries the fixer's resolution — the same commit rebased onto
+// current main. It returns the workspace and the resolved local tip.
+//
+// The fixer's container holds no push credentials, so this divergence between
+// the local and origin refs IS the handoff; the daemon publishing it is what the
+// deploy sees.
+func resolvedBranchRepo(t *testing.T) (ws, branch, resolvedTip string) {
+	t.Helper()
+	root := t.TempDir()
+	origin := filepath.Join(root, "origin.git")
+	runGit(t, root, "init", "--bare", "-b", "main", origin)
+	ws = filepath.Join(root, "ws")
+	runGit(t, root, "clone", origin, ws)
+
+	write(t, ws, "a.txt", "one\n")
+	runGit(t, ws, "add", "a.txt")
+	runGit(t, ws, "commit", "-m", "base")
+	runGit(t, ws, "push", "-u", "origin", "main")
+
+	// The handoff branch edits a.txt; it is published at that tip.
+	branch = "autofix/x"
+	runGit(t, ws, "checkout", "-b", branch)
+	write(t, ws, "a.txt", "one\nbranch\n")
+	runGit(t, ws, "add", "a.txt")
+	runGit(t, ws, "commit", "-m", "fix")
+	runGit(t, ws, "push", "origin", branch)
+
+	// main advances with a conflicting edit to the same file — the mechanical
+	// rebase the deploy runs on the ORIGIN tip cannot resolve this.
+	runGit(t, ws, "checkout", "main")
+	write(t, ws, "a.txt", "one\nmain\n")
+	runGit(t, ws, "add", "a.txt")
+	runGit(t, ws, "commit", "-m", "advance")
+	runGit(t, ws, "push", "origin", "main")
+
+	// The fixer's resolution: the branch, rebased onto current main with both
+	// sides kept, committed on the LOCAL branch ref and never pushed.
+	runGit(t, ws, "checkout", branch)
+	runGit(t, ws, "reset", "--hard", "origin/main")
+	write(t, ws, "a.txt", "one\nmain\nbranch\n")
+	runGit(t, ws, "add", "a.txt")
+	runGit(t, ws, "commit", "-m", "fix, rebased onto main")
+	resolvedTip = runGit(t, ws, "rev-parse", "HEAD")
+	return ws, branch, resolvedTip
+}
+
+func write(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+}
+
+// The stranded-resolution regression: a deploy-fixer resolves a conflict on the
+// local branch and cannot push (board containers hold no credentials), so
+// without a daemon-side publish the deploy re-reads the unresolved ORIGIN tip
+// and hits the identical conflict forever. PublishResolvedBranch must carry the
+// local resolution to origin (SC-2845).
+func TestPublishResolvedBranch_PublishesLocalResolution(t *testing.T) {
+	requireGit(t)
+	ws, branch, resolved := resolvedBranchRepo(t)
+
+	published, err := forgeDeployer{}.PublishResolvedBranch(context.Background(), ws, branch)
+	if err != nil {
+		t.Fatalf("publishing a resolved branch must succeed, got: %v", err)
+	}
+	if !published {
+		t.Error("a local ref that resolves the conflict must be reported as published")
+	}
+
+	runGit(t, ws, "fetch", "origin")
+	if tip := runGit(t, ws, "rev-parse", "origin/"+branch); tip != resolved {
+		t.Errorf("origin/%s = %s, want the fixer's resolved tip %s", branch, tip, resolved)
+	}
+	// The published tip contains the base — which is the whole point: the deploy
+	// that follows can merge it without another rebase.
+	mainTip := runGit(t, ws, "rev-parse", "origin/main")
+	if out, e := exec.Command("git", "-C", ws, "merge-base", "--is-ancestor", mainTip, "origin/"+branch).CombinedOutput(); e != nil {
+		t.Errorf("the published branch must contain the base tip: %s", out)
+	}
+}
+
+// A local ref that does NOT contain the base tip is not the resolution the
+// deploy is waiting for — a fixer that reported done without rebasing, or a
+// stale ref. Publishing it would ship an unexamined tip over the branch, so it
+// is left alone for the deploy's own freshness rebase to handle.
+func TestPublishResolvedBranch_LeavesUnresolvedLocalRef(t *testing.T) {
+	requireGit(t)
+	ws, branch, _ := resolvedBranchRepo(t)
+	originTip := runGit(t, ws, "rev-parse", "origin/"+branch)
+	// Roll the local ref back to a tip that predates the base advance.
+	runGit(t, ws, "reset", "--hard", originTip)
+
+	published, err := forgeDeployer{}.PublishResolvedBranch(context.Background(), ws, branch)
+	if err != nil {
+		t.Fatalf("an unresolved local ref is not an error, got: %v", err)
+	}
+	if published {
+		t.Error("a local ref that does not contain the base tip must not be published")
+	}
+	runGit(t, ws, "fetch", "origin")
+	if tip := runGit(t, ws, "rev-parse", "origin/"+branch); tip != originTip {
+		t.Errorf("origin/%s = %s, want it untouched at %s", branch, tip, originTip)
+	}
+}
+
+// Re-entry must be a no-op: a resolution already on origin (a retried deploy, a
+// second Stop event for the same fixer) is nothing to carry, and reporting it as
+// published would claim work that did not happen.
+func TestPublishResolvedBranch_AlreadyPublishedIsNoOp(t *testing.T) {
+	requireGit(t)
+	ws, branch, resolved := resolvedBranchRepo(t)
+	if _, err := (forgeDeployer{}).PublishResolvedBranch(context.Background(), ws, branch); err != nil {
+		t.Fatalf("first publish: %v", err)
+	}
+
+	published, err := forgeDeployer{}.PublishResolvedBranch(context.Background(), ws, branch)
+	if err != nil {
+		t.Fatalf("re-publishing an already-published resolution must not error, got: %v", err)
+	}
+	if published {
+		t.Error("an already-published resolution must report published=false")
+	}
+	runGit(t, ws, "fetch", "origin")
+	if tip := runGit(t, ws, "rev-parse", "origin/"+branch); tip != resolved {
+		t.Errorf("origin/%s = %s, want it unchanged at %s", branch, tip, resolved)
+	}
+}
+
+// No local branch at all — the fixer never checked one out, or a foreign card's
+// branch — is nothing to publish, not a failure. The deploy proceeds on origin.
+func TestPublishResolvedBranch_NoLocalBranch(t *testing.T) {
+	requireGit(t)
+	ws, branch, _ := resolvedBranchRepo(t)
+	runGit(t, ws, "checkout", "main")
+	runGit(t, ws, "branch", "-D", branch)
+
+	published, err := forgeDeployer{}.PublishResolvedBranch(context.Background(), ws, branch)
+	if err != nil {
+		t.Fatalf("a missing local branch is not an error, got: %v", err)
+	}
+	if published {
+		t.Error("there is no local resolution to publish")
+	}
+}
+
+// The publish goes through pushBranch, so it inherits the
+// never-publish-behind-origin guard: a resolution that is strictly behind newer
+// origin work must be refused, not lease-pushed over it. Without this, carrying
+// the fixer's work would become a new way to lose someone else's.
+func TestPublishResolvedBranch_RefusesBehindOrigin(t *testing.T) {
+	requireGit(t)
+	ws, branch, resolved := resolvedBranchRepo(t)
+	// The resolution lands on origin, then origin gains newer work on top of it
+	// while the local ref stays frozen at the older resolved tip.
+	if _, err := (forgeDeployer{}).PublishResolvedBranch(context.Background(), ws, branch); err != nil {
+		t.Fatalf("seeding publish: %v", err)
+	}
+	write(t, ws, "later.txt", "later\n")
+	runGit(t, ws, "add", "later.txt")
+	runGit(t, ws, "commit", "-m", "newer work that must survive")
+	runGit(t, ws, "push", "origin", branch)
+	newTip := runGit(t, ws, "rev-parse", "HEAD")
+	runGit(t, ws, "reset", "--hard", resolved)
+
+	published, err := forgeDeployer{}.PublishResolvedBranch(context.Background(), ws, branch)
+	if err == nil {
+		t.Fatal("publishing a resolution behind origin must be refused")
+	}
+	if published {
+		t.Error("a refused publish must not report published=true")
+	}
+	if !strings.Contains(err.Error(), "newer work that must survive") {
+		t.Errorf("the refusal must name the commit it protected, got: %v", err)
+	}
+	runGit(t, ws, "fetch", "origin")
+	if tip := runGit(t, ws, "rev-parse", "origin/"+branch); tip != newTip {
+		t.Errorf("origin/%s = %s, want the preserved newer tip %s", branch, tip, newTip)
+	}
+}

--- a/internal/claude/embed/human-deploy-fix-skill.md
+++ b/internal/claude/embed/human-deploy-fix-skill.md
@@ -1,6 +1,6 @@
 ---
 name: human-deploy-fix
-description: Recover a failed deploy — dispatch the deploy fixer to rebase onto the base, resolve conflicts, fix failing CI, and push
+description: Recover a failed deploy — dispatch the deploy fixer to rebase onto the base, resolve conflicts, and fix failing CI on the branch
 argument-hint: <key> --pr=<number> --branch=<branch>
 ---
 
@@ -12,4 +12,4 @@ Run the fixer at the `sonnet` tier: recovering a deploy is visible-failure work 
 Task(subagent_type="human-deploy-fixer", model="sonnet", prompt="Recover the failed deploy of PR <number> for ticket <KEY> --branch=<branch>")
 ```
 
-The agent rebases the branch onto the base, resolves conflicts, fixes the failing lint/tests, pushes to the branch, and records its exit (`done | needs-input | needs-human-work`) in `stage.deploy-fix`. The daemon re-runs Deploy after a `done` and reds the card on anything else, so you do **not** post board markers or re-trigger Deploy yourself: run the agent and report what it changed.
+The agent rebases the branch onto the base, resolves conflicts, fixes the failing lint/tests, leaves the result on the local branch ref, and records its exit (`done | needs-input | needs-human-work`) in `stage.deploy-fix`. After a `done` the daemon publishes that branch with the host's credentials — the fixer's container has none — and re-runs Deploy; anything else reds the card. So you do **not** push, post board markers, or re-trigger Deploy yourself: run the agent and report what it changed.

--- a/internal/claude/embed/human-deploy-fixer-agent.md
+++ b/internal/claude/embed/human-deploy-fixer-agent.md
@@ -1,13 +1,13 @@
 ---
 name: human-deploy-fixer
-description: Recovers a failed deploy by rebasing the branch onto the base, resolving conflicts, fixing failing CI checks, and pushing to the PR branch
+description: Recovers a failed deploy by rebasing the branch onto the base, resolving conflicts, and fixing failing CI checks, leaving the result on the branch for the daemon to publish
 tools: Bash, Read, Grep, Glob, Write, Edit
 model: inherit
 ---
 
 # Human Deploy Fixer Agent
 
-You recover a **failed deploy** of an open pull request: the branch drifted behind the base and now conflicts, or its CI checks (lint/tests) fail. You rebase it current, resolve the conflicts, make CI green, and push. You are the deploy-stage sibling of the human-pr-fixer — that one answers review COMMENTS; you fix the deploy gate's mechanical failures.
+You recover a **failed deploy** of an open pull request: the branch drifted behind the base and now conflicts, or its CI checks (lint/tests) fail. You rebase it current, resolve the conflicts, and make CI green, leaving the result on the branch. You are the deploy-stage sibling of the human-pr-fixer — that one answers review COMMENTS; you fix the deploy gate's mechanical failures.
 
 ## Dispatch
 
@@ -31,7 +31,13 @@ gh run view <run-id> --log-failed
 2. **Rebase onto the base.** Rebase onto the PR's base branch: `git rebase origin/<baseRefName>`. Resolve every conflict with the smallest correct merge — keep BOTH sides' intent; a conflict is two changes to reconcile, not one to drop. `git rebase --continue` to completion. An already-current branch makes this a no-op.
 3. **Make CI green.** Reproduce the failing checks locally against the project's fast tier, scoped to the packages this change touches (the deploy CI gate runs the full suite). Fix the failures: a drifted API/signature, a broken call site, a stale test. If a fix changes behavior, pin it with a test.
 <!-- human:include build-gate -->
-4. **Commit & push.** Commit referencing the key (`human commits prefix <WORK_KEY>` for the subject prefix) and push the rebased branch with `git push --force-with-lease origin HEAD:<branch>`. A rebase rewrites history, so the push MUST be `--force-with-lease` (never a plain push, never `--force`). The push re-triggers the PR's CI and gives the deploy a current, green head to merge.
+4. **Commit & land the branch.** Commit referencing the key (`human commits prefix <WORK_KEY>` for the subject prefix), then make sure the rebased result is **on the local branch ref**, not on a detached HEAD: `git rev-parse --abbrev-ref HEAD` must print `<branch>`, and `git rev-parse <branch>` must be your rebased tip. That ref is your deliverable.
+
+## Why you do NOT push
+
+You have no push credentials in board context, and you do not need them. The daemon publishes your rebased branch with the host's credentials the moment you exit `done`, then re-runs Deploy on it — the same division of labour the pr-fixer relies on. A rebased **local** branch is the complete, expected deliverable: do not push, and never report failure for the inability to push.
+
+The one exception is a standalone run outside the board (you were invoked directly, not dispatched by the daemon) — there you own the publish: `git push --force-with-lease origin HEAD:<branch>`. A rebase rewrites history, so that push MUST be `--force-with-lease` (never a plain push, never `--force`).
 
 ## Convergence
 
@@ -47,9 +53,9 @@ human state set <WORK_KEY> stage.deploy-fix --json --body-file - <<'EOF'
 EOF
 ```
 
-- `done` — rebased current, the deploy-relevant checks pass locally, pushed; the daemon re-runs Deploy.
+- `done` — rebased current on the branch ref, the deploy-relevant checks pass locally; the daemon publishes the branch and re-runs Deploy. Record `"pushed":false` in board context — that is the expected shape, not a shortfall.
 - `needs-input` — a conflict or failure hinges on a decision only a human can make. State it and stop.
-- `needs-human-work` — the blocker is real and beyond an agent (an infra/secret the branch cannot change). Name it.
+- `needs-human-work` — the blocker is real and beyond an agent (an infra/secret the branch cannot change). Name it. A missing push credential is NOT such a blocker — see "Why you do NOT push".
 
 Do NOT use `AskUserQuestion` — you cannot interact with a human.
 

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -64,6 +64,15 @@ type Deployer interface {
 	// MarkReadyForReview converts the draft PR opened for the review loop to
 	// ready-for-review, so the adopted PR can merge once the machine review approves.
 	MarkReadyForReview(ctx context.Context, workspaceDir string, number int) error
+	// PublishResolvedBranch publishes a conflict resolution the deploy-fixer left
+	// on the LOCAL branch ref. Board agents hold no push credentials, so the
+	// daemon — which does — is what carries their work to the forge; without this
+	// the resolution is unreachable, because the deploy reads the branch from
+	// origin and would re-run the same conflicting rebase (SC-2845). It reports
+	// whether it published: a local ref that is absent, unchanged, or does not
+	// yet contain the base tip is no resolution, and is left for the deploy's own
+	// freshness rebase to handle.
+	PublishResolvedBranch(ctx context.Context, workspaceDir, branch string) (published bool, err error)
 }
 
 // PRRequest carries everything needed to push a branch and open its PR.
@@ -834,10 +843,10 @@ func unrecordedStepReason(stage PRLoopStage, outcome PRLoopOutcome, diagnose Boa
 
 // AdvanceDeployFix is the deploy-fixer's Stop-event driver. On the fixer's exit the
 // failure watcher calls it with the exit the agent recorded in stage.deploy-fix. A
-// `done` exit re-runs the deploy pipeline (the fixer rebased/fixed and pushed, so the
-// branch is ready for a fresh CI gate + merge); any other exit reds the card with a
-// terminal deploy-failed. The deployFixRounds budget already bounds how many times
-// the pipeline re-enters here, so a genuinely unfixable failure terminates.
+// `done` exit publishes the fixer's local resolution and re-runs the deploy pipeline
+// (the branch is then ready for a fresh CI gate + merge); any other exit reds the card
+// with a terminal deploy-failed. The deployFixRounds budget already bounds how many
+// times the pipeline re-enters here, so a genuinely unfixable failure terminates.
 func (d BoardTransitionDeps) AdvanceDeployFix(ctx context.Context, pmKey, fixExit string) error {
 	comments, err := d.Commenter.ListComments(ctx, pmKey)
 	if err != nil {
@@ -845,6 +854,18 @@ func (d BoardTransitionDeps) AdvanceDeployFix(ctx context.Context, pmKey, fixExi
 	}
 	card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
 	if fixExit == ExitDone {
+		// The fixer resolved the conflict in a container that holds no push
+		// credentials, exactly like every other board fixer — so its deliverable is
+		// the local branch, and publishing it is the daemon's job. Publishing before
+		// the deploy runs is what makes the resolution visible at all: the deploy
+		// reads the branch from origin (branchTip prefers the origin ref), so an
+		// unpublished resolution would be silently discarded and the same conflict
+		// re-hit (SC-2845).
+		if _, err := d.Deployer.PublishResolvedBranch(ctx, d.WorkspaceDir, card.Branch); err != nil {
+			return d.deployFailed(pmKey, "", deployReason(
+				"the deploy fixer's resolution could not be published to "+card.Branch+" — check the branch, then re-run Deploy",
+				err))
+		}
 		return d.DeployBranch(ctx, pmKey, pmKey, doneBody(pmKey, card), card.Branch)
 	}
 	_, _ = d.Commenter.AddComment(ctx, pmKey,

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -115,6 +115,22 @@ type fakeDeployer struct {
 	markedReady   int
 	markReadyErr  error
 	markReadyCall int
+	// published records the branches whose deploy-fixer resolution was carried to
+	// origin, and publishErr models a publish the host refused (a source behind
+	// origin) — the fixer's work is local, so an unpublished resolution is
+	// invisible to the deploy that follows.
+	published    []string
+	publishErr   error
+	publishCalls int
+}
+
+func (f *fakeDeployer) PublishResolvedBranch(_ context.Context, _, branch string) (bool, error) {
+	f.publishCalls++
+	if f.publishErr != nil {
+		return false, f.publishErr
+	}
+	f.published = append(f.published, branch)
+	return true, nil
 }
 
 func (f *fakeDeployer) PushAndCreatePR(_ context.Context, req PRRequest) (PRResult, error) {
@@ -1446,6 +1462,10 @@ func (f *gateProbeDeployer) BranchMerged(_ context.Context, _, _ string) bool { 
 
 func (f *gateProbeDeployer) MarkReadyForReview(_ context.Context, _ string, _ int) error { return nil }
 
+func (f *gateProbeDeployer) PublishResolvedBranch(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+
 func TestDeploysQueueOneAtATime(t *testing.T) {
 	// Regression (SC-296): the Deploy button ships every ready fix at once.
 	// Concurrent pipelines race the mainline — the first merge moves the base
@@ -1931,8 +1951,9 @@ func TestDeployBranch_FixerLaunchError_Reds(t *testing.T) {
 	assert.Greater(t, failedIdx, startedIdx, "the deploy-failed marker follows the deploy-fix-started marker")
 }
 
-// On the fixer's `done` exit the deploy re-runs end to end — the fixer rebased,
-// fixed and pushed, so the branch is ready for a fresh CI gate + merge.
+// On the fixer's `done` exit the deploy re-runs end to end — the fixer rebased
+// and fixed on the local branch, the daemon publishes it, and it is ready for a
+// fresh CI gate + merge.
 func TestAdvanceDeployFix_Done_RerunsDeploy(t *testing.T) {
 	syncDeploy(t)
 	c := &fakeCommenter{comments: deployFixReadyComments()}
@@ -1951,6 +1972,65 @@ func TestAdvanceDeployFix_Done_RerunsDeploy(t *testing.T) {
 		assert.False(t, strings.HasPrefix(b, DeployFailedHeader), "a done exit must not red the card: %q", b)
 	}
 	require.NotEmpty(t, deployed, "the re-run deploy posts the deployed marker")
+}
+
+// The fixer resolves the conflict in a container that holds no push credentials,
+// so its deliverable is the LOCAL branch: the daemon must carry it to origin
+// before re-running the deploy. Without this the deploy re-reads the unresolved
+// origin tip and hits the identical conflict, discarding the finished work
+// (SC-2845 — the failure mode that stranded a resolved branch for a human).
+func TestAdvanceDeployFix_Done_PublishesResolutionBeforeDeploy(t *testing.T) {
+	syncDeploy(t)
+	c := &fakeCommenter{comments: deployFixReadyComments()}
+	p := &fakeDeployer{res: PRResult{URL: "https://example/pr/13", Number: 13},
+		checks: []forge.ChecksState{forge.ChecksPassing}}
+	deps := newDeps(c, &fakeLauncher{}, p)
+	require.NoError(t, deps.AdvanceDeployFix(context.Background(), "SC-1", ExitDone))
+	assert.Equal(t, []string{"feat/x"}, p.published,
+		"the fixer's local resolution must be published to the card's branch")
+	assert.Equal(t, 1, p.publishCalls, "the resolution is published exactly once per done exit")
+}
+
+// A publish the host refuses (the never-publish-behind-origin guard, an
+// unreadable ref) must red the card with the reason and NOT deploy: deploying
+// anyway would merge the unresolved origin tip the fixer was dispatched to fix.
+// It also pins the ordering — publish happens before the deploy, not after.
+func TestAdvanceDeployFix_PublishFails_RedsWithoutDeploying(t *testing.T) {
+	syncDeploy(t)
+	c := &fakeCommenter{comments: deployFixReadyComments()}
+	// Wired to deploy cleanly if it were reached — so a regression that deploys
+	// past a failed publish fails on the assertions below, not on a panic.
+	p := &fakeDeployer{res: PRResult{URL: "https://example/pr/13", Number: 13},
+		checks:     []forge.ChecksState{forge.ChecksPassing},
+		publishErr: errors.New("refusing to publish feat/x: the source is behind origin")}
+	deps := newDeps(c, &fakeLauncher{}, p)
+	err := deps.AdvanceDeployFix(context.Background(), "SC-1", ExitDone)
+	require.Error(t, err, "an unpublishable resolution is a deploy failure")
+	assert.Zero(t, p.call, "a failed publish must not open or re-gate a pull request")
+	assert.Zero(t, p.merged, "a failed publish must never reach the merge")
+
+	var failed string
+	for _, b := range c.added {
+		if strings.HasPrefix(b, DeployFailedHeader) {
+			failed = b
+		}
+	}
+	require.NotEmpty(t, failed, "the card reds when the resolution cannot be published")
+	assert.Contains(t, failed, "could not be published to feat/x")
+	assert.Contains(t, failed, "behind origin", "the marker carries the host's reason")
+}
+
+// Only a done exit has a resolution to carry: a fixer that stopped for a human
+// left nothing publishable, and publishing on its behalf would ship whatever
+// half-finished state its branch happens to hold.
+func TestAdvanceDeployFix_NonDoneExit_PublishesNothing(t *testing.T) {
+	for _, exit := range []string{ExitNeedsInput, ExitNeedsHumanWork, ""} {
+		c := &fakeCommenter{comments: deployFixReadyComments()}
+		p := &fakeDeployer{}
+		deps := newDeps(c, &fakeLauncher{}, p)
+		require.NoError(t, deps.AdvanceDeployFix(context.Background(), "SC-1", exit))
+		assert.Zero(t, p.publishCalls, "exit %q must not publish a branch", exit)
+	}
 }
 
 // A non-done fixer exit reds the card with an actionable, exit-specific reason.


### PR DESCRIPTION
## Problem

A deploy blocked by a merge conflict dispatches the deploy fixer, which resolves it correctly — and then the card reds with "the deploy failure needs manual work the fixer could not do". Observed on SC-2555, twice on the same card; recovering it by hand meant publishing a branch the machine had already finished.

The recovery path could never succeed on the board, for two reasons that close the loop on each other:

- The fixer's contract made **pushing** the only way to hand its work over, but board containers hold no push credentials by design — the convention every sibling fixer encodes explicitly ("Why you do NOT push"). So it always exited `needs-human-work` for a credential it is never given.
- Even a `done` exit would not have helped: the deploy reads the branch from **origin** (`branchTip` prefers the origin ref), so the resolution sitting on the local ref would have been silently discarded and the same conflict re-hit.

Fixing only the prompt would have been a silent half-fix.

## Change

- **`PublishResolvedBranch`** on the deployer: on a `done` exit the daemon carries the fixer's local branch ref to origin before re-running the deploy, using the credentials it already holds. It goes through the existing `pushBranch`, inheriting the lease and the never-publish-behind-origin guard.
- **Only a genuine resolution is published** — a ref that is absent, unchanged, or does not yet contain the base tip is left for the deploy's own freshness rebase, so a fixer that reported done without rebasing cannot make the daemon ship an unexamined tip.
- **A refused publish reds the card** with the host's reason instead of merging the tip the fixer was dispatched to fix.
- **The fixer prompt** gets the board-context clause its siblings carry: the local branch is the deliverable, a missing push credential is not a blocker. A standalone run outside the board still owns its own lease push.

## Verification

`make check` green. New tests fail before the change and pass after:

- `internal/daemon` — the resolution is published before the deploy; a failed publish reds without opening or merging a PR; non-`done` exits publish nothing.
- `cmd/cmddaemon` — real-git coverage of the stranded-resolution case, an unresolved local ref left untouched, re-entry as a no-op, no local branch, and the behind-origin refusal naming the commit it protected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)