### PR TITLE
[SC-3404] Dim everything that is not mine, and dim it enough to see

### DIFF
--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -20,6 +20,13 @@
   --turn-done: var(--done);
   --drop-ok: #2f4a2f;
   --drop-reject: #4a2f2f;
+  /* How faint a card that is not yours renders. A token rather than a literal
+     because it is a presentation choice a theme may want to make differently —
+     a lighter appearance needs less of a drop to read as secondary — and
+     because "how strong is this hint" is the kind of value a person eventually
+     wants to set. Everything derived from it (hover, the degraded overlap)
+     follows automatically, so the relationships between them cannot drift. */
+  --not-mine-opacity: 0.35;
 }
 
 * {
@@ -757,24 +764,27 @@ body {
   cursor: not-allowed;
 }
 
-/* A ticket owned by someone other than the viewer (SC-3339): visibly secondary
-   but fully readable and fully interactive — dimming is a hint, never a
-   restriction, so this touches ONLY opacity (no cursor / pointer-events change,
-   unlike .degraded). opacity is relative to the card's backdrop, so it reads
-   correctly in the dark theme, the fancy theme, and any light appearance. */
+/* A ticket that is not the viewer's own (SC-3339, SC-3404): clearly secondary
+   at a glance, still readable, still fully interactive — dimming is a hint,
+   never a restriction, so this touches ONLY opacity (no cursor / pointer-events
+   change, unlike .degraded). At 0.6 the distinction was too weak to survive a
+   glance across a full column, which is the one job it has; hover returns the
+   card to full strength so reading someone else's work costs nothing. opacity
+   is relative to the card's backdrop, so it reads correctly in the dark theme,
+   the fancy theme, and any light appearance. */
 .card.not-mine {
-  opacity: 0.6;
+  opacity: var(--not-mine-opacity);
 }
 .card.not-mine:hover {
-  opacity: 0.9;
+  opacity: 1;
 }
-/* A card that is both degraded (fetch failure) and not-mine must stay at the
-   more restrictive .degraded dimming — otherwise equal-specificity cascade
-   order would let not-mine's lighter 0.6 win and make a degraded card read
-   LESS dim than a healthy one, undermining the ticket-1700 signal. The extra
-   class in the selector raises specificity above either rule alone. */
+/* A card that is both degraded (fetch failure) and not-mine must never read
+   LESS dim than either signal alone, or equal-specificity cascade order would
+   weaken whichever rule lost — undermining the ticket-1700 degraded signal.
+   The extra class raises specificity above either lone rule; the value stays
+   below both. */
 .card.degraded.not-mine {
-  opacity: 0.55;
+  opacity: calc(var(--not-mine-opacity) * 0.85);
 }
 
 /* Floating clone that follows the cursor during a pointer-drag. pointer-events

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -20,6 +20,13 @@
   --turn-done: var(--done);
   --drop-ok: #2f4a2f;
   --drop-reject: #4a2f2f;
+  /* How faint a card that is not yours renders. A token rather than a literal
+     because it is a presentation choice a theme may want to make differently —
+     a lighter appearance needs less of a drop to read as secondary — and
+     because "how strong is this hint" is the kind of value a person eventually
+     wants to set. Everything derived from it (hover, the degraded overlap)
+     follows automatically, so the relationships between them cannot drift. */
+  --not-mine-opacity: 0.35;
 }
 
 * {
@@ -757,24 +764,27 @@ body {
   cursor: not-allowed;
 }
 
-/* A ticket owned by someone other than the viewer (SC-3339): visibly secondary
-   but fully readable and fully interactive — dimming is a hint, never a
-   restriction, so this touches ONLY opacity (no cursor / pointer-events change,
-   unlike .degraded). opacity is relative to the card's backdrop, so it reads
-   correctly in the dark theme, the fancy theme, and any light appearance. */
+/* A ticket that is not the viewer's own (SC-3339, SC-3404): clearly secondary
+   at a glance, still readable, still fully interactive — dimming is a hint,
+   never a restriction, so this touches ONLY opacity (no cursor / pointer-events
+   change, unlike .degraded). At 0.6 the distinction was too weak to survive a
+   glance across a full column, which is the one job it has; hover returns the
+   card to full strength so reading someone else's work costs nothing. opacity
+   is relative to the card's backdrop, so it reads correctly in the dark theme,
+   the fancy theme, and any light appearance. */
 .card.not-mine {
-  opacity: 0.6;
+  opacity: var(--not-mine-opacity);
 }
 .card.not-mine:hover {
-  opacity: 0.9;
+  opacity: 1;
 }
-/* A card that is both degraded (fetch failure) and not-mine must stay at the
-   more restrictive .degraded dimming — otherwise equal-specificity cascade
-   order would let not-mine's lighter 0.6 win and make a degraded card read
-   LESS dim than a healthy one, undermining the ticket-1700 signal. The extra
-   class in the selector raises specificity above either rule alone. */
+/* A card that is both degraded (fetch failure) and not-mine must never read
+   LESS dim than either signal alone, or equal-specificity cascade order would
+   weaken whichever rule lost — undermining the ticket-1700 degraded signal.
+   The extra class raises specificity above either lone rule; the value stays
+   below both. */
 .card.degraded.not-mine {
-  opacity: 0.55;
+  opacity: calc(var(--not-mine-opacity) * 0.85);
 }
 
 /* Floating clone that follows the cursor during a pointer-drag. pointer-events

--- a/internal/board/ownership.go
+++ b/internal/board/ownership.go
@@ -7,17 +7,24 @@ import (
 	"github.com/gethuman-sh/human/internal/vieweridentity"
 )
 
-// MarkOwnership dims every card whose owner is provably someone other than the
-// current viewer. Ownership is the assignee, falling back to the reporter when
-// there is no assignee (SC-3339) — which decides nearly every card, since the
-// pipeline sets no assignee. A card is dimmed (NotMine=true) ONLY when the
-// viewer is known AND the card has an owner AND they differ; a card with no
-// owner, or an unknown viewer, is left untouched so it renders at full opacity.
-// Dimming is a hint applied on certainty, never on a guess.
+// MarkOwnership dims every card that is not the viewer's own. Ownership is the
+// assignee, falling back to the reporter when there is no assignee (SC-3339) —
+// which decides nearly every card, since the pipeline sets no assignee.
+//
+// Full opacity means "mine", so everything else dims, INCLUDING a card whose
+// owner could not be resolved at all (SC-3404). An unowned card is not mine
+// either, and rendering it like my own work is the reading that misleads —
+// previously it was left bright, so a card with no recorded owner was
+// indistinguishable from one I filed myself.
 //
 // The viewer is a SET of names, not one: the same person is a display name on
 // Shortcut and a login on GitHub, so any declared identity matching the owner
 // means the card is yours.
+//
+// An UNKNOWN VIEWER is the one case that still dims nothing, and it is not the
+// same question as an unknown owner: with no identity to compare against every
+// card would dim, which is a board carrying no distinction at all rather than a
+// board telling you nothing here is yours.
 //
 // Viewer-local by construction: called from the desktop overlay (applyLocal),
 // never from Compose, so the shared board stays identical for every consumer.
@@ -26,11 +33,7 @@ func MarkOwnership(cards []daemon.BoardViewCard, viewer vieweridentity.Identity)
 		return
 	}
 	for i := range cards {
-		owner := ownerOf(cards[i])
-		if owner == "" {
-			continue
-		}
-		cards[i].NotMine = !viewer.Matches(owner)
+		cards[i].NotMine = !viewer.Matches(ownerOf(cards[i]))
 	}
 }
 

--- a/internal/board/ownership_test.go
+++ b/internal/board/ownership_test.go
@@ -45,9 +45,19 @@ func TestMarkOwnership(t *testing.T) {
 			wantNotMine: false,
 		},
 		{
-			name:        "noOwner",
+			// SC-3404: a card nobody owns is not mine either. Leaving it bright
+			// made it indistinguishable from work I filed myself.
+			name:        "noOwnerIsNotMine",
 			card:        daemon.BoardViewCard{Assignee: "", Reporter: ""},
 			viewer:      []string{"Alice"},
+			wantNotMine: true,
+		},
+		{
+			// The one thing an unknown viewer must NOT do is dim the whole
+			// board: with nothing to compare against, no card is claimed.
+			name:        "unknownViewerLeavesUnownedCardAlone",
+			card:        daemon.BoardViewCard{Assignee: "", Reporter: ""},
+			viewer:      nil,
 			wantNotMine: false,
 		},
 		{


### PR DESCRIPTION
Fixes SC-3404.

Two things read wrong in use.

**A card nobody owns looked like mine.** Dimming applied only when a card had a resolvable owner who was demonstrably someone else, so an unowned card rendered exactly like work I filed myself. Full opacity says "mine", so anything not provably mine now dims — someone else's, or nobody's.

An unknown *viewer* is still the one case that dims nothing, and it is a different question: with no identity to compare against, every card would dim, which is a board carrying no distinction rather than a board saying none of this is yours.

**The dimming was too weak to see.** 0.6 did not survive a glance across a full column. Now 0.35, with hover returning the card to full strength so reading someone else's work costs nothing.

The value is a `--not-mine-opacity` token beside the other root tokens rather than a literal in a rule: how strong a presentation hint should be is a theme's business — a light appearance needs less of a drop than a dark one — and a theme can now override it in one line. The degraded overlap derives from it (`calc(var(--not-mine-opacity) * 0.85)`), so "a degraded card never reads less dim than a not-mine one" holds by construction instead of by two literals kept in step by hand.

`dist/style.css` is refreshed byte-identically to what `scripts/bundle.mjs` produces, so the checked-in bundle cannot ship stale.

Longer term this belongs in real settings rather than the stylesheet — viewer-local prefs (where the theme choice already lives) or a project `ui:` block. Follow-up, not this PR.

`make check` green (4579 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)