### PR TITLE
[SC-2849] Render an issue's relations and labels when reading it

### DIFF
--- a/cmd/cmdprovider/provider.go
+++ b/cmd/cmdprovider/provider.go
@@ -388,12 +388,54 @@ func RunGetIssue(ctx context.Context, p tracker.Provider, out io.Writer, key str
 	if issue.ParentKey != "" {
 		_, _ = fmt.Fprintf(out, "| Parent   | %s |\n", issue.ParentKey)
 	}
+	writeLinkRows(out, issue.Links)
+	if len(issue.Labels) > 0 {
+		_, _ = fmt.Fprintf(out, "| Labels   | %s |\n", strings.Join(issue.Labels, ", "))
+	}
 
 	if issue.Description != "" {
 		_, _ = fmt.Fprintf(out, "\n## Description\n\n%s", issue.Description)
 	}
 
 	return nil
+}
+
+// writeLinkRows renders an issue's relationships as three separate rows.
+// Blocked-by, blocks and related are kept apart rather than listed together
+// because that is the distinction the link model calls load-bearing: only a
+// directional link can say one piece of work must finish before another starts,
+// and a reader who cannot tell "waits for" from "is waited on" learns nothing
+// actionable from the row. Direction is already resolved at the provider
+// boundary (tracker.IssueLink.Inbound), so this never re-derives it.
+//
+// Rows are emitted only when non-empty, following the Parent row: a backend
+// that does not report links renders nothing, which the model documents as a
+// correct answer rather than a gap. Nothing here fetches — it prints what
+// GetIssue already returned.
+func writeLinkRows(out io.Writer, links []tracker.IssueLink) {
+	var blockedBy, blocks, related []string
+	for _, l := range links {
+		switch {
+		case l.Kind == tracker.LinkBlocks && l.Inbound:
+			blockedBy = append(blockedBy, l.Key)
+		case l.Kind == tracker.LinkBlocks:
+			blocks = append(blocks, l.Key)
+		case l.Kind == tracker.LinkRelated:
+			related = append(related, l.Key)
+		}
+	}
+	for _, row := range []struct {
+		label string
+		keys  []string
+	}{
+		{"Blocked by", blockedBy},
+		{"Blocks", blocks},
+		{"Related", related},
+	} {
+		if len(row.keys) > 0 {
+			_, _ = fmt.Fprintf(out, "| %-8s | %s |\n", row.label, strings.Join(row.keys, ", "))
+		}
+	}
 }
 
 // RunCreateIssue creates a new issue. When parent is non-empty, the issue is

--- a/cmd/cmdprovider/provider_test.go
+++ b/cmd/cmdprovider/provider_test.go
@@ -243,6 +243,78 @@ func TestRunGetIssue_WithParent(t *testing.T) {
 	assert.Contains(t, buf.String(), "| Parent   | KAN-1 |")
 }
 
+// Relationships are fetched into the issue on every backend that reports them
+// and were then dropped at the last step, so a reader — and every pipeline
+// agent, whose first command is `human get` — could not see that a ticket was
+// blocked or that a sibling covered the same ground.
+func TestRunGetIssue_RendersLinksByDirection(t *testing.T) {
+	p := &mockProvider{
+		getIssueFn: func(_ context.Context, _ string) (*tracker.Issue, error) {
+			return &tracker.Issue{
+				Key:    "KAN-7",
+				Title:  "Linked",
+				Status: "To Do",
+				Links: []tracker.IssueLink{
+					{Key: "KAN-1", Kind: tracker.LinkBlocks, Inbound: true},
+					{Key: "KAN-2", Kind: tracker.LinkBlocks},
+					{Key: "KAN-3", Kind: tracker.LinkRelated},
+					{Key: "KAN-4", Kind: tracker.LinkRelated},
+					{Key: "KAN-5", Kind: tracker.LinkBlocks, Inbound: true},
+				},
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, RunGetIssue(context.Background(), p, &buf, "KAN-7"))
+
+	out := buf.String()
+	// The three kinds stay apart: only a directional link says one piece of work
+	// must finish first, and a reader who cannot tell "waits for" from "is waited
+	// on" learns nothing actionable.
+	assert.Contains(t, out, "| Blocked by | KAN-1, KAN-5 |")
+	assert.Contains(t, out, "| Blocks   | KAN-2 |")
+	assert.Contains(t, out, "| Related  | KAN-3, KAN-4 |")
+}
+
+// A backend that reports no links renders no link rows at all — the model
+// documents an empty Links as a correct answer, not a gap, so an empty
+// "Related" row would invent a distinction the tracker never made.
+func TestRunGetIssue_NoLinksRendersNoLinkRows(t *testing.T) {
+	p := &mockProvider{
+		getIssueFn: func(_ context.Context, _ string) (*tracker.Issue, error) {
+			return &tracker.Issue{Key: "KAN-8", Title: "Unlinked", Status: "To Do"}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, RunGetIssue(context.Background(), p, &buf, "KAN-8"))
+
+	out := buf.String()
+	assert.NotContains(t, out, "Blocked by")
+	assert.NotContains(t, out, "| Blocks")
+	assert.NotContains(t, out, "| Related")
+}
+
+// Labels classify a ticket — an idea carries the idea label — so dropping them
+// meant `human get` could not show why a ticket sits where it does.
+func TestRunGetIssue_RendersLabels(t *testing.T) {
+	p := &mockProvider{
+		getIssueFn: func(_ context.Context, _ string) (*tracker.Issue, error) {
+			return &tracker.Issue{
+				Key:    "KAN-9",
+				Title:  "Labelled",
+				Status: "To Do",
+				Labels: []string{"human/idea", "ui"},
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, RunGetIssue(context.Background(), p, &buf, "KAN-9"))
+	assert.Contains(t, buf.String(), "| Labels   | human/idea, ui |")
+}
+
 func TestRunGetIssue_Error(t *testing.T) {
 	p := &mockProvider{
 		getIssueFn: func(_ context.Context, _ string) (*tracker.Issue, error) {


### PR DESCRIPTION
## Problem

`human get <KEY>` prints status, priority, people, parent and description — and drops the issue's relations and labels, even though both arrive with the issue and the link direction is already resolved at the provider boundary (`tracker.IssueLink.Inbound`). Shortcut populates `Links` on every `GetIssue`; the renderer simply had no row for it.

That blindness is the starting condition for the whole pipeline, since reading the issue is the first command every agent runs: blocked work reads as ready, a ticket whose sibling already covers the ground reads as novel, and the label that classifies a raw idea as an idea is invisible.

## Change

- Three separate rows — `Blocked by`, `Blocks`, `Related` — rather than one list. Only a directional link says one piece of work must finish before another starts, and a reader who cannot tell "waits for" from "is waited on" learns nothing actionable. Direction is read from `Inbound`, never re-derived.
- A `Labels` row.
- Rows are emitted only when non-empty, following the existing `Parent` row, so a backend that reports no links renders nothing — which the model documents as a correct answer rather than a gap.
- No new fetching. This prints what `GetIssue` already returned.

## Verification

`make check` green. Three new tests in `cmd/cmdprovider`: links grouped by direction (including two inbound blockers rendered as one row), no link rows at all when `Links` is empty, and labels rendered.

Note: `human get` executes inside the daemon, so the new rows appear once the daemon is rebuilt and restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)