### PR TITLE
[SC-3402] Declare who I am in config instead of asking a tracker

### DIFF
--- a/.humanconfig.example
+++ b/.humanconfig.example
@@ -68,6 +68,20 @@ amplitudes:
     # key comes from env: export AMPLITUDE_PRODUCT_KEY=your-api-key
     # secret comes from env: export AMPLITUDE_PRODUCT_SECRET=your-secret-key
 
+# Who you are, for the board's "mine vs someone else's" distinction: a card
+# owned by a name listed here renders normally, any other owner renders dimmed.
+# One entry per identity you hold, because the name a tracker puts on a ticket
+# differs per backend — a display name on Shortcut, Jira and Azure DevOps, a
+# login on GitHub and GitLab. Matching ignores case.
+# Declared rather than looked up: an API answer covers one tracker, needs a live
+# call and a credential, and fails in the one direction nobody notices — every
+# ticket looking like yours. With no `me` section the board asks the PM tracker
+# who is authenticated, and dims nothing if that cannot be answered.
+me:
+  names:
+    - Your Name
+    - your-github-login
+
 proxy:
   mode: allowlist
   domains:

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gethuman-sh/human/internal/ideaspace"
 	"github.com/gethuman-sh/human/internal/pipeline"
 	"github.com/gethuman-sh/human/internal/recentprojects"
+	"github.com/gethuman-sh/human/internal/vieweridentity"
 )
 
 // App is the Go backend bound into the webview via options.App.Bind. Every
@@ -76,22 +77,24 @@ type App struct {
 	// runtime.Quit calls it a second time) to permit the close this time,
 	// instead of preventing it again — see closeflow.go.
 	readyToQuit atomic.Bool
-	// currentUser is the authenticated PM-tracker user's display name, fetched
-	// from the daemon and reused for the session (identity does not change
-	// while the app runs). Feeds the board's ownership dimming (SC-3339); empty
-	// means "unknown", and no card is dimmed. Only a *successful* fetch is
-	// memoized (currentUserResolved) — a transient failure (locked vault
-	// prompt, credential blip, daemon still on an older protocol) must not
-	// latch the board into "no dimming" for the rest of the process lifetime,
-	// since the desktop app is a long-lived tray process; the next refresh
-	// retries until it succeeds.
+	// currentUser caches the tracker's answer for who is authenticated, the
+	// FALLBACK identity used only when .humanconfig declares no "me" names.
+	// Reused for the session (identity does not change while the app runs).
+	// Only a *successful* fetch is memoized (currentUserResolved) — a transient
+	// failure (locked vault prompt, credential blip, daemon still on an older
+	// protocol) must not latch the board into "no dimming" for the rest of the
+	// process lifetime, since the desktop app is a long-lived tray process; the
+	// next refresh retries until it succeeds.
 	currentUserMu       sync.Mutex
 	currentUser         string
 	currentUserResolved bool
-	// currentUserFetch is the actual IPC call, indirected so viewerName's
+	// currentUserFetch is the actual IPC call, indirected so viewerIdentity's
 	// memoize-only-on-success retry logic can be exercised in a test without a
 	// running daemon. Always daemon.GetCurrentUserName outside tests.
 	currentUserFetch func(addr, token string) (string, error)
+	// viewerConfig reads the declared "me" identity for a project directory,
+	// indirected for the same testing reason. Always vieweridentity.Load.
+	viewerConfig func(dir string) (vieweridentity.Identity, error)
 }
 
 // NewApp constructs the backend. Wails injects the lifecycle context via
@@ -103,6 +106,7 @@ func NewApp() *App {
 		prefs:            boardprefs.NewStore(boardprefs.DefaultPath()),
 		session:          appsession.NewStore(appsession.DefaultPath()),
 		currentUserFetch: daemon.GetCurrentUserName,
+		viewerConfig:     vieweridentity.Load,
 	}
 }
 
@@ -131,7 +135,7 @@ func (a *App) Cards() (BoardData, error) {
 		return BoardData{}, daemonCause(err)
 	}
 	project := projectKeyOf(info)
-	data := applyLocal(view, a.ideas.Assignments(project), cardMockups(), a.prefs.Snapshot(project), a.viewerName(info))
+	data := applyLocal(view, a.ideas.Assignments(project), cardMockups(), a.prefs.Snapshot(project), a.viewerIdentity(info))
 	// The keep sets come from `results` — the same fetch CanPrune judges — not
 	// from the composed view, which is a separate request that can answer with
 	// an empty board while this one is healthy (SC-2400).
