### PR TITLE
[SC-3292] Ctrl-C no longer quits the desktop app

### DIFF
--- a/desktop/closeflow.go
+++ b/desktop/closeflow.go
@@ -23,6 +23,10 @@ const closeBusyPollInterval = 3 * time.Second
 // (busy check, dialog, waiting) happens on the goroutine spawned below; this
 // function only flips fast, lock-free flags and returns.
 //
+// It answers a window close only. A terminal Ctrl-C/SIGTERM never gets this
+// far — signalexit.go ends the process first — because a dialog inside the
+// window is no answer to a question asked from a console (SC-3292).
+//
 // Wails' own runtime.Quit re-invokes this hook (confirmed in wails v2's
 // platform frontends) — that is how a delayed "actually close now" is
 // expressed: stopAndQuit sets readyToQuit first, then calls runtime.Quit,

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -21,6 +21,11 @@ var assets embed.FS
 func main() {
 	app := NewApp()
 
+	// Before wails.Run installs its own signal handler: a terminal Ctrl-C must
+	// end the app outright rather than being answered by the window's close
+	// dialog (SC-3292). See signalexit.go.
+	app.installConsoleExit()
+
 	// REGRESSION GUARD: this app must be built with `wails build` (make desktop)
 	// — NOT `go build ./desktop/`. Wails' main() requires the build tags that
 	// only `wails build`/`wails dev` inject; a plain `go build` links but the app

--- a/desktop/signalexit.go
+++ b/desktop/signalexit.go
@@ -1,0 +1,51 @@
+//go:build wailsapp
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// installConsoleExit makes a terminal signal end the app the way it did before
+// the window-close confirmation existed: immediately, and without touching the
+// daemon.
+//
+// It is needed because Wails installs its own SIGINT/SIGTERM handler
+// (wails/v2/internal/signal), which replaces Go's default terminate-on-Ctrl-C
+// and routes the signal into App.Shutdown → Frontend.Quit → OnBeforeClose. With
+// closeflow.go wired there, Ctrl-C stopped ending the app: it asked its
+// three-way question in a dialog inside the window while the person who pressed
+// it was looking at a terminal, and Wails' handler reads its channel exactly
+// once, so no later Ctrl-C could reach it either (SC-3292).
+//
+// A console launch is also a statement about ownership: whoever starts the app
+// from a shell manages their own daemon, so this path deliberately performs no
+// busy check and no daemon stop. It only drops the app's session marker — a
+// local file, never the daemon — so the next launch treats a daemon left
+// running as intentional rather than crash-orphaned, which is exactly what it
+// was before SC-3015 introduced the marker. Force-quit still leaves the marker
+// behind and is still detected as an orphan.
+//
+// Go delivers a signal to every registered channel, so Wails' handler still
+// runs; it simply loses to the os.Exit below, whichever order they start in.
+func (a *App) installConsoleExit() {
+	sigs := make(chan os.Signal, 2)
+	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		// A second signal must always end the process, even if clearing the
+		// marker below is somehow held up (a hung home directory) — never
+		// repeat the "Ctrl-C does nothing, twice" failure this fixes.
+		go func() {
+			<-sigs
+			os.Exit(1)
+		}()
+		_ = a.session.Clear()
+		// Zero, not 130: before the close hook existed this path unwound
+		// through gtk_main_quit and main returned normally, and a console
+		// launch should keep seeing the same exit status.
+		os.Exit(0)
+	}()
+}

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -89,6 +89,14 @@ CGO_LDFLAGS="-framework UniformTypeIdentifiers" \
 
 Equivalent dev-loop command: `wails dev` (or `make desktop-dev`, if defined).
 
+## Exiting the app
+
+The app has two exit paths, and they answer to different people.
+
+**Closing the window** goes through the confirmation flow (`desktop/closeflow.go`): an idle daemon is stopped silently, a busy one raises the three-way dialog (Cancel / Stop anyway / Wait and close), and the app clears its session marker so a cleanly stopped daemon is never later reported orphaned.
+
+**Ctrl-C (or SIGTERM) in the terminal** ends the process immediately and leaves the daemon running (`desktop/signalexit.go`). It performs no busy check, shows no dialog, and never stops the daemon: whoever starts the app from a console manages their own daemon. A dialog inside the window is no answer to a question asked from a shell — and Wails' own signal handler replaces Go's default terminate and routes signals into `OnBeforeClose`, so without this the app could not be ended from the terminal it was started in at all.
+
 ## Desktop-ticket verification template
 
 Any ticket that touches `desktop/` must state its verification this way:
@@ -98,6 +106,8 @@ Any ticket that touches `desktop/` must state its verification this way:
 > Additionally, for any change touching project lifecycle: quit the daemon (`human daemon stop`), relaunch the app, and confirm the Projects Overview screen appears (or the last project auto-loads if its directory still exists); pick a project and confirm the board loads; click **Switch Project** and confirm it stops the daemon and returns to the Projects Overview.
 >
 > For SC-3015 (close/orphan behavior): with the daemon idle, close the window and confirm the daemon process actually exits (`human daemon status`) with no dialog; start an agent run (or hold a stage lease) and close the window, confirming the three-way dialog appears, and that Cancel/Stop anyway/Wait and close each behave as described; force-quit the app (not the normal close) while its daemon is still running, then relaunch and confirm the orphan-cleanup prompt appears and both its choices (stop it / leave it running) behave correctly; separately, start a daemon manually via `human daemon start` with no app attached, launch the app, and confirm NO orphan prompt appears for it.
+>
+> For SC-3292 (console exit): launch from a terminal (`make desktop-dev`, or run the built binary directly), press Ctrl-C, and confirm the process ends at once — with an agent run in flight as well as idle, with no dialog either time — and that `human daemon status` shows the daemon still running afterwards. Relaunch and confirm NO orphan prompt appears for that daemon.
 
 ## Regression guard
 


### PR DESCRIPTION
Closing the window keeps its confirmation flow. A terminal Ctrl-C now ends the app immediately again — no busy check, no dialog, and the daemon is left running for whoever started it from a console to manage.

## Why it broke

Wails installs its own SIGINT/SIGTERM handler (`wails/v2/internal/signal`), which replaces Go's default terminate and calls `App.Shutdown` → `Frontend.Quit` → `OnBeforeClose`. Once SC-3015 wired `app.beforeClose` there, a signal took the window-close path: the terminal printed "Ctrl+C detected. Shutting down..." and the app raised its three-way dialog inside a window nobody was looking at. Wails reads its signal channel exactly once with no loop, so a second Ctrl-C reached nothing at all — the app could only be killed from another terminal.

## The fix

`desktop/signalexit.go` registers our own handler before `wails.Run`. Go delivers a signal to every registered channel, so Wails' handler still runs and simply loses to `os.Exit`, whichever starts first.

- No busy check, no daemon stop — a console launch owns its daemon.
- Clears only the local app-session marker, so a daemon left running reads as intentional rather than crash-orphaned (what it was before the marker existed). A force-quit still leaves the marker and is still detected as an orphan.
- A second signal exits unconditionally, so "Ctrl-C does nothing, twice" cannot recur even if the marker write hangs.
- Exit status 0, matching the pre-hook path that unwound through `gtk_main_quit`.

## Verification

`make check` green. `go vet -tags wailsapp,webkit2_41 ./desktop/...` clean — desktop code sits behind the `wailsapp` tag, so the default suite does not compile it. Manual smoke test per `docs/desktop-app.md` (console launch, Ctrl-C idle and mid-run, daemon still up afterwards, no orphan prompt on relaunch) is left to the reviewer's machine.

Fixes SC-3292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)