### PR TITLE
[SC-3397] Ask Shortcut for the current member at the path that exists

### DIFF
--- a/internal/tracker/shortcut/client.go
+++ b/internal/tracker/shortcut/client.go
@@ -481,9 +481,13 @@ func (c *Client) AssignIssue(ctx context.Context, key string, userID string) err
 	return nil
 }
 
-// GetCurrentUser implements tracker.CurrentUserGetter.
+// GetCurrentUser implements tracker.CurrentUserGetter. The endpoint is
+// /api/v3/member ("Get Current Member Info"); /api/v3/member-info does not
+// exist and answers 404, which is what silently withheld the board's viewer
+// identity — and with it every ownership decision that depends on knowing who
+// is looking.
 func (c *Client) GetCurrentUser(ctx context.Context) (string, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, "/api/v3/member-info", "", nil, "")
+	resp, err := c.doRequest(ctx, http.MethodGet, "/api/v3/member", "", nil, "")
 	if err != nil {
 		return "", err
 	}

--- a/internal/tracker/shortcut/client_test.go
+++ b/internal/tracker/shortcut/client_test.go
@@ -868,10 +868,15 @@ func TestAssignIssue_error(t *testing.T) {
 	assert.Contains(t, err.Error(), "returned")
 }
 
+// The path is asserted by omission: the fake serves only /api/v3/member, so a
+// call to any other path — notably the /api/v3/member-info that Shortcut
+// answers with a 404 — fails the test. The endpoint name is the whole content
+// of this call, and the previous fake mirrored whatever the client sent, so it
+// agreed with the client instead of with Shortcut.
 func TestGetCurrentUser_happy(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/v3/member-info":
+		case "/api/v3/member":
 			assert.Equal(t, http.MethodGet, r.Method)
 			assert.Equal(t, "tok-test", r.Header.Get("Shortcut-Token"))
 
@@ -907,7 +912,7 @@ func TestGetCurrentUser_error(t *testing.T) {
 func TestCurrentUserName_happy(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/v3/member-info":
+		case "/api/v3/member":
 			_, _ = fmt.Fprint(w, `{"id":"uuid-me"}`)
 		case "/api/v3/members/uuid-me":
 			_, _ = fmt.Fprint(w, `{"id":"uuid-me","profile":{"display_name":"Stephan Schmidt"}}`)
@@ -940,7 +945,7 @@ func TestCurrentUserName_memberInfoError(t *testing.T) {
 func TestCurrentUserName_nameFallbackToProfileName(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/v3/member-info":
+		case "/api/v3/member":
 			_, _ = fmt.Fprint(w, `{"id":"uuid-me"}`)
 		case "/api/v3/members/uuid-me":
 			_, _ = fmt.Fprint(w, `{"id":"uuid-me","profile":{"display_name":"","name":"stephan"}}`)

--- a/internal/tracker/shortcut/types.go
+++ b/internal/tracker/shortcut/types.go
@@ -89,7 +89,7 @@ type scGroup struct {
 	Name string `json:"name"`
 }
 
-// scMemberInfo is the response from /api/v3/member-info.
+// scMemberInfo is the response from /api/v3/member.
 type scMemberInfo struct {
 	ID string `json:"id"` // UUID
 }


### PR DESCRIPTION
Fixes SC-3397.

The board renders every card at full opacity — the ownership dimming from SC-3339 never appears — because the board never learns who is looking:

```
shortcut GET /api/v3/member-info returned 404: {"message":"Page not Found"}
```

That path does not exist. Shortcut's own generated client documents the current-member call as `GET /api/v3/member` ("Returns information about the authenticated member") and carries no `member-info` path at all, so every lookup has failed since the code was written.

`MarkOwnership` dims only when the viewer is known AND the card has an owner AND they differ — dim on certainty, never on a guess. An unresolvable viewer therefore degrades to "dim nothing", which is indistinguishable from "every ticket is yours". The desktop app memoises only a success, so it re-asks on every refresh and gets the same 404 (33 calls in one daemon log).

Assigning a ticket to yourself goes through the same `GetCurrentUser`, so that was broken too and is fixed by the same line.

**Why this was green.** The unit tests stood up a fake HTTP server serving whatever path the client asked for — it agreed with the client instead of with Shortcut. The fake now serves only `/api/v3/member`; restoring the old path fails both tests with `unexpected request: GET /api/v3/member-info`, which I verified before committing.

`make check` green (4562 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)