### PR TITLE
[SC-3345] Keep optional capabilities alive through the outermost wrapper

### DIFF
--- a/internal/marker/signing.go
+++ b/internal/marker/signing.go
@@ -122,6 +122,22 @@ func (s *SigningProvider) AddComment(ctx context.Context, key, body string) (*tr
 	return s.Provider.AddComment(ctx, key, Sign(body, s.machine, s.build))
 }
 
+// AssignToReporter re-exposes an OPTIONAL capability of the wrapped provider.
+//
+// Embedding tracker.Provider promotes only the methods that interface declares,
+// so a capability callers reach by type assertion — one deliberately kept off
+// Provider so backends without it need not fake it — does not survive the wrap.
+// It is invisible: nothing fails to compile, the assertion simply returns false
+// and the caller concludes the tracker cannot do something it can. Every
+// optional capability added to a provider needs a line here.
+func (s *SigningProvider) AssignToReporter(ctx context.Context, key string) error {
+	assigner, ok := s.Provider.(tracker.ReporterAssigner)
+	if !ok {
+		return tracker.ErrOwnershipUnsupported
+	}
+	return assigner.AssignToReporter(ctx, key)
+}
+
 // SigningCommenter is the Commenter-narrowed twin of SigningProvider, for the
 // daemon's internal board posts which hold only a tracker.Commenter. It signs
 // AddComment bodies with the same Sign helper and delegates ListComments.

--- a/internal/marker/signing_capability_test.go
+++ b/internal/marker/signing_capability_test.go
@@ -1,0 +1,58 @@
+package marker_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/marker"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// SigningProvider is the OUTERMOST decorator in the provider chain, and it
+// embeds tracker.Provider — which promotes only the methods that interface
+// declares. Any capability deliberately kept off Provider so backends without it
+// need not fake it therefore vanishes at the last wrap, silently: nothing fails
+// to compile, the type assertion just returns false, and the caller concludes
+// the tracker cannot do something it can.
+//
+// That is not hypothetical. AssignToReporter was implemented on the client and
+// relayed through the four inner wrappers, and calls still answered "tracker
+// does not support assignment" — because this one, which nobody had counted,
+// dropped it.
+func TestSigningProviderPreservesOptionalCapabilities(t *testing.T) {
+	inner := &capableProvider{}
+	wrapped := marker.NewSigningProvider(inner, "machine-1", "build-1")
+
+	assigner, ok := wrapped.(tracker.ReporterAssigner)
+	require.True(t, ok, "the outermost wrapper drops ReporterAssigner — a caller sees a provider that cannot do what it can")
+
+	require.NoError(t, assigner.AssignToReporter(context.Background(), "SC-1"))
+	assert.Equal(t, []string{"SC-1"}, inner.reporterAssigned, "the call must reach the wrapped provider")
+}
+
+// A wrapped provider that genuinely lacks the capability reports it as absent
+// rather than pretending, so the caller's fallback still works.
+func TestSigningProviderReportsAGenuinelyAbsentCapability(t *testing.T) {
+	wrapped := marker.NewSigningProvider(&plainProvider{}, "m", "b")
+
+	assigner, ok := wrapped.(tracker.ReporterAssigner)
+	require.True(t, ok, "the method exists on the wrapper either way")
+
+	err := assigner.AssignToReporter(context.Background(), "SC-1")
+	require.ErrorIs(t, err, tracker.ErrOwnershipUnsupported)
+}
+
+type plainProvider struct{ tracker.Provider }
+
+type capableProvider struct {
+	tracker.Provider
+	reporterAssigned []string
+}
+
+func (c *capableProvider) AssignToReporter(_ context.Context, key string) error {
+	c.reporterAssigned = append(c.reporterAssigned, key)
+	return nil
+}


### PR DESCRIPTION
PM ticket: SC-3345
Branch: sc-3345d-signing-passthrough
