### PR TITLE
[SC-2857] A code-generated domain account of the product

### DIFF
--- a/cmd/cmdcodenav/codenav.go
+++ b/cmd/cmdcodenav/codenav.go
@@ -53,6 +53,7 @@ func BuildCodenavCmd() *cobra.Command {
 		buildSymbolsCmd(),
 		buildOutlineCmd(),
 		buildOverviewCmd(),
+		buildAccountCmd(),
 		buildSearchCmd(),
 		buildDefCmd(),
 		buildRefsCmd(),
@@ -393,6 +394,65 @@ func buildOverviewCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&repo, "repo", "", "limit to a project")
+	return cmd
+}
+
+func buildAccountCmd() *cobra.Command {
+	var repo string
+	var limit int
+	cmd := &cobra.Command{
+		Use:   "account",
+		Short: "Product account: the domain nouns, their shape, and their meaning",
+		Long: "account is a page-sized, code-generated summary of what a product is " +
+			"made of — its domain nouns (types), each with its shape and the intent " +
+			"recorded above it — ranked so plumbing does not dominate. Regenerated " +
+			"from the current index; nothing is hand-maintained.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			st, err := openStore(cmd)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = st.Close() }()
+			acct, err := query.GetAccount(st.DB(), repo, limit)
+			if err != nil {
+				return err
+			}
+			if jsonOut(cmd) {
+				return emitJSON(cmd, acct)
+			}
+			if len(acct.Nouns) == 0 {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), acct.Note)
+				return nil
+			}
+			scope := "(all indexed)"
+			if repo != "" {
+				scope = repo
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "product account: %s\n", scope)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%d domain nouns (from the current index)\n\n", len(acct.Nouns))
+			for _, n := range acct.Nouns {
+				shape := n.Shape
+				if shape == "" {
+					shape = n.Name
+				}
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s\t%s\n", n.Name, shape)
+				meaning := n.Meaning
+				if meaning == "" {
+					meaning = "(no description recorded)"
+				}
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "      %s\n", meaning)
+				// SC-2860 seam: rules constraining this noun, shown alongside it.
+				for _, inv := range n.Invariants {
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "      ! %s\n", inv)
+				}
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "      %s:%d\n", n.File, n.Line)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&repo, "repo", "", "limit to a project")
+	cmd.Flags().IntVar(&limit, "limit", 24, "max domain nouns (page-sized)")
 	return cmd
 }
 

