### PR TITLE
[SC-3497] Rank cost by ticket on the stats page, replacing tokens per hour

### DIFF
--- a/desktop/frontend/dist/statsview.js
+++ b/desktop/frontend/dist/statsview.js
@@ -211,7 +211,7 @@ function renderHeadlines() {
 }
 function renderPanels() {
     return (`<div class="stats-panels">` +
-        panelTokens() +
+        panelTicketCosts() +
         panelTokensByModel() +
         panelTools() +
         panelAudit() +
@@ -228,31 +228,36 @@ function panelShell(title, badge, body) {
 function emptyBody() {
     return `<div class="stats-empty">No data yet</div>`;
 }
-// Tokens-per-hour: two bars per hour (output, context) normalized against the
-// overall max so the two series stay comparable across the row. Context folds
-// input + cache-create + cache-read — everything that isn't producing output.
-function panelTokens() {
-    const rows = latest.tokensPerHour;
+// Cost by ticket: one row per ticket over the range, most expensive first, with
+// the same two bars every other token panel uses (answers, context). It
+// replaces the per-hour burn, which showed WHEN tokens were spent — a question
+// nobody acts on — where this one shows WHICH WORK spent them, which is the
+// question the money is actually attached to (SC-3497).
+//
+// A ticket with no priced spend still lists, at $0.00: rows written before the
+// proxy could read usage off a compressed body carry duration only, and hiding
+// them would claim the work never ran.
+function panelTicketCosts() {
+    const rows = latest.ticketCosts;
     if (rows.length === 0)
-        return panelShell("Tokens per hour", "", emptyBody());
-    const all = rows.flatMap((r) => [r.output, contextTokens(r)]);
+        return panelShell("Cost by ticket", "", emptyBody());
+    const all = rows.flatMap((r) => [r.outputTokens, r.contextTokens]);
     const pcts = barPercents(all);
     const body = rows
         .map((r, i) => {
         const op = pcts[i * 2];
         const cp = pcts[i * 2 + 1];
-        const hour = r.bucket.slice(11); // "HH:00"
         return (`<div class="stats-hour-row">` +
-            `<span class="stats-hour-label">${escapeHtml(hour)}</span>` +
+            `<span class="stats-hour-label">${escapeHtml(r.ticket)}</span>` +
             `<span class="stats-hour-bars">` +
             `<span class="token-bar"><span class="token-bar-fill fresh" style="width:${op}%"></span></span>` +
             `<span class="token-bar"><span class="token-bar-fill cache" style="width:${cp}%"></span></span>` +
             `</span>` +
-            `<span class="stats-hour-val">${escapeHtml(fmtNum(r.output))}/${escapeHtml(fmtNum(contextTokens(r)))} · ${escapeHtml(fmtUSD(r.costUSD))}</span>` +
+            `<span class="stats-hour-val">${escapeHtml(fmtUSD(r.costUSD))} · ${escapeHtml(fmtNum(r.outputTokens))}/${escapeHtml(fmtNum(r.contextTokens))}</span>` +
             `</div>`);
     })
         .join("");
-    return panelShell("Tokens per hour", "output / context", body);
+    return panelShell("Cost by ticket", "answers / context", body);
 }
 // Tokens-by-model: one row per model with two bars (output, context)
 // normalized against the overall max, so the tier split (opus/sonnet/haiku)

--- a/desktop/frontend/scripts/statsview.test.mjs
+++ b/desktop/frontend/scripts/statsview.test.mjs
@@ -89,7 +89,7 @@ test("in-flight guard: overlapping showStats calls do not stack Stats() calls (S
         toolCalls: { total: 0, success: 0, failure: 0 },
         audit: { total: 0, success: 0, failure: 0 },
         agentRuns: { total: 0, success: 0, failure: 0 },
-        tokensPerHour: [],
+        ticketCosts: [],
         tokensByModel: [],
         toolsByTool: [],
         auditByDay: [],
@@ -121,7 +121,7 @@ test("showStats renders the Tokens by model panel from tokensByModel (SC-1316)",
         toolCalls: { total: 0, success: 0, failure: 0 },
         audit: { total: 0, success: 0, failure: 0 },
         agentRuns: { total: 0, success: 0, failure: 0 },
-        tokensPerHour: [],
+        ticketCosts: [],
         tokensByModel: [{ model: "opus 4.8", input: 100, output: 200, cacheCreate: 50, cacheRead: 30, costUSD: 0 }],
         toolsByTool: [],
         auditByDay: [],
@@ -133,6 +133,71 @@ test("showStats renders the Tokens by model panel from tokensByModel (SC-1316)",
 
   assert.match(el.innerHTML, /Tokens by model/, "the panel title renders");
   assert.match(el.innerHTML, /opus 4\.8/, "the model row renders");
+});
+
+// SC-3497: the stats page shows which WORK spent the range's tokens, ranked by
+// cost — the question the money is attached to. It replaced the per-hour burn,
+// which showed only when tokens were spent, and that panel must be gone rather
+// than merely unlinked.
+test("showStats renders the Cost by ticket panel from ticketCosts (SC-3497)", async () => {
+  const el = installStatsDOM();
+  initStatsView(() => ({
+    Stats: () =>
+      Promise.resolve({
+        range: "24h",
+        generatedAt: "",
+        daemonStartedAt: "",
+        tokens: { input: 0, output: 0, cacheCreate: 0, cacheRead: 0, costUSD: 0 },
+        toolCalls: { total: 0, success: 0, failure: 0 },
+        audit: { total: 0, success: 0, failure: 0 },
+        agentRuns: { total: 0, success: 0, failure: 0 },
+        ticketCosts: [
+          { ticket: "SC-637", costUSD: 1.5, contextCostUSD: 1.14, answersCostUSD: 0.36, outputTokens: 14449, contextTokens: 558705, durationMs: 226947 },
+          { ticket: "SC-3321", costUSD: 0.05, contextCostUSD: 0.04, answersCostUSD: 0.01, outputTokens: 158, contextTokens: 18317, durationMs: 4000 },
+        ],
+        tokensByModel: [],
+        toolsByTool: [],
+        auditByDay: [],
+        networkDecisions: [],
+      }),
+  }));
+
+  await showStats();
+
+  assert.match(el.innerHTML, /Cost by ticket/, "the panel title renders");
+  assert.match(el.innerHTML, /SC-637/, "the most expensive ticket renders");
+  assert.match(el.innerHTML, /\$1\.50/, "the ticket's cost renders as money");
+  assert.doesNotMatch(el.innerHTML, /Tokens per hour/, "the per-hour burn panel it replaced must be gone");
+});
+
+// A ticket whose rows carry duration but no priced tokens still lists, at
+// $0.00: hiding it would claim the work never ran (SC-3440 left 520 such rows).
+test("showStats lists an unpriced ticket rather than dropping it (SC-3497)", async () => {
+  const el = installStatsDOM();
+  initStatsView(() => ({
+    Stats: () =>
+      Promise.resolve({
+        range: "24h",
+        generatedAt: "",
+        daemonStartedAt: "",
+        tokens: { input: 0, output: 0, cacheCreate: 0, cacheRead: 0, costUSD: 0 },
+        toolCalls: { total: 0, success: 0, failure: 0 },
+        audit: { total: 0, success: 0, failure: 0 },
+        agentRuns: { total: 0, success: 0, failure: 0 },
+        ticketCosts: [
+          { ticket: "SC-BLIND", costUSD: 0, contextCostUSD: 0, answersCostUSD: 0, outputTokens: 0, contextTokens: 0, durationMs: 6387000 },
+        ],
+        tokensByModel: [],
+        toolsByTool: [],
+        auditByDay: [],
+        networkDecisions: [],
+      }),
+  }));
+
+  await showStats();
+
+  assert.match(el.innerHTML, /SC-BLIND/, "an unpriced ticket still appears");
+  assert.match(el.innerHTML, /\$0\.00/, "priced at zero rather than hidden");
 });
 
 // SC-2549: context is everything spent establishing/re-reading context

--- a/desktop/frontend/scripts/style.test.mjs
+++ b/desktop/frontend/scripts/style.test.mjs
@@ -207,26 +207,35 @@ test("partial badge uses the machine register, not the needs-a-person amber (SC-
 // the card with cursor:not-allowed), .card.not-mine must touch opacity only.
 test("not-mine card is dimmed via opacity only, never locked like a degraded card (SC-3339)", () => {
   const body = ruleBody(".card.not-mine");
-  assert.match(body, /opacity:\s*[\d.]+/, ".card.not-mine must set opacity");
+  assert.match(body, /opacity:\s*(var\(--not-mine-opacity\)|[\d.]+)/, ".card.not-mine must set opacity");
   assert.doesNotMatch(body, /cursor:\s*not-allowed/, "not-mine must not disable the pointer like .degraded does");
   assert.doesNotMatch(body, /pointer-events:\s*none/, "not-mine must not block interaction");
 });
 
-// SC-3339: a card that is both degraded (fetch failure) and not-mine must
-// keep the more restrictive .degraded dimming, so a degraded card never
-// reads as LESS urgent than a healthy not-mine one.
-test("a degraded not-mine card keeps the degraded (more restrictive) opacity, not the lighter not-mine one (SC-3339)", () => {
-  const notMine = ruleBody(".card.not-mine").match(/opacity:\s*([\d.]+)/);
-  const degraded = ruleBody(".card.degraded").match(/opacity:\s*([\d.]+)/);
-  assert.ok(notMine, ".card.not-mine must set opacity");
-  assert.ok(degraded, ".card.degraded must set opacity");
+// SC-3404: the dimming strength is a token so a theme can set it, and the
+// derived rules must follow it rather than repeat a literal that can drift.
+test("not-mine dimming comes from the --not-mine-opacity token (SC-3404)", () => {
+  const root = ruleBody(":root").match(/--not-mine-opacity:\s*([\d.]+)/);
+  assert.ok(root, ":root must define --not-mine-opacity");
+  assert.ok(Number(root[1]) > 0 && Number(root[1]) < 1, "the token must be a usable opacity");
+  assert.match(ruleBody(".card.not-mine"), /var\(--not-mine-opacity\)/, "the rule must read the token");
+});
 
-  const combined = ruleBody(".card.degraded.not-mine").match(/opacity:\s*([\d.]+)/);
-  assert.ok(combined, ".card.degraded.not-mine must set an explicit opacity to break the cascade tie");
-  assert.equal(
-    Number(combined[1]), Number(degraded[1]),
-    ".card.degraded.not-mine must resolve to .degraded's opacity, not .not-mine's lighter one",
-  );
+// SC-3339/SC-3404: a card that is both degraded (fetch failure) and not-mine
+// must never read LESS dim than either signal alone, so neither signal is
+// weakened by the overlap. not-mine is now the stronger of the two, so the
+// combined rule derives from its token rather than matching .degraded's value.
+test("a degraded not-mine card is at least as dim as either signal alone (SC-3339)", () => {
+  const token = Number(ruleBody(":root").match(/--not-mine-opacity:\s*([\d.]+)/)[1]);
+  const degraded = Number(ruleBody(".card.degraded").match(/opacity:\s*([\d.]+)/)[1]);
+  const combined = ruleBody(".card.degraded.not-mine");
+  assert.notEqual(combined, "", ".card.degraded.not-mine must set an explicit opacity to break the cascade tie");
+
+  const factor = combined.match(/calc\(var\(--not-mine-opacity\)\s*\*\s*([\d.]+)\)/);
+  assert.ok(factor, "the overlap must derive from the token, not repeat a literal");
+  const resolved = token * Number(factor[1]);
+  assert.ok(resolved <= token, `overlap ${resolved} must be at least as dim as not-mine ${token}`);
+  assert.ok(resolved <= degraded, `overlap ${resolved} must be at least as dim as degraded ${degraded}`);
 });
 
 // SC-1830: the four "whose turn" semantic tokens must exist and alias the

--- a/desktop/frontend/src/statsview.ts
+++ b/desktop/frontend/src/statsview.ts
@@ -25,13 +25,14 @@ export interface StatsOverview {
   toolCalls: Headline;
   audit: Headline;
   agentRuns: Headline;
-  tokensPerHour: {
-    bucket: string;
-    input: number;
-    output: number;
-    cacheCreate: number;
-    cacheRead: number;
+  ticketCosts: {
+    ticket: string;
     costUSD: number;
+    contextCostUSD: number;
+    answersCostUSD: number;
+    outputTokens: number;
+    contextTokens: number;
+    durationMs: number;
   }[];
   tokensByModel: {
     model: string;
@@ -270,7 +271,7 @@ function renderHeadlines(): string {
 function renderPanels(): string {
   return (
     `<div class="stats-panels">` +
-    panelTokens() +
+    panelTicketCosts() +
     panelTokensByModel() +
     panelTools() +
     panelAudit() +
@@ -293,32 +294,37 @@ function emptyBody(): string {
   return `<div class="stats-empty">No data yet</div>`;
 }
 
-// Tokens-per-hour: two bars per hour (output, context) normalized against the
-// overall max so the two series stay comparable across the row. Context folds
-// input + cache-create + cache-read — everything that isn't producing output.
-function panelTokens(): string {
-  const rows = latest!.tokensPerHour;
-  if (rows.length === 0) return panelShell("Tokens per hour", "", emptyBody());
-  const all = rows.flatMap((r) => [r.output, contextTokens(r)]);
+// Cost by ticket: one row per ticket over the range, most expensive first, with
+// the same two bars every other token panel uses (answers, context). It
+// replaces the per-hour burn, which showed WHEN tokens were spent — a question
+// nobody acts on — where this one shows WHICH WORK spent them, which is the
+// question the money is actually attached to (SC-3497).
+//
+// A ticket with no priced spend still lists, at $0.00: rows written before the
+// proxy could read usage off a compressed body carry duration only, and hiding
+// them would claim the work never ran.
+function panelTicketCosts(): string {
+  const rows = latest!.ticketCosts;
+  if (rows.length === 0) return panelShell("Cost by ticket", "", emptyBody());
+  const all = rows.flatMap((r) => [r.outputTokens, r.contextTokens]);
   const pcts = barPercents(all);
   const body = rows
     .map((r, i) => {
       const op = pcts[i * 2];
       const cp = pcts[i * 2 + 1];
-      const hour = r.bucket.slice(11); // "HH:00"
       return (
         `<div class="stats-hour-row">` +
-        `<span class="stats-hour-label">${escapeHtml(hour)}</span>` +
+        `<span class="stats-hour-label">${escapeHtml(r.ticket)}</span>` +
         `<span class="stats-hour-bars">` +
         `<span class="token-bar"><span class="token-bar-fill fresh" style="width:${op}%"></span></span>` +
         `<span class="token-bar"><span class="token-bar-fill cache" style="width:${cp}%"></span></span>` +
         `</span>` +
-        `<span class="stats-hour-val">${escapeHtml(fmtNum(r.output))}/${escapeHtml(fmtNum(contextTokens(r)))} · ${escapeHtml(fmtUSD(r.costUSD))}</span>` +
+        `<span class="stats-hour-val">${escapeHtml(fmtUSD(r.costUSD))} · ${escapeHtml(fmtNum(r.outputTokens))}/${escapeHtml(fmtNum(r.contextTokens))}</span>` +
         `</div>`
       );
     })
     .join("");
-  return panelShell("Tokens per hour", "output / context", body);
+  return panelShell("Cost by ticket", "answers / context", body);
 }
 
 // Tokens-by-model: one row per model with two bars (output, context)

--- a/internal/costledger/store.go
+++ b/internal/costledger/store.go
@@ -207,3 +207,86 @@ func (s *Store) Close() error {
 	}
 	return s.db.Close()
 }
+
+// TicketSpend is one ticket's priced spend over a window, ranked for the stats
+// view. It carries the answers/context split as tokens as well as dollars,
+// because the split is the number that says whether a ticket was expensive for
+// a good reason (SC-3497).
+type TicketSpend struct {
+	Ticket         string  `json:"ticket"`
+	CostUSD        float64 `json:"costUSD"`
+	ContextCostUSD float64 `json:"contextCostUSD"`
+	AnswersCostUSD float64 `json:"answersCostUSD"`
+	OutputTokens   int     `json:"outputTokens"`
+	ContextTokens  int     `json:"contextTokens"`
+	DurationMs     int64   `json:"durationMs"`
+}
+
+// TopTicketSpend ranks the tickets that cost the most over a window, most
+// expensive first. Pricing happens here, per (ticket, model), for the same
+// reason TicketCost prices at read time: the rate card can change, and a stored
+// dollar figure would silently keep the old rate.
+//
+// Rows the pricing cannot value — a model the rate card does not know, or the
+// zero-token rows written before the proxy read usage off a compressed body
+// (SC-3440) — still rank, at zero. They are part of the truth about a ticket:
+// it ran, and what it cost is not known.
+func (s *Store) TopTicketSpend(ctx context.Context, project string, since, until time.Time, limit int) ([]TicketSpend, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT ticket, model, SUM(input_tokens), SUM(output_tokens), SUM(cache_create_tokens), SUM(cache_read_tokens), SUM(duration_ms)
+		 FROM ticket_calls
+		 WHERE project = ? AND started_at >= ? AND started_at <= ?
+		 GROUP BY ticket, model`,
+		project, since.UTC().Format("2006-01-02 15:04:05"), until.UTC().Format("2006-01-02 15:04:05"))
+	if err != nil {
+		return nil, errors.WrapWithDetails(err, "query ticket spend", "project", project)
+	}
+	defer func() { _ = rows.Close() }()
+
+	byTicket := map[string]*TicketSpend{}
+	for rows.Next() {
+		var ticket, model string
+		var in, outTok, cc, cr int
+		var durMs int64
+		if err := rows.Scan(&ticket, &model, &in, &outTok, &cc, &cr, &durMs); err != nil {
+			return nil, errors.WrapWithDetails(err, "scan ticket spend row")
+		}
+		ts, ok := byTicket[ticket]
+		if !ok {
+			ts = &TicketSpend{Ticket: ticket}
+			byTicket[ticket] = ts
+		}
+		ts.CostUSD += claude.CostUSD(model, in, outTok, cc, cr)
+		ts.ContextCostUSD += claude.CostUSD(model, in, 0, cc, cr)
+		ts.AnswersCostUSD += claude.CostUSD(model, 0, outTok, 0, 0)
+		ts.OutputTokens += outTok
+		ts.ContextTokens += in + cc + cr
+		ts.DurationMs += durMs
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.WrapWithDetails(err, "iterate ticket spend rows")
+	}
+
+	out := make([]TicketSpend, 0, len(byTicket))
+	for _, ts := range byTicket {
+		out = append(out, *ts)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CostUSD != out[j].CostUSD {
+			return out[i].CostUSD > out[j].CostUSD
+		}
+		// Cost ties on unpriced rows, so fall back to the work actually done and
+		// then to the key, keeping the order stable rather than map-random.
+		if out[i].DurationMs != out[j].DurationMs {
+			return out[i].DurationMs > out[j].DurationMs
+		}
+		return out[i].Ticket < out[j].Ticket
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}

--- a/internal/costledger/store_test.go
+++ b/internal/costledger/store_test.go
@@ -2,6 +2,7 @@ package costledger
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,6 +12,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// testModel is a model the rate card prices, so a test asserting on dollars is
+// asserting on pricing rather than on a zero.
+const testModel = "claude-opus-4-8"
 
 func newTestStore(t *testing.T) *Store {
 	t.Helper()
@@ -169,4 +174,93 @@ func TestDefaultDBPath(t *testing.T) {
 	p := DefaultDBPath()
 	assert.Equal(t, "costledger.db", filepath.Base(p))
 	assert.Contains(t, p, ".human")
+}
+
+// TopTicketSpend ranks by money, not by call count or recency: the panel exists
+// to answer "where did this range's spend go", and the most expensive ticket is
+// the answer even when a chattier one made more calls.
+func TestTopTicketSpend_ranksByCostAndHonoursTheWindow(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// Cheap but chatty: many calls, few tokens.
+	for i := 0; i < 5; i++ {
+		require.NoError(t, s.InsertCall(ctx, CallRecord{
+			Project: "p", Ticket: "SC-CHATTY", Stage: "implementation", Model: testModel,
+			InputTokens: 10, OutputTokens: 10, DurationMs: 100, StartedAt: now.Add(-time.Hour),
+		}))
+	}
+	// Expensive: one call, a lot of context.
+	require.NoError(t, s.InsertCall(ctx, CallRecord{
+		Project: "p", Ticket: "SC-COSTLY", Stage: "verification", Model: testModel,
+		InputTokens: 5000, OutputTokens: 2000, CacheReadTokens: 900000, DurationMs: 5000,
+		StartedAt: now.Add(-time.Hour),
+	}))
+	// Outside the window: must not appear at all.
+	require.NoError(t, s.InsertCall(ctx, CallRecord{
+		Project: "p", Ticket: "SC-OLD", Stage: "implementation", Model: testModel,
+		InputTokens: 999999, OutputTokens: 999999, DurationMs: 9999,
+		StartedAt: now.Add(-72 * time.Hour),
+	}))
+	// Another project's ticket, same window: never summed in (AD5).
+	require.NoError(t, s.InsertCall(ctx, CallRecord{
+		Project: "other", Ticket: "SC-COSTLY", Stage: "implementation", Model: testModel,
+		InputTokens: 777777, OutputTokens: 777777, DurationMs: 7777, StartedAt: now.Add(-time.Hour),
+	}))
+
+	got, err := s.TopTicketSpend(ctx, "p", now.Add(-24*time.Hour), now, 10)
+	require.NoError(t, err)
+
+	require.Len(t, got, 2, "the stale row and the other project's row are both excluded")
+	assert.Equal(t, "SC-COSTLY", got[0].Ticket, "most expensive first, not most calls")
+	assert.Equal(t, "SC-CHATTY", got[1].Ticket)
+	assert.Greater(t, got[0].CostUSD, got[1].CostUSD)
+	assert.Equal(t, 905000, got[0].ContextTokens, "input + cache-create + cache-read")
+	assert.Equal(t, 2000, got[0].OutputTokens)
+	assert.InDelta(t, got[0].CostUSD, got[0].ContextCostUSD+got[0].AnswersCostUSD, 1e-9,
+		"the split must account for the whole cost")
+}
+
+// A ticket whose rows carry no tokens — every row written before the proxy read
+// usage off a compressed body (SC-3440) — still ranks, at zero. Dropping it
+// would hide that the work ran at all.
+func TestTopTicketSpend_keepsUnpricedTickets(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	require.NoError(t, s.InsertCall(ctx, CallRecord{
+		Project: "p", Ticket: "SC-BLIND", Stage: "prreview", DurationMs: 6387000, StartedAt: now.Add(-time.Hour),
+	}))
+
+	got, err := s.TopTicketSpend(ctx, "p", now.Add(-24*time.Hour), now, 10)
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "SC-BLIND", got[0].Ticket)
+	assert.Zero(t, got[0].CostUSD)
+	assert.Equal(t, int64(6387000), got[0].DurationMs, "the time it took is still known")
+}
+
+// The limit caps the panel, keeping the most expensive rather than an arbitrary
+// slice of the map.
+func TestTopTicketSpend_limitKeepsTheMostExpensive(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	for i, tokens := range []int{100, 5000, 200, 90000, 300} {
+		require.NoError(t, s.InsertCall(ctx, CallRecord{
+			Project: "p", Ticket: fmt.Sprintf("SC-%d", i), Stage: "implementation", Model: testModel,
+			OutputTokens: tokens, DurationMs: 10, StartedAt: now.Add(-time.Hour),
+		}))
+	}
+
+	got, err := s.TopTicketSpend(ctx, "p", now.Add(-24*time.Hour), now, 2)
+	require.NoError(t, err)
+
+	require.Len(t, got, 2)
+	assert.Equal(t, "SC-3", got[0].Ticket, "90000 output tokens is the most expensive")
+	assert.Equal(t, "SC-1", got[1].Ticket)
 }

--- a/internal/daemon/stats_overview.go
+++ b/internal/daemon/stats_overview.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gethuman-sh/human/internal/audit"
 	"github.com/gethuman-sh/human/internal/claude"
+	"github.com/gethuman-sh/human/internal/costledger"
 	"github.com/gethuman-sh/human/internal/stats"
 )
 
@@ -69,12 +70,17 @@ type StatsOverview struct {
 	ToolCalls        StatsHeadline            `json:"toolCalls"` // over range
 	Audit            StatsHeadline            `json:"audit"`     // over range
 	AgentRuns        StatsHeadline            `json:"agentRuns"` // over range
-	TokensPerHour    []claude.TokenHourBucket `json:"tokensPerHour"`
+	TicketCosts      []costledger.TicketSpend `json:"ticketCosts"`
 	TokensByModel    []claude.ModelTokens     `json:"tokensByModel"`
 	ToolsByTool      []stats.ToolCount        `json:"toolsByTool"`
 	AuditByDay       []AuditDayCount          `json:"auditByDay"`
 	NetworkDecisions []NetworkEvent           `json:"networkDecisions"` // live, ignores range
 }
+
+// statsTicketLimit bounds the cost-by-ticket panel. Long enough to show where a
+// range's money went, short enough that the panel stays a glance rather than a
+// report.
+const statsTicketLimit = 12
 
 // rangeSince maps a StatsRange to the start of its window relative to now.
 // An unknown range falls back to 24h, matching the route's default.
@@ -113,8 +119,26 @@ func (s *Server) buildStatsOverview(ctx context.Context, r StatsRange) (StatsOve
 	ov.Tokens.CacheCreate = scan.WindowCacheCreate
 	ov.Tokens.CacheRead = scan.WindowCacheRead
 	ov.Tokens.CostUSD = scan.WindowCostUSD
-	ov.TokensPerHour = scan.PerHour
 	ov.TokensByModel = scan.ByModel
+
+	// Cost by ticket replaces the per-hour burn: which hour the tokens were
+	// spent in is not a question anyone acts on, whereas which ticket spent
+	// them is (SC-3497). Best-effort like every other source here — no ledger,
+	// or a read that fails, yields an empty panel rather than failing the whole
+	// overview. Scoped to the project the board serves, the same first-entry
+	// convention boardProjectKey uses, so two projects' colliding keys can
+	// never be summed together.
+	if s.CostLedger != nil {
+		project := ""
+		if s.Projects != nil {
+			if entries := s.Projects.Entries(); len(entries) > 0 {
+				project = entries[0].Dir
+			}
+		}
+		if spend, err := s.CostLedger.TopTicketSpend(ctx, project, since, now, statsTicketLimit); err == nil {
+			ov.TicketCosts = spend
+		}
+	}
 
 	// Tool calls: panel breakdown plus the ok/error headline split.
 	if s.StatsStore != nil {

--- a/internal/daemon/stats_overview_test.go
+++ b/internal/daemon/stats_overview_test.go
@@ -208,7 +208,6 @@ func TestBuildStatsOverview_tokenScanCachedWithinTTL(t *testing.T) {
 		assert.Equal(t, 1000, ov.Tokens.CacheCreate)
 		assert.Equal(t, 1300, ov.Tokens.CacheRead)
 		assert.Equal(t, scan.WindowCostUSD, ov.Tokens.CostUSD)
-		assert.Equal(t, scan.PerHour, ov.TokensPerHour)
 		assert.Equal(t, scan.ByModel, ov.TokensByModel)
 	}
 }


### PR DESCRIPTION
Fixes SC-3497.

The stats page opened on a bar chart of tokens per hour. Nobody acts on it — knowing 3pm was expensive says nothing about what to do, because the hour did not spend the money, a piece of work did. That panel is replaced by cost by ticket over the selected range, most expensive first.

Each row keeps the answers/context split the other token panels use, since that split is what says whether a ticket was expensive for a good reason. On live data the shape is stark: SC-637's verification stage spent 14k output tokens against 558k cache reads — $0.36 of answers against $1.14 of context.

- `TopTicketSpend` prices at read time per (ticket, model), like `TicketCost`, so a rate-card change re-prices history instead of a stored figure keeping the old rate.
- It rides in the existing stats overview payload — no new route, no second round trip, and the range selector applies for free.
- Scoped to the board's project (the `boardProjectKey` first-entry convention), so two projects' colliding keys are never summed.
- A ticket whose calls carry no priced tokens still lists at $0.00. The 520 rows written before SC-3440 have duration only, and hiding them would render work that ran as work that did not.

**Found while building:** no gate runs the frontend test suite — not `make check`, not CI. Four of its 157 tests were failing, two of them broken by my own SC-3404 merge (the style guards still asserted the literal `0.6` and required the degraded overlap to equal `.degraded`'s opacity — both untrue once the dimming moved behind `--not-mine-opacity`). Last commit updates those guards to what the rules now promise. The suite is green at 160. Wiring it into a gate needs a CI decision about node in the Go workflow, so it is a follow-up rather than this PR.

`make check` green (4611 tests), `npm test` green (160 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)