### PR TITLE
[SC-3051] A ticket filed under the wrong kind can never be corrected

### DIFF
--- a/cmd/cmdprovider/provider.go
+++ b/cmd/cmdprovider/provider.go
@@ -157,18 +157,20 @@ func buildPRCreateCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 }
 
 func buildIssueEditCmd(kind string, deps cmdutil.Deps) *cobra.Command {
-	var title, description string
+	var title, description, issueType string
 	var addLabels, removeLabels []string
 
 	cmd := &cobra.Command{
-		Use:     "edit KEY",
-		Short:   "Edit an issue's title, description, and/or labels",
-		Example: `  human jira issue edit KAN-1 --title "New title" --remove-label human/idea`,
-		Args:    cobra.ExactArgs(1),
+		Use:   "edit KEY",
+		Short: "Edit an issue's title, description, type, and/or labels",
+		Example: `  human jira issue edit KAN-1 --title "New title" --remove-label human/idea
+  human shortcut issue edit SC-1 --type Bug     # retype product work as a defect
+  human shortcut issue edit SC-1 --type Feature # and back again`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !cmd.Flags().Changed("title") && !cmd.Flags().Changed("description") &&
-				len(addLabels) == 0 && len(removeLabels) == 0 {
-				return errors.WithDetails("at least one of --title, --description, --add-label, or --remove-label is required")
+				!cmd.Flags().Changed("type") && len(addLabels) == 0 && len(removeLabels) == 0 {
+				return errors.WithDetails("at least one of --title, --description, --type, --add-label, or --remove-label is required")
 			}
 			p, cleanup, err := cmdutil.ResolveProvider(cmd, kind, deps)
 			if err != nil {
@@ -183,12 +185,16 @@ func buildIssueEditCmd(kind string, deps cmdutil.Deps) *cobra.Command {
 			if cmd.Flags().Changed("description") {
 				opts.Description = &description
 			}
+			if cmd.Flags().Changed("type") {
+				opts.Type = &issueType
+			}
 
 			return RunEditIssue(cmd.Context(), p, cmd.OutOrStdout(), args[0], opts)
 		},
 	}
 	cmd.Flags().StringVar(&title, "title", "", "New issue title")
 	cmd.Flags().StringVar(&description, "description", "", "New issue description (markdown)")
+	cmd.Flags().StringVar(&issueType, "type", "", "New issue type (e.g. Task, Bug) — retypes the issue; Bug maps to every tracker's native defect marker")
 	cmd.Flags().StringArrayVar(&addLabels, "add-label", nil, "Label to add (repeatable)")
 	cmd.Flags().StringArrayVar(&removeLabels, "remove-label", nil, "Label to remove (repeatable; absent labels are ignored)")
 	return cmd
@@ -385,6 +391,14 @@ func RunGetIssue(ctx context.Context, p tracker.Provider, out io.Writer, key str
 	_, _ = fmt.Fprintf(out, "| Priority | %s |\n", displayOrNone(issue.Priority))
 	_, _ = fmt.Fprintf(out, "| Assignee | %s |\n", displayOrNone(issue.Assignee))
 	_, _ = fmt.Fprintf(out, "| Reporter | %s |\n", displayOrNone(issue.Reporter))
+	// The kind decides which pipeline picks the ticket up, so it has to be
+	// readable: a mistyped ticket used to be discoverable only when the wrong
+	// pipeline started work on it (SC-3051). Omitted when the tracker reports
+	// none rather than printed as "None", so trackers that carry no type add no
+	// empty row.
+	if issue.Type != "" {
+		_, _ = fmt.Fprintf(out, "| Type     | %s |\n", issue.Type)
+	}
 	if issue.ParentKey != "" {
 		_, _ = fmt.Fprintf(out, "| Parent   | %s |\n", issue.ParentKey)
 	}

--- a/cmd/cmdprovider/provider_test.go
+++ b/cmd/cmdprovider/provider_test.go
@@ -182,6 +182,7 @@ func TestRunGetIssue_Success(t *testing.T) {
 				Priority:    "High",
 				Assignee:    "alice",
 				Reporter:    "bob",
+				Type:        "Bug",
 				Description: "This is the description.",
 			}, nil
 		},
@@ -197,6 +198,9 @@ func TestRunGetIssue_Success(t *testing.T) {
 	assert.Contains(t, out, "| Priority | High |")
 	assert.Contains(t, out, "| Assignee | alice |")
 	assert.Contains(t, out, "| Reporter | bob |")
+	// The kind decides which pipeline picks the ticket up, so reading a ticket
+	// has to show it — a mistyped ticket used to be invisible (SC-3051).
+	assert.Contains(t, out, "| Type     | Bug |")
 	assert.Contains(t, out, "## Description")
 	assert.Contains(t, out, "This is the description.")
 }
@@ -1099,6 +1103,50 @@ func TestCmd_IssueEdit_Success(t *testing.T) {
 	assert.Contains(t, buf.String(), "KAN-1")
 }
 
+// Retyping is what makes a mistyped ticket recoverable at all, so --type has to
+// reach the provider on its own — with no other flag alongside it (SC-3051).
+func TestCmd_IssueEdit_TypeAlone(t *testing.T) {
+	var got tracker.EditOptions
+	mp := &mockProvider{
+		editIssueFn: func(_ context.Context, key string, opts tracker.EditOptions) (*tracker.Issue, error) {
+			assert.Equal(t, "KAN-1", key)
+			got = opts
+			return &tracker.Issue{Key: "KAN-1", Title: "T", Type: "Bug"}, nil
+		},
+	}
+	root, _ := newTestRoot(mp)
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetArgs([]string{"jira", "issue", "edit", "KAN-1", "--type", "Bug"})
+	require.NoError(t, root.Execute())
+
+	require.NotNil(t, got.Type)
+	assert.Equal(t, "Bug", *got.Type)
+	assert.Nil(t, got.Title, "a retype must not carry a title the user never gave")
+	assert.Nil(t, got.Description)
+}
+
+// An edit that does not mention the kind must never change it: nil is the
+// difference between "leave it alone" and "make it the empty type".
+func TestCmd_IssueEdit_TypeUnsetLeavesTheKindAlone(t *testing.T) {
+	var got tracker.EditOptions
+	mp := &mockProvider{
+		editIssueFn: func(_ context.Context, _ string, opts tracker.EditOptions) (*tracker.Issue, error) {
+			got = opts
+			return &tracker.Issue{Key: "KAN-1", Title: "New title"}, nil
+		},
+	}
+	root, _ := newTestRoot(mp)
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetArgs([]string{"jira", "issue", "edit", "KAN-1", "--title", "New title"})
+	require.NoError(t, root.Execute())
+
+	assert.Nil(t, got.Type)
+}
+
 func TestCmd_IssueEdit_NoFlags(t *testing.T) {
 	mp := &mockProvider{}
 	root, _ := newTestRoot(mp)
@@ -1107,7 +1155,7 @@ func TestCmd_IssueEdit_NoFlags(t *testing.T) {
 	root.SetArgs([]string{"jira", "issue", "edit", "KAN-1"})
 	err := root.Execute()
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "at least one of --title, --description, --add-label, or --remove-label is required")
+	assert.Contains(t, err.Error(), "at least one of --title, --description, --type, --add-label, or --remove-label is required")
 }
 
 func TestCmd_IssueDelete_Success(t *testing.T) {

--- a/internal/tracker/azuredevops/client.go
+++ b/internal/tracker/azuredevops/client.go
@@ -175,14 +175,7 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 		return nil, errors.WrapWithDetails(err, "marshalling create request", "project", project)
 	}
 
-	// Azure's native defect marker is the work item type itself: bug-typed
-	// issues must be created as $Bug, not as a tagged $Issue, or they lose
-	// their place in Azure's own bug tracking (queries, boards, rules).
-	witType := "Issue"
-	if tracker.IsBugType(issue.Type) {
-		witType = "Bug"
-	}
-	path := fmt.Sprintf("/%s/%s/_apis/wit/workitems/$%s", url.PathEscape(c.org), url.PathEscape(project), url.PathEscape(witType))
+	path := fmt.Sprintf("/%s/%s/_apis/wit/workitems/$%s", url.PathEscape(c.org), url.PathEscape(project), url.PathEscape(adoWorkItemType(issue.Type)))
 	resp, err := c.doRequest(ctx, http.MethodPost, path, "api-version=7.1", bytes.NewReader(body), "application/json-patch+json")
 	if err != nil {
 		return nil, err
@@ -201,6 +194,19 @@ func (c *Client) CreateIssue(ctx context.Context, issue *tracker.Issue) (*tracke
 		ParentKey:   issue.ParentKey,
 		Labels:      splitTags(wi.Fields.Tags),
 	}, nil
+}
+
+// adoWorkItemType maps a provider-agnostic issue type onto Azure DevOps' own
+// work item type. Azure's native defect marker is the type itself: a bug must
+// be a Bug, not a tagged Issue, or it loses its place in Azure's bug tracking
+// (queries, boards, rules). Everything else is an Issue, Azure's ordinary work
+// item. Shared by create (which names the type in the URL) and retype (which
+// patches the same value as a field), so the two can never disagree.
+func adoWorkItemType(issueType string) string {
+	if tracker.IsBugType(issueType) {
+		return "Bug"
+	}
+	return "Issue"
 }
 
 // adoCategoryToType maps an Azure DevOps state category to a tracker.Category.
@@ -341,6 +347,15 @@ func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOpt
 	}
 	if opts.Description != nil {
 		ops = append(ops, patchOp{Op: "replace", Path: "/fields/System.Description", Value: *opts.Description})
+	}
+	// The work item type is chosen in the URL at create time but is an ordinary
+	// field afterwards, so a retype is a patch on System.WorkItemType. The same
+	// bug-token normalisation create uses applies, so "bug" in any spelling
+	// reaches Azure DevOps as its native "Bug". A move Azure DevOps will not
+	// make (across process templates, say) is refused by the API and that
+	// refusal is returned unchanged — never swallowed into a false success.
+	if opts.Type != nil {
+		ops = append(ops, patchOp{Op: "add", Path: "/fields/System.WorkItemType", Value: adoWorkItemType(*opts.Type)})
 	}
 	// System.Tags has no per-tag patch semantics — "add" on a field path
 	// overwrites the whole value — so the live tag set is read and merged

--- a/internal/tracker/azuredevops/retype_test.go
+++ b/internal/tracker/azuredevops/retype_test.go
@@ -1,0 +1,81 @@
+package azuredevops
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// Azure DevOps chooses the work item type in the URL at create time, but it is
+// an ordinary field afterwards — so a retype is a patch on System.WorkItemType
+// carrying the same value create would have used (SC-3051).
+func TestEditIssue_retypePatchesWorkItemType(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		asked    string
+		wantWire string
+	}{
+		{name: "product work becomes a bug", asked: "Bug", wantWire: "Bug"},
+		{name: "a spelling variant still reaches Azure's own marker", asked: "type:bug", wantWire: "Bug"},
+		{name: "a bug becomes ordinary work", asked: "Task", wantWire: "Issue"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotOps []patchOp
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPatch {
+					body, err := io.ReadAll(r.Body)
+					require.NoError(t, err)
+					require.NoError(t, json.Unmarshal(body, &gotOps))
+				}
+				_, _ = fmt.Fprintf(w, `{"id":5,"fields":{"System.Title":"Item","System.State":"New","System.WorkItemType":%q,"System.TeamProject":"Human"}}`, tc.wantWire)
+			}))
+			defer srv.Close()
+
+			client := New(srv.URL, "myorg", "pat-test")
+			issue, err := client.EditIssue(context.Background(), "Human/5", tracker.EditOptions{Type: &tc.asked})
+
+			require.NoError(t, err)
+			require.Len(t, gotOps, 1, "a retype is exactly one field patch")
+			assert.Equal(t, "/fields/System.WorkItemType", gotOps[0].Path)
+			assert.Equal(t, tc.wantWire, gotOps[0].Value)
+			assert.Equal(t, tc.wantWire, issue.Type)
+		})
+	}
+}
+
+// A retype alone must not drag the tag set through a read-modify-write: tags
+// are a different field and an untouched one must stay untouched.
+func TestEditIssue_retypeLeavesTagsAlone(t *testing.T) {
+	var gotOps []patchOp
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			t.Error("a retype must not fetch the work item for tag merging")
+		}
+		if r.Method == http.MethodPatch {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &gotOps))
+		}
+		_, _ = fmt.Fprint(w, `{"id":5,"fields":{"System.Title":"Item","System.State":"New","System.WorkItemType":"Bug","System.TeamProject":"Human","System.Tags":"alpha"}}`)
+	}))
+	defer srv.Close()
+
+	bug := "Bug"
+	client := New(srv.URL, "myorg", "pat-test")
+	issue, err := client.EditIssue(context.Background(), "Human/5", tracker.EditOptions{Type: &bug})
+
+	require.NoError(t, err)
+	for _, op := range gotOps {
+		assert.NotEqual(t, "/fields/System.Tags", op.Path)
+	}
+	assert.Equal(t, []string{"alpha"}, issue.Labels)
+}

--- a/internal/tracker/clickup/client.go
+++ b/internal/tracker/clickup/client.go
@@ -309,6 +309,13 @@ func (c *Client) GetCurrentUser(ctx context.Context) (string, error) {
 // PUT; labels use ClickUp's dedicated per-tag endpoints, so a labels-only
 // edit skips the field update entirely.
 func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOptions) (*tracker.Issue, error) {
+	// ClickUp has no task type: the kind is a tag, so a retype is a tag swap
+	// and joins the tag changes below (SC-3051).
+	opts, err := tracker.RetypeIntoLabels(ctx, c, key, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	fields := make(map[string]string)
 	if opts.Title != nil {
 		fields["name"] = *opts.Title

--- a/internal/tracker/clickup/retype_test.go
+++ b/internal/tracker/clickup/retype_test.go
@@ -1,0 +1,60 @@
+package clickup
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// ClickUp has no task type: the kind is a tag, so a retype becomes the same tag
+// add/remove an ordinary label edit uses (SC-3051).
+func TestEditIssue_retypeSwapsTheKindTag(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		live     string
+		asked    string
+		wantCall string
+	}{
+		{
+			name:     "product work becomes a bug",
+			live:     `[{"name":"backend"}]`,
+			asked:    "Bug",
+			wantCall: "POST /api/v2/task/abc123/tag/bug",
+		},
+		{
+			name:     "a bug becomes product work",
+			live:     `[{"name":"bug"}]`,
+			asked:    "Feature",
+			wantCall: "DELETE /api/v2/task/abc123/tag/bug",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls []string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls = append(calls, r.Method+" "+r.URL.Path)
+				if r.Method == http.MethodGet {
+					_, _ = fmt.Fprintf(w, `{"id":"abc123","name":"T","status":{"status":"open","type":"open"},"list":{"id":"901"},"tags":%s}`, tc.live)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			client := New(srv.URL, "tok-test", "")
+			_, err := client.EditIssue(context.Background(), "abc123", tracker.EditOptions{Type: &tc.asked})
+
+			require.NoError(t, err)
+			assert.Contains(t, calls, tc.wantCall)
+			for _, c := range calls {
+				assert.NotEqual(t, "PUT /api/v2/task/abc123", c, "a retype alone must not PUT the task's fields")
+			}
+		})
+	}
+}

--- a/internal/tracker/github/client.go
+++ b/internal/tracker/github/client.go
@@ -436,6 +436,12 @@ func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOpt
 	if err != nil {
 		return nil, err
 	}
+	// GitHub has no issue type: the kind is a label, so a retype is a label
+	// swap and joins the label edits below (SC-3051).
+	opts, err = tracker.RetypeIntoLabels(ctx, c, key, opts)
+	if err != nil {
+		return nil, err
+	}
 
 	var patched *tracker.Issue
 	if opts.Title != nil || opts.Description != nil {

--- a/internal/tracker/github/retype_test.go
+++ b/internal/tracker/github/retype_test.go
@@ -1,0 +1,82 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// GitHub has no issue type: the kind is a label, so a retype has to become a
+// label swap that actually reaches the wire (SC-3051).
+func TestEditIssue_retypeAddsTheKindLabel(t *testing.T) {
+	var addBody map[string][]string
+	var deletePaths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/octocat/repo/issues/1/labels":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &addBody))
+			_, _ = fmt.Fprint(w, `[{"name":"backend"},{"name":"bug"}]`)
+		case r.Method == http.MethodDelete:
+			deletePaths = append(deletePaths, r.URL.EscapedPath())
+			_, _ = fmt.Fprint(w, `[]`)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/octocat/repo/issues/1":
+			_, _ = fmt.Fprint(w, `{"number":1,"title":"T","body":"d","state":"open","labels":[{"name":"backend"}]}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	bug := "Bug"
+	client := New(srv.URL, "ghp_test")
+	_, err := client.EditIssue(context.Background(), "octocat/repo#1", tracker.EditOptions{Type: &bug})
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string][]string{"labels": {"bug"}}, addBody)
+	assert.Empty(t, deletePaths, "nothing to remove: the issue carried no kind label")
+}
+
+// The other direction: retyping a defect back to product work has to take the
+// kind label OFF, or the ticket keeps being picked up by the bug pipeline.
+func TestEditIssue_retypeRemovesTheKindLabel(t *testing.T) {
+	var deletePaths []string
+	postCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			postCalled = true
+			_, _ = fmt.Fprint(w, `[]`)
+		case http.MethodDelete:
+			deletePaths = append(deletePaths, r.URL.EscapedPath())
+			_, _ = fmt.Fprint(w, `[]`)
+		case http.MethodGet:
+			// Non-canonical spelling on purpose: the kind is recognised by
+			// token, so "kind/bug" must be the label that is removed.
+			_, _ = fmt.Fprint(w, `{"number":1,"title":"T","body":"d","state":"open","labels":[{"name":"kind/bug"},{"name":"backend"}]}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	feature := "Feature"
+	client := New(srv.URL, "ghp_test")
+	_, err := client.EditIssue(context.Background(), "octocat/repo#1", tracker.EditOptions{Type: &feature})
+
+	require.NoError(t, err)
+	assert.False(t, postCalled, "nothing to add when the new kind has no label of its own")
+	assert.Equal(t, []string{"/repos/octocat/repo/issues/1/labels/kind/bug"}, deletePaths)
+}

--- a/internal/tracker/gitlab/client.go
+++ b/internal/tracker/gitlab/client.go
@@ -432,6 +432,12 @@ func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOpt
 	if err != nil {
 		return nil, err
 	}
+	// GitLab has no issue type: the kind is a label, so a retype is a label
+	// swap and joins the label edits below (SC-3051).
+	opts, err = tracker.RetypeIntoLabels(ctx, c, key, opts)
+	if err != nil {
+		return nil, err
+	}
 
 	fields := make(map[string]string)
 	if opts.Title != nil {

--- a/internal/tracker/gitlab/retype_test.go
+++ b/internal/tracker/gitlab/retype_test.go
@@ -1,0 +1,73 @@
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// GitLab has no issue type: the kind is a label, so a retype becomes the same
+// atomic add/remove a label swap uses (SC-3051).
+func TestEditIssue_retypeSwapsTheKindLabel(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		live       string
+		asked      string
+		wantAdd    any
+		wantRemove any
+	}{
+		{
+			name:    "product work becomes a bug",
+			live:    `["backend"]`,
+			asked:   "Bug",
+			wantAdd: "bug",
+		},
+		{
+			name:       "a bug becomes product work",
+			live:       `["backend","bug"]`,
+			asked:      "Feature",
+			wantRemove: "bug",
+		},
+		{
+			name:       "a non-canonical kind label is the one removed",
+			live:       `["type:bug"]`,
+			asked:      "Task",
+			wantRemove: "type:bug",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodGet:
+					_, _ = fmt.Fprintf(w, `{"iid":1,"title":"T","state":"opened","labels":%s}`, tc.live)
+				case http.MethodPut:
+					body, err := io.ReadAll(r.Body)
+					require.NoError(t, err)
+					require.NoError(t, json.Unmarshal(body, &got))
+					_, _ = fmt.Fprint(w, `{"iid":1,"title":"T","state":"opened","labels":[]}`)
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer srv.Close()
+
+			client := New(srv.URL, "glpat-test")
+			_, err := client.EditIssue(context.Background(), "group/proj#1", tracker.EditOptions{Type: &tc.asked})
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantAdd, got["add_labels"])
+			assert.Equal(t, tc.wantRemove, got["remove_labels"])
+			assert.NotContains(t, got, "title", "a retype must not touch the title")
+		})
+	}
+}

--- a/internal/tracker/jira/client.go
+++ b/internal/tracker/jira/client.go
@@ -424,6 +424,14 @@ func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOpt
 	if opts.Description != nil {
 		fields["description"] = adf.FromMarkdown(*opts.Description)
 	}
+	// Jira names the kind natively, exactly as create does. Whether a given
+	// project permits a particular move is Jira's own rule (issue types outside
+	// the project's scheme, or across a parent/subtask boundary, are refused) —
+	// its refusal reaches the caller unchanged rather than being pre-guessed
+	// here, so a retype never reports a success Jira did not perform (SC-3051).
+	if opts.Type != nil {
+		fields["issuetype"] = nameOnly{Name: *opts.Type}
+	}
 
 	body := map[string]any{"fields": fields}
 	// Labels go through the update section's atomic add/remove operations

--- a/internal/tracker/jira/retype_test.go
+++ b/internal/tracker/jira/retype_test.go
@@ -1,0 +1,75 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// Jira names the kind natively, so a retype is the issuetype field on the same
+// edit call create already uses (SC-3051).
+func TestEditIssue_retypeWritesIssueType(t *testing.T) {
+	var gotFields map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/rest/api/3/issue/KAN-1":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var got map[string]map[string]any
+			require.NoError(t, json.Unmarshal(body, &got))
+			gotFields = got["fields"]
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && r.URL.Path == "/rest/api/3/issue/KAN-1":
+			_, _ = fmt.Fprint(w, `{"key":"KAN-1","fields":{"summary":"S","status":{"name":"Open"},"issuetype":{"name":"Bug"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	bug := "Bug"
+	client := New(srv.URL, "user@example.com", "token")
+	issue, err := client.EditIssue(context.Background(), "KAN-1", tracker.EditOptions{Type: &bug})
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"name": "Bug"}, gotFields["issuetype"])
+	assert.NotContains(t, gotFields, "summary", "a retype must not touch the title")
+	assert.Equal(t, "Bug", issue.Type)
+}
+
+// The reverse direction is the same one field — a defect becoming ordinary
+// product work must be as ordinary an edit as the other way round.
+func TestEditIssue_retypeBackToProductWork(t *testing.T) {
+	var gotFields map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var got map[string]map[string]any
+			require.NoError(t, json.Unmarshal(body, &got))
+			gotFields = got["fields"]
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			_, _ = fmt.Fprint(w, `{"key":"KAN-1","fields":{"summary":"S","status":{"name":"Open"},"issuetype":{"name":"Task"}}}`)
+		}
+	}))
+	defer srv.Close()
+
+	task := "Task"
+	client := New(srv.URL, "user@example.com", "token")
+	issue, err := client.EditIssue(context.Background(), "KAN-1", tracker.EditOptions{Type: &task})
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"name": "Task"}, gotFields["issuetype"])
+	assert.Equal(t, "Task", issue.Type)
+}

--- a/internal/tracker/linear/client.go
+++ b/internal/tracker/linear/client.go
@@ -598,6 +598,13 @@ func (c *Client) GetCurrentUser(ctx context.Context) (string, error) {
 
 // EditIssue implements tracker.Editor.
 func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOptions) (*tracker.Issue, error) {
+	// Linear has no issue type: the kind is a label, so a retype is a label
+	// swap and joins the label edits buildEditInput already resolves (SC-3051).
+	opts, err := tracker.RetypeIntoLabels(ctx, c, key, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	issueID, input, err := c.buildEditInput(ctx, key, opts)
 	if err != nil {
 		return nil, err

--- a/internal/tracker/linear/retype_test.go
+++ b/internal/tracker/linear/retype_test.go
@@ -1,0 +1,54 @@
+package linear
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// Linear has no issue type: the kind is a label, so a retype must arrive as a
+// change to the issue's label set (SC-3051). Linear's labelIds is
+// full-replacement, so the assertion is on the final set, not on a delta.
+func TestEditIssue_retypeRemovesTheKindLabel(t *testing.T) {
+	var gotLabelIDs []any
+	seenIssueQuery := 0
+	srv := httptest.NewServer(&graphQLHandler{
+		t: t,
+		handlers: map[string]func(vars map[string]any) string{
+			"issueUpdate": func(vars map[string]any) string {
+				input := vars["input"].(map[string]any)
+				gotLabelIDs, _ = input["labelIds"].([]any)
+				assert.NotContains(t, input, "title", "a retype must not touch the title")
+				return `{"data":{"issueUpdate":{"success":true}}}`
+			},
+			"issue(": func(_ map[string]any) string {
+				seenIssueQuery++
+				// First: RetypeIntoLabels reads the live labels. Second: the
+				// label-context lookup. Last: the post-edit re-read.
+				if seenIssueQuery == 2 {
+					return `{"data":{"issue":{"id":"uuid-1","team":{"id":"team-1"},"labels":{"nodes":[
+						{"id":"lbl-bug","name":"bug"},{"id":"lbl-be","name":"backend"}]}}}}`
+				}
+				return `{"data":{"issue":{
+					"identifier":"ENG-42","title":"T","description":"",
+					"state":{"name":"Todo","type":"unstarted"},"priorityLabel":"",
+					"assignee":null,"creator":null,
+					"labels":{"nodes":[{"id":"lbl-bug","name":"bug"},{"id":"lbl-be","name":"backend"}]}
+				}}}`
+			},
+		},
+	})
+	defer srv.Close()
+
+	feature := "Feature"
+	client := New(srv.URL, "lin_test")
+	_, err := client.EditIssue(context.Background(), "ENG-42", tracker.EditOptions{Type: &feature})
+
+	require.NoError(t, err)
+	assert.Equal(t, []any{"lbl-be"}, gotLabelIDs, "the kind label goes, every other label stays")
+}

--- a/internal/tracker/retype_test.go
+++ b/internal/tracker/retype_test.go
@@ -1,0 +1,132 @@
+package tracker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetypeLabels(t *testing.T) {
+	tests := []struct {
+		name       string
+		current    []string
+		newType    string
+		wantAdd    []string
+		wantRemove []string
+	}{
+		{
+			name:    "product work becomes a bug",
+			current: []string{"backend"},
+			newType: "Bug",
+			wantAdd: []string{"bug"},
+		},
+		{
+			name:       "a bug becomes product work",
+			current:    []string{"backend", "bug"},
+			newType:    "Feature",
+			wantRemove: []string{"bug"},
+		},
+		{
+			// The kind is recognised by token, so a ticket labelled "kind/bug"
+			// must lose THAT label — removing only the canonical "bug" would
+			// leave it reading as a bug after a retype that reported success.
+			name:       "a non-canonical kind label is removed too",
+			current:    []string{"kind/bug", "backend"},
+			newType:    "Chore",
+			wantRemove: []string{"kind/bug"},
+		},
+		{
+			name:       "bug becomes security: one kind replaces the other",
+			current:    []string{"bug"},
+			newType:    "Security",
+			wantAdd:    []string{"security"},
+			wantRemove: []string{"bug"},
+		},
+		{
+			// Already the requested kind: nothing to do, and in particular the
+			// label is not added a second time.
+			name:    "retyping to the kind it already is changes nothing",
+			current: []string{"type:bug", "backend"},
+			newType: "Bug",
+		},
+		{
+			name:    "no labels at all",
+			current: nil,
+			newType: "Bug",
+			wantAdd: []string{"bug"},
+		},
+		{
+			// Labels that are not kind markers are never touched, whichever
+			// direction the retype goes.
+			name:       "unrelated labels survive",
+			current:    []string{"p1", "bug", "customer/acme"},
+			newType:    "Task",
+			wantRemove: []string{"bug"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			add, remove := RetypeLabels(tc.current, tc.newType)
+			assert.Equal(t, tc.wantAdd, add, "labels to add")
+			assert.Equal(t, tc.wantRemove, remove, "labels to remove")
+		})
+	}
+}
+
+// retypeGetter is a Getter that hands back one fixed issue and counts reads, so
+// the tests can assert the extra fetch happens only for an actual retype.
+type retypeGetter struct {
+	issue *Issue
+	err   error
+	calls int
+}
+
+func (g *retypeGetter) GetIssue(context.Context, string) (*Issue, error) {
+	g.calls++
+	return g.issue, g.err
+}
+
+func TestRetypeIntoLabels_foldsTheKindIntoLabelEdits(t *testing.T) {
+	g := &retypeGetter{issue: &Issue{Labels: []string{"backend", "bug"}}}
+	feature := "Feature"
+
+	got, err := RetypeIntoLabels(context.Background(), g, "KEY-1", EditOptions{
+		Type:      &feature,
+		AddLabels: []string{"already-asked-for"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"already-asked-for"}, got.AddLabels, "the caller's own label edits survive")
+	assert.Equal(t, []string{"bug"}, got.RemoveLabels)
+	assert.Nil(t, got.Type, "Type is cleared once it has become label work")
+	assert.Equal(t, 1, g.calls)
+}
+
+func TestRetypeIntoLabels_noTypeAskedForReadsNothing(t *testing.T) {
+	g := &retypeGetter{issue: &Issue{Labels: []string{"bug"}}}
+	title := "New title"
+
+	got, err := RetypeIntoLabels(context.Background(), g, "KEY-1", EditOptions{Title: &title})
+
+	require.NoError(t, err)
+	assert.Equal(t, &title, got.Title)
+	assert.Empty(t, got.AddLabels)
+	assert.Empty(t, got.RemoveLabels)
+	assert.Zero(t, g.calls, "an edit that does not retype must not pay for a read")
+}
+
+func TestRetypeIntoLabels_unreadableIssueFailsTheEdit(t *testing.T) {
+	g := &retypeGetter{err: assert.AnError}
+	bug := "Bug"
+
+	_, err := RetypeIntoLabels(context.Background(), g, "KEY-1", EditOptions{Type: &bug})
+
+	// Proceeding blind would write a label swap computed from no labels, which
+	// can silently leave the old kind in place — the one thing a retype must
+	// never do. Failing is the honest answer.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading current labels to retype the issue")
+}

--- a/internal/tracker/shortcut/client.go
+++ b/internal/tracker/shortcut/client.go
@@ -507,6 +507,18 @@ func (c *Client) EditIssue(ctx context.Context, key string, opts tracker.EditOpt
 	if opts.Description != nil {
 		fields["description"] = *opts.Description
 	}
+	// Shortcut carries the kind natively, so a retype is one field. An
+	// unrecognised type is refused rather than dropped: silently leaving the
+	// story a bug while reporting the edit succeeded is the failure mode a
+	// retype exists to end (SC-3051).
+	if opts.Type != nil {
+		st := normalizeStoryType(*opts.Type)
+		if st == "" {
+			return nil, errors.WithDetails("shortcut cannot express this issue type",
+				"key", key, "type", *opts.Type, "known", "feature, bug, chore")
+		}
+		fields["story_type"] = st
+	}
 	// Shortcut's story update replaces the full label set, so the current
 	// labels must be fetched and merged before writing. Labels stay out of
 	// the body entirely when the edit doesn't touch them, keeping

--- a/internal/tracker/shortcut/retype_test.go
+++ b/internal/tracker/shortcut/retype_test.go
@@ -1,0 +1,75 @@
+package shortcut
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// Shortcut names the kind natively, so a retype is one field on the story
+// update and must reach the wire as Shortcut's own vocabulary (SC-3051).
+func TestEditIssue_retypeWritesStoryType(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		asked    string
+		wantWire string
+	}{
+		{name: "product work becomes a bug", asked: "Bug", wantWire: "bug"},
+		{name: "a bug becomes product work", asked: "Feature", wantWire: "feature"},
+		{name: "chore is Shortcut's own vocabulary", asked: "chore", wantWire: "chore"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBody map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPut && r.URL.Path == "/api/v3/stories/123":
+					body, err := io.ReadAll(r.Body)
+					require.NoError(t, err)
+					require.NoError(t, json.Unmarshal(body, &gotBody))
+					_, _ = fmt.Fprintf(w, `{"id":123,"name":"Story","story_type":%q,"workflow_state_id":500,"owner_ids":[],"requested_by_id":""}`, tc.wantWire)
+				case r.URL.Path == "/api/v3/workflows":
+					_, _ = fmt.Fprint(w, `[{"id":1,"name":"Default","states":[{"id":500,"name":"To Do","type":"unstarted"}]}]`)
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer srv.Close()
+
+			client := New(srv.URL, "tok-test")
+			issue, err := client.EditIssue(context.Background(), "123", tracker.EditOptions{Type: &tc.asked})
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantWire, gotBody["story_type"], "PUT body must carry the new story type")
+			assert.Equal(t, tc.wantWire, issue.Type)
+			assert.NotContains(t, gotBody, "labels", "a retype must not rewrite the label set")
+		})
+	}
+}
+
+// A type Shortcut cannot express is refused rather than dropped: reporting a
+// successful edit that left the story a bug is the exact failure a retype
+// exists to end.
+func TestEditIssue_retypeRefusesAnUnknownType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("no request must be made for a type Shortcut cannot express: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	epic := "Epic"
+	client := New(srv.URL, "tok-test")
+	_, err := client.EditIssue(context.Background(), "123", tracker.EditOptions{Type: &epic})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot express this issue type")
+}

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -398,6 +398,68 @@ func CreateLabels(i *Issue) []string {
 	return labels
 }
 
+// RetypeLabels returns the label edits that change a ticket's KIND on a
+// provider without a native issue type, where the kind is carried by a label
+// and nothing else: add is the label the new kind needs, remove is every label
+// currently marking a kind the ticket is no longer.
+//
+// It is CreateLabels' counterpart for an existing ticket, and it exists for the
+// same reason: without the translation, retyping on a label-only tracker
+// (Linear, GitHub, GitLab, ClickUp) would silently do nothing.
+//
+// current is the ticket's live label set, which the caller must read first. It
+// is not optional: kinds are recognised by token ("bug", "kind/bug",
+// "type:bug" all count), so removing only the canonical spelling would leave a
+// ticket labelled "kind/bug" still reading as a bug after a retype that
+// reported success — the one outcome a retype must never produce.
+func RetypeLabels(current []string, newType string) (add, remove []string) {
+	wantBug, wantSecurity := isBugToken(newType), isSecurityToken(newType)
+	for _, l := range current {
+		switch {
+		case isBugToken(l) && !wantBug, isSecurityToken(l) && !wantSecurity:
+			remove = append(remove, l)
+		}
+	}
+	if wantBug && !slices.ContainsFunc(current, isBugToken) {
+		add = append(add, BugLabel)
+	}
+	if wantSecurity && !slices.ContainsFunc(current, isSecurityToken) {
+		add = append(add, SecurityLabel)
+	}
+	return add, remove
+}
+
+// RetypeIntoLabels turns a requested kind change into ordinary label edits, for
+// a provider whose kind IS a label (Linear, GitHub, GitLab, ClickUp). It reads
+// the ticket's live labels through g — the retype cannot be computed without
+// them — and hands back opts with the work folded into AddLabels/RemoveLabels
+// and Type cleared, so the provider's existing label-merge path carries it and
+// cannot forget it halfway.
+//
+// Returns opts untouched when no retype was asked for, so every provider can
+// call it unconditionally at the top of EditIssue and pay one extra read only
+// when a kind actually changes.
+func RetypeIntoLabels(ctx context.Context, g Getter, key string, opts EditOptions) (EditOptions, error) {
+	if opts.Type == nil {
+		return opts, nil
+	}
+	issue, err := g.GetIssue(ctx, key)
+	if err != nil {
+		return opts, errors.WrapWithDetails(err, "reading current labels to retype the issue", "key", key)
+	}
+	return applyRetypeLabels(opts, issue.Labels), nil
+}
+
+// applyRetypeLabels is RetypeIntoLabels' pure half: the fold itself, given
+// labels already read.
+func applyRetypeLabels(opts EditOptions, current []string) EditOptions {
+	add, remove := RetypeLabels(current, *opts.Type)
+	opts.AddLabels = append(slices.Clone(opts.AddLabels), add...)
+	opts.RemoveLabels = append(slices.Clone(opts.RemoveLabels), remove...)
+	opts.Type = nil
+	return opts
+}
+
 // SecurityLabel marks a security/vulnerability ticket on providers without a
 // native security type, matching the classification IsSecurity accepts.
 const SecurityLabel = "security"
@@ -752,6 +814,16 @@ type CurrentUserGetter interface {
 type EditOptions struct {
 	Title       *string
 	Description *string
+	// Type retypes the issue: "Bug" and "Security" name the two kinds the
+	// pipeline routes on, anything else is ordinary product work. nil leaves
+	// the kind alone, so an edit that does not mention it can never change it.
+	//
+	// A kind is chosen at create time and, until this existed, could never be
+	// corrected — the only remedies were the tracker's own web UI or refiling
+	// the ticket and losing its key, history and comments (SC-3051). Every
+	// provider expresses it in its own vocabulary: a native type field where
+	// one exists, a label swap where the kind is a label (RetypeLabels).
+	Type *string
 	// AddLabels are labels to add to the issue. Providers whose label model
 	// requires pre-existing label entities create them on the fly.
 	AddLabels []string
@@ -760,7 +832,7 @@ type EditOptions struct {
 	RemoveLabels []string
 }
 
-// Editor updates an existing issue's title, description, and/or labels.
+// Editor updates an existing issue's title, description, kind, and/or labels.
 type Editor interface {
 	EditIssue(ctx context.Context, key string, opts EditOptions) (*Issue, error)
 }


### PR DESCRIPTION
Fixes SC-3051.

A ticket's kind — defect or product work — decides which pipeline picks it up. It could only be set at create time, so getting it wrong left two remedies, both bad: the tracker's own web UI, or refiling the ticket and losing its key, history, links and every comment the pipeline had written on it. And it was invisible: the kind was fetched and carried, never displayed, so the mistake surfaced only when the wrong pipeline started work.

- `EditOptions.Type` — nil means "leave the kind alone", so an edit that does not mention it can never change it.
- **Native-type trackers** (Shortcut, Jira, Azure DevOps) write their own field. Shortcut refuses a type it cannot express rather than dropping it; Jira lets its own project-scheme refusal reach the caller; Azure DevOps now shares one type mapping between create and retype.
- **Label-marked trackers** (Linear, GitHub, GitLab, ClickUp) swap the kind label, folded into each provider's existing label merge so unrelated labels are never clobbered.
- The live labels are read before a swap: kinds are recognised by token, so a ticket labelled `kind/bug` would survive a retype that removed only the canonical spelling — still a bug after an edit that reported success. A label set that cannot be read fails the edit rather than guessing.
- `issue edit --type` retypes in either direction; `issue get` shows a Type row (omitted, not "None", where a tracker carries no type).

24 new tests across the abstraction, all seven providers and the CLI; `make check` green.