### PR TITLE
[SC-3295] Honour a gate's recorded stop in the durable reconcile pass

### DIFF
--- a/internal/daemon/board_reconcile.go
+++ b/internal/daemon/board_reconcile.go
@@ -547,6 +547,18 @@ func stuckCardIsOursToRed(derived BoardCard, card ReconcileCard) bool {
 	if cardPausedOnOpenOptions(derived) {
 		return false
 	}
+	// A gate that recorded a deliberate stop verdict (superseded/escalated/
+	// rejected) ended the work on purpose — the durable twin of the live path's
+	// deliberateStopRecorded guard, which handleBoardAgentExit and stageSettled
+	// have honoured since SC-2302 while this pass did not. That asymmetry is what
+	// let the class recur: whenever the live watcher misses the exit (a daemon
+	// restart, a dropped hook, a machine powered off) the card falls through to
+	// here, is redded as a hang, and is relaunched to reach the same verdict
+	// again — SC-3149 twelve times in one night. Read the same way on both paths,
+	// so the two can never disagree about what an ending is.
+	if deliberateStopRecorded(card.Comments) {
+		return false
+	}
 	return true
 }
 

--- a/internal/daemon/board_reconcile_retry_test.go
+++ b/internal/daemon/board_reconcile_retry_test.go
@@ -75,6 +75,73 @@ func TestReconcileStuckRunning_OpenSameStageOptionsIsCleanPause(t *testing.T) {
 	require.Empty(t, relaunched, "nothing to relaunch — the card is not dead, it is waiting on a human")
 }
 
+// SC-3295: the ticket-review gate runs UNDER planning but files its verdict as
+// a backlog-stage [human:ticket-review] marker, so a card that reached a
+// terminal verdict still derives planning/running. The live exit path has
+// honoured that verdict as a clean ending since SC-2302; this pass did not, so
+// whenever the live watcher missed the exit the card was redded as a hang and
+// relaunched to reach the same verdict again — SC-3149, twelve times in one
+// night. No failed marker, no relaunch.
+func TestReconcileStuckRunning_RecordedStopVerdictIsNotAHang(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	started := now.Add(-StuckRunningGrace - time.Minute)
+	for _, verdict := range []string{"superseded", "escalated", "rejected"} {
+		t.Run(verdict, func(t *testing.T) {
+			cards := []ReconcileCard{{
+				Key: "SC-1",
+				Comments: []tracker.Comment{
+					cmt(PlanningStartedHeader, started),
+					cmt("[human:ticket-review] "+verdict+"\nlinked: SC-2", started.Add(time.Second)),
+				},
+			}}
+			var posted []struct{ Key, Body string }
+			var relaunched []BoardStage
+			retry := StageRetry{
+				Max:      2,
+				Outcome:  func(string, BoardStage) (string, bool) { return "", false },
+				Attempts: func(string, BoardStage) (int, error) { return 0, nil },
+				Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
+			}
+
+			n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
+				capturingPoster(&posted), retry, nil, nil, "d1", now, zerolog.Nop())
+
+			require.Equal(t, 0, n, "a recorded stop verdict is a deliberate ending, not a hang")
+			require.Empty(t, posted, "no failed marker for work a gate stopped on purpose")
+			require.Empty(t, relaunched, "relaunching only reaches the same verdict again")
+		})
+	}
+}
+
+// The guard must not swallow a genuine hang: a card whose gate said the ticket
+// is fine (ready/reframed) is still ordinary in-flight work, and a stage of it
+// that dies silently must still be redded and relaunched.
+func TestReconcileStuckRunning_ContinueVerdictStillReds(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	started := now.Add(-StuckRunningGrace - time.Minute)
+	cards := []ReconcileCard{{
+		Key: "SC-1",
+		Comments: []tracker.Comment{
+			cmt(PlanningStartedHeader, started),
+			cmt("[human:ticket-review] ready", started.Add(time.Second)),
+		},
+	}}
+	var posted []struct{ Key, Body string }
+	var relaunched []BoardStage
+	retry := StageRetry{
+		Max:      2,
+		Outcome:  func(string, BoardStage) (string, bool) { return "", false },
+		Attempts: func(string, BoardStage) (int, error) { return 1, nil },
+		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
+	}
+
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
+		capturingPoster(&posted), retry, nil, nil, "d1", now, zerolog.Nop())
+
+	require.Equal(t, 1, n, "a ready verdict means the work continues, so a dead stage is still a hang")
+	require.Equal(t, []BoardStage{BoardPlanning}, relaunched)
+}
+
 // 1957: a question raised late in a card's life deliberately names an
 // EARLIER rework stage — answering it means going back and redoing that
 // work. That is still a deliberate human pause, not a hang: reconcile must


### PR DESCRIPTION
Closes SC-3295. Follow-up to SC-3282, and the reason that class recurred.

SC-2302 already built the general guarantee: `terminalStopVerdicts` +
`deliberateStopRecorded`, stage-agnostic, so "a new gate registers one table
entry and can never be mistaken for a crash by default".

It is consulted on the **live** exit path only — `handleBoardAgentExit` and
`stageSettled`. The durable reconcile pass never asked. `stuckCardIsOursToRed`
carries the twin of the live path's *options* guard, but had no twin for the
stop verdict — so whenever the live watcher missed an exit (daemon restart,
dropped hook, machine powered off), the card fell through to the durable net,
was redded as "Stuck in planning: no terminal marker and no live agent", and
relaunched to reach the same verdict again. SC-3149: twelve times in one night.

`deliberateStopRecorded` reads the latest marker *of its type*, not the latest
marker overall, so it stays true across re-dispatches — which is what makes it
usable here.

Tests: all three stop verdicts (superseded/escalated/rejected) are left alone
(verified failing before the guard, on all three), and a `ready` verdict still
reds and relaunches a silently-dead stage, so the guard cannot swallow a real
hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)