### PR TITLE
[SC-3376] Planning runs that produce a plan no longer red-card as crashes

### DIFF
--- a/internal/claude/embed/human-plan-skill.md
+++ b/internal/claude/embed/human-plan-skill.md
@@ -177,6 +177,16 @@ human marker post <PM_KEY> plan-ready
 
 `<PM_KEY>` is the original PM ticket key from the plan's `**PM ticket**:` header. This mirrors the `[human:ready-for-review]` handoff that `human-executor` posts after implementation.
 
+**This marker is what finishes a planning run.** Attaching the plan in Phase 5
+does not advance the card and neither does any state record — a plan comment is
+content, not a stage signal. A run that attaches a plan and stops here exits 0,
+looks successful in its own summary, and still reddens the card as a crash.
+Verify it landed before reporting anything:
+
+```bash
+human marker list <PM_KEY> | grep plan-ready
+```
+
 ## Retry budgets, flakes, and how this run may end
 
 The board's planning stage runs this skill, so it must recover like every other stage rather than stopping at the first failure.
@@ -191,22 +201,37 @@ human state get  <PM_KEY> budget.planning.attempts --default 0
 
 Infrastructure trouble — a dead container, a network blip — is never a real attempt; it is a `retryable` ending, and the board relaunches the stage automatically rather than reddening the card.
 
-Record the outcome before finishing, so the board can tell a glitch from a blocker:
+Record the outcome so the board can tell a glitch from a blocker:
 
 ```bash
 human state set <PM_KEY> stage.planning --json --body-file - <<'EOF'
 {"exit":"done",
- "outcome":"<plan-ready|nothing-to-do|decision-required>",
+ "outcome":"<planned|nothing-to-do|decision-required>",
  "summary":"<one line>",
  "evidence":"<the marker or ticket that carries the result>"}
 EOF
 ```
 
+**This state record is NOT the stage handoff, and writing it does not finish the
+run.** The board never reads agent state to advance a card — only the
+`[human:plan-ready]` marker from Phase 6 does that. Writing `exit: done` here
+while that marker is missing is the one combination that strands a card: the
+plan is attached and correct, the run exits 0, and the board still reads a crash
+and reddens it. If you have written this and not yet posted the Phase 6 marker,
+**go back and post it now** — that, not this record, is the last act of a
+planning run.
+
 <!-- human:include exit-contract -->
 
 ## After completion
+
+Before reporting, confirm the run actually ended: a planning run is finished
+only once `[human:plan-ready]` is on the PM ticket (or a terminal marker from
+Phase 3a/3b took its place). If it is not there, post it — do not report a plan
+as ready on the strength of the plan comment alone.
 
 Tell the user:
 - A short summary of the plan (3-5 bullet points: what will change, key files, risks)
 - Whether verification found issues and what was corrected
 - Where the plan landed: the engineering ticket key (split topology) or the `[human:plan]` comment on the ticket (single-tracker topology)
+- That `[human:plan-ready]` is posted, so the card can advance

