### PR TITLE
[SC-3362] Install the container proxy redirect reliably, and never fail it in silence

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
     "source=${localEnv:HOME}/.human/ca.crt,target=/home/vscode/.human/ca.crt,type=bind,readonly"
   ],
   "name": "human secure container",
-  "postStartCommand": "export HUMAN_PROXY_ADDR=$(getent hosts host.docker.internal | awk '{print $1}'):19287 \u0026\u0026 sudo -E human-proxy-setup \u0026\u0026 sudo cp /home/vscode/.human/ca.crt /usr/local/share/ca-certificates/human-proxy.crt \u0026\u0026 sudo update-ca-certificates \u0026\u0026 human install --agent claude \u0026\u0026 human chrome-bridge \u0026\u0026 go install golang.org/x/tools/gopls@latest \u0026\u0026 go install golang.org/x/tools/gopls@latest \u0026\u0026 npm install -g @vtsls/language-server",
+  "postStartCommand": "export HUMAN_PROXY_ADDR=$(getent hosts host.docker.internal | awk 'NR==1{print $1}'):19287 \u0026\u0026 sudo -E human-proxy-setup \u0026\u0026 sudo cp /home/vscode/.human/ca.crt /usr/local/share/ca-certificates/human-proxy.crt \u0026\u0026 sudo update-ca-certificates \u0026\u0026 human install --agent claude \u0026\u0026 human chrome-bridge \u0026\u0026 go install golang.org/x/tools/gopls@latest \u0026\u0026 go install golang.org/x/tools/gopls@latest \u0026\u0026 npm install -g @vtsls/language-server",
   "remoteEnv": {
     "BROWSER": "human-browser",
     "HUMAN_CHROME_ADDR": "host.docker.internal:19286",

--- a/internal/devcontainer/hooks.go
+++ b/internal/devcontainer/hooks.go
@@ -155,6 +155,18 @@ func lastLines(s string, maxBytes int) string {
 	return "...\n" + tail
 }
 
+// reportHookFailure announces a failed lifecycle hook on both the logger and
+// the caller's writer. The writer is the load-bearing half: agent launches
+// build a Manager without a Logger, and a zero zerolog.Logger is disabled, so a
+// logger-only warning vanishes — which is how containers ran for months with a
+// dead postStartCommand (no proxy redirect, no CA trust) while the output read
+// as a clean success. out already carries the "Running <hook>..." lines, so the
+// failure lands wherever the caller is already looking.
+func reportHookFailure(logger zerolog.Logger, out io.Writer, what string, err error) {
+	logger.Warn().Err(err).Msgf("%s failed, container is running but may be incomplete", what)
+	_, _ = fmt.Fprintf(out, "WARNING: %s failed, container is running but may be incomplete: %v\n", what, err)
+}
+
 // RunLifecycleHooks executes the devcontainer lifecycle hooks in order inside a container.
 // Sequence: onCreateCommand -> updateContentCommand -> postCreateCommand -> postStartCommand
 func RunLifecycleHooks(ctx context.Context, docker DockerClient, containerID, user string, cfg *DevcontainerConfig, logger zerolog.Logger, out io.Writer) error {

--- a/internal/devcontainer/manager.go
+++ b/internal/devcontainer/manager.go
@@ -149,7 +149,7 @@ func (m *Manager) createFresh(ctx context.Context, cfg *DevcontainerConfig, proj
 	// Features are already baked into the image by EnsureImage.
 	// Run lifecycle hooks only.
 	if err := RunLifecycleHooks(ctx, m.Docker, containerID, remoteUser, cfg, m.Logger, out); err != nil {
-		m.Logger.Warn().Err(err).Msg("lifecycle hooks failed, container is running but may be incomplete")
+		reportHookFailure(m.Logger, out, "lifecycle hooks", err)
 	}
 
 	now := time.Now()
@@ -251,7 +251,7 @@ func (m *Manager) handleExisting(ctx context.Context, existing ContainerSummary,
 		if cfg.PostStartCommand != nil {
 			_, _ = fmt.Fprintln(out, "Running postStartCommand...")
 			if err := RunHook(ctx, m.Docker, existing.ID, remoteUser, cfg.PostStartCommand, m.Logger); err != nil {
-				m.Logger.Warn().Err(err).Msg("postStartCommand failed")
+				reportHookFailure(m.Logger, out, "postStartCommand", err)
 			}
 		}
 

--- a/internal/devcontainer/manager_test.go
+++ b/internal/devcontainer/manager_test.go
@@ -1176,3 +1176,25 @@ func TestManager_Up_DoesNotDuplicateInjectedExtraHost(t *testing.T) {
 		t.Errorf("ExtraHosts = %v, want exactly one host.docker.internal entry", hosts)
 	}
 }
+
+// Agent launches build a Manager with no Logger, and a zero zerolog.Logger is
+// disabled — so a failed hook must still be announced on the caller's writer,
+// or a container comes up incomplete (no proxy redirect, no CA trust) while the
+// output reads as a clean success.
+func TestManager_Up_FailedHookIsVisibleWithoutLogger(t *testing.T) {
+	projectDir, mock, docker := setupTestProject(t, `{
+		"name": "test", "image": "ubuntu:22.04", "remoteUser": "vscode",
+		"postStartCommand": "human-proxy-setup"
+	}`)
+	mock.execExit = 1
+
+	mgr := &Manager{Docker: docker} // no Logger: the agent-launch condition
+	var buf bytes.Buffer
+	if _, err := mgr.Up(context.Background(), UpOptions{ProjectDir: projectDir, Out: &buf}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(buf.String(), "WARNING") || !strings.Contains(buf.String(), "may be incomplete") {
+		t.Errorf("a failed lifecycle hook must be reported on the writer: %s", buf.String())
+	}
+}

--- a/internal/devcontainer/manager_test.go
+++ b/internal/devcontainer/manager_test.go
@@ -1151,3 +1151,28 @@ func writeCachesConfig(t *testing.T, projectDir, content string) {
 		t.Fatal(err)
 	}
 }
+
+// A project that declares the same --add-host the manager already injects must
+// not end up with the host twice: Docker writes one /etc/hosts line per entry,
+// and a duplicate line makes `getent hosts` print two — which is how the
+// container's proxy redirect silently stopped being installed.
+func TestManager_Up_DoesNotDuplicateInjectedExtraHost(t *testing.T) {
+	projectDir, mock, docker := setupTestProject(t, `{
+		"name": "test", "image": "ubuntu:22.04", "remoteUser": "vscode",
+		"runArgs": ["--add-host=host.docker.internal:host-gateway"]
+	}`)
+
+	mgr := &Manager{Docker: docker, Logger: testLogger()}
+	var buf bytes.Buffer
+	if _, err := mgr.Up(context.Background(), UpOptions{ProjectDir: projectDir, Out: &buf}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(mock.createCalls) != 1 {
+		t.Fatalf("expected 1 create call, got %d", len(mock.createCalls))
+	}
+	hosts := mock.createCalls[0].ExtraHosts
+	if len(hosts) != 1 || hosts[0] != "host.docker.internal:host-gateway" {
+		t.Errorf("ExtraHosts = %v, want exactly one host.docker.internal entry", hosts)
+	}
+}

--- a/internal/devcontainer/runargs.go
+++ b/internal/devcontainer/runargs.go
@@ -36,11 +36,11 @@ func needsValue(key string) bool {
 func applyRunArg(key, val string, opts *ContainerCreateOptions, logger zerolog.Logger, raw string) {
 	switch key {
 	case "--add-host":
-		opts.ExtraHosts = append(opts.ExtraHosts, val)
+		opts.ExtraHosts = appendUnique(opts.ExtraHosts, val)
 	case "--cap-add":
-		opts.CapAdd = append(opts.CapAdd, val)
+		opts.CapAdd = appendUnique(opts.CapAdd, val)
 	case "--security-opt":
-		opts.SecurityOpt = append(opts.SecurityOpt, val)
+		opts.SecurityOpt = appendUnique(opts.SecurityOpt, val)
 	case "--privileged":
 		opts.Privileged = true
 	case "--network":
@@ -48,4 +48,21 @@ func applyRunArg(key, val string, opts *ContainerCreateOptions, logger zerolog.L
 	default:
 		logger.Warn().Str("flag", raw).Msg("unsupported runArg, skipping")
 	}
+}
+
+// appendUnique adds val unless the list already carries it. These three flags
+// are sets, and runArgs are merged on top of entries the manager injects itself
+// — so the project's own "--add-host=host.docker.internal:host-gateway"
+// duplicates the injected one. Docker writes each entry to /etc/hosts, and the
+// duplicate line then makes `getent hosts host.docker.internal` return two
+// lines: every consumer that substitutes that output into an address gets a
+// value with a newline in it, which is how the container proxy redirect stopped
+// being installed at all.
+func appendUnique(list []string, val string) []string {
+	for _, existing := range list {
+		if existing == val {
+			return list
+		}
+	}
+	return append(list, val)
 }

--- a/internal/init/step_devcontainer.go
+++ b/internal/init/step_devcontainer.go
@@ -227,6 +227,12 @@ func buildDevcontainerConfig(proxy, intercept bool, stacks []StackType, caPresen
 		},
 	}
 
+	// The proxy address is read out of /etc/hosts at start-up, and NR==1 is
+	// load-bearing: a host mapped twice (the manager injects the same
+	// --add-host these runArgs carry) makes getent print two lines, and the
+	// resulting HUMAN_PROXY_ADDR holds a newline. human-proxy-setup then hands
+	// that to iptables, dies under set -e, and takes the whole && chain with it
+	// — no redirect, no CA trust, no agent install, and nothing said so.
 	switch {
 	case proxy && intercept:
 		cfg.CapAdd = []string{"NET_ADMIN"}
@@ -240,13 +246,13 @@ func buildDevcontainerConfig(proxy, intercept bool, stacks []StackType, caPresen
 			// Node's PEM parse then fails on every run.
 			cfg.Mounts = []string{"source=${localEnv:HOME}/.human/ca.crt,target=/home/vscode/.human/ca.crt,type=bind,readonly"}
 			cfg.RemoteEnv["NODE_EXTRA_CA_CERTS"] = "/home/vscode/.human/ca.crt"
-			cfg.PostStartCommand = "export HUMAN_PROXY_ADDR=$(getent hosts host.docker.internal | awk '{print $1}'):19287 && sudo -E human-proxy-setup && sudo cp /home/vscode/.human/ca.crt /usr/local/share/ca-certificates/human-proxy.crt && sudo update-ca-certificates && human install --agent claude && human chrome-bridge"
+			cfg.PostStartCommand = "export HUMAN_PROXY_ADDR=$(getent hosts host.docker.internal | awk 'NR==1{print $1}'):19287 && sudo -E human-proxy-setup && sudo cp /home/vscode/.human/ca.crt /usr/local/share/ca-certificates/human-proxy.crt && sudo update-ca-certificates && human install --agent claude && human chrome-bridge"
 		} else {
-			cfg.PostStartCommand = "export HUMAN_PROXY_ADDR=$(getent hosts host.docker.internal | awk '{print $1}'):19287 && sudo -E human-proxy-setup && human install --agent claude && human chrome-bridge"
+			cfg.PostStartCommand = "export HUMAN_PROXY_ADDR=$(getent hosts host.docker.internal | awk 'NR==1{print $1}'):19287 && sudo -E human-proxy-setup && human install --agent claude && human chrome-bridge"
 		}
 	case proxy:
 		cfg.CapAdd = []string{"NET_ADMIN"}
-		cfg.PostStartCommand = "export HUMAN_PROXY_ADDR=$(getent hosts host.docker.internal | awk '{print $1}'):19287 && sudo -E human-proxy-setup && human install --agent claude && human chrome-bridge"
+		cfg.PostStartCommand = "export HUMAN_PROXY_ADDR=$(getent hosts host.docker.internal | awk 'NR==1{print $1}'):19287 && sudo -E human-proxy-setup && human install --agent claude && human chrome-bridge"
 	default:
 		cfg.PostStartCommand = "human install --agent claude && human chrome-bridge"
 	}

--- a/internal/init/step_devcontainer_test.go
+++ b/internal/init/step_devcontainer_test.go
@@ -43,3 +43,35 @@ func TestBuildDevcontainerConfig_CACertMountGating(t *testing.T) {
 		})
 	}
 }
+
+// Every generated proxy variant reads the proxy host out of /etc/hosts. A host
+// mapped twice makes getent print two lines, and an unqualified awk turns that
+// into a HUMAN_PROXY_ADDR carrying a newline — human-proxy-setup then feeds it
+// to iptables, dies under set -e, and takes the rest of the && chain (CA trust,
+// agent install, chrome bridge) with it. NR==1 is what keeps a duplicate host
+// entry from silently disarming the container's proxy redirect.
+func TestBuildDevcontainerConfig_ProxyAddrTakesFirstHostsLine(t *testing.T) {
+	tests := []struct {
+		name      string
+		proxy     bool
+		intercept bool
+		caPresent bool
+	}{
+		{name: "proxy and intercept with ca", proxy: true, intercept: true, caPresent: true},
+		{name: "proxy and intercept without ca", proxy: true, intercept: true, caPresent: false},
+		{name: "proxy only", proxy: true, intercept: false, caPresent: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := buildDevcontainerConfig(tt.proxy, tt.intercept, nil, tt.caPresent)
+			cmd := cfg.PostStartCommand
+			if !strings.Contains(cmd, "getent hosts host.docker.internal") {
+				t.Fatalf("postStartCommand does not read the proxy host: %s", cmd)
+			}
+			if !strings.Contains(cmd, "awk 'NR==1{print $1}'") {
+				t.Errorf("postStartCommand must take only the first hosts line: %s", cmd)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes SC-3362.

Agent containers were coming up with their whole postStart chain dead — no proxy redirect, no CA in the trust store, no chrome bridge — while the daemon output read as a clean success.

**The chain**

1. The container manager injects `host.docker.internal:host-gateway` and a project's `runArgs` name the same mapping, so Docker writes the `/etc/hosts` line twice.
2. The generated postStart command resolves the proxy address with `getent hosts … | awk '{print $1}'`, which then returns two lines — the exported address carries a newline.
3. The setup script feeds that to iptables, fails, and under `set -e` takes the rest of the `&&` chain with it.
4. The failure was reported only through the manager's logger, and an agent launch builds the manager without one. A zero-value `zerolog.Logger` is disabled, so the warning was discarded.

**The fix**, one commit per link:

- merge `--add-host` / `--cap-add` / `--security-opt` as sets, so an entry the manager already injected is never added twice;
- pin the address lookup to the first hosts line, which also repairs `devcontainer.json` files generated before the merge was deduplicated;
- report a failed lifecycle hook on the caller's writer as well, where the "Running <hook>…" lines already go.

Both regressions fail before the fix with the real symptom (two identical `ExtraHosts` entries; a silent clean-success output) and pass after. `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)