### PR TITLE
[SC-3282] End the stage on a terminal ticket-review verdict

### DIFF
--- a/internal/claude/embed/human-ticket-reviewer-agent.md
+++ b/internal/claude/embed/human-ticket-reviewer-agent.md
@@ -84,6 +84,21 @@ EOF
 The board reads `linked:` to show the pointed-at ticket on the decided card and make it reachable — the
 value must be a single bare ticket key (the `<TICKET_KEY>` form), nothing else.
 
+### A terminal verdict also needs a terminal marker
+
+`superseded`, `escalated` and `rejected` all mean **there is nothing to plan on this ticket**. The
+`[human:ticket-review]` marker records *why*, but it does not end the stage: it classifies as a
+backlog-stage marker, so a card that already carries `[human:planning-started]` still reads as planning
+in progress. Exiting there looks exactly like a crash — no plan, no terminal marker — and the board reds
+the card and relaunches you to reach the same verdict again. Post the planning stage's terminal marker
+alongside the verdict:
+
+```bash
+human marker post <KEY> nothing-to-do --field "evidence=<the verdict, and the key that carries the work>"
+```
+
+Then stop. `ready` and `reframed` never post it — planning continues on those.
+
 Post `ticket-review-started` first, so the card shows the gate running instead of sitting in Backlog
 looking idle.
 

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -1504,11 +1504,22 @@ func (d BoardTransitionDeps) launchDeployFixAgent(ctx context.Context, pmKey, pr
 // cases that stay plannable, and stops with the reason recorded in the cases that
 // do not. A ticket already carrying a [human:ticket-review] marker skips the gate
 // so a planning retry does not re-review it.
+//
+// A terminal verdict must ALSO post [human:nothing-to-do], because "stop after
+// recording it" is not a stop the board can see: the [human:ticket-review]
+// marker classifies as a backlog-stage marker, so a card already carrying
+// [human:planning-started] still derives planning/running, and the stuck-running
+// pass reds it and relaunches — re-reaching the same verdict, forever (SC-3149
+// re-planned twelve times overnight on a verdict it got right the first time).
+// [human:nothing-to-do] is the planning stage's terminal resolved marker; naming
+// it here is what turns a correct verdict into a stop.
 func planPrompt(key string) string {
 	return "/human-ticket-review " + key +
 		" — then, if the verdict is ready or reframed, continue with /human-plan " + key +
 		" (a reframed verdict's corrected framing is in the [human:ticket-review] marker; plan against that, not the description)." +
-		" If the verdict is superseded, escalated or rejected, stop after recording it: the marker names the ticket that carries the work." +
+		" If the verdict is superseded, escalated or rejected, there is nothing to plan on this ticket:" +
+		" post the terminal marker — human marker post " + key + " nothing-to-do --field \"evidence=<the verdict, and the key that carries the work>\" —" +
+		" and then stop. Without it the board reads this run as a crash and re-plans the ticket forever." +
 		" Skip the review and go straight to /human-plan " + key + " when the ticket already carries a [human:ticket-review] marker." +
 		" BOARD CONTEXT: there is no user to ask — never end the run with a question; act on what you find and record it."
 }

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -2258,3 +2258,16 @@ func TestPlanPromptGatesPlanningOnTicketReview(t *testing.T) {
 	// The gate acts on its own findings; a board run has nobody to ask.
 	assert.Contains(t, p, "no user to ask")
 }
+
+// A terminal verdict stops the run, and a stop the board cannot see is not a
+// stop: without the terminal marker the card keeps deriving planning/running and
+// the stuck-running pass re-plans it forever (SC-3149, twelve times overnight).
+func TestPlanPromptNamesTheTerminalMarkerForUnplannableVerdicts(t *testing.T) {
+	p := planPrompt("SC-1")
+
+	assert.Contains(t, p, "superseded, escalated or rejected", "all three terminal verdicts must be covered")
+	assert.Contains(t, p, "human marker post SC-1 nothing-to-do",
+		"a terminal verdict must post the marker that resolves the planning stage")
+	assert.Contains(t, p, "re-plans the ticket forever",
+		"the dispatch must say what happens without the marker, so the rule is not dropped as boilerplate")
+}


### PR DESCRIPTION
Closes SC-3282.

SC-3149 was re-planned twelve times overnight on a verdict it got right the
first time. Every run succeeded: reviewed the ticket, concluded `superseded`
by SC-3030, posted the `[human:ticket-review]` marker, exited 0.

The planning dispatch told the agent to "stop after recording it" but never
named a marker the board recognises as a stop. `[human:ticket-review]`
classifies as a *backlog*-stage marker, so a card already carrying
`[human:planning-started]` still derives planning/running — and the
stuck-running pass reds it and relaunches, forever.

`[human:nothing-to-do]` is the planning stage's terminal resolved marker and
already exists; `human-plan-skill.md` documents this exact rule for the
planner's already-implemented path. The ticket-review gate was never given it.

- `planPrompt` now names the marker for all three terminal verdicts
  (`superseded`, `escalated`, `rejected`) and says what happens without it.
- The reviewer agent carries the rule itself, so a reviewer launched by a
  daemon that predates this change still terminates its own stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)