### PR TITLE
[SC-2858] Start every fresh ideation session from a captured idea

### DIFF
--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -2633,7 +2633,16 @@ async function sendIdeationReply(text) {
     startIdeationPoll();
     try {
         if (isFresh) {
-            ideation = await go().StartIdeation(text, ideationMode ?? "chat", restart, "", []);
+            // SC-2858: every fresh session — however the panel was opened (Product
+            // "+", post-import "Create first ticket", rail nav "new ticket") — must
+            // start from a captured idea, never a ticket created outright. The
+            // seed text becomes the idea's title, then the same conversation
+            // continues in evolve mode against that freshly captured ticket,
+            // mirroring the Ideas-column promotion path (promoteIdea) rather than
+            // duplicating it. The idea marker stays on the ticket until the
+            // conversation's terminal action (evolveTicket) removes it.
+            const ideaKey = await go().CreateIdea(text);
+            ideation = await go().StartIdeation(text, ideationMode ?? "chat", restart, ideaKey, []);
         }
         else {
             ideation = await go().ReplyIdeation(ideation.sessionId, text);

--- a/desktop/frontend/scripts/idea-first-ideation.test.mjs
+++ b/desktop/frontend/scripts/idea-first-ideation.test.mjs
@@ -1,0 +1,73 @@
+// Regression guard for SC-2858: every fresh ideation session — however the
+// panel was opened (Product "+", post-import "Create first ticket", rail nav
+// "new ticket") — must capture an idea first and continue in evolve mode,
+// rather than creating a finished ticket outright. The frontend is
+// intentionally dependency-free (no DOM test runner), so this asserts the
+// source wiring rather than rendering, like ideation-done.test.mjs.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const ts = readFileSync(resolve(here, "..", "src", "board.ts"), "utf8");
+
+function functionBody(source, signature) {
+  const start = source.indexOf(signature);
+  assert.ok(start >= 0, `${signature} must exist`);
+  const fn = source.slice(start);
+  return fn.slice(0, fn.indexOf("\n}"));
+}
+
+const sendIdeationReplyBody = functionBody(ts, "async function sendIdeationReply");
+
+test("fresh sessions capture an idea before starting the conversation (SC-2858)", () => {
+  assert.match(
+    sendIdeationReplyBody,
+    /const ideaKey = await go\(\)\.CreateIdea\(text\)/,
+    "a fresh session must call CreateIdea with the seed text before starting the conversation",
+  );
+});
+
+test("the captured idea key is passed as StartIdeation's evolveKey (SC-2858)", () => {
+  assert.match(
+    sendIdeationReplyBody,
+    /StartIdeation\(text,\s*ideationMode \?\? "chat",\s*restart,\s*ideaKey,\s*\[\]\)/,
+    "StartIdeation must be called in evolve mode against the freshly captured idea",
+  );
+});
+
+test("no remaining direct-create call passes an empty evolveKey (SC-2858)", () => {
+  assert.doesNotMatch(
+    sendIdeationReplyBody,
+    /StartIdeation\([^)]*,\s*""\s*,\s*\[\]\)/,
+    "a future edit must not silently reintroduce the direct-create (empty evolveKey) path",
+  );
+});
+
+test("promoteIdea (the existing Ideas-column path) is untouched", () => {
+  const body = functionBody(ts, "async function promoteIdea");
+  assert.match(
+    body,
+    /StartIdeation\(seed,\s*"guided",\s*true,\s*card\.key,\s*card\.labels\s*\?\?\s*\[\]\)/,
+    "the drag-to-promote flow must still call StartIdeation directly with the card's own key/labels",
+  );
+});
+
+test("CreateIdea failure is caught the same way as a StartIdeation failure", () => {
+  const tryStart = sendIdeationReplyBody.indexOf("try {");
+  const catchStart = sendIdeationReplyBody.indexOf("} catch (err) {", tryStart);
+  assert.ok(tryStart >= 0 && catchStart > tryStart, "sendIdeationReply must have a try/catch block");
+  const tryBlock = sendIdeationReplyBody.slice(tryStart, catchStart);
+  assert.match(tryBlock, /go\(\)\.CreateIdea\(/, "CreateIdea must be called inside the try block");
+  assert.match(tryBlock, /go\(\)\.StartIdeation\(/, "StartIdeation must be called inside the same try block");
+
+  const catchBlock = sendIdeationReplyBody.slice(
+    catchStart,
+    sendIdeationReplyBody.indexOf("}", sendIdeationReplyBody.indexOf("return;", catchStart)) + 1,
+  );
+  assert.match(catchBlock, /renderIdeationError\(errMessage\(err\)\)/);
+  assert.match(catchBlock, /stopIdeationPoll\(\)/);
+  assert.match(catchBlock, /return;/);
+});

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -3101,7 +3101,16 @@ async function sendIdeationReply(text: string): Promise<void> {
 
   try {
     if (isFresh) {
-      ideation = await go().StartIdeation(text, ideationMode ?? "chat", restart, "", []);
+      // SC-2858: every fresh session — however the panel was opened (Product
+      // "+", post-import "Create first ticket", rail nav "new ticket") — must
+      // start from a captured idea, never a ticket created outright. The
+      // seed text becomes the idea's title, then the same conversation
+      // continues in evolve mode against that freshly captured ticket,
+      // mirroring the Ideas-column promotion path (promoteIdea) rather than
+      // duplicating it. The idea marker stays on the ticket until the
+      // conversation's terminal action (evolveTicket) removes it.
+      const ideaKey = await go().CreateIdea(text);
+      ideation = await go().StartIdeation(text, ideationMode ?? "chat", restart, ideaKey, []);
     } else {
       ideation = await go().ReplyIdeation(ideation.sessionId!, text);
     }

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -111,23 +111,32 @@ The desktop artifact must never be published through a goreleaser `builds:` entr
 
 ## Creating tickets — ideation chat
 
-The Backlog column header shows a '+' button. Clicking it opens a chat-style
-panel docked to the right side of the board. (The idea space has its own
-lighter '+': it quick-captures a title-only ticket labeled `human/idea` into
-its leftmost sub-column, no
-chat involved; dragging that idea card onto Backlog opens this same panel in
-**evolve mode**, whose terminal action rewrites the idea ticket in place —
-title and description replaced, idea label removed, key preserved — instead of
-creating a new ticket.) Typing a seed idea starts a
-daemon-side ideation agent: the daemon runs headless `claude -p` turns on the
-daemon host (`--resume`d per reply, so multi-turn context comes from Claude
-Code's own session store), asking one challenge question per turn until it is
+The Backlog column header shows a '+' button, the post-project-import
+"Create first ticket" prompt, and the left rail's "new ticket" action all
+open the same chat-style panel docked to the right side of the board. (The
+idea space has its own lighter '+': it quick-captures a title-only ticket
+labeled `human/idea` into its leftmost sub-column, no chat involved; dragging
+that idea card onto Backlog opens this same panel in **evolve mode**, whose
+terminal action rewrites the idea ticket in place — title and description
+replaced, idea label removed, key preserved — instead of creating a new
+ticket.) Every fresh session opened from any of these entry points follows
+the same idea-first path (SC-2858): the seed text first quick-captures a
+title-only idea ticket (exactly what the idea space's own '+' does), then the
+same conversation continues against that ticket in evolve mode — so a ticket
+that started as a chat carries the idea marker exactly as long as one started
+by dragging an idea card, and there is no UI path left that creates a
+finished ticket outright. Typing a seed idea starts a daemon-side ideation
+agent: the daemon runs headless `claude -p` turns on the daemon host
+(`--resume`d per reply, so multi-turn context comes from Claude Code's own
+session store), asking one challenge question per turn until it is
 confident, then emits a structured `[human:ideation-ticket]` block that the
-daemon parses and uses to create the PM ticket via the tracker `Creator`
-abstraction, on the single PM-role tracker (resolved by role, the same way the
-board's `Cards()` resolves `firstPMResult`). The new card then appears in the
-Backlog column through the existing subscribe/refetch loop — no bespoke
-refresh path is added for ideation.
+daemon parses and uses to rewrite the captured idea ticket in place via the
+tracker `Editor` abstraction (evolve mode), removing the idea label. The
+underlying direct-create path (`creator.CreateIssue`, no idea stage) still
+exists in the daemon engine and is used by non-UI callers such as the
+command-line tool — the desktop UI simply never reaches it anymore. The
+updated card then appears in the Backlog column through the existing
+subscribe/refetch loop — no bespoke refresh path is added for ideation.
 
 The panel talks to three dedicated daemon routes — `ideation-start`,
 `ideation-reply`, `ideation-status` — each taking a single JSON argument and


### PR DESCRIPTION
## Summary
- The Product "+" button, the post-import "Create first ticket" prompt, and the rail nav's "new ticket" action all funnel into `sendIdeationReply`'s shared fresh-session branch, which used to call `StartIdeation` with an empty `evolveKey` and create a finished ticket outright — unlike the Ideas-column drag-to-promote path.
- That branch now calls `CreateIdea` first, then continues in evolve mode against the freshly captured idea, so every UI entry point that produces a ticket passes through the idea stage. `promoteIdea` (existing Ideas-column path) and the daemon's non-UI direct-create path (used by the CLI) are both untouched.
- Docs updated (`docs/desktop-app.md`) to describe the new idea-first flow for all three entry points.

## Test plan
- [x] `npm run build` (tsc + bundle) — clean
- [x] `npm test` — 141/141 passing, including 5 new regression tests in `idea-first-ideation.test.mjs`
- [x] `go build ./...`, `go vet ./...` — clean
- [x] Full Go test suite — passing (pre-existing local `internal/chrome` timing flakiness reproduced identically on a clean main checkout, unrelated to this change)
- [x] `golangci-lint run ./...` — clean in isolation (intermittent pre-existing SA5011 findings in `cmd/cmdagent` / `internal/agent` tied to `GOEXPERIMENT=runtimesecret`, reproduced identically on a clean main checkout, unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)