### PR TITLE
[SC-3440] Read a call's usage off a compressed response body

### DIFF
--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -2174,6 +2174,9 @@ async function bootstrapProject() {
     if (result.orphan) {
         void offerOrphanCleanup(result.orphanProject);
     }
+    if (result.conflict) {
+        void offerProjectConflict(result.project, result.conflictProject);
+    }
 }
 // offerOrphanCleanup runs once at launch when ProjectBootstrap detects a
 // daemon left running by a crashed/force-quit prior session (no attached
@@ -2189,6 +2192,54 @@ async function offerOrphanCleanup(project) {
     catch (err) {
         showError(errMessage(err));
     }
+}
+// noticeDialog is confirmDialog's one-button counterpart: a plain
+// acknowledgement with no choice to make, for launch-time notices where
+// offering a choice would be scope this ticket deliberately defers
+// (SC-3346's conflict signal — see offerProjectConflict below).
+function noticeDialog(title, body, buttonLabel = "OK") {
+    return new Promise((resolve) => {
+        const overlay = document.createElement("div");
+        overlay.className = "modal-overlay";
+        const modal = document.createElement("div");
+        modal.className = "modal";
+        modal.innerHTML = `
+      <div class="modal-title">${escapeHtml(title)}</div>
+      <div class="modal-body">${escapeHtml(body)}</div>
+      <div class="modal-actions">
+        <button class="modal-confirm" type="button">${escapeHtml(buttonLabel)}</button>
+      </div>
+    `;
+        overlay.appendChild(modal);
+        document.body.appendChild(overlay);
+        const cleanup = () => {
+            document.removeEventListener("keydown", onKey);
+            overlay.remove();
+            resolve();
+        };
+        const onKey = (e) => {
+            if (e.key === "Escape")
+                cleanup();
+        };
+        overlay.addEventListener("click", (e) => {
+            if (e.target === overlay)
+                cleanup();
+        });
+        modal.querySelector(".modal-confirm").addEventListener("click", () => cleanup());
+        document.addEventListener("keydown", onKey);
+        modal.querySelector(".modal-confirm").focus();
+    });
+}
+// offerProjectConflict runs once at launch when ProjectBootstrap detects that
+// the working directory the app was launched from holds a different project
+// than the one a reachable daemon is already serving (SC-3346). Fire-and-
+// forget and purely informational: the running project's board is already
+// showing behind it, and nothing was switched — the interactive choice
+// between the two is a follow-up ticket, so this only names them.
+async function offerProjectConflict(runningProject, cwdProject) {
+    const running = runningProject || "the running project";
+    const here = cwdProject || "this directory's project";
+    await noticeDialog("A different project is already running", `This directory holds "${here}", but "${running}" is the project currently running here. Nothing has changed — use Switch Project if you want to open "${here}" instead.`);
 }
 function errMessage(err) {
     if (err instanceof Error)

--- a/internal/proxy/mitm.go
+++ b/internal/proxy/mitm.go
@@ -188,7 +188,7 @@ func (li *LoggingInterceptor) Intercept(ctx context.Context, conn net.Conn, host
 	dialStart := time.Now()
 	upstreamConn, err := li.dialUpstream(ctx, hostname)
 	if err != nil {
-		li.emitOutcome(remoteAddr, hostname, 0, err, dialStart, nil)
+		li.emitOutcome(remoteAddr, hostname, 0, err, dialStart, nil, nil)
 		return errors.WrapWithDetails(err, "upstream dial failed", "hostname", hostname)
 	}
 	defer func() { _ = upstreamConn.Close() }()
@@ -218,7 +218,7 @@ func (li *LoggingInterceptor) proxyHTTP(ctx context.Context, client, upstream ne
 			}
 			// A genuine read error before any call went out is a pre-output
 			// failure worth recording (content-free, StatusCode 0).
-			li.emitOutcome(remoteAddr, hostname, 0, err, time.Now(), nil)
+			li.emitOutcome(remoteAddr, hostname, 0, err, time.Now(), nil, nil)
 			return errors.WrapWithDetails(err, "reading client request", "hostname", hostname)
 		}
 
@@ -232,7 +232,7 @@ func (li *LoggingInterceptor) proxyHTTP(ctx context.Context, client, upstream ne
 			reqBody, err = io.ReadAll(io.LimitReader(req.Body, maxBodyLog))
 			_ = req.Body.Close()
 			if err != nil {
-				li.emitOutcome(remoteAddr, hostname, 0, err, start, nil)
+				li.emitOutcome(remoteAddr, hostname, 0, err, start, nil, nil)
 				return errors.WrapWithDetails(err, "reading request body", "hostname", hostname)
 			}
 		}
@@ -250,7 +250,7 @@ func (li *LoggingInterceptor) proxyHTTP(ctx context.Context, client, upstream ne
 		// Forward request to upstream with body.
 		req.Body = io.NopCloser(bytes.NewReader(reqBody))
 		if err := req.Write(upstream); err != nil {
-			li.emitOutcome(remoteAddr, hostname, 0, err, start, nil)
+			li.emitOutcome(remoteAddr, hostname, 0, err, start, nil, nil)
 			return errors.WrapWithDetails(err, "writing to upstream", "hostname", hostname)
 		}
 		// The request is now sent and unanswered: this is the "outstanding model
@@ -264,7 +264,7 @@ func (li *LoggingInterceptor) proxyHTTP(ctx context.Context, client, upstream ne
 		resp, err := http.ReadResponse(upstreamReader, req)
 		if err != nil {
 			li.markInflight(remoteAddr, hostname, -1)
-			li.emitOutcome(remoteAddr, hostname, 0, err, start, nil)
+			li.emitOutcome(remoteAddr, hostname, 0, err, start, nil, nil)
 			return errors.WrapWithDetails(err, "reading upstream response", "hostname", hostname)
 		}
 
@@ -295,7 +295,7 @@ func (li *LoggingInterceptor) proxyHTTP(ctx context.Context, client, upstream ne
 		// Record the outcome AFTER the client write (success and non-2xx alike),
 		// mirroring the existing write-then-log order so accounting can never
 		// delay or break the proxied response (SC-2555 constraint 1).
-		li.emitOutcome(remoteAddr, hostname, resp.StatusCode, nil, start, respBodyBuf.Bytes())
+		li.emitOutcome(remoteAddr, hostname, resp.StatusCode, nil, start, resp.Header, respBodyBuf.Bytes())
 
 		if writeErr != nil {
 			return errors.WrapWithDetails(writeErr, "writing to client", "hostname", hostname)

--- a/internal/proxy/mitm_test.go
+++ b/internal/proxy/mitm_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -343,6 +344,44 @@ func handleEchoHTTPS(conn net.Conn) {
 		ProtoMajor:    1,
 		ProtoMinor:    1,
 		Header:        http.Header{"Content-Type": {"application/json"}},
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Close:         true,
+	}
+	_ = resp.Write(conn)
+}
+
+// handleGzippedSSEResponse answers with the SAME streamed usage events as
+// handleSSEResponse, gzip-encoded and declared with Content-Encoding — which is
+// what an Anthropic SDK actually receives, since every one of them sends
+// accept-encoding: gzip. The plaintext handler below agrees with our own parser
+// rather than with the wire, which is how the proxy shipped recording 520
+// attributed calls priced at $0.00 (SC-3440).
+func handleGzippedSSEResponse(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+
+	req, err := http.ReadRequest(bufio.NewReader(conn))
+	if err != nil {
+		return
+	}
+	_, _ = io.ReadAll(req.Body)
+	_ = req.Body.Close()
+
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, _ = zw.Write([]byte(streamingUsageBody))
+	_ = zw.Close()
+	body := buf.Bytes()
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header: http.Header{
+			"Content-Type":     {"text/event-stream"},
+			"Content-Encoding": {"gzip"},
+		},
 		Body:          io.NopCloser(bytes.NewReader(body)),
 		ContentLength: int64(len(body)),
 		Close:         true,

--- a/internal/proxy/modeloutcome.go
+++ b/internal/proxy/modeloutcome.go
@@ -1,7 +1,12 @@
 package proxy
 
 import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
 	"encoding/json"
+	"io"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -137,6 +142,66 @@ type usageEnvelope struct {
 		Usage *tokenUsage `json:"usage"`
 	} `json:"message"`
 	Usage *tokenUsage `json:"usage"` // top-level: non-streaming object AND message_delta
+}
+
+// maxDecodedBody caps how much of a compressed body is expanded for accounting.
+// A response is read for four integers and a model id, all of which arrive in
+// the first events, so this is a decompression-bomb guard rather than a limit
+// anything legitimate approaches.
+const maxDecodedBody = 32 * 1024 * 1024
+
+// decodeBody returns the body as the API meant it to be read, expanding the
+// content coding the client negotiated. The MITM path reads the response with
+// http.ReadResponse and tees the bytes straight through, and ReadResponse
+// decodes only the transfer encoding — Go's Transport is what would undo a
+// content encoding, and this path deliberately has none. So a client that sent
+// `accept-encoding: gzip` (every current Anthropic SDK does) left the captured
+// copy compressed, and the usage scan found no `data:` line and no JSON object
+// in it: 520 attributed calls landed in the ledger with a blank model and four
+// zero counts, priced at $0.00 (SC-3440).
+//
+// Only the accounting copy is expanded. The bytes streamed to the client are
+// untouched, still compressed, still byte-identical — accounting must never
+// alter the call it measures (SC-2555 constraint 1).
+//
+// An unreadable or unsupported encoding returns the body unchanged rather than
+// an error: the scan then finds nothing and records zeros, exactly as before,
+// so a coding we cannot expand costs a measurement and never a call.
+func decodeBody(header http.Header, body []byte) []byte {
+	if len(body) == 0 || header == nil {
+		return body
+	}
+
+	var r io.Reader
+	switch strings.ToLower(strings.TrimSpace(header.Get("Content-Encoding"))) {
+	case "", "identity":
+		return body
+	case "gzip", "x-gzip":
+		zr, err := gzip.NewReader(bytes.NewReader(body))
+		if err != nil {
+			return body
+		}
+		defer func() { _ = zr.Close() }()
+		r = zr
+	case "deflate":
+		fr := flate.NewReader(bytes.NewReader(body))
+		defer func() { _ = fr.Close() }()
+		r = fr
+	default:
+		// br, zstd and anything else: not expanded here. emitOutcome reports the
+		// resulting blind spot, because "this call cost nothing" and "we could
+		// not tell what it cost" are different claims and only one is true.
+		return body
+	}
+
+	// A streamed response captured mid-flight is a truncated compressed stream,
+	// so an unexpected-EOF read still yields every complete event before the
+	// cut. Take what decoded and let the scan work on it.
+	decoded, err := io.ReadAll(io.LimitReader(r, maxDecodedBody))
+	if err != nil && len(decoded) == 0 {
+		return body
+	}
+	return decoded
 }
 
 // usageFromResponse extracts the four token counts and the model id from a
@@ -276,7 +341,7 @@ func (li *LoggingInterceptor) markInflight(remoteAddr, host string, delta int) {
 // (SC-2847). It is nil on every path that has no response line (a transport
 // failure) and is never stored; only fixed metadata fields are read, so the
 // outcome struct stays content-free (SC-2555). No other outcome touches the body.
-func (li *LoggingInterceptor) emitOutcome(remoteAddr, host string, statusCode int, transportErr error, start time.Time, body []byte) {
+func (li *LoggingInterceptor) emitOutcome(remoteAddr, host string, statusCode int, transportErr error, start time.Time, header http.Header, body []byte) {
 	if li.RecordOutcome == nil || !li.isModelHost(host) {
 		return
 	}
@@ -288,6 +353,7 @@ func (li *LoggingInterceptor) emitOutcome(remoteAddr, host string, statusCode in
 			ticket, stage = t, s
 		}
 	}
+	body = decodeBody(header, body)
 	errType := ""
 	if statusCode == 400 {
 		errType = anthropicErrorType(body)
@@ -296,6 +362,17 @@ func (li *LoggingInterceptor) emitOutcome(remoteAddr, host string, statusCode in
 	var inTok, outTok, cacheCreate, cacheRead int
 	if statusCode >= 200 && statusCode < 300 {
 		model, inTok, outTok, cacheCreate, cacheRead = usageFromResponse(body)
+		// A successful call whose usage would not parse is a hole in the
+		// accounting, and it is invisible downstream: the ledger stores the row
+		// either way, so the ticket simply reads as costing nothing. Say so
+		// once, here, with the coding that defeated the read — the alternative
+		// is a board reporting $0.00 with total confidence (SC-3440).
+		if model == "" && len(body) > 0 {
+			li.Logger.Warn().
+				Str("content_encoding", header.Get("Content-Encoding")).
+				Int("body_bytes", len(body)).
+				Msg("model call recorded without usage: response body did not parse, its cost is unmeasured")
+		}
 	}
 	li.RecordOutcome(ModelCallOutcome{
 		Ticket:            ticket,

--- a/internal/proxy/modeloutcome_test.go
+++ b/internal/proxy/modeloutcome_test.go
@@ -58,14 +58,14 @@ func TestEmitOutcome_SpendLimitFrom400Body(t *testing.T) {
 	li := &LoggingInterceptor{RecordOutcome: func(o ModelCallOutcome) { got = o }}
 
 	billing := []byte(`{"type":"error","error":{"type":"billing_error","message":"secret prose that must never be read"}}`)
-	li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 400, nil, time.Now(), billing)
+	li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 400, nil, time.Now(), nil, billing)
 	assert.Equal(t, ClassSpendLimit, got.Class, "a billing_error 400 is a spend-limit")
 
 	generic := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"bad request"}}`)
-	li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 400, nil, time.Now(), generic)
+	li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 400, nil, time.Now(), nil, generic)
 	assert.Equal(t, ClassOther, got.Class, "a non-billing 400 stays other")
 
-	li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 400, nil, time.Now(), nil)
+	li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 400, nil, time.Now(), nil, nil)
 	assert.Equal(t, ClassOther, got.Class, "a 400 with no body is other, never a panic")
 }
 
@@ -96,17 +96,17 @@ func TestModelAPIHost_DefaultAndOverride(t *testing.T) {
 func TestEmitOutcome_NilRecorderNoOp(t *testing.T) {
 	li := &LoggingInterceptor{}
 	// Must not panic with no recorder wired.
-	li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 200, nil, time.Now(), nil)
+	li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 200, nil, time.Now(), nil, nil)
 }
 
 func TestEmitOutcome_GatedOnModelHost(t *testing.T) {
 	var got []ModelCallOutcome
 	li := &LoggingInterceptor{RecordOutcome: func(o ModelCallOutcome) { got = append(got, o) }}
 
-	li.emitOutcome("1.2.3.4:5", "example.com", 200, nil, time.Now(), nil)
+	li.emitOutcome("1.2.3.4:5", "example.com", 200, nil, time.Now(), nil, nil)
 	assert.Empty(t, got, "a non-model host is never accounted")
 
-	li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 200, nil, time.Now(), nil)
+	li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 200, nil, time.Now(), nil, nil)
 	require.Len(t, got, 1, "the model host is accounted")
 	assert.Equal(t, ClassOK, got[0].Class)
 	assert.Equal(t, "api.anthropic.com", got[0].Host)
@@ -121,7 +121,7 @@ func TestEmitOutcome_Attribution(t *testing.T) {
 			return "SC-2555", "implementation", true
 		},
 	}
-	li.emitOutcome("10.0.0.7:44003", "api.anthropic.com", 200, nil, time.Now(), nil)
+	li.emitOutcome("10.0.0.7:44003", "api.anthropic.com", 200, nil, time.Now(), nil, nil)
 	assert.Equal(t, "SC-2555", got.Ticket)
 	assert.Equal(t, "implementation", got.Stage)
 }
@@ -133,7 +133,7 @@ func TestEmitOutcome_UnattributedIsStillRecorded(t *testing.T) {
 		RecordOutcome: func(o ModelCallOutcome) { got = o; recorded = true },
 		Attribute:     func(string) (string, string, bool) { return "", "", false },
 	}
-	li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 401, nil, time.Now(), nil)
+	li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 401, nil, time.Now(), nil, nil)
 	require.True(t, recorded, "an unattributed failure is recorded, not dropped")
 	assert.Empty(t, got.Ticket)
 	assert.Empty(t, got.Stage)
@@ -147,7 +147,7 @@ func TestEmitOutcome_PanicInSinkSwallowed(t *testing.T) {
 	}
 	// Constraint 1: a recording fault must never escape to break the call.
 	assert.NotPanics(t, func() {
-		li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 200, nil, time.Now(), nil)
+		li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 200, nil, time.Now(), nil, nil)
 	})
 }
 
@@ -198,7 +198,7 @@ func TestUsageFromResponse_empty(t *testing.T) {
 func TestEmitOutcome_recordsTokens(t *testing.T) {
 	var got ModelCallOutcome
 	li := &LoggingInterceptor{RecordOutcome: func(o ModelCallOutcome) { got = o }}
-	li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 200, nil, time.Now(), []byte(streamingUsageBody))
+	li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 200, nil, time.Now(), nil, []byte(streamingUsageBody))
 	assert.Equal(t, "claude-opus-4-8", got.Model)
 	assert.Equal(t, 100, got.InputTokens)
 	assert.Equal(t, 200, got.OutputTokens)
@@ -210,7 +210,7 @@ func TestEmitOutcome_recordsTokens(t *testing.T) {
 func TestEmitOutcome_failureNoTokens(t *testing.T) {
 	var got ModelCallOutcome
 	li := &LoggingInterceptor{RecordOutcome: func(o ModelCallOutcome) { got = o }}
-	li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 0, errors.New("dial refused"), time.Now(), nil)
+	li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 0, errors.New("dial refused"), time.Now(), nil, nil)
 	assert.Equal(t, "", got.Model)
 	assert.Equal(t, 0, got.InputTokens+got.OutputTokens+got.CacheCreateTokens+got.CacheReadTokens,
 		"a call that never produced a response has no cost")
@@ -465,4 +465,69 @@ func doOneRequest(t *testing.T, env *interceptTestEnv, li *LoggingInterceptor, h
 	_, _ = bytes.NewBuffer(nil).ReadFrom(resp.Body)
 	_ = resp.Body.Close()
 	_ = conn.Close()
+}
+
+// TestIntercept_RecordsGzippedStreamedTokens is the wire-accurate version of
+// TestIntercept_RecordsStreamedTokens: identical usage events, gzip-encoded and
+// declared, exactly as an Anthropic SDK receives them. Nothing on the MITM path
+// undoes a content encoding — http.ReadResponse decodes only the transfer
+// encoding — so the captured copy stayed compressed and the usage scan found
+// nothing in it. Every attributed call landed in the cost ledger with a blank
+// model and four zero counts, which the board then priced, with total
+// confidence, at $0.00 (SC-3440).
+func TestIntercept_RecordsGzippedStreamedTokens(t *testing.T) {
+	env := newInterceptTestEnv(t)
+	hostname := "api.anthropic.com"
+	upstreamLn := startUpstreamTLS(t, env, hostname, handleGzippedSSEResponse)
+
+	rec := &recordingSink{}
+	li := &LoggingInterceptor{
+		Domains:       []string{hostname},
+		LeafCache:     env.LeafCache,
+		Logger:        zerolog.Nop(),
+		LogDir:        env.LogDir,
+		RecordOutcome: rec.record,
+		Attribute:     func(string) (string, string, bool) { return "SC-3440", "implementation", true },
+		Dialer: func(_ context.Context, _, _ string) (net.Conn, error) {
+			return tls.Dial("tcp", upstreamLn.Addr().String(), &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec // test only
+			})
+		},
+	}
+	withLogMode(t, LogModeOff)
+
+	doOneRequest(t, env, li, hostname, `{"model":"claude-opus-4-8","stream":true}`)
+
+	o := rec.wait(t, 1)[0]
+	assert.Equal(t, ClassOK, o.Class)
+	assert.Equal(t, "claude-opus-4-8", o.Model, "a compressed body must still yield the model")
+	assert.Equal(t, 100, o.InputTokens)
+	assert.Equal(t, 200, o.OutputTokens, "cumulative streamed output, not the near-1 message_start value")
+	assert.Equal(t, 50, o.CacheCreateTokens)
+	assert.Equal(t, 900, o.CacheReadTokens)
+}
+
+// A body the accounting cannot expand must cost a measurement and never a call:
+// the outcome is still recorded, with its class, status and timing intact.
+func TestEmitOutcome_unreadableEncodingStillRecordsTheCall(t *testing.T) {
+	var got ModelCallOutcome
+	li := &LoggingInterceptor{RecordOutcome: func(o ModelCallOutcome) { got = o }}
+	header := http.Header{"Content-Encoding": {"br"}}
+
+	li.emitOutcome("1.2.3.4:5", "api.anthropic.com", 200, nil, time.Now(), header, []byte("\x1b\x07\x00brotli-ish"))
+
+	assert.Equal(t, ClassOK, got.Class)
+	assert.Equal(t, 200, got.StatusCode)
+	assert.Equal(t, "", got.Model, "an unreadable coding yields no usage rather than a wrong one")
+	assert.Equal(t, 0, got.InputTokens+got.OutputTokens+got.CacheCreateTokens+got.CacheReadTokens)
+}
+
+// A gzip header on a body that is not gzip (a truncated capture, a mislabelled
+// response) must degrade to "no usage", never to a panic on the accounting path.
+func TestDecodeBody_corruptGzipFallsBackToRawBytes(t *testing.T) {
+	header := http.Header{"Content-Encoding": {"gzip"}}
+	raw := []byte("not actually gzip")
+
+	assert.Equal(t, raw, decodeBody(header, raw))
+	assert.Equal(t, raw, decodeBody(nil, raw), "no header is the identity case")
 }


### PR DESCRIPTION
Fixes SC-3440.

The cost ledger filled with correctly attributed calls that all cost nothing. After the container proxy redirect started working, 520 rows landed against real tickets and stages — `SC-3305/prreview`, `SC-3339/implementation` — with correct durations and **a blank model and four zero token counts on every one**. So SC-2847's whole point, what a ticket cost, read as $0.00 with total confidence.

**Why.** The MITM path reads the upstream response with `http.ReadResponse` and tees the bytes through (`mitm.go:265`). That undoes the *transfer* encoding only — undoing a *content* encoding is `Transport`'s job, and this path deliberately has none. Every current Anthropic SDK sends `accept-encoding: gzip`, so the captured copy was gzip and the usage scan found no `data:` line and no JSON object in it.

Demonstrated, not inferred: the parser fed plaintext events returns `model=claude-opus-4 in=100 out=250 cr=2000`; fed the identical body gzipped it returns a blank model and four zeros — the exact signature of all 520 live rows. `human proxy model-outcomes` shows `status=200`, so these are not error responses, and `maxBodyLog` is 10 MB, so it is not truncation.

**The fix.** Expand the accounting copy per `Content-Encoding` (gzip, deflate) before reading it. The bytes streamed to the client stay untouched and still compressed — accounting must never alter the call it measures (SC-2555 constraint 1). A truncated stream still yields every complete event before the cut. A coding that cannot be expanded (br, zstd) still records the call, now with a warning naming the coding, because "this call cost nothing" and "we could not tell what it cost" are different claims.

**Why every test passed.** The streaming test serves plaintext, which the real API never sends — the fake agreed with our own parser instead of with the wire, the same shape as the Shortcut endpoint that answered 404 from the day it was written. `TestIntercept_RecordsGzippedStreamedTokens` is its wire-accurate counterpart and fails on the old code with `expected: "claude-opus-4-8", actual: ""`.

Second commit is unrelated drift found while building: the checked-in `dist/board.js` was missing SC-3346's launch-time conflict dialog, so the bundle embedded at build time lacked a feature its source has.

`make check` green (4585 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)