### PR TITLE
[SC-3379] Stop building the desktop app on Windows in CI

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,9 +1,12 @@
 name: Desktop
 
 # The workflow-board desktop app (Wails v2) is a cgo backend and CANNOT be
-# cross-compiled: Linux uses webkit2gtk+gtk3, Windows uses the WebView2 runtime,
-# macOS uses the Obj-C toolchain. So it is built on a 3-runner matrix, each with
-# its own native toolchain. This is intentionally a SEPARATE workflow from ci.yml
+# cross-compiled: Linux uses webkit2gtk+gtk3, macOS uses the Obj-C toolchain. So
+# it is built on a per-OS matrix, each row with its own native toolchain.
+# Windows is deliberately absent: its row took ~8 minutes against ~1-2 for the
+# others and sat in front of every desktop merge. The windows/amd64 CLI binary
+# still ships from the release build, which cross-compiles without a runner.
+# This is intentionally a SEPARATE workflow from ci.yml
 # — the main lint/test/build jobs run on a plain Linux runner with no webview
 # headers, and the `wailsapp` build tag keeps the cgo path out of `go vet ./...`,
 # `go list ./...` and `go build .` so those jobs stay green without GTK installed.
@@ -44,9 +47,6 @@ jobs:
           - os: macos-14
             platform: darwin/universal
             tags: "wailsapp"
-          - os: windows-2022
-            platform: windows/amd64
-            tags: "wailsapp"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -67,8 +67,7 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev || \
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
 
-      # Windows ships the WebView2 runtime on supported images; nothing to
-      # install. macOS uses the system Obj-C/WebKit toolchain.
+      # macOS uses the system Obj-C/WebKit toolchain; nothing to install.
 
       - name: Install Wails CLI
         run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,7 +4,9 @@ version: 2
 # is a plain `go build` which links but fails at startup (Wails requires the
 # `desktop` build tag that only `wails build` injects). The desktop artifact is
 # cgo and cannot be cross-compiled, so it is built per-OS by `make desktop`
-# (wraps `wails build`) on the 3-runner matrix in .github/workflows/desktop.yml.
+# (wraps `wails build`) on the runner matrix in .github/workflows/desktop.yml —
+# which covers Linux and macOS only, so a Windows desktop bundle would need that
+# row restored before it could ship.
 # When it ships, attach the per-OS bundles via release.extra_files. See
 # docs/desktop-app.md.
 

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -35,8 +35,8 @@ tag for cgo backend selection.
 All three Wails backends are cgo — Linux uses webkit2gtk + gtk3, Windows uses
 the WebView2 runtime, macOS uses the Obj-C/WebKit toolchain. You therefore
 **cannot cross-compile** all OSes from one machine; each target builds on its
-own native runner. CI uses a 3-runner matrix (`.github/workflows/desktop.yml`):
-`ubuntu-24.04`, `macos-14`, `windows-2022`, each installing its native webview
+own native runner. CI uses a 2-runner matrix (`.github/workflows/desktop.yml`):
+`ubuntu-24.04` and `macos-14`, each installing its native webview
 toolchain.
 
 Wails v2 also guards its `main()` entry point with a build-tag check that is
@@ -115,7 +115,7 @@ So a future change that breaks `wails build` is caught automatically rather than
 
 1. A comment in `desktop/main.go` directly above the build-tag-guarded `wails.Run` call, explaining that a plain `go build` fails at startup by design and pointing here.
 2. `make desktop` runs `wails build -tags wailsapp`; `make desktop-dev` runs `wails dev -tags wailsapp`; `make desktop-package` produces a clean distributable bundle.
-3. A CI matrix (`.github/workflows/desktop.yml`) that runs the real `wails build` on all three OSes (`ubuntu-24.04`, `macos-14`, `windows-2022`) so the cgo build path is exercised on every change under `desktop/`. This is a SEPARATE workflow from `ci.yml`; the main lint/test/build jobs deliberately do not install webview headers and rely on the `wailsapp` build tag to keep the cgo path out of `go vet ./...` / `go build .`.
+3. A CI matrix (`.github/workflows/desktop.yml`) that runs the real `wails build` on `ubuntu-24.04` and `macos-14` so the cgo build path is exercised on every change under `desktop/`. Windows is not built: its runner took ~8 minutes and gated every desktop merge, and no Windows desktop bundle ships today — restore the row before one does. This is a SEPARATE workflow from `ci.yml`; the main lint/test/build jobs deliberately do not install webview headers and rely on the `wailsapp` build tag to keep the cgo path out of `go vet ./...` / `go build .`.
 
 ## Release safety
 


### PR DESCRIPTION
Fixes SC-3379.

The `windows-2022` row took ~8 minutes against ~1-2 for Linux and macOS, so it set the pace of every desktop merge — including the card that prompted this, where it was the last check outstanding on an otherwise green PR.

What it bought was a compile check and a CI artifact nobody consumes: no Windows desktop bundle ships (the release attaches no desktop artifacts at all), and the Windows **CLI** binary comes from the release build, which cross-compiles with `CGO_ENABLED=0` and needs no runner. That entry in `.goreleaser.yaml` is unaffected.

The accepted trade-off is that a Windows-only break in the Wails cgo path is now invisible until someone builds it. That is written down in the two places that documented the matrix as 3-runner — the guard comment in `.goreleaser.yaml` and `docs/desktop-app.md` — each now saying the row must be restored before a Windows desktop bundle can ship.

`make check` green (4543 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)