--- a/internal/daemon/board_retry.go
+++ b/internal/daemon/board_retry.go
@@ -124,6 +124,18 @@ const (
 // a flake, relaunched charged. Anything else is a deliberate exit we do not
 // recognise and is left for a human rather than looped on a sentence we cannot
 // parse.
+//
+// ExitDone is the contradiction case, and it is relaunched rather than left red.
+// This classifier only runs once a stage has already been judged failed for
+// finishing without its done-marker, so a recorded "done" means the agent
+// believes it succeeded while the board holds no evidence that it did. Markers
+// are what advance a card, so as far as the pipeline is concerned the stage did
+// not complete, and a bounded relaunch is the remedy every other incomplete
+// stage gets. Sitting in relaunchNone it was treated identically to
+// needs-human-work — "deliberate, ask a human" — which stranded planning runs
+// that had produced a perfectly good plan and only missed the marker. The
+// attempt cap bounds it, and a stage that really had finished re-posts a
+// latest-wins marker rather than duplicating work.
 func classifyRelaunch(outcome string, recorded bool) relaunchKind {
 	if !recorded {
 		return relaunchBounded
@@ -131,7 +143,7 @@ func classifyRelaunch(outcome string, recorded bool) relaunchKind {
 	switch outcome {
 	case ExitOutage:
 		return relaunchOutage
-	case ExitRetryable:
+	case ExitRetryable, ExitDone:
 		return relaunchBounded
 	default:
 		return relaunchNone

--- a/internal/daemon/board_retry_test.go
+++ b/internal/daemon/board_retry_test.go
@@ -65,7 +65,14 @@ func TestClassifyRelaunch_ExitClasses(t *testing.T) {
 	// A stage that reached a deliberate conclusion must not be looped on.
 	require.Equal(t, relaunchNone, classifyRelaunch(ExitNeedsHumanWork, true))
 	require.Equal(t, relaunchNone, classifyRelaunch(ExitNeedsInput, true))
-	require.Equal(t, relaunchNone, classifyRelaunch(ExitDone, true))
+
+	// "done" is the contradiction: this classifier only runs on a stage already
+	// judged failed for finishing without its done-marker, so the agent claims
+	// success the board has no evidence of. Markers advance cards, so the stage
+	// is incomplete and gets the same bounded relaunch as any other incomplete
+	// stage — it must NOT be filed alongside needs-human-work, which stranded
+	// planning runs that had a good plan and only missed the marker.
+	require.Equal(t, relaunchBounded, classifyRelaunch(ExitDone, true))
 
 	// An outcome we do not recognise is deliberate output we cannot parse —
 	// retrying it would burn attempts to no purpose.
@@ -235,4 +242,33 @@ func TestTryRelaunch_DisabledWhenUnwired(t *testing.T) {
 func TestStageRetry_MaxDefaultsWhenUnset(t *testing.T) {
 	require.Equal(t, DefaultStageRetries, StageRetry{}.max())
 	require.Equal(t, 5, StageRetry{Max: 5}.max())
+}
+
+// The end-to-end shape of the stranded-planning bug: an agent attaches its plan,
+// records exit "done", and exits 0 without posting the stage's done-marker. The
+// board judges that a failure (no marker), and the recorded "done" must not stop
+// the relaunch that recovers it.
+func TestTryRelaunch_DoneWithoutTheDoneMarkerIsRelaunched(t *testing.T) {
+	rec := &retryRecorder{}
+	policy := rec.policy(ExitDone, true)
+
+	ok := policy.tryRelaunch(context.Background(), "SC-1", BoardPlanning, rec, "daemon-1", zerolog.Nop())
+
+	require.True(t, ok, "the failure is absorbed by a relaunch rather than left red for a human")
+	require.Equal(t, []BoardStage{BoardPlanning}, rec.relaunched)
+}
+
+// The relaunch stays bounded: a stage that keeps claiming done without ever
+// posting its marker reaches a human instead of looping.
+func TestTryRelaunch_DoneWithoutTheDoneMarkerStopsAtTheAttemptCap(t *testing.T) {
+	rec := &retryRecorder{}
+	policy := rec.policy(ExitDone, true)
+	ctx := context.Background()
+
+	require.True(t, policy.tryRelaunch(ctx, "SC-1", BoardPlanning, rec, "d", zerolog.Nop()))
+	require.True(t, policy.tryRelaunch(ctx, "SC-1", BoardPlanning, rec, "d", zerolog.Nop()))
+	require.False(t, policy.tryRelaunch(ctx, "SC-1", BoardPlanning, rec, "d", zerolog.Nop()),
+		"a stage that never posts its marker must reach a human, not loop")
+
+	require.Len(t, rec.relaunched, 2)
 }


### PR DESCRIPTION
PM ticket: SC-3376
Branch: sc-3372-planning-handoff
