### PR TITLE
[SC-3284] Pin board-dispatched Task delegation to the foreground

### DIFF
--- a/internal/agent/botenv_test.go
+++ b/internal/agent/botenv_test.go
@@ -41,6 +41,7 @@ func TestExecClaudeDetached_injectsBotGitEnv(t *testing.T) {
 	for _, want := range []string{
 		"HUMAN_AGENT_NAME=a",
 		"HUMAN_DAEMON_ID=d1",
+		"CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0",
 		"GIT_AUTHOR_NAME=acmebot",
 		"GIT_AUTHOR_EMAIL=bot@acme.dev",
 		"GIT_COMMITTER_NAME=acmebot",

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -219,7 +219,12 @@ func (m *Manager) execClaudeDetached(ctx context.Context, containerID, remoteUse
 	claudeArgs = append(claudeArgs, extraArgs...)
 	claudeArgs = append(claudeArgs, "-p", opts.Prompt)
 	cmd := append([]string{"claude"}, claudeArgs...)
-	env := []string{"HUMAN_AGENT_NAME=" + opts.Name, "HUMAN_DAEMON_ID=" + opts.DaemonID}
+	// A headless run's own Task delegation is pinned to the foreground (see the
+	// embedded skill prompts), but this is a backstop against any that isn't: it
+	// removes the CLI's own background-task wait ceiling so a stray backgrounded
+	// subagent is waited for indefinitely rather than silently killed at 10
+	// minutes and misreported as "finished without posting the handoff" (SC-3284).
+	env := []string{"HUMAN_AGENT_NAME=" + opts.Name, "HUMAN_DAEMON_ID=" + opts.DaemonID, "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0"}
 	// Attribute the agent's commits to the bot so authorship alone separates
 	// agent work from developer work (SC-371). A config read failure must never
 	// fail the launch — fall back to the default identity.

--- a/internal/claude/embed/human-autofix-skill.md
+++ b/internal/claude/embed/human-autofix-skill.md
@@ -70,7 +70,7 @@ Then take ownership: `human assign <BUG_KEY>`. Ownership records who is working 
 Before any work, run preflight. It resolves what this run may do, settles what the evidence can settle, and surfaces a decision only a human can make **now** rather than halfway through:
 
 ```
-Task(subagent_type="human-preflight", prompt="Preflight bug ticket <BUG_KEY> before an autonomous fix run: resolve capabilities, mirror decisions already made, and surface any genuine product/scope fork as a DECISION REQUIRED terminal.")
+Task(subagent_type="human-preflight", prompt="Preflight bug ticket <BUG_KEY> before an autonomous fix run: resolve capabilities, mirror decisions already made, and surface any genuine product/scope fork as a DECISION REQUIRED terminal.", run_in_background=false)
 ```
 
 Read its outcome from state:
@@ -128,7 +128,7 @@ human plan show <BUG_KEY>        # non-empty -> a [human:plan] comment exists; t
 Delegate to the **human-bug-triage** agent:
 
 ```
-Task(subagent_type="human-bug-triage", model="opus", prompt="Triage bug ticket <BUG_KEY>: reproduce it minimally, trace the full cause chain (symptom → proximate cause → underlying cause) with file:line evidence and the regression window, scan for sibling occurrences of the same defect pattern, and reach a verdict. Post the verdict comment on the ticket with a plain-language Explanation section a non-engineer can follow.")
+Task(subagent_type="human-bug-triage", model="opus", prompt="Triage bug ticket <BUG_KEY>: reproduce it minimally, trace the full cause chain (symptom → proximate cause → underlying cause) with file:line evidence and the regression window, scan for sibling occurrences of the same defect pattern, and reach a verdict. Post the verdict comment on the ticket with a plain-language Explanation section a non-engineer can follow.", run_in_background=false)
 ```
 
 It posts a `[human:bug-verdict] <verdict>` comment on the bug ticket — the ticket's permanent root-cause record: a plain-language explanation first, then the reproduction, the cause chain down to the underlying cause (not just the line that crashed), the regression window, and sibling occurrences. **Read the verdict from state, not from the agent's prose:**
@@ -161,7 +161,7 @@ For a confirmed bug the record also carries the root cause and fix outline. If t
 Dispatch the skeptic against the verdict:
 
 ```
-Task(subagent_type="human-verdict-skeptic", model="opus", prompt="Challenge the latest bug-verdict on ticket <BUG_KEY>")
+Task(subagent_type="human-verdict-skeptic", model="opus", prompt="Challenge the latest bug-verdict on ticket <BUG_KEY>", run_in_background=false)
 ```
 
 Read its outcome from state:
@@ -200,7 +200,7 @@ challenge: upheld
 2. Delegate to the **human-planner** agent, seeding it with the triage root cause:
 
 ```
-Task(subagent_type="human-planner", model="opus", prompt="Create an implementation plan to fix bug <BUG_KEY>. Decisions already settled for this ticket (do not re-open any of them): <paste the output of `human state get <BUG_KEY> decisions --default '{}'`>. The root-cause analysis from triage:\n<paste the triage root cause + fix outline>\nThe plan's Changes section MUST begin with adding a regression test that fails because of the bug, then fixing the root cause. Return the plan as output; do not write files or create tickets.")
+Task(subagent_type="human-planner", model="opus", prompt="Create an implementation plan to fix bug <BUG_KEY>. Decisions already settled for this ticket (do not re-open any of them): <paste the output of `human state get <BUG_KEY> decisions --default '{}'`>. The root-cause analysis from triage:\n<paste the triage root cause + fix outline>\nThe plan's Changes section MUST begin with adding a regression test that fails because of the bug, then fixing the root cause. Return the plan as output; do not write files or create tickets.", run_in_background=false)
 ```
 
 Capture the output as `<PLAN_CONTENT>`. Ensure its header has a `**PM ticket**: <BUG_KEY>` line and, in split topology, an `**Engineering ticket**: TBD` line.
@@ -233,13 +233,13 @@ Verify with `human plan show <BUG_KEY>` — the fixer and verify agents read the
 Delegate to the **human-bug-fixer** agent. When `<BOARD_CONTEXT>` is true the fixer must NOT push — the board container has no push credentials and Deploy owns shipping — so forward the board instruction explicitly in the dispatch prompt (the fixer cannot see `$ARGUMENTS`):
 
 ```
-Task(subagent_type="human-bug-fixer", model="sonnet", prompt="Fix ticket <WORK_KEY> (PM bug <BUG_KEY>) test-first on a feature branch. BOARD CONTEXT: do NOT run git push — leave the branch local; the daemon's Deploy stage ships it. Report the local branch name. Iterate on the fast test+lint tier (not the full `make check`) to go green — the verify gate runs the single full suite.")
+Task(subagent_type="human-bug-fixer", model="sonnet", prompt="Fix ticket <WORK_KEY> (PM bug <BUG_KEY>) test-first on a feature branch. BOARD CONTEXT: do NOT run git push — leave the branch local; the daemon's Deploy stage ships it. Report the local branch name. Iterate on the fast test+lint tier (not the full `make check`) to go green — the verify gate runs the single full suite.", run_in_background=false)
 ```
 
 Otherwise (standalone, `<BOARD_CONTEXT>` false) dispatch the existing push prompt:
 
 ```
-Task(subagent_type="human-bug-fixer", model="sonnet", prompt="Fix ticket <WORK_KEY> (PM bug <BUG_KEY>) test-first on a feature branch and push it. Iterate on the fast test+lint tier (not the full `make check`) to go green — the verify gate runs the single full suite.")
+Task(subagent_type="human-bug-fixer", model="sonnet", prompt="Fix ticket <WORK_KEY> (PM bug <BUG_KEY>) test-first on a feature branch and push it. Iterate on the fast test+lint tier (not the full `make check`) to go green — the verify gate runs the single full suite.", run_in_background=false)
 ```
 
 It creates branch `autofix/<work-key>` (the key lowercased), writes a regression test that **fails** because of the bug, implements the root-cause fix, confirms the suite is green, commits with subjects starting with the `human commits prefix <BUG_KEY> [<ENG_KEY>]` prefix (e.g. `[<PM_KEY>] [<ENG_KEY>]` in split topology, `[<PM_KEY>]` otherwise), and returns the branch name. In a standalone run it pushes the branch; in board context it leaves the branch local (the bind-mounted host repo) and returns its name without pushing. If it reports it could not reach a green build/test, STOP and report — do not open a PR.
@@ -249,7 +249,7 @@ It creates branch `autofix/<work-key>` (the key lowercased), writes a regression
 Delegate to the **human-bug-verify** agent:
 
 ```
-Task(subagent_type="human-bug-verify", model="sonnet", prompt="Verify ticket <WORK_KEY> (PM bug <BUG_KEY>): confirm the regression test fails before / passes after the fix, the full suite is green, and the fix addresses the root cause. Post the verdict as a comment on <BUG_KEY>.")
+Task(subagent_type="human-bug-verify", model="sonnet", prompt="Verify ticket <WORK_KEY> (PM bug <BUG_KEY>): confirm the regression test fails before / passes after the fix, the full suite is green, and the fix addresses the root cause. Post the verdict as a comment on <BUG_KEY>.", run_in_background=false)
 ```
 
 This is the pipeline's ONE full-suite pass; the fixer used the fast tier. Ensure the `[human:bug-verify]` comment records the `## Evidence` block (branch/commit/command/result) so the review can trust it without re-running the suite.
@@ -309,7 +309,7 @@ human marker post <BUG_KEY> review-started
 ```
 
 ```
-Task(subagent_type="human-reviewer", model="opus", prompt="Review changes for ticket <WORK_KEY>: check out branch autofix/<work-key> and review its diff against main against the ticket's plan and acceptance criteria.")
+Task(subagent_type="human-reviewer", model="opus", prompt="Review changes for ticket <WORK_KEY>: check out branch autofix/<work-key> and review its diff against main against the ticket's plan and acceptance criteria.", run_in_background=false)
 ```
 
 The reviewer writes `.human/reviews/<work-key>.md` and records its outcome in state. **Read the verdict from state, never from the file's prose:**
@@ -338,7 +338,7 @@ REVIEW_EOF
 - **pass** or **pass with notes** — a pass is the one review outcome nothing downstream checks, and it is about to be made irreversible by a merge. Before continuing, get one adversarial second opinion:
 
   ```
-  Task(subagent_type="human-second-opinion", model="opus", prompt="The pipeline is about to merge branch autofix/<work-key> for ticket <WORK_KEY> on the strength of a passing review. Lens: did-you-actually-look. Evidence: the ticket, the branch diff against main, and stage.review in agent state. Try to refute that the review examined the change. Do not read the reviewer's reasoning first.")
+  Task(subagent_type="human-second-opinion", model="opus", prompt="The pipeline is about to merge branch autofix/<work-key> for ticket <WORK_KEY> on the strength of a passing review. Lens: did-you-actually-look. Evidence: the ticket, the branch diff against main, and stage.review in agent state. Try to refute that the review examined the change. Do not read the reviewer's reasoning first.", run_in_background=false)
   ```
 
   ```bash

--- a/internal/claude/embed/human-deploy-fix-skill.md
+++ b/internal/claude/embed/human-deploy-fix-skill.md
@@ -9,7 +9,7 @@ argument-hint: <key> --pr=<number> --branch=<branch>
 Run the fixer at the `sonnet` tier: recovering a deploy is visible-failure work — the re-run deploy's CI gate catches what it misses — so the expensive tier is not warranted.
 
 ```
-Task(subagent_type="human-deploy-fixer", model="sonnet", prompt="Recover the failed deploy of PR <number> for ticket <KEY> --branch=<branch>")
+Task(subagent_type="human-deploy-fixer", model="sonnet", prompt="Recover the failed deploy of PR <number> for ticket <KEY> --branch=<branch>", run_in_background=false)
 ```
 
 The agent rebases the branch onto the base, resolves conflicts, fixes the failing lint/tests, leaves the result on the local branch ref, and records its exit (`done | needs-input | needs-human-work`) in `stage.deploy-fix`. After a `done` the daemon publishes that branch with the host's credentials — the fixer's container has none — and re-runs Deploy; anything else reds the card. So you do **not** push, post board markers, or re-trigger Deploy yourself: run the agent and report what it changed.

--- a/internal/claude/embed/human-execute-skill.md
+++ b/internal/claude/embed/human-execute-skill.md
@@ -11,7 +11,7 @@ argument-hint: <ticket-key>
 Delegate to the **human-executor** agent using the Task tool:
 
 ```
-Task(subagent_type="human-executor", prompt="Execute $ARGUMENTS as a plan")
+Task(subagent_type="human-executor", prompt="Execute $ARGUMENTS as a plan", run_in_background=false)
 ```
 
 After the agent finishes, tell the user what was done and whether the review checkpoint passed.

--- a/internal/claude/embed/human-plan-skill.md
+++ b/internal/claude/embed/human-plan-skill.md
@@ -19,7 +19,7 @@ Run `human mockups chosen <KEY>` (the PM key this skill received). If it prints 
 Run the planner agent. It returns the plan as its output (no files written):
 
 ```
-Task(subagent_type="human-planner", prompt="Create an implementation plan for ticket $ARGUMENTS. Return the complete plan as your output. Do not write any files.")
+Task(subagent_type="human-planner", prompt="Create an implementation plan for ticket $ARGUMENTS. Return the complete plan as your output. Do not write any files.", run_in_background=false)
 ```
 
 Wait for the planner agent to finish. Capture its output as `<PLAN_CONTENT>`.
@@ -29,9 +29,9 @@ Wait for the planner agent to finish. Capture its output as `<PLAN_CONTENT>`.
 Launch both verification agents **in a single message** so they run in parallel. Pass the plan content inline using markers. Each agent returns its report as output (no files written):
 
 ```
-Task(subagent_type="plan-verify-code", prompt="Verify all code references in the following implementation plan against the actual codebase. Return your verification report as output. Do not write any files.\n\n---BEGIN PLAN---\n<PLAN_CONTENT>\n---END PLAN---")
+Task(subagent_type="plan-verify-code", prompt="Verify all code references in the following implementation plan against the actual codebase. Return your verification report as output. Do not write any files.\n\n---BEGIN PLAN---\n<PLAN_CONTENT>\n---END PLAN---", run_in_background=false)
 
-Task(subagent_type="plan-verify-docs", prompt="Verify all library, framework, and API assumptions in the following implementation plan against actual documentation and source. Return your verification report as output. Do not write any files.\n\n---BEGIN PLAN---\n<PLAN_CONTENT>\n---END PLAN---")
+Task(subagent_type="plan-verify-docs", prompt="Verify all library, framework, and API assumptions in the following implementation plan against actual documentation and source. Return your verification report as output. Do not write any files.\n\n---BEGIN PLAN---\n<PLAN_CONTENT>\n---END PLAN---", run_in_background=false)
 ```
 
 Wait for both agents to finish before proceeding.

--- a/internal/claude/embed/human-pr-fix-skill.md
+++ b/internal/claude/embed/human-pr-fix-skill.md
@@ -9,7 +9,7 @@ argument-hint: <key> --pr=<number> --branch=<branch>
 Run the fixer at the `sonnet` tier: implementing a fix is visible-failure work — a red re-review or a failed check catches what it misses — so the expensive tier is not warranted here.
 
 ```
-Task(subagent_type="human-pr-fixer", model="sonnet", prompt="Address review comments on PR <number> for ticket <KEY> --branch=<branch>")
+Task(subagent_type="human-pr-fixer", model="sonnet", prompt="Address review comments on PR <number> for ticket <KEY> --branch=<branch>", run_in_background=false)
 ```
 
 The agent reads the machine reviewer's findings from `stage.pr-review` (**and any comment a human left on the PR out of band**), addresses them, commits on the local branch — it does not push; the daemon ships the branch at merge — and records its exit (`done | needs-input`) plus the post-fix head in `stage.pr-fix`. The daemon re-reviews the new commit after a `done` and escalates on `needs-input`, so you do **not** post board markers or decide the next step yourself: run the agent and report what it changed.

--- a/internal/claude/embed/human-pr-review-skill.md
+++ b/internal/claude/embed/human-pr-review-skill.md
@@ -9,7 +9,7 @@ argument-hint: <key> --pr=<number> --branch=<branch>
 Run the reviewer at the `opus` tier: it is the adversarial gate before a merge, and a weaker model gets talked out of real objections, turning the check into a rubber stamp (never tier down an adversary).
 
 ```
-Task(subagent_type="human-pr-reviewer", model="opus", prompt="Review PR <number> for ticket <KEY> --branch=<branch>")
+Task(subagent_type="human-pr-reviewer", model="opus", prompt="Review PR <number> for ticket <KEY> --branch=<branch>", run_in_background=false)
 ```
 
 The agent reviews the fixer's **local** branch commit (not the stale pushed head — the fixer never pushes in board context, so origin's head is pre-fix), records its findings and the machine verdict (`approved | changes-requested | unreviewable`) in `stage.pr-review`, and mirrors findings onto the PR as inline comments when it has a write path. The daemon's loop reads that verdict to decide the next step — another fix pass, or the merge — so you do **not** post board markers, dispatch a fixer, or merge anything yourself: run the agent and report its verdict. Human review of the PR happens out of band and never gates this run.

--- a/internal/claude/embed/human-review-skill.md
+++ b/internal/claude/embed/human-review-skill.md
@@ -7,7 +7,7 @@ argument-hint: <dispatched-key> [--branch=…] [--commits=…]
 `$ARGUMENTS` is `<DISPATCHED_KEY> [--branch=…] [--commits=…]`. The first token is the **dispatched key** — the ONE ticket this review is bound to. The optional `--branch=` and `--commits=` flags are the authoritative handoff binding the daemon derived: the exact branch and SHAs under review. Parse them out, then delegate to the **human-reviewer** agent, threading the binding through verbatim so the agent can verify the checked-out code IS this branch and these commits before reviewing:
 
 ```
-Task(subagent_type="human-reviewer", prompt="Review changes for ticket <DISPATCHED_KEY> --branch=<branch> --commits=<commits>")
+Task(subagent_type="human-reviewer", prompt="Review changes for ticket <DISPATCHED_KEY> --branch=<branch> --commits=<commits>", run_in_background=false)
 ```
 
 The dispatched key is fixed for the whole run. Every marker you post below goes on `<DISPATCHED_KEY>` and **no other ticket** — never re-derive a "PM ticket" from the reviewed diff or from whatever HEAD the worktree sits on. That re-derivation is the exact bug this binding closes: a review dispatched for one ticket must never post its verdict on another.

--- a/internal/claude/embed/human-security-fix-skill.md
+++ b/internal/claude/embed/human-security-fix-skill.md
@@ -74,7 +74,7 @@ Then take ownership: `human assign <SEC_KEY>`. Ownership records who is working 
 Before any work, run preflight. It resolves what this run may do, settles what the evidence can settle, and surfaces a decision only a human can make **now** rather than halfway through:
 
 ```
-Task(subagent_type="human-preflight", prompt="Preflight security ticket <SEC_KEY> before an autonomous fix run: resolve capabilities, mirror decisions already made, and surface any genuine product/scope fork as a DECISION REQUIRED terminal.")
+Task(subagent_type="human-preflight", prompt="Preflight security ticket <SEC_KEY> before an autonomous fix run: resolve capabilities, mirror decisions already made, and surface any genuine product/scope fork as a DECISION REQUIRED terminal.", run_in_background=false)
 ```
 
 Read its outcome from state:
@@ -125,7 +125,7 @@ human plan show <SEC_KEY>        # non-empty -> a [human:plan] comment exists; t
 Delegate to the **human-security-triage** agent:
 
 ```
-Task(subagent_type="human-security-triage", model="opus", prompt="Triage security ticket <SEC_KEY>: confirm whether the reported weakness is a real, exploitable vulnerability by tracing the source→sink data flow with file:line evidence, build the threat model (attacker, vector, asset, impact), rate severity, scan for sibling occurrences of the same weakness, and reach a verdict. Post the verdict comment on the ticket with a plain-language Explanation a non-engineer can follow. Keep exploit specifics on the tracker.")
+Task(subagent_type="human-security-triage", model="opus", prompt="Triage security ticket <SEC_KEY>: confirm whether the reported weakness is a real, exploitable vulnerability by tracing the source→sink data flow with file:line evidence, build the threat model (attacker, vector, asset, impact), rate severity, scan for sibling occurrences of the same weakness, and reach a verdict. Post the verdict comment on the ticket with a plain-language Explanation a non-engineer can follow. Keep exploit specifics on the tracker.", run_in_background=false)
 ```
 
 It posts a `[human:bug-verdict] <verdict>` comment on the ticket — the permanent record: a plain-language explanation, the threat model, the severity, the source→sink cause chain, the regression window, and sibling occurrences. **Read the verdict from state, not from the agent's prose:**
@@ -155,7 +155,7 @@ If the recorded analysis stops at a proximate cause (a reachable sink without *w
 Dispatch the skeptic against the verdict, with a security lens:
 
 ```
-Task(subagent_type="human-verdict-skeptic", model="opus", prompt="Challenge the latest bug-verdict on security ticket <SEC_KEY>. Lens: try to reach the sink. Attempt to prove the path IS exploitable — an unsanitized source, an auth check that can be bypassed, a guard that does not cover the payload — before the vulnerability is dismissed.")
+Task(subagent_type="human-verdict-skeptic", model="opus", prompt="Challenge the latest bug-verdict on security ticket <SEC_KEY>. Lens: try to reach the sink. Attempt to prove the path IS exploitable — an unsanitized source, an auth check that can be bypassed, a guard that does not cover the payload — before the vulnerability is dismissed.", run_in_background=false)
 ```
 
 Read its outcome from state:
@@ -188,7 +188,7 @@ The `[human:no-fix-needed]` marker is **mandatory in board context**: the pipeli
 2. Delegate to the **human-planner** agent, seeding it with the triage threat model and root cause:
 
 ```
-Task(subagent_type="human-planner", model="opus", prompt="Create an implementation plan to fix security ticket <SEC_KEY>. Decisions already settled (do not re-open): <paste `human state get <SEC_KEY> decisions --default '{}'`>. The threat model and source→sink root cause from triage:\n<paste the triage threat model + root cause + fix outline>\nThe plan's Changes section MUST begin with adding a SECURITY regression test that demonstrates the exploit and fails because of the vulnerability, then closing the root cause at the source (parameterize/encode/guard/tighten the check — not merely suppress the symptom). Address the sibling occurrences from triage or state them out of scope. Return the plan as output; do not write files or create tickets.")
+Task(subagent_type="human-planner", model="opus", prompt="Create an implementation plan to fix security ticket <SEC_KEY>. Decisions already settled (do not re-open): <paste `human state get <SEC_KEY> decisions --default '{}'`>. The threat model and source→sink root cause from triage:\n<paste the triage threat model + root cause + fix outline>\nThe plan's Changes section MUST begin with adding a SECURITY regression test that demonstrates the exploit and fails because of the vulnerability, then closing the root cause at the source (parameterize/encode/guard/tighten the check — not merely suppress the symptom). Address the sibling occurrences from triage or state them out of scope. Return the plan as output; do not write files or create tickets.", run_in_background=false)
 ```
 
 Capture the output as `<PLAN_CONTENT>`. Ensure its header has a `**PM ticket**: <SEC_KEY>` line and, in split topology, an `**Engineering ticket**: TBD` line.
@@ -221,13 +221,13 @@ Verify with `human plan show <SEC_KEY>`. Commits reference only `<SEC_KEY>`. Set
 Delegate to the **human-bug-fixer** agent (shared with autofix — it writes the failing regression test and the root-cause fix; the security framing comes from the plan it reads). When `<BOARD_CONTEXT>` is true the fixer must NOT push — forward the board instruction explicitly (the fixer cannot see `$ARGUMENTS`):
 
 ```
-Task(subagent_type="human-bug-fixer", model="sonnet", prompt="Fix ticket <WORK_KEY> (PM security ticket <SEC_KEY>) test-first on a feature branch, following the plan. The plan's first change is a SECURITY regression test that demonstrates the exploit and must fail before the fix. BOARD CONTEXT: do NOT run git push — leave the branch local; the daemon's Deploy stage ships it. Report the local branch name. Iterate on the fast test+lint tier (not the full `make check`) to go green — the verify gate runs the single full suite. Keep exploit specifics out of commit messages — reference the ticket and describe the hardening.")
+Task(subagent_type="human-bug-fixer", model="sonnet", prompt="Fix ticket <WORK_KEY> (PM security ticket <SEC_KEY>) test-first on a feature branch, following the plan. The plan's first change is a SECURITY regression test that demonstrates the exploit and must fail before the fix. BOARD CONTEXT: do NOT run git push — leave the branch local; the daemon's Deploy stage ships it. Report the local branch name. Iterate on the fast test+lint tier (not the full `make check`) to go green — the verify gate runs the single full suite. Keep exploit specifics out of commit messages — reference the ticket and describe the hardening.", run_in_background=false)
 ```
 
 Otherwise (standalone, `<BOARD_CONTEXT>` false) dispatch the push variant:
 
 ```
-Task(subagent_type="human-bug-fixer", model="sonnet", prompt="Fix ticket <WORK_KEY> (PM security ticket <SEC_KEY>) test-first on a feature branch and push it, following the plan (its first change is a security regression test that demonstrates the exploit and fails before the fix). Iterate on the fast test+lint tier to go green — the verify gate runs the single full suite. Keep exploit specifics out of commit messages.")
+Task(subagent_type="human-bug-fixer", model="sonnet", prompt="Fix ticket <WORK_KEY> (PM security ticket <SEC_KEY>) test-first on a feature branch and push it, following the plan (its first change is a security regression test that demonstrates the exploit and fails before the fix). Iterate on the fast test+lint tier to go green — the verify gate runs the single full suite. Keep exploit specifics out of commit messages.", run_in_background=false)
 ```
 
 It creates branch `autofix/<work-key>` (the key lowercased), writes the security regression test, implements the root-cause fix, confirms the suite is green, commits with subjects starting with the `human commits prefix <SEC_KEY> [<ENG_KEY>]` prefix, and returns the branch name. In a standalone run it pushes; in board context it leaves the branch local. If it reports it could not go green, STOP and report — do not open a PR.
@@ -237,7 +237,7 @@ It creates branch `autofix/<work-key>` (the key lowercased), writes the security
 Delegate to the **human-security-verify** agent:
 
 ```
-Task(subagent_type="human-security-verify", model="sonnet", prompt="Verify ticket <WORK_KEY> (PM security ticket <SEC_KEY>): confirm the security regression test demonstrates the exploit and fails before / passes after the fix, the vulnerability from the triage threat model is actually closed (the attack no longer succeeds), the full suite is green, and no new weakness was introduced. Post the verdict as a comment on <SEC_KEY>.")
+Task(subagent_type="human-security-verify", model="sonnet", prompt="Verify ticket <WORK_KEY> (PM security ticket <SEC_KEY>): confirm the security regression test demonstrates the exploit and fails before / passes after the fix, the vulnerability from the triage threat model is actually closed (the attack no longer succeeds), the full suite is green, and no new weakness was introduced. Post the verdict as a comment on <SEC_KEY>.", run_in_background=false)
 ```
 
 This is the pipeline's ONE full-suite pass; the fixer used the fast tier. Ensure the `[human:bug-verify]` comment records the `## Evidence` block and the `## Vulnerability closed` finding so the review can trust it without re-running the suite.
@@ -287,7 +287,7 @@ human marker post <SEC_KEY> review-started
 ```
 
 ```
-Task(subagent_type="human-reviewer", model="opus", prompt="Review changes for security ticket <WORK_KEY>: check out branch autofix/<work-key> and review its diff against main against the ticket's plan and acceptance criteria. Security lens: confirm the fix closes the vulnerability at its source (not just the reported payload), covers the sibling occurrences the triage found, and introduces no new weakness (an over-broad allow, a widened permission, a secret written to a log, a check that can still be bypassed). The security regression test must genuinely exercise the exploit.")
+Task(subagent_type="human-reviewer", model="opus", prompt="Review changes for security ticket <WORK_KEY>: check out branch autofix/<work-key> and review its diff against main against the ticket's plan and acceptance criteria. Security lens: confirm the fix closes the vulnerability at its source (not just the reported payload), covers the sibling occurrences the triage found, and introduces no new weakness (an over-broad allow, a widened permission, a secret written to a log, a check that can still be bypassed). The security regression test must genuinely exercise the exploit.", run_in_background=false)
 ```
 
 The reviewer writes `.human/reviews/<work-key>.md` and records its outcome in state. **Read the verdict from state, never from the file's prose:**
@@ -317,7 +317,7 @@ REVIEW_EOF
 - **pass** or **pass with notes** — a pass is about to be made irreversible by a merge. Before continuing, get one adversarial second opinion **through a security lens**:
 
   ```
-  Task(subagent_type="human-second-opinion", model="opus", prompt="The pipeline is about to merge branch autofix/<work-key> for security ticket <WORK_KEY> on the strength of a passing review. Lens: is-the-vulnerability-actually-closed. Evidence: the ticket's threat model, the branch diff against main, and stage.review in agent state. Try to refute that the fix closes the source→sink path — look for a residual bypass, an uncovered sibling, or a new weakness the fix introduced. Do not read the reviewer's reasoning first.")
+  Task(subagent_type="human-second-opinion", model="opus", prompt="The pipeline is about to merge branch autofix/<work-key> for security ticket <WORK_KEY> on the strength of a passing review. Lens: is-the-vulnerability-actually-closed. Evidence: the ticket's threat model, the branch diff against main, and stage.review in agent state. Try to refute that the fix closes the source→sink path — look for a residual bypass, an uncovered sibling, or a new weakness the fix introduced. Do not read the reviewer's reasoning first.", run_in_background=false)
   ```
 
   ```bash

--- a/internal/claude/embed/human-ticket-review-skill.md
+++ b/internal/claude/embed/human-ticket-review-skill.md
@@ -11,7 +11,7 @@ Follow these steps in order:
 1. **Review**: Delegate to the **human-ticket-reviewer** agent:
 
 ```
-Task(subagent_type="human-ticket-reviewer", prompt="Review ticket $ARGUMENTS before it enters the pipeline. Judge whether solving it solves the problem — root or symptom, complete, coherent with existing siblings, right altitude. Act on what you find: reframe, supersede, escalate or reject. Record the verdict as a [human:ticket-review] marker.")
+Task(subagent_type="human-ticket-reviewer", prompt="Review ticket $ARGUMENTS before it enters the pipeline. Judge whether solving it solves the problem — root or symptom, complete, coherent with existing siblings, right altitude. Act on what you find: reframe, supersede, escalate or reject. Record the verdict as a [human:ticket-review] marker.", run_in_background=false)
 ```
 
 2. **Report** the verdict and what the agent did. The agent has already acted — it rewrote the framing,


### PR DESCRIPTION
## Summary
- Every board-dispatched skill (`human-execute`, `human-ticket-review`, `human-plan`, `human-review`, `human-deploy-fix`, `human-pr-fix`, `human-pr-review`, `human-autofix`, `human-security-fix`) delegated to its worker subagent via a bare `Task(...)` call, defaulting to `run_in_background=true`. Since the daemon dispatches these headless (a single `claude -p` turn, no later interactive turn), the CLI's own 10-minute background-task wait ceiling killed the subagent mid-flight and the run was misdiagnosed as a clean-but-incomplete exit, causing an infinite retry loop for any stage whose work legitimately exceeds ~10 minutes.
- Add `run_in_background=false` to all 27 `Task(...)` calls across the 9 affected skill prompts under `internal/claude/embed/` — including `human-ticket-review-skill.md`, which is chained by planning but was missing from the ticket's own file list.
- Add `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0` to `execClaudeDetached`'s exec env ([internal/agent/manager.go](internal/agent/manager.go)) as a defensive backstop for any call this pass missed.
- Linked [SC-1931](https://app.shortcut.com/work/story/1931) as a related, narrower duplicate of this same root cause.

## Test plan
- [x] `make check` (fmt, tests, lint, gosec, govulncheck, gitleaks) — all green
- [x] Extended `TestExecClaudeDetached_injectsBotGitEnv` to assert the new env var
- [x] Verified via grep that all 27 `Task(` call sites in the 9 skill files now carry `run_in_background=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)