--- a/cmd/cmdcodenav/codenav_test.go
+++ b/cmd/cmdcodenav/codenav_test.go
@@ -1,0 +1,142 @@
+package cmdcodenav
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gethuman-sh/human/internal/codenav/index"
+	"github.com/gethuman-sh/human/internal/codenav/query"
+	"github.com/gethuman-sh/human/internal/codenav/store"
+)
+
+// indexModule writes the given files as a module rooted at a temp dir, indexes
+// them into a fresh SQLite database, and returns the database path so a command
+// test can run against it via --db.
+func indexModule(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for name, body := range files {
+		full := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dbPath := filepath.Join(t.TempDir(), "codenav.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	scan := index.RepoScan{Project: "cmdfix", Root: root}
+	backends := index.PickFor(scan)
+	if len(backends) == 0 {
+		t.Fatal("no indexer matched the fixture")
+	}
+	w, err := st.NewWriter(scan.Project, scan.Root)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	for _, ix := range backends {
+		if err := ix.Index(context.Background(), scan, w); err != nil {
+			t.Fatalf("index with %s: %v", ix.Name(), err)
+		}
+	}
+	if err := w.Commit(""); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	_ = st.Close()
+	return dbPath
+}
+
+func runCodenav(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := BuildCodenavCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestAccountCmd_json(t *testing.T) {
+	db := indexModule(t, map[string]string{
+		"go.mod": "module example.com/cmdfix\n\ngo 1.21\n",
+		"dom.go": `package cmdfix
+
+// Booking is a reservation a customer makes.
+type Booking struct {
+	ID string
+}
+
+// Confirm records a booking.
+func Confirm(b Booking) error { return nil }
+`,
+	})
+	out, err := runCodenav(t, "account", "--db", db, "--json")
+	if err != nil {
+		t.Fatalf("account --json: %v (out: %s)", err, out)
+	}
+	var acct query.Account
+	if err := json.Unmarshal([]byte(out), &acct); err != nil {
+		t.Fatalf("account --json did not parse to query.Account: %v\n%s", err, out)
+	}
+	if len(acct.Nouns) == 0 {
+		t.Fatalf("expected >=1 noun, got none: %s", out)
+	}
+	if nounHas(acct, "Booking") == nil {
+		t.Errorf("expected Booking in account, got %v", acct.Nouns)
+	}
+}
+
+func TestAccountCmd_textEmpty(t *testing.T) {
+	// A module of only funcs has no domain types; the text output must be the
+	// plain note (and exit 0), never silence.
+	db := indexModule(t, map[string]string{
+		"go.mod": "module example.com/cmdfix\n\ngo 1.21\n",
+		"main.go": `package main
+
+func A() {}
+func main() { A() }
+`,
+	})
+	out, err := runCodenav(t, "account", "--db", db)
+	if err != nil {
+		t.Fatalf("account (text): %v (out: %s)", err, out)
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("empty account printed nothing; want a plain note")
+	}
+	if !strings.Contains(out, "no type declarations") {
+		t.Errorf("empty-account text = %q, want the plain no-types note", out)
+	}
+}
+
+func TestAccountCmd_unindexedErrors(t *testing.T) {
+	// A fresh, empty database must yield the actionable "index first" error
+	// rather than an empty account — account is a gated query verb.
+	dbPath := filepath.Join(t.TempDir(), "empty.db")
+	_, err := runCodenav(t, "account", "--db", dbPath)
+	if err == nil {
+		t.Fatal("account on an un-indexed db returned no error")
+	}
+	if !strings.Contains(err.Error(), "no repository is indexed") {
+		t.Errorf("error = %v, want the actionable index-first message", err)
+	}
+}
+
+func nounHas(a query.Account, name string) *query.Noun {
+	for i := range a.Nouns {
+		if a.Nouns[i].Name == name {
+			return &a.Nouns[i]
+		}
+	}
+	return nil
+}

--- a/internal/codenav/README.md
+++ b/internal/codenav/README.md
@@ -8,6 +8,7 @@
 - Reports blast radius of a symbol or a git diff
 - Full-text search over code bodies and symbol names
 - Lists detected web routes and their handlers
+- Prints a product account: the domain nouns (types) with their shape and recorded intent, ranked so plumbing does not dominate
 - Keeps one local index for many repositories
 - Refreshes incrementally — reprocesses only added, modified, and deleted files (Go at package granularity) and leaves unchanged files in place, so staying current is cheap; `--full` forces a complete rebuild. The call graph is exact except for interface-dispatch edges between full rebuilds.
 - Served by the daemon as one shared index for every agent and worktree, kept fresh in the background; falls back to a local index when no daemon runs

--- a/internal/codenav/query/account_test.go
+++ b/internal/codenav/query/account_test.go
@@ -1,0 +1,326 @@
+package query
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gethuman-sh/human/internal/codenav/index"
+	"github.com/gethuman-sh/human/internal/codenav/store"
+)
+
+// indexDomainFixture writes a small multi-package Go module that exercises every
+// signal GetAccount weighs — a documented struct named in a route handler
+// (Booking), a documented struct with no route (Invoice, the route-boost
+// control), an undocumented struct with many references (Ledger, the intent-vs-
+// refs control), a documented interface (Store), an unused undocumented alias
+// (Unused, which must be dropped), and an infra type under util/ (Helper, which
+// must be excluded by path) — then indexes it through the real pipeline.
+func indexDomainFixture(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	root := t.TempDir()
+	files := map[string]string{
+		"go.mod": "module example.com/dom\n\ngo 1.21\n",
+		"dom.go": `package dom
+
+import "net/http"
+
+// Booking is a reservation a customer makes for a room.
+type Booking struct {
+	ID string
+}
+
+// Invoice bills a completed booking.
+type Invoice struct {
+	Total int
+}
+
+type Ledger struct {
+	rows int
+}
+
+// Store persists and retrieves bookings.
+type Store interface {
+	Save(b Booking) error
+}
+
+type Unused int
+
+// handleBooking names Booking in its signature so the route-handler boost fires.
+func handleBooking(w http.ResponseWriter, r *http.Request, b Booking) {}
+
+func useInvoice(i Invoice) Invoice { return i }
+
+func useLedger(l Ledger) Ledger       { return l }
+func moreLedger(l Ledger) Ledger      { return useLedger(l) }
+func evenMoreLedger(l Ledger) Ledger  { return moreLedger(l) }
+
+type router struct{}
+
+func (router) Get(path string, h func(http.ResponseWriter, *http.Request, Booking)) {}
+
+func wire(rt router) { rt.Get("/bookings", handleBooking) }
+`,
+		"util/helper.go": `package util
+
+// Helper is infra glue that must never surface as a domain noun.
+type Helper struct {
+	n int
+}
+`,
+	}
+	for name, body := range files {
+		full := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "codenav.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	scan := index.RepoScan{Project: "dom", Root: root}
+	backends := index.PickFor(scan)
+	if len(backends) == 0 {
+		t.Fatal("no indexer matched the domain fixture")
+	}
+	w, err := st.NewWriter(scan.Project, scan.Root)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	for _, ix := range backends {
+		if err := ix.Index(context.Background(), scan, w); err != nil {
+			t.Fatalf("index with %s: %v", ix.Name(), err)
+		}
+	}
+	if err := w.Commit(""); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	return st.DB(), scan.Project
+}
+
+// nounByName returns the account noun with the given name, or nil.
+func nounByName(a *Account, name string) *Noun {
+	for i := range a.Nouns {
+		if a.Nouns[i].Name == name {
+			return &a.Nouns[i]
+		}
+	}
+	return nil
+}
+
+// rankOf returns the zero-based position of a named noun in the account, or -1.
+func rankOf(a *Account, name string) int {
+	for i := range a.Nouns {
+		if a.Nouns[i].Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestGetAccount_surfacesDomainNoun(t *testing.T) {
+	db, repo := indexDomainFixture(t)
+	acct, err := GetAccount(db, repo, 24)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	b := nounByName(acct, "Booking")
+	if b == nil {
+		t.Fatalf("Booking not in account; got %v", acct.Nouns)
+	}
+	if !strings.Contains(b.Meaning, "reservation") {
+		t.Errorf("Booking meaning = %q, want it to carry the recorded intent", b.Meaning)
+	}
+	if b.Shape == "" {
+		t.Error("Booking shape is empty, want the compact signature")
+	}
+	if b.Kind != "type" {
+		t.Errorf("Booking kind = %q, want type", b.Kind)
+	}
+}
+
+func TestGetAccount_excludesInfraPackage(t *testing.T) {
+	db, repo := indexDomainFixture(t)
+	acct, err := GetAccount(db, repo, 24)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	if n := nounByName(acct, "Helper"); n != nil {
+		t.Errorf("Helper (util/ infra) surfaced in the account: %+v", *n)
+	}
+}
+
+func TestGetAccount_dropsUnusedUndocumentedAlias(t *testing.T) {
+	db, repo := indexDomainFixture(t)
+	acct, err := GetAccount(db, repo, 24)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	if n := nounByName(acct, "Unused"); n != nil {
+		t.Errorf("Unused (no doc, no refs, no shape) surfaced: %+v", *n)
+	}
+}
+
+func TestGetAccount_intentDrivesOrderNotCalls(t *testing.T) {
+	db, repo := indexDomainFixture(t)
+	acct, err := GetAccount(db, repo, 24)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	// Invoice is documented with few references; Ledger is undocumented with
+	// many. Recorded intent, not reference/call count, must rank Invoice higher.
+	inv, led := rankOf(acct, "Invoice"), rankOf(acct, "Ledger")
+	if inv < 0 || led < 0 {
+		t.Fatalf("expected both Invoice and Ledger in account; got %v", acct.Nouns)
+	}
+	if inv >= led {
+		t.Errorf("Invoice (documented) ranked %d, Ledger (undocumented, more refs) ranked %d; intent must win", inv, led)
+	}
+	// The account is nouns only — a heavily-called func never leaks in.
+	for _, n := range acct.Nouns {
+		if n.Kind != "type" {
+			t.Errorf("account carried a non-type noun %q (kind %q)", n.Name, n.Kind)
+		}
+	}
+}
+
+func TestGetAccount_routeHandlerBoost(t *testing.T) {
+	db, repo := indexDomainFixture(t)
+	acct, err := GetAccount(db, repo, 24)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	// Booking and Invoice are both documented structs with equal reference
+	// counts; only Booking is named in a route handler, so the +route boost must
+	// place it ahead of Invoice.
+	bk, inv := rankOf(acct, "Booking"), rankOf(acct, "Invoice")
+	if bk < 0 || inv < 0 {
+		t.Fatalf("expected Booking and Invoice in account; got %v", acct.Nouns)
+	}
+	if bk >= inv {
+		t.Errorf("Booking (route handler) ranked %d, Invoice (no route) ranked %d; route boost must win", bk, inv)
+	}
+}
+
+func TestGetAccount_emptyReportsPlainly(t *testing.T) {
+	// indexFixture indexes a module of only funcs (A→B→C) — no type declarations.
+	db, repo := indexFixture(t)
+	acct, err := GetAccount(db, repo, 24)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	if len(acct.Nouns) != 0 {
+		t.Fatalf("expected no nouns from a func-only module, got %v", acct.Nouns)
+	}
+	if acct.Note == "" {
+		t.Fatal("empty account must carry a plain note, not silence")
+	}
+	if !strings.Contains(acct.Note, "no type declarations") {
+		t.Errorf("note = %q, want it to explain there are no type declarations", acct.Note)
+	}
+}
+
+func TestGetAccount_defaultLimit(t *testing.T) {
+	db, repo := indexDomainFixture(t)
+	// A non-positive limit falls back to the page-sized default rather than
+	// returning everything or nothing.
+	acct, err := GetAccount(db, repo, 0)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	if len(acct.Nouns) == 0 {
+		t.Fatal("default-limit account returned no nouns")
+	}
+}
+
+func TestGetAccount_limitCapsPage(t *testing.T) {
+	db, repo := indexDomainFixture(t)
+	acct, err := GetAccount(db, repo, 1)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	if len(acct.Nouns) != 1 {
+		t.Errorf("limit 1 returned %d nouns, want 1", len(acct.Nouns))
+	}
+}
+
+func TestGetAccount_unknownRepoReportsPlainly(t *testing.T) {
+	db, _ := indexDomainFixture(t)
+	acct, err := GetAccount(db, "doesnotexist", 24)
+	if err != nil {
+		t.Fatalf("GetAccount unknown repo errored: %v", err)
+	}
+	if len(acct.Nouns) != 0 {
+		t.Errorf("unknown repo returned nouns: %v", acct.Nouns)
+	}
+	if acct.Note == "" {
+		t.Error("unknown repo must report plainly, not with an empty silent account")
+	}
+}
+
+func TestInInfraPackage(t *testing.T) {
+	cases := map[string]bool{
+		"internal/util/x.go":    true,
+		"internal/tracker/x.go": false,
+		"errors/x.go":           true,
+		"pkg/mocks/y.go":        true,
+		"cmd/app/main.go":       false,
+		"helper.go":             false, // a bare filename named helper is not an infra dir
+	}
+	for path, want := range cases {
+		if got := inInfraPackage(path); got != want {
+			t.Errorf("inInfraPackage(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+func TestWholeWordIn(t *testing.T) {
+	hay := "func(w http.ResponseWriter, r *http.Request, b dom.Booking)"
+	cases := map[string]bool{
+		"Booking": true,
+		"Book":    false,
+		"king":    false,
+		"":        false,
+	}
+	for name, want := range cases {
+		if got := wholeWordIn(hay, name); got != want {
+			t.Errorf("wholeWordIn(hay, %q) = %v, want %v", name, got, want)
+		}
+	}
+	// A repeated near-miss followed by a real match must still be found.
+	if !wholeWordIn("xBooking yBooking Booking", "Booking") {
+		t.Error("wholeWordIn missed a whole-word match after embedded near-misses")
+	}
+	// Only embedded occurrences must report no match.
+	if wholeWordIn("xBookingy", "Booking") {
+		t.Error("wholeWordIn matched an embedded-only occurrence")
+	}
+}
+
+func TestFoldOneLine_degenerateWidth(t *testing.T) {
+	if got := foldOneLine("a b  c", 0); got != "a b c" {
+		t.Errorf("foldOneLine width 0 = %q, want folded-but-uncapped %q", got, "a b c")
+	}
+	if got := foldOneLine("a b  c", 100); got != "a b c" {
+		t.Errorf("foldOneLine width 100 = %q, want %q", got, "a b c")
+	}
+	long := strings.Repeat("x", 50)
+	got := foldOneLine(long, 10)
+	if len([]rune(got)) != 10 {
+		t.Errorf("foldOneLine capped length = %d runes, want 10", len([]rune(got)))
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("capped foldOneLine = %q, want an ellipsis suffix", got)
+	}
+}

--- a/internal/codenav/query/query.go
+++ b/internal/codenav/query/query.go
@@ -350,50 +350,8 @@ func GetAccount(db *sql.DB, repo string, limit int) (*Account, error) {
 	}
 	defer func() { _ = rows.Close() }()
 
-	type scored struct {
-		n     Noun
-		score int
-		refs  int
-	}
-	var cands []scored
-	sawType := false
-	for rows.Next() {
-		var qname, name, sig, doc, path string
-		var line, refs int
-		if err := rows.Scan(&qname, &name, &sig, &doc, &path, &line, &refs); err != nil {
-			return nil, err
-		}
-		sawType = true
-		if inInfraPackage(path) {
-			continue
-		}
-		score := refs
-		if score > 8 {
-			score = 8
-		}
-		if doc != "" {
-			score += 5
-		}
-		if strings.HasPrefix(strings.TrimSpace(sig), "struct{") {
-			score += 3
-		}
-		if wholeWordIn(handlerSigs, name) {
-			score += 4
-		}
-		if score == 0 {
-			continue // pure plumbing alias — no intent, no shape, unused
-		}
-		cands = append(cands, scored{
-			n: Noun{
-				QName: qname, Name: name, Kind: "type",
-				Shape:   foldOneLine(sig, 100),
-				Meaning: foldOneLine(doc, 160),
-				File:    path, Line: line,
-			},
-			score: score, refs: refs,
-		})
-	}
-	if err := rows.Err(); err != nil {
+	cands, sawType, err := accountCandidates(rows, handlerSigs)
+	if err != nil {
 		return nil, err
 	}
 
@@ -417,6 +375,74 @@ func GetAccount(db *sql.DB, repo string, limit int) (*Account, error) {
 		acct.Note = accountEmptyNote(db, repo, sawType)
 	}
 	return acct, nil
+}
+
+// scoredNoun pairs a candidate noun with the evidence that ranked it, so the
+// sort can fall back to reference count when two nouns score alike.
+type scoredNoun struct {
+	n     Noun
+	score int
+	refs  int
+}
+
+// accountCandidates turns the type-symbol rows into scored candidates, dropping
+// infra packages and score-zero plumbing. It also reports whether the query saw
+// any type at all, which is what tells an empty account "no types indexed" apart
+// from "types indexed, none of them nouns". Extracted from GetAccount so the
+// scan and the ranking each stay readable on their own.
+func accountCandidates(rows *sql.Rows, handlerSigs string) ([]scoredNoun, bool, error) {
+	var cands []scoredNoun
+	sawType := false
+	for rows.Next() {
+		var qname, name, sig, doc, path string
+		var line, refs int
+		if err := rows.Scan(&qname, &name, &sig, &doc, &path, &line, &refs); err != nil {
+			return nil, sawType, err
+		}
+		sawType = true
+		if inInfraPackage(path) {
+			continue
+		}
+		score := nounScore(refs, doc, sig, name, handlerSigs)
+		if score == 0 {
+			continue // pure plumbing alias — no intent, no shape, unused
+		}
+		cands = append(cands, scoredNoun{
+			n: Noun{
+				QName: qname, Name: name, Kind: "type",
+				Shape:   foldOneLine(sig, 100),
+				Meaning: foldOneLine(doc, 160),
+				File:    path, Line: line,
+			},
+			score: score, refs: refs,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, sawType, err
+	}
+	return cands, sawType, nil
+}
+
+// nounScore ranks a type by recorded intent rather than call frequency: a doc
+// comment (the author saying what it is) outweighs everything, a route handler
+// naming it marks it as part of the product's surface, and reference count only
+// breaks ties — capped so one heavily-used helper cannot outrank a documented
+// domain type.
+func nounScore(refs int, doc, sig, name, handlerSigs string) int {
+	score := refs
+	if score > 8 {
+		score = 8
+	}
+	if doc != "" {
+		score += 5
+	}
+	if strings.HasPrefix(strings.TrimSpace(sig), "struct{") {
+		score += 3
+	}
+	if wholeWordIn(handlerSigs, name) {
+		score += 4
+	}
+	return score
 }
 
 // routeHandlerSignatures returns every detected route handler's signature joined

--- a/internal/codenav/query/query.go
+++ b/internal/codenav/query/query.go
@@ -291,16 +291,22 @@ func wholeWordIn(hay, name string) bool {
 	if name == "" {
 		return false
 	}
-	for i := strings.Index(hay, name); i >= 0; i = strings.Index(hay[i+1:], name) + (i + 1) {
+	// Scanning from an advancing offset (rather than re-indexing a suffix and
+	// correcting the position) keeps an embedded near-miss from ending the
+	// search: "xBooking yBooking Booking" must still find the standalone one.
+	for off := 0; off <= len(hay)-len(name); {
+		i := strings.Index(hay[off:], name)
+		if i < 0 {
+			break
+		}
+		i += off
 		before := i == 0 || !isIdentByte(hay[i-1])
 		end := i + len(name)
 		after := end >= len(hay) || !isIdentByte(hay[end])
 		if before && after {
 			return true
 		}
-		if strings.Index(hay[i+1:], name) < 0 {
-			break
-		}
+		off = i + 1
 	}
 	return false
 }

--- a/internal/codenav/query/query.go
+++ b/internal/codenav/query/query.go
@@ -223,6 +223,249 @@ func GetOverview(db *sql.DB, repo string, hubLimit int) (*Overview, error) {
 	return ov, rows.Err()
 }
 
+// Noun is one domain concept in the product account: a type the product is
+// about, paired with its shape (compact signature), its meaning (the SC-2856
+// intent recorded above its declaration), and where it is defined.
+type Noun struct {
+	QName   string `json:"qname"`
+	Name    string `json:"name"`
+	Kind    string `json:"kind"`              // "type" today; retained for forward-compat
+	Shape   string `json:"shape,omitempty"`   // compact one-line signature
+	Meaning string `json:"meaning,omitempty"` // SC-2856 intent, folded to one line
+	File    string `json:"file"`
+	Line    int    `json:"line"`
+	// Invariants is the SC-2860 seam: the rules that constrain this noun, shown
+	// alongside it. Empty until SC-2860 lands; the account is complete without it.
+	Invariants []string `json:"invariants,omitempty"`
+}
+
+// Account is the compact, code-generated domain account of a product: the nouns
+// it is about, regenerated from the current index so it cannot disagree with the
+// code. Note is set (and Nouns empty) when an account cannot be produced, so a
+// caller never mistakes an empty list for a silent failure.
+type Account struct {
+	Repo  string `json:"repo,omitempty"`
+	Nouns []Noun `json:"nouns"`
+	Note  string `json:"note,omitempty"`
+}
+
+// infraSegments are directory names that mark a package as plumbing/infra; a
+// type defined under any of them is excluded from the account. "internal" is
+// deliberately absent — repos routinely root all code under internal/.
+var infraSegments = map[string]bool{
+	"util": true, "utils": true, "helper": true, "helpers": true,
+	"errors": true, "log": true, "logs": true, "logging": true, "logger": true,
+	"config": true, "configs": true, "testutil": true, "testutils": true,
+	"mock": true, "mocks": true, "fixture": true, "fixtures": true,
+	"testdata": true, "vendor": true, "node_modules": true,
+}
+
+// inInfraPackage reports whether any directory segment of a repo-relative path
+// is an infra/util package (the final path element, the filename, is ignored).
+func inInfraPackage(path string) bool {
+	segs := strings.Split(path, "/")
+	for _, s := range segs[:max(0, len(segs)-1)] {
+		if infraSegments[strings.ToLower(s)] {
+			return true
+		}
+	}
+	return false
+}
+
+// foldOneLine collapses runs of whitespace to single spaces and caps the result
+// at n runes with an ellipsis, so shape and meaning each stay one readable line.
+// A non-positive n is treated as "no cap" so the helper can never slice out of
+// range on a degenerate width.
+func foldOneLine(s string, n int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if r := []rune(s); n > 1 && len(r) > n {
+		return string(r[:n-1]) + "…"
+	}
+	return s
+}
+
+// wholeWordIn reports whether name appears as a whole identifier token in hay
+// (bounded by non-identifier characters), used to spot a type used in a route
+// handler's signature without a full parse.
+func wholeWordIn(hay, name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := strings.Index(hay, name); i >= 0; i = strings.Index(hay[i+1:], name) + (i + 1) {
+		before := i == 0 || !isIdentByte(hay[i-1])
+		end := i + len(name)
+		after := end >= len(hay) || !isIdentByte(hay[end])
+		if before && after {
+			return true
+		}
+		if strings.Index(hay[i+1:], name) < 0 {
+			break
+		}
+	}
+	return false
+}
+
+func isIdentByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
+// GetAccount computes the domain account: the type-kind symbols that are the
+// product's nouns, ranked so recorded intent (SC-2856) — never call frequency —
+// drives what surfaces, infra/util packages excluded. limit <= 0 uses 24.
+func GetAccount(db *sql.DB, repo string, limit int) (*Account, error) {
+	if limit <= 0 {
+		limit = 24
+	}
+	acct := &Account{Repo: repo}
+
+	// Route-handler signatures: a type named in one is a request/response noun.
+	handlerSigs, err := routeHandlerSignatures(db, repo)
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := `
+		SELECT s.qname, s.name, COALESCE(s.signature,''), COALESCE(s.doc,''),
+		       f.path, s.start_line,
+		       (SELECT COUNT(*) FROM reference r WHERE r.symbol_id = s.id) AS refs
+		FROM symbol s
+		JOIN file f    ON f.id = s.file_id
+		JOIN project p ON p.id = s.project_id
+		WHERE s.kind = 'type'`
+	var args []any
+	if repo != "" {
+		stmt += " AND p.name = ?"
+		args = append(args, repo)
+	}
+	rows, err := db.Query(stmt, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	type scored struct {
+		n     Noun
+		score int
+		refs  int
+	}
+	var cands []scored
+	sawType := false
+	for rows.Next() {
+		var qname, name, sig, doc, path string
+		var line, refs int
+		if err := rows.Scan(&qname, &name, &sig, &doc, &path, &line, &refs); err != nil {
+			return nil, err
+		}
+		sawType = true
+		if inInfraPackage(path) {
+			continue
+		}
+		score := refs
+		if score > 8 {
+			score = 8
+		}
+		if doc != "" {
+			score += 5
+		}
+		if strings.HasPrefix(strings.TrimSpace(sig), "struct{") {
+			score += 3
+		}
+		if wholeWordIn(handlerSigs, name) {
+			score += 4
+		}
+		if score == 0 {
+			continue // pure plumbing alias — no intent, no shape, unused
+		}
+		cands = append(cands, scored{
+			n: Noun{
+				QName: qname, Name: name, Kind: "type",
+				Shape:   foldOneLine(sig, 100),
+				Meaning: foldOneLine(doc, 160),
+				File:    path, Line: line,
+			},
+			score: score, refs: refs,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	sort.Slice(cands, func(i, j int) bool {
+		if cands[i].score != cands[j].score {
+			return cands[i].score > cands[j].score
+		}
+		if cands[i].refs != cands[j].refs {
+			return cands[i].refs > cands[j].refs
+		}
+		return cands[i].n.QName < cands[j].n.QName
+	})
+	if len(cands) > limit {
+		cands = cands[:limit]
+	}
+	for _, c := range cands {
+		acct.Nouns = append(acct.Nouns, c.n)
+	}
+
+	if len(acct.Nouns) == 0 {
+		acct.Note = accountEmptyNote(db, repo, sawType)
+	}
+	return acct, nil
+}
+
+// routeHandlerSignatures returns every detected route handler's signature joined
+// into one string, for cheap whole-word membership tests.
+func routeHandlerSignatures(db *sql.DB, repo string) (string, error) {
+	stmt := `
+		SELECT COALESCE(s.signature,'')
+		FROM route r
+		JOIN project p  ON p.id = r.project_id
+		JOIN symbol s   ON s.id = r.handler_id`
+	var args []any
+	if repo != "" {
+		stmt += " WHERE p.name = ?"
+		args = append(args, repo)
+	}
+	rows, err := db.Query(stmt, args...)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = rows.Close() }()
+	var b strings.Builder
+	for rows.Next() {
+		var sig string
+		if err := rows.Scan(&sig); err != nil {
+			return "", err
+		}
+		b.WriteString(sig)
+		b.WriteByte('\n')
+	}
+	return b.String(), rows.Err()
+}
+
+// accountEmptyNote states plainly why no account could be produced, rather than
+// returning a bare empty list.
+func accountEmptyNote(db *sql.DB, repo string, sawType bool) string {
+	if sawType {
+		return "no domain account: the index holds types, but all are plumbing/infra " +
+			"or unused (no recorded intent, no entity shape). Add doc comments to the " +
+			"product's core types (see SC-2856) so they surface."
+	}
+	var total int
+	q := `SELECT COUNT(*) FROM symbol s JOIN project p ON p.id = s.project_id`
+	var args []any
+	if repo != "" {
+		q += " WHERE p.name = ?"
+		args = append(args, repo)
+	}
+	_ = db.QueryRow(q, args...).Scan(&total)
+	if total == 0 {
+		return "nothing indexed (run: human codenav index <path>)"
+	}
+	return "no domain account: the index found no type declarations for this " +
+		"project. The indexer may read this language only structurally."
+}
+
 // RouteHit is a detected web route, optionally bound to a handler symbol.
 type RouteHit struct {
 	Method    string `json:"method"`


### PR DESCRIPTION
Closes SC-2857.

A run had no cheap account of *what a product is about*: the only cold-start
summary (`codenav overview`) ranks symbols by call frequency, which
structurally surfaces plumbing hubs and never the domain types a customer
would name.

This adds `human codenav account` — a page-sized account of the product's
nouns, generated from the index and ranked by recorded intent (doc comments,
route-surface membership) rather than call frequency, with infra packages
excluded. Dogfooded on this repo it returns 24 real domain nouns
(Comment, Issue, Instance, Provider, …), not plumbing.

Review found and this branch fixes: a staticcheck S1003 in the whole-word
scan, and a complexity-gate failure in `GetAccount` (now split into the row
scan, the scoring rule, and the ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)