@@ -261,29 +265,51 @@ func (a *App) CardsQuick() (BoardData, error) {
 		return BoardData{}, daemonCause(err)
 	}
 	project := projectKeyOf(info)
-	return boardFromResults(results, true, a.ideas.Assignments(project), cardMockups(), a.prefs.Snapshot(project), a.viewerName(info)), nil
+	return boardFromResults(results, true, a.ideas.Assignments(project), cardMockups(), a.prefs.Snapshot(project), a.viewerIdentity(info)), nil
 }
 
-// viewerName returns the authenticated PM-tracker user's display name, fetched
-// once and cached for the session. A failure (older daemon, no PM identity,
-// transient credential/timeout error) degrades to an empty name for this call
-// only: the board renders normally, just without the mine/not-mine
-// distinction, and — because only success is memoized — the next call retries
-// instead of latching the failure in for the rest of the app's lifetime.
-func (a *App) viewerName(info daemon.DaemonInfo) string {
+// viewerIdentity returns the names that mean "me" for the board's ownership
+// dimming. The declared identity in .humanconfig wins: it is the only source
+// that covers every tracker (a GitHub login and a Shortcut display name are the
+// same person), needs no credential or live call, and cannot fail in a way that
+// silently makes every ticket look like yours.
+//
+// Only when nothing is declared does it fall back to asking the PM tracker who
+// is authenticated — one provider's opinion, so it can name you on Shortcut and
+// nowhere else, but better than no distinction at all for an unconfigured
+// install. That fallback degrades to an empty identity on any failure (older
+// daemon, no PM identity, credential blip): the board renders normally, just
+// without the mine/not-mine distinction, and because only success is memoized
+// the next call retries instead of latching the failure in for the app's life.
+func (a *App) viewerIdentity(info daemon.DaemonInfo) vieweridentity.Identity {
+	if dir := projectKeyOf(info); dir != "" {
+		if declared, err := a.viewerConfig(dir); err == nil && declared.Known() {
+			return declared
+		}
+	}
+
 	a.currentUserMu.Lock()
 	defer a.currentUserMu.Unlock()
 
 	if a.currentUserResolved {
-		return a.currentUser
+		return identityOf(a.currentUser)
 	}
 	name, err := a.currentUserFetch(info.Addr, info.Token)
 	if err != nil {
-		return ""
+		return vieweridentity.Identity{}
 	}
 	a.currentUser = name
 	a.currentUserResolved = true
-	return a.currentUser
+	return identityOf(a.currentUser)
+}
+
+// identityOf lifts a single tracker-reported name into an Identity, dropping an
+// empty one so "the tracker knows of no name" stays "viewer unknown".
+func identityOf(name string) vieweridentity.Identity {
+	if strings.TrimSpace(name) == "" {
+		return vieweridentity.Identity{}
+	}
+	return vieweridentity.Identity{Names: []string{name}}
 }
 
 // projectKeyOf identifies the project a board snapshot belongs to. v1 serves one
@@ -318,8 +344,8 @@ func (a *App) boardView(info daemon.DaemonInfo) (daemon.BoardView, []daemon.Trac
 // boardFromResults composes the shared board and then applies this viewer's own
 // overlay. The split is the point: Compose produces what is true of the project,
 // applyLocal adds what is true only of the person looking.
-func boardFromResults(results []daemon.TrackerIssuesResult, dockerAvailable bool, ideaCols map[string]int, mocks map[string]cardMockupInfo, prefs boardprefs.Prefs, currentUser string) BoardData {
-	return applyLocal(board.Compose(results, dockerAvailable), ideaCols, mocks, prefs, currentUser)
+func boardFromResults(results []daemon.TrackerIssuesResult, dockerAvailable bool, ideaCols map[string]int, mocks map[string]cardMockupInfo, prefs boardprefs.Prefs, viewer vieweridentity.Identity) BoardData {
+	return applyLocal(board.Compose(results, dockerAvailable), ideaCols, mocks, prefs, viewer)
 }
 
 // applyLocal fills the fields Compose deliberately leaves blank because they
@@ -328,7 +354,7 @@ func boardFromResults(results []daemon.TrackerIssuesResult, dockerAvailable bool
 //
 // Hidden cards are marked, not dropped — the frontend filters them so a user can
 // reveal them without a refetch, which is why Compose returns them at all.
-func applyLocal(view daemon.BoardView, ideaCols map[string]int, mocks map[string]cardMockupInfo, prefs boardprefs.Prefs, currentUser string) BoardData {
+func applyLocal(view daemon.BoardView, ideaCols map[string]int, mocks map[string]cardMockupInfo, prefs boardprefs.Prefs, viewer vieweridentity.Identity) BoardData {
 	view.ColumnOrder = prefs.Columns
 	for i := range view.Cards {
 		c := &view.Cards[i]
@@ -342,7 +368,7 @@ func applyLocal(view daemon.BoardView, ideaCols map[string]int, mocks map[string
 		_, c.Hidden = prefs.Hidden[c.Key]
 	}
 	// Ownership is viewer-local, like Hidden: dim cards owned by someone else.
-	board.MarkOwnership(view.Cards, currentUser)
+	board.MarkOwnership(view.Cards, viewer)
 	return view
 }
 

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -7,15 +7,23 @@ import (
 
 	"github.com/gethuman-sh/human/errors"
 	"github.com/gethuman-sh/human/internal/daemon"
+	"github.com/gethuman-sh/human/internal/vieweridentity"
 )
+
+// noDeclaredIdentity is the unconfigured project: .humanconfig declares no "me"
+// names, so the viewer falls back to asking the tracker.
+func noDeclaredIdentity(string) (vieweridentity.Identity, error) {
+	return vieweridentity.Identity{}, nil
+}
 
 // SC-3339: a transient failure fetching the viewer's identity (locked vault
 // prompt, credential blip, daemon still on an older protocol) must not latch
 // the board into "no dimming" for the rest of the app's lifetime — only a
 // *successful* fetch may be memoized, so the next board refresh retries.
-func TestViewerNameRetriesAfterFailure(t *testing.T) {
+func TestViewerIdentityRetriesAfterFailure(t *testing.T) {
 	calls := 0
 	app := &App{
+		viewerConfig: noDeclaredIdentity,
 		currentUserFetch: func(addr, token string) (string, error) {
 			calls++
 			if calls == 1 {
@@ -26,25 +34,54 @@ func TestViewerNameRetriesAfterFailure(t *testing.T) {
 	}
 	info := daemon.DaemonInfo{Addr: "127.0.0.1:0", Token: "t"}
 
-	if got := app.viewerName(info); got != "" {
-		t.Fatalf("first call: got %q, want empty on failure", got)
+	if got := app.viewerIdentity(info); got.Known() {
+		t.Fatalf("first call: got %v, want an unknown viewer on failure", got.Names)
 	}
 	if calls != 1 {
 		t.Fatalf("expected exactly 1 fetch after the first call, got %d", calls)
 	}
 
-	if got := app.viewerName(info); got != "alice" {
-		t.Fatalf("second call: got %q, want %q — a failed fetch must not block a retry", got, "alice")
+	if got := app.viewerIdentity(info); !got.Matches("alice") {
+		t.Fatalf("second call: got %v, want alice — a failed fetch must not block a retry", got.Names)
 	}
 	if calls != 2 {
 		t.Fatalf("expected the second call to retry the fetch, got %d total calls", calls)
 	}
 
 	// A resolved name must stay memoized: no further IPC calls.
-	if got := app.viewerName(info); got != "alice" {
-		t.Fatalf("third call: got %q, want %q from cache", got, "alice")
+	if got := app.viewerIdentity(info); !got.Matches("alice") {
+		t.Fatalf("third call: got %v, want alice from cache", got.Names)
 	}
 	if calls != 2 {
 		t.Fatalf("expected the resolved name to be memoized (no extra fetch), got %d total calls", calls)
+	}
+}
+
+// The declared identity is authoritative: it covers every tracker at once and
+// cannot fail into "everything looks mine", so a project that declares one must
+// never be asked to spend a credential and a round trip on the question.
+func TestViewerIdentityPrefersDeclaredNames(t *testing.T) {
+	calls := 0
+	app := &App{
+		viewerConfig: func(dir string) (vieweridentity.Identity, error) {
+			return vieweridentity.Identity{Names: []string{"Alice", "alice-gh"}}, nil
+		},
+		currentUserFetch: func(addr, token string) (string, error) {
+			calls++
+			return "someone-else", nil
+		},
+	}
+	info := daemon.DaemonInfo{
+		Addr: "127.0.0.1:0", Token: "t",
+		Projects: []daemon.ProjectInfo{{Dir: "/tmp/project"}},
+	}
+
+	got := app.viewerIdentity(info)
+
+	if !got.Matches("alice-gh") {
+		t.Fatalf("declared identity must be used: got %v", got.Names)
+	}
+	if calls != 0 {
+		t.Fatalf("a declared identity must not ask the tracker, got %d fetches", calls)
 	}
 }

--- a/internal/board/ownership.go
+++ b/internal/board/ownership.go
@@ -4,21 +4,25 @@ import (
 	"strings"
 
 	"github.com/gethuman-sh/human/internal/daemon"
+	"github.com/gethuman-sh/human/internal/vieweridentity"
 )
 
 // MarkOwnership dims every card whose owner is provably someone other than the
 // current viewer. Ownership is the assignee, falling back to the reporter when
 // there is no assignee (SC-3339) — which decides nearly every card, since the
 // pipeline sets no assignee. A card is dimmed (NotMine=true) ONLY when the
-// viewer's name is known AND the card has an owner AND they differ; a card with
-// no owner, or an unknown viewer identity, is left untouched so it renders at
-// full opacity. Dimming is a hint applied on certainty, never on a guess.
+// viewer is known AND the card has an owner AND they differ; a card with no
+// owner, or an unknown viewer, is left untouched so it renders at full opacity.
+// Dimming is a hint applied on certainty, never on a guess.
+//
+// The viewer is a SET of names, not one: the same person is a display name on
+// Shortcut and a login on GitHub, so any declared identity matching the owner
+// means the card is yours.
 //
 // Viewer-local by construction: called from the desktop overlay (applyLocal),
 // never from Compose, so the shared board stays identical for every consumer.
-func MarkOwnership(cards []daemon.BoardViewCard, currentUser string) {
-	me := strings.TrimSpace(currentUser)
-	if me == "" {
+func MarkOwnership(cards []daemon.BoardViewCard, viewer vieweridentity.Identity) {
+	if !viewer.Known() {
 		return
 	}
 	for i := range cards {
@@ -26,7 +30,7 @@ func MarkOwnership(cards []daemon.BoardViewCard, currentUser string) {
 		if owner == "" {
 			continue
 		}
-		cards[i].NotMine = owner != me
+		cards[i].NotMine = !viewer.Matches(owner)
 	}
 }
 

--- a/internal/board/ownership_test.go
+++ b/internal/board/ownership_test.go
@@ -4,61 +4,78 @@ import (
 	"testing"
 
 	"github.com/gethuman-sh/human/internal/daemon"
+	"github.com/gethuman-sh/human/internal/vieweridentity"
 )
 
 func TestMarkOwnership(t *testing.T) {
 	cases := []struct {
 		name        string
 		card        daemon.BoardViewCard
-		currentUser string
+		viewer      []string
 		wantNotMine bool
 	}{
 		{
 			name:        "assigneeIsMe",
 			card:        daemon.BoardViewCard{Assignee: "Alice"},
-			currentUser: "Alice",
+			viewer:      []string{"Alice"},
 			wantNotMine: false,
 		},
 		{
 			name:        "assigneeIsOther",
 			card:        daemon.BoardViewCard{Assignee: "Bob"},
-			currentUser: "Alice",
+			viewer:      []string{"Alice"},
 			wantNotMine: true,
 		},
 		{
 			name:        "reporterFallbackIsMe",
 			card:        daemon.BoardViewCard{Assignee: "", Reporter: "Alice"},
-			currentUser: "Alice",
+			viewer:      []string{"Alice"},
 			wantNotMine: false,
 		},
 		{
 			name:        "reporterFallbackIsOther",
 			card:        daemon.BoardViewCard{Assignee: "", Reporter: "Bob"},
-			currentUser: "Alice",
+			viewer:      []string{"Alice"},
 			wantNotMine: true,
 		},
 		{
 			name:        "assigneeWinsOverReporter",
 			card:        daemon.BoardViewCard{Assignee: "Alice", Reporter: "Bob"},
-			currentUser: "Alice",
+			viewer:      []string{"Alice"},
 			wantNotMine: false,
 		},
 		{
 			name:        "noOwner",
 			card:        daemon.BoardViewCard{Assignee: "", Reporter: ""},
-			currentUser: "Alice",
+			viewer:      []string{"Alice"},
 			wantNotMine: false,
 		},
 		{
 			name:        "unknownViewer",
 			card:        daemon.BoardViewCard{Assignee: "Bob"},
-			currentUser: "",
+			viewer:      nil,
+			wantNotMine: false,
+		},
+		{
+			// One person, two trackers: the Shortcut display name and the
+			// GitHub login are both "me", so a card owned by either is mine.
+			name:        "secondDeclaredIdentityMatches",
+			card:        daemon.BoardViewCard{Assignee: "alice-gh"},
+			viewer:      []string{"Alice", "alice-gh"},
+			wantNotMine: false,
+		},
+		{
+			// A tracker that cases a login differently must not turn a card of
+			// mine into someone else's.
+			name:        "caseInsensitive",
+			card:        daemon.BoardViewCard{Assignee: "ALICE-GH"},
+			viewer:      []string{"alice-gh"},
 			wantNotMine: false,
 		},
 		{
 			name:        "trimsWhitespace",
 			card:        daemon.BoardViewCard{Assignee: " Alice "},
-			currentUser: "Alice",
+			viewer:      []string{"Alice"},
 			wantNotMine: false,
 		},
 	}
@@ -66,10 +83,10 @@ func TestMarkOwnership(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cards := []daemon.BoardViewCard{tc.card}
-			MarkOwnership(cards, tc.currentUser)
+			MarkOwnership(cards, vieweridentity.Identity{Names: tc.viewer})
 			if cards[0].NotMine != tc.wantNotMine {
-				t.Fatalf("MarkOwnership(%+v, %q): NotMine = %v, want %v",
-					tc.card, tc.currentUser, cards[0].NotMine, tc.wantNotMine)
+				t.Fatalf("MarkOwnership(%+v, %v): NotMine = %v, want %v",
+					tc.card, tc.viewer, cards[0].NotMine, tc.wantNotMine)
 			}
 		})
 	}

--- a/internal/vieweridentity/identity.go
+++ b/internal/vieweridentity/identity.go
@@ -1,0 +1,72 @@
+// Package vieweridentity resolves who is looking at the board, so a card owned
+// by someone else can be told apart from one of your own. The identity is
+// declared in the .humanconfig "me" section rather than asked of a tracker: an
+// API answer is one provider's opinion, needs a live call and a credential to
+// obtain, and silently withholds the answer when it fails — at which point
+// every ticket looks like yours.
+//
+// Names, not emails, because names are the only key every backend puts on a
+// card: GitHub and GitLab carry a login/username on an assignee and expose no
+// email at all, and Jira hides emailAddress behind privacy settings. It is a
+// LIST for the same reason — the same person is "Stephan Schmidt" on Shortcut
+// and a login on GitHub, so one entry per identity you hold.
+package vieweridentity
+
+import (
+	"strings"
+
+	"github.com/gethuman-sh/human/internal/config"
+)
+
+// Identity is the set of names that mean "me" across the configured trackers.
+type Identity struct {
+	Names []string `mapstructure:"names"`
+}
+
+// Load reads the "me" section from .humanconfig in dir. A missing file or
+// section yields an empty identity, which every consumer reads as "viewer
+// unknown" and leaves the board undimmed. Package var so callers can stub it.
+var Load = func(dir string) (Identity, error) {
+	var id Identity
+	if err := config.UnmarshalSection(dir, "me", &id); err != nil {
+		return Identity{}, err
+	}
+	return id.cleaned(), nil
+}
+
+// cleaned drops blank entries and surrounding whitespace so a stray list item
+// or a trailing space in the config cannot make a name un-matchable.
+func (i Identity) cleaned() Identity {
+	out := make([]string, 0, len(i.Names))
+	for _, n := range i.Names {
+		if trimmed := strings.TrimSpace(n); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	if len(out) == 0 {
+		return Identity{}
+	}
+	return Identity{Names: out}
+}
+
+// Matches reports whether name is one of the viewer's identities. Comparison is
+// case-insensitive: a tracker that title-cases a login must not turn a card of
+// yours into someone else's. An empty name never matches — "no owner recorded"
+// is not "owned by me".
+func (i Identity) Matches(name string) bool {
+	candidate := strings.TrimSpace(name)
+	if candidate == "" {
+		return false
+	}
+	for _, n := range i.Names {
+		if strings.EqualFold(n, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+// Known reports whether the viewer declared any identity at all. Callers use it
+// to distinguish "not mine" from "no idea who you are", which must render
+// differently: the first dims, the second must not.
+func (i Identity) Known() bool { return len(i.Names) > 0 }

--- a/internal/vieweridentity/identity_test.go
+++ b/internal/vieweridentity/identity_test.go
@@ -1,0 +1,121 @@
+package vieweridentity
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".humanconfig.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestLoad_readsDeclaredNames(t *testing.T) {
+	dir := writeConfig(t, "me:\n  names:\n    - Stephan Schmidt\n    - stephanschmidt\n")
+
+	id, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !id.Known() {
+		t.Fatal("declared names must produce a known viewer")
+	}
+	if !id.Matches("Stephan Schmidt") || !id.Matches("stephanschmidt") {
+		t.Fatalf("both declared identities must match, got %v", id.Names)
+	}
+	if id.Matches("André Neubauer") {
+		t.Fatal("someone else's name must not match")
+	}
+}
+
+// An unconfigured project must read as "viewer unknown" rather than as an
+// identity that matches nothing — the board dims nothing in the first case and
+// would dim EVERY card in the second.
+func TestLoad_noSectionIsUnknown(t *testing.T) {
+	dir := writeConfig(t, "project: cli\n")
+
+	id, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if id.Known() {
+		t.Fatalf("no me section must yield an unknown viewer, got %v", id.Names)
+	}
+}
+
+func TestLoad_missingFileIsUnknown(t *testing.T) {
+	id, err := Load(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id.Known() {
+		t.Fatalf("missing config must yield an unknown viewer, got %v", id.Names)
+	}
+}
+
+// A blank or whitespace-only entry is a config typo, not an identity: keeping
+// it would make Known() true while matching nothing, which dims the whole board.
+func TestLoad_dropsBlankEntries(t *testing.T) {
+	dir := writeConfig(t, "me:\n  names:\n    - \"  \"\n    - \"\"\n")
+
+	id, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if id.Known() {
+		t.Fatalf("blank entries must not count as an identity, got %v", id.Names)
+	}
+}
+
+func TestLoad_trimsSurroundingWhitespace(t *testing.T) {
+	dir := writeConfig(t, "me:\n  names:\n    - \"  Stephan Schmidt  \"\n")
+
+	id, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !id.Matches("Stephan Schmidt") {
+		t.Fatalf("a padded config entry must still match, got %v", id.Names)
+	}
+}
+
+func TestMatches(t *testing.T) {
+	id := Identity{Names: []string{"Alice", "alice-gh"}}
+
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "exact", input: "Alice", want: true},
+		{name: "secondIdentity", input: "alice-gh", want: true},
+		{name: "differentCase", input: "ALICE-GH", want: true},
+		{name: "paddedInput", input: "  Alice  ", want: true},
+		{name: "otherPerson", input: "Bob", want: false},
+		{name: "empty", input: "", want: false},
+		{name: "whitespaceOnly", input: "   ", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := id.Matches(tc.input); got != tc.want {
+				t.Fatalf("Matches(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestKnown_zeroValue(t *testing.T) {
+	if (Identity{}).Known() {
+		t.Fatal("the zero identity must never be known")
+	}
+}


### PR DESCRIPTION
Fixes SC-3402.

The board asked the PM tracker who is authenticated. Three problems, the first two structural rather than bugs:

- **It covers one tracker.** The answer is a Shortcut identity; the same person is a login on GitHub and a display name on Jira.
- **It costs a credential and a live call** for something that never changes while the app runs.
- **It fails in the one direction nobody notices.** An unresolvable viewer degrades to "dim nothing", which looks exactly like "every ticket is yours" — how SC-3397 stayed hidden.

```yaml
me:
  names:
    - Stephan Schmidt      # Shortcut / Jira / Azure DevOps display name
    - stephanschmidt       # GitHub / GitLab login
```

**Names, not emails**, because the name is the only owner key every backend puts on a card: GitHub carries `Assignee.Login`, GitLab `Assignees[0].Username`, and Jira hides `emailAddress` behind privacy settings. **A list**, because the flavour differs per backend, so one entry per identity you hold. Matching ignores case and surrounding whitespace.

New `internal/vieweridentity` reads the section, mirroring how `internal/botidentity` reads `bot:`. The desktop app reads it directly for the project dir — the same way it already reads hidden cards and idea columns — so there is no wire change and no daemon change.

**The inverse trap is guarded:** an identity that is "known" but matches nobody would dim *every* card. Blank or whitespace-only entries therefore collapse to "unknown", with a test pinning it.

Asking the tracker survives as the fallback for a project that declares nothing, so unconfigured installs keep today's behaviour. `GetCurrentUser` stays — assign-to-self still uses it.

`make check` green (4578 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)