### PR TITLE
[SC-3374] Hand containers a proxy address they can use, not one they must derive

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
     "source=${localEnv:HOME}/.human/ca.crt,target=/home/vscode/.human/ca.crt,type=bind,readonly"
   ],
   "name": "human secure container",
-  "postStartCommand": "export HUMAN_PROXY_ADDR=$(getent hosts host.docker.internal | awk 'NR==1{print $1}'):19287 \u0026\u0026 sudo -E human-proxy-setup \u0026\u0026 sudo cp /home/vscode/.human/ca.crt /usr/local/share/ca-certificates/human-proxy.crt \u0026\u0026 sudo update-ca-certificates \u0026\u0026 human install --agent claude \u0026\u0026 human chrome-bridge \u0026\u0026 go install golang.org/x/tools/gopls@latest \u0026\u0026 go install golang.org/x/tools/gopls@latest \u0026\u0026 npm install -g @vtsls/language-server",
+  "postStartCommand": "case \"$HUMAN_PROXY_ADDR\" in ''|*[!0-9.:]*) HUMAN_PROXY_ADDR=\"$(getent hosts host.docker.internal | awk 'NR==1{print $1}'):19287\";; esac; export HUMAN_PROXY_ADDR;  sudo -E human-proxy-setup && sudo cp /home/vscode/.human/ca.crt /usr/local/share/ca-certificates/human-proxy.crt && sudo update-ca-certificates && human install --agent claude && human chrome-bridge && go install golang.org/x/tools/gopls@latest && go install golang.org/x/tools/gopls@latest && npm install -g @vtsls/language-server",
   "remoteEnv": {
     "BROWSER": "human-browser",
     "HUMAN_CHROME_ADDR": "host.docker.internal:19286",

--- a/internal/devcontainer/host.go
+++ b/internal/devcontainer/host.go
@@ -2,11 +2,14 @@ package devcontainer
 
 import (
 	"context"
+	"net"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/moby/moby/client"
 
+	"github.com/gethuman-sh/human/internal/daemon"
 	"github.com/gethuman-sh/human/internal/dockerhost"
 )
 
@@ -43,6 +46,22 @@ func ContainerReachableHost() string {
 		return gw
 	}
 	return LoopbackHost
+}
+
+// proxyAddrForContainer returns the proxy address in the form a container's
+// redirect can actually use. iptables resolves nothing — nf_tables rejects a
+// hostname in --to-destination outright — so the redirect needs a literal IP,
+// and the container was left deriving one out of /etc/hosts. On Linux the
+// daemon binds the proxy on the docker bridge gateway, which is precisely what
+// host.docker.internal maps to inside the container, so hand it over already
+// resolved and nothing in the container has to read /etc/hosts at all. Where
+// the gateway is not knowable host-side (Docker Desktop, Docker down) the
+// hostname stays and the container resolves it itself.
+func proxyAddrForContainer(reachableHost string, port int) string {
+	if reachableHost == "" || reachableHost == LoopbackHost {
+		return net.JoinHostPort(daemon.DockerHost, strconv.Itoa(port))
+	}
+	return net.JoinHostPort(reachableHost, strconv.Itoa(port))
 }
 
 // dockerBridgeGateway returns the gateway IP of Docker's default bridge network,

--- a/internal/devcontainer/host_test.go
+++ b/internal/devcontainer/host_test.go
@@ -1,0 +1,28 @@
+package devcontainer
+
+import "testing"
+
+// The container's redirect is installed with iptables, which refuses a hostname
+// outright — so the address handed to a container has to be an IP wherever the
+// host can determine one, and may only fall back to the name the container
+// resolves itself when it cannot.
+func TestProxyAddrForContainer(t *testing.T) {
+	tests := []struct {
+		name      string
+		reachable string
+		want      string
+	}{
+		{name: "bridge gateway is handed over resolved", reachable: "172.17.0.1", want: "172.17.0.1:19287"},
+		{name: "loopback is not container-reachable, keep the name", reachable: LoopbackHost, want: "host.docker.internal:19287"},
+		{name: "unknown host keeps the name", reachable: "", want: "host.docker.internal:19287"},
+		{name: "ipv6 gateway is bracketed", reachable: "fd00::1", want: "[fd00::1]:19287"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := proxyAddrForContainer(tt.reachable, 19287); got != tt.want {
+				t.Errorf("proxyAddrForContainer(%q) = %q, want %q", tt.reachable, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/devcontainer/manager.go
+++ b/internal/devcontainer/manager.go
@@ -295,7 +295,7 @@ func (m *Manager) buildCreateOptions(cfg *DevcontainerConfig, projectDir, config
 			"HUMAN_DAEMON_ADDR="+daemon.DockerHost+":"+fmt.Sprint(daemon.DefaultPort),
 			"HUMAN_DAEMON_TOKEN="+daemonInfo.Token,
 			"HUMAN_CHROME_ADDR="+daemon.DockerHost+":"+fmt.Sprint(daemon.DefaultChromePort),
-			"HUMAN_PROXY_ADDR="+daemon.DockerHost+":"+fmt.Sprint(daemon.DefaultProxyPort),
+			"HUMAN_PROXY_ADDR="+proxyAddrForContainer(ContainerReachableHost(), daemon.DefaultProxyPort),
 			"BROWSER=human-browser",
 		)
 	}

--- a/internal/init/step_devcontainer.go
+++ b/internal/init/step_devcontainer.go
@@ -193,6 +193,20 @@ func checkDevcontainerPrereqs() []string {
 	return hints
 }
 
+// proxyAddrPrelude prepares HUMAN_PROXY_ADDR for the container's redirect
+// script. The daemon hands containers it starts an address already resolved to
+// an IP, so this leaves it untouched and nothing reads /etc/hosts at all. It
+// only falls back to resolving the hostname on the standalone `devcontainer up`
+// path, where nothing injects a resolved address and iptables would otherwise
+// be handed a name it flatly refuses (nf_tables rejects a hostname in
+// --to-destination). NR==1 is load-bearing in that fallback: a host mapped
+// twice makes getent print two lines, and the address would carry a newline.
+func proxyAddrPrelude() string {
+	return fmt.Sprintf(
+		`case "$HUMAN_PROXY_ADDR" in ''|*[!0-9.:]*) HUMAN_PROXY_ADDR="$(getent hosts %s | awk 'NR==1{print $1}'):%d";; esac; export HUMAN_PROXY_ADDR; `,
+		daemon.DockerHost, daemon.DefaultProxyPort)
+}
+
 func buildDevcontainerConfig(proxy, intercept bool, stacks []StackType, caPresent bool) devcontainerConfig {
 	featureOpts := map[string]any{}
 	if proxy {
@@ -227,12 +241,6 @@ func buildDevcontainerConfig(proxy, intercept bool, stacks []StackType, caPresen
 		},
 	}
 
-	// The proxy address is read out of /etc/hosts at start-up, and NR==1 is
-	// load-bearing: a host mapped twice (the manager injects the same
-	// --add-host these runArgs carry) makes getent print two lines, and the
-	// resulting HUMAN_PROXY_ADDR holds a newline. human-proxy-setup then hands
-	// that to iptables, dies under set -e, and takes the whole && chain with it
-	// — no redirect, no CA trust, no agent install, and nothing said so.
 	switch {
 	case proxy && intercept:
 		cfg.CapAdd = []string{"NET_ADMIN"}
@@ -246,13 +254,13 @@ func buildDevcontainerConfig(proxy, intercept bool, stacks []StackType, caPresen
 			// Node's PEM parse then fails on every run.
 			cfg.Mounts = []string{"source=${localEnv:HOME}/.human/ca.crt,target=/home/vscode/.human/ca.crt,type=bind,readonly"}
 			cfg.RemoteEnv["NODE_EXTRA_CA_CERTS"] = "/home/vscode/.human/ca.crt"
-			cfg.PostStartCommand = "export HUMAN_PROXY_ADDR=$(getent hosts host.docker.internal | awk 'NR==1{print $1}'):19287 && sudo -E human-proxy-setup && sudo cp /home/vscode/.human/ca.crt /usr/local/share/ca-certificates/human-proxy.crt && sudo update-ca-certificates && human install --agent claude && human chrome-bridge"
+			cfg.PostStartCommand = proxyAddrPrelude() + "sudo -E human-proxy-setup && sudo cp /home/vscode/.human/ca.crt /usr/local/share/ca-certificates/human-proxy.crt && sudo update-ca-certificates && human install --agent claude && human chrome-bridge"
 		} else {
-			cfg.PostStartCommand = "export HUMAN_PROXY_ADDR=$(getent hosts host.docker.internal | awk 'NR==1{print $1}'):19287 && sudo -E human-proxy-setup && human install --agent claude && human chrome-bridge"
+			cfg.PostStartCommand = proxyAddrPrelude() + "sudo -E human-proxy-setup && human install --agent claude && human chrome-bridge"
 		}
 	case proxy:
 		cfg.CapAdd = []string{"NET_ADMIN"}
-		cfg.PostStartCommand = "export HUMAN_PROXY_ADDR=$(getent hosts host.docker.internal | awk 'NR==1{print $1}'):19287 && sudo -E human-proxy-setup && human install --agent claude && human chrome-bridge"
+		cfg.PostStartCommand = proxyAddrPrelude() + "sudo -E human-proxy-setup && human install --agent claude && human chrome-bridge"
 	default:
 		cfg.PostStartCommand = "human install --agent claude && human chrome-bridge"
 	}

--- a/internal/init/step_devcontainer_test.go
+++ b/internal/init/step_devcontainer_test.go
@@ -44,12 +44,13 @@ func TestBuildDevcontainerConfig_CACertMountGating(t *testing.T) {
 	}
 }
 
-// Every generated proxy variant reads the proxy host out of /etc/hosts. A host
-// mapped twice makes getent print two lines, and an unqualified awk turns that
-// into a HUMAN_PROXY_ADDR carrying a newline — human-proxy-setup then feeds it
-// to iptables, dies under set -e, and takes the rest of the && chain (CA trust,
-// agent install, chrome bridge) with it. NR==1 is what keeps a duplicate host
-// entry from silently disarming the container's proxy redirect.
+// The daemon hands containers it starts an address already resolved to an IP,
+// so no generated variant may overwrite it: reading /etc/hosts is the fallback
+// for the standalone `devcontainer up` path only. The fallback itself stays
+// pinned to the first line — a host mapped twice makes getent print two, and
+// the address would carry a newline, which iptables rejects under set -e,
+// taking the rest of the && chain (CA trust, agent install, chrome bridge)
+// with it.
 func TestBuildDevcontainerConfig_ProxyAddrTakesFirstHostsLine(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -71,6 +72,9 @@ func TestBuildDevcontainerConfig_ProxyAddrTakesFirstHostsLine(t *testing.T) {
 			}
 			if !strings.Contains(cmd, "awk 'NR==1{print $1}'") {
 				t.Errorf("postStartCommand must take only the first hosts line: %s", cmd)
+			}
+			if !strings.Contains(cmd, `case "$HUMAN_PROXY_ADDR" in`) {
+				t.Errorf("postStartCommand must leave an already-resolved address alone: %s", cmd)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes SC-3374. Follow-on to SC-3362 (#383).

The container's redirect is installed with iptables, which refuses a hostname outright — verified: `iptables ... --to-destination host.docker.internal:19287` fails with `Bad IP address`. So the address must be an IP by the time it reaches the container, and the container was deriving one itself by parsing `/etc/hosts` at start-up. That parse is what a duplicated host mapping broke in SC-3362.

The daemon already binds the proxy on the docker bridge gateway — precisely what `host.docker.internal` maps to inside the container — so it now hands that over already resolved, and a container it starts reads nothing out of `/etc/hosts`. Where the container-visible address is not knowable host-side (Docker Desktop, Docker down) the name is passed unchanged rather than a wrong IP.

The generated start-up command now resolves *only* when the address is not already an IP, which keeps the documented standalone `devcontainer up` path working — nothing injects an address there. Verified in a container with a deliberately duplicated host mapping, all three cases land on `172.17.0.1:19287`:

| `HUMAN_PROXY_ADDR` in | result |
|---|---|
| `172.17.0.1:19287` | untouched, no `/etc/hosts` read |
| `host.docker.internal:19287` | resolved |
| unset | resolved |

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)