### PR TITLE
Describe the pipeline's state transitions, and when the machine reaps a container

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ Do NOT use a custom tracker status for review signalling — that would require 
 
 A prompt saying "after X, post Y" is a definition of a transition, exactly as much as the Go code that reads Y. Both belong in the document, and a transition that exists in one but not the other is the bug.
 
+`docs/reaper.md` is its companion along the other axis: the FSM document follows one ticket, the reaper document follows one container — every condition under which the machine kills an agent (the zombie sweep, the silence reap, the stuck-running and orphan reconcile passes, close-is-cancellation), what it deliberately spares, what the reap costs the ticket's retry budget, and what artifacts it leaves behind. Same rules: read it before changing the sweep, the idle budgets, or any path that stops an agent, and update it in the same commit.
+
 # Daemon
 
 When the human daemon is running, all CLI commands (except `daemon`, `install` and `init`) are automatically forwarded to it. The daemon holds all tracker credentials on the host — **do NOT set tokens manually when the daemon is running**. Just run `human` commands directly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,16 @@ The `human-executor` agent posts this comment automatically as its final step. A
 
 Do NOT use a custom tracker status for review signalling — that would require every team to reconfigure their tracker. Comments are the universal primitive.
 
+# Pipeline state machine
+
+`docs/pipeline-fsm.json` describes how one item — a ticket — moves through the pipeline: every state, every transition, and for each transition the actor that causes it (user, daemon, or skill), the skill that does the work, the marker that records it, and where in the code or the prompt it is implemented. It describes the system **as it is**.
+
+**Read it before you plan.** Any change to the derivation, the launchers, the reconcile passes, the marker vocabulary, the board rendering, or any agent prompt that posts a marker: read the document first and plan the change against it, naming the states and transitions you add, remove or redefine. Planning a pipeline change without reading it is how the same bug gets reintroduced under a new number.
+
+**Update it in the same commit.** A commit that moves the machine but not its description leaves the two to drift, which is the failure the document exists to prevent.
+
+A prompt saying "after X, post Y" is a definition of a transition, exactly as much as the Go code that reads Y. Both belong in the document, and a transition that exists in one but not the other is the bug.
+
 # Daemon
 
 When the human daemon is running, all CLI commands (except `daemon`, `install` and `init`) are automatically forwarded to it. The daemon holds all tracker credentials on the host — **do NOT set tokens manually when the daemon is running**. Just run `human` commands directly.

--- a/docs/pipeline-fsm.json
+++ b/docs/pipeline-fsm.json
@@ -1,0 +1,229 @@
+{
+  "$comment": "The state transitions of one item (a ticket) through the human pipeline, as the code and prompts implement them today. Each transition names the ACTOR that causes it, the SKILL that does the work, the MARKER that records it, and WHERE it is implemented. Topology is name/src/dst only; every other field is annotation.",
+  "version": 1,
+  "describes": "commit 16cfe7e2, 2026-08-05",
+  "item": "a ticket, from filing to merged",
+  "initial": "filed",
+
+  "actors": {
+    "user": "a person, via a board gesture (drag, button) or a CLI command",
+    "daemon": "the host process — it launches agents, posts their started markers, and is the only thing with push credentials",
+    "skill": "an agent running in a container, following the named prompt"
+  },
+
+  "states": [
+    { "name": "filed", "doc": "The ticket exists. No pipeline activity.", "board": "Backlog" },
+    { "name": "ticket-review", "doc": "The pre-planning gate is judging whether solving this ticket solves the problem.", "board": "Backlog, running" },
+    { "name": "ticket-reviewed", "doc": "The gate returned a verdict: ready, reframed, superseded, escalated or rejected. The last three are stop decisions.", "board": "Backlog, done" },
+
+    { "name": "planning", "doc": "A planner is exploring the codebase and writing an implementation plan.", "board": "Planning, running" },
+    { "name": "planned", "doc": "A plan is attached to the ticket. The item waits for a human to start the build.", "board": "Planning, done" },
+    { "name": "nothing-to-do", "doc": "The planner proved the work is already merged. Clean terminal.", "board": "Planning, resolved", "terminal": true },
+
+    { "name": "preflight", "doc": "The fix run is resolving what it may do and settling what the evidence can settle, before any work.", "board": "Fix, running" },
+    { "name": "triaging", "doc": "The run is reproducing the report to reach a verdict.", "board": "Fix, running" },
+    { "name": "challenging", "doc": "A skeptic is trying to refute a not-a-bug or undetermined verdict before it is acted on.", "board": "Fix, running" },
+    { "name": "resolved-no-fix", "doc": "The no-fix verdict survived the challenge. Clean terminal — the ticket needs no code change.", "board": "Fix, resolved", "terminal": true },
+    { "name": "fix-planning", "doc": "The self-planning fix run is producing its own plan.", "board": "Fix, running" },
+    { "name": "fixing", "doc": "A regression test that fails first, then the change that makes it pass.", "board": "Fix, running" },
+    { "name": "verifying", "doc": "Proving the test fails before and passes after, on a green suite.", "board": "Fix, running" },
+    { "name": "implementing", "doc": "A plan executor is carrying out an attached plan (the non-bug path).", "board": "Code, running" },
+
+    { "name": "handed-off", "doc": "Branch and commits are recorded on the ticket, checked reachable.", "board": "Code, done" },
+    { "name": "in-review", "doc": "A reviewer is checking the change against the ticket's acceptance criteria. In a board fix run this happens inline, in the same warm container.", "board": "Review, running" },
+    { "name": "reviewed", "doc": "The review returned a verdict. A failing verdict blocks the deploy and sends the item back to be rebuilt.", "board": "Review, done" },
+
+    { "name": "deploying", "doc": "The daemon pushed the branch and opened a draft pull request.", "board": "Deploy, running" },
+    { "name": "pr-review", "doc": "The machine reviewer is reading the open pull request.", "board": "Deploy, running" },
+    { "name": "pr-fix", "doc": "The machine fixer is addressing the review's findings on the local branch.", "board": "Deploy, running" },
+    { "name": "ci-gate", "doc": "Every check must be green before the merge.", "board": "Deploy, running" },
+    { "name": "deploy-fixing", "doc": "A CI failure or a rebase conflict dispatched the deploy fixer instead of failing the item.", "board": "Deploy, running" },
+    { "name": "merged", "doc": "Merged, branch deleted, ticket closed. The shipping terminal.", "board": "Deploy, done", "terminal": true },
+
+    { "name": "awaiting-decision", "doc": "The item is parked on a genuine fork. Only a human choosing an answer moves it.", "board": "any column, decision needed" },
+    { "name": "stopped", "doc": "A stage gave up and said why: a spent budget, an unreviewable change, a failed deploy. Needs a human.", "board": "any column, error" },
+    { "name": "substrate-down", "doc": "A stage reported the thing it needs was unreachable. Not a failure — it spends no retry budget and is relaunched when the substrate returns.", "board": "any column, outage" }
+  ],
+
+  "events": [
+    { "name": "start-ticket-review", "src": ["filed"], "dst": "ticket-review",
+      "actor": "user", "runs": "human-ticket-reviewer", "marker": "[human:ticket-review-started]",
+      "where": "internal/daemon/board_transition.go startAgentStage" },
+
+    { "name": "ticket-review-verdict", "src": ["ticket-review"], "dst": "ticket-reviewed",
+      "actor": "skill", "runs": "human-ticket-reviewer", "marker": "[human:ticket-review]",
+      "head_enum": ["ready", "reframed", "superseded", "escalated", "rejected"],
+      "prompt": "human-ticket-reviewer-agent.md" },
+
+    { "name": "start-planning", "src": ["filed", "ticket-reviewed", "planned", "stopped", "substrate-down"], "dst": "planning",
+      "actor": "user", "runs": "human-planner", "marker": "[human:planning-started]",
+      "where": "board_transition.go launchForwardStage / isPlanningRetry",
+      "doc": "A drop on Planning. From planned it is a replan; from stopped or substrate-down it is a retry in place." },
+
+    { "name": "plan-attached", "src": ["planning"], "dst": "planned",
+      "actor": "skill", "runs": "human-planner", "marker": "[human:plan-ready]",
+      "prompt": "human-plan-skill.md",
+      "doc": "The plan itself is attached as a [human:plan] comment; plan-ready is what moves the item." },
+
+    { "name": "plan-finds-nothing-to-do", "src": ["planning"], "dst": "nothing-to-do",
+      "actor": "skill", "runs": "human-planner", "marker": "[human:nothing-to-do]",
+      "prompt": "human-plan-skill.md" },
+
+    { "name": "planning-failed", "src": ["planning"], "dst": "stopped",
+      "actor": "daemon", "marker": "[human:planning-failed]",
+      "where": "board_failure.go" },
+
+    { "name": "start-fix-run", "src": ["filed", "ticket-reviewed", "stopped", "substrate-down"], "dst": "preflight",
+      "actor": "user", "runs": "human-autofix", "marker": "[human:implementation-started]",
+      "where": "board_transition.go ApplyFix",
+      "doc": "Dropping a bug on Fix. The run is self-planning — it produces its own plan rather than requiring one." },
+
+    { "name": "preflight-clear", "src": ["preflight"], "dst": "triaging",
+      "actor": "skill", "runs": "human-autofix", "state_key": "stage.preflight ready=yes",
+      "prompt": "human-autofix-skill.md Step 1a" },
+
+    { "name": "preflight-asks", "src": ["preflight"], "dst": "awaiting-decision",
+      "actor": "skill", "runs": "human-autofix", "marker": "[human:options]",
+      "state_key": "stage.implementation exit=needs-input",
+      "prompt": "human-autofix-skill.md Step 1a",
+      "doc": "The one place the pipeline asks a question, asked up front rather than halfway through." },
+
+    { "name": "triage-verdict-confirmed", "src": ["triaging"], "dst": "fix-planning",
+      "actor": "skill", "runs": "human-bug-triage", "marker": "[human:bug-verdict]",
+      "state_key": "stage.triage verdict=confirmed",
+      "prompt": "human-bug-triage-agent.md" },
+
+    { "name": "triage-verdict-no-bug", "src": ["triaging"], "dst": "challenging",
+      "actor": "skill", "runs": "human-bug-triage", "marker": "[human:bug-verdict]",
+      "state_key": "stage.triage verdict=not-a-bug | undetermined",
+      "prompt": "human-autofix-skill.md Step 3",
+      "doc": "A no-fix verdict is never acted on directly — it must survive a challenge first." },
+
+    { "name": "challenge-upholds", "src": ["challenging"], "dst": "resolved-no-fix",
+      "actor": "skill", "runs": "human-verdict-skeptic", "marker": "[human:no-fix-needed]",
+      "state_key": "stage.challenge challenge=upheld, stage.implementation exit=done",
+      "prompt": "human-autofix-skill.md Step 3a" },
+
+    { "name": "challenge-refutes", "src": ["challenging"], "dst": "fix-planning",
+      "actor": "skill", "runs": "human-verdict-skeptic",
+      "state_key": "stage.challenge challenge=refuted",
+      "prompt": "human-autofix-skill.md Step 3a",
+      "doc": "The skeptic reproduced it. The run continues as a confirmed bug, using the skeptic's reproduction. Runs once — never loops back through triage." },
+
+    { "name": "fix-plan-written", "src": ["fix-planning"], "dst": "fixing",
+      "actor": "skill", "runs": "human-autofix", "marker": "[human:plan]",
+      "prompt": "human-autofix-skill.md Step 4" },
+
+    { "name": "fix-written", "src": ["fixing"], "dst": "verifying",
+      "actor": "skill", "runs": "human-autofix", "state_key": "stage.fix",
+      "prompt": "human-autofix-skill.md Step 5" },
+
+    { "name": "verify-done", "src": ["verifying"], "dst": "handed-off",
+      "actor": "skill", "runs": "human-bug-verify", "marker": "[human:bug-verify]",
+      "state_key": "stage.verify verdict=DONE",
+      "prompt": "human-bug-verify-agent.md" },
+
+    { "name": "verify-not-done", "src": ["verifying"], "dst": "fixing",
+      "actor": "skill", "runs": "human-bug-verify", "marker": "[human:bug-verify]",
+      "state_key": "stage.verify verdict=NOT DONE",
+      "prompt": "human-autofix-skill.md Step 6",
+      "guard": "under the retry budget; only a failure that reproduced charges an attempt" },
+
+    { "name": "fix-budget-spent", "src": ["verifying"], "dst": "stopped",
+      "actor": "skill", "runs": "human-autofix", "marker": "[human:implementation-failed]",
+      "state_key": "stage.implementation exit=needs-human-work",
+      "prompt": "human-autofix-skill.md Step 6" },
+
+    { "name": "start-implementation", "src": ["planned", "reviewed", "stopped", "substrate-down"], "dst": "implementing",
+      "actor": "user", "runs": "human-executor", "marker": "[human:implementation-started]",
+      "where": "board_transition.go launchForwardStage / isReworkTransition / isBuildRetry",
+      "doc": "The plan-executing path. From reviewed it is the rework loop — a failing review verdict sends the item back to be rebuilt with the findings." },
+
+    { "name": "handoff-posted", "src": ["implementing", "verifying"], "dst": "handed-off",
+      "actor": "skill", "runs": "human-executor | human-autofix", "marker": "[human:ready-for-review]",
+      "required_fields": ["branch", "commits"],
+      "prompt": "human-executor-agent.md, human-autofix-skill.md Step 7.1",
+      "where": "posted via `human handoff post`, which verifies the commits are reachable on the branch first" },
+
+    { "name": "implementation-failed", "src": ["implementing"], "dst": "stopped",
+      "actor": "daemon", "marker": "[human:implementation-failed]",
+      "where": "board_failure.go",
+      "doc": "The daemon's failure watcher classifies an agent that exited without posting its handoff." },
+
+    { "name": "start-review", "src": ["handed-off", "stopped", "substrate-down"], "dst": "in-review",
+      "actor": "daemon", "runs": "human-reviewer", "marker": "[human:review-started]",
+      "where": "board_failure.go chainReviewAfterCleanBuild; board_reconcile.go if that hook was lost",
+      "doc": "Automatic: a clean build whose handoff names a reachable branch flows straight into its review. A board fix run instead runs the review inline in its own container and the daemon launches no second one." },
+
+    { "name": "review-verdict", "src": ["in-review"], "dst": "reviewed",
+      "actor": "skill", "runs": "human-reviewer", "marker": "[human:review-complete]",
+      "required_fields": ["verdict"],
+      "prompt": "human-review-skill.md",
+      "doc": "Pass and fail are the same marker and the same state — the verdict rides in a field, and it is what decides whether the item may deploy or must be rebuilt." },
+
+    { "name": "review-failed", "src": ["in-review"], "dst": "stopped",
+      "actor": "daemon", "marker": "[human:review-failed]", "required_fields": ["reason"],
+      "doc": "The review stage itself failed — a binding gate such as a missing branch or unreachable commits — not a failing verdict." },
+
+    { "name": "start-deploy", "src": ["reviewed", "stopped", "substrate-down"], "dst": "deploying",
+      "actor": "user", "marker": "[human:deploy-started]",
+      "where": "board_transition.go runDoneStage / isDeployRetry",
+      "guard": "the review verdict must not be failing",
+      "doc": "Dropping on Deploy. The daemon does this itself — no agent holds push credentials." },
+
+    { "name": "pr-opened", "src": ["deploying"], "dst": "pr-review",
+      "actor": "daemon", "runs": "human-pr-reviewer", "marker": "[human:pr-review-started]",
+      "doc": "The pull request is opened as a draft, so a half-reviewed change is not mergeable by anyone." },
+
+    { "name": "pr-changes-requested", "src": ["pr-review"], "dst": "pr-fix",
+      "actor": "daemon", "runs": "human-pr-fixer", "marker": "[human:pr-fix-started]",
+      "guard": "bounded: 3 rounds",
+      "doc": "The fixer commits to the LOCAL branch and never pushes, so the reviewer reads the new commit rather than a stale pushed head." },
+
+    { "name": "pr-refixed", "src": ["pr-fix"], "dst": "pr-review",
+      "actor": "daemon", "runs": "human-pr-reviewer", "marker": "[human:pr-review-started]" },
+
+    { "name": "pr-review-passed", "src": ["pr-review"], "dst": "ci-gate",
+      "actor": "daemon",
+      "where": "board_transition.go AdvancePRLoop",
+      "doc": "The draft is un-drafted and the item goes to the CI gate." },
+
+    { "name": "pr-loop-escalates", "src": ["pr-review", "pr-fix"], "dst": "stopped",
+      "actor": "daemon", "marker": "[human:pr-review-failed]",
+      "doc": "Budget spent, unreviewable, or an outcome it cannot parse. It never merges on a state it cannot read." },
+
+    { "name": "ci-red", "src": ["ci-gate"], "dst": "deploy-fixing",
+      "actor": "daemon", "runs": "human-deploy-fixer", "marker": "[human:deploy-fix-started]",
+      "guard": "bounded: 2 rounds",
+      "doc": "A red-but-mechanical failure dispatches the fixer instead of failing the item. A cancelled check counts as no answer yet, not as a no." },
+
+    { "name": "ci-regated", "src": ["deploy-fixing"], "dst": "ci-gate", "actor": "daemon" },
+
+    { "name": "ci-green-merged", "src": ["ci-gate"], "dst": "merged",
+      "actor": "daemon", "marker": "[human:deployed]", "required_fields": ["pr"],
+      "doc": "If the base moved on, the branch is rebased and CI re-gated on the new head before merging. Past the merge, branch cleanup and closing the ticket are best-effort and never fail the item." },
+
+    { "name": "deploy-failed", "src": ["ci-gate", "deploy-fixing", "deploying"], "dst": "stopped",
+      "actor": "daemon", "marker": "[human:deploy-failed]", "required_fields": ["reason"] },
+
+    { "name": "stage-asks", "src": ["planning", "triaging", "fixing", "verifying", "implementing", "in-review", "pr-review"], "dst": "awaiting-decision",
+      "actor": "skill", "marker": "[human:options]", "required_fields": ["stage"],
+      "where": "board_state.go pauseOnOpenOptions",
+      "doc": "A stage found a genuine fork and stopped. The item is not working and not dead — it is waiting on a person." },
+
+    { "name": "decision-made", "src": ["awaiting-decision"], "dst": "planning",
+      "actor": "user", "marker": "[human:option-chosen]",
+      "where": "board_state.go optionChosenQueued",
+      "doc": "A human picked an answer. The chosen stage is relaunched with the choice in hand; dst is whichever stage the block named — planning is the common case." },
+
+    { "name": "substrate-unreachable", "src": ["planning", "triaging", "fixing", "verifying", "implementing", "in-review", "deploying", "ci-gate"], "dst": "substrate-down",
+      "actor": "daemon", "marker": "[human:planning-outage] | [human:implementation-outage] | [human:review-outage] | [human:deploy-outage]",
+      "where": "board_retry.go ExitOutage",
+      "doc": "One marker per stage. It costs no retry budget and the reconcile pass relaunches it each interval until the substrate returns." },
+
+    { "name": "launch-refused-no-plan", "src": ["implementing"], "dst": "stopped",
+      "actor": "daemon", "marker": "[human:needs-planning]",
+      "where": "board_transition.go refuseIfUnplanned",
+      "doc": "The plan executor was launched on a ticket with no plan, so the launch is refused before any agent claims it. The item surfaces back at planning where a human can start one." }
+  ]
+}

--- a/docs/reaper.md
+++ b/docs/reaper.md
@@ -1,0 +1,303 @@
+# The reaper — when a container/agent is killed
+
+Every pipeline stage runs as one agent: a devcontainer holding a claude process,
+a private git worktree, and an execution log directory. Something has to end
+that run. This document lists **every condition under which the machine ends an
+agent**, what it spares, what it costs the ticket, and what it leaves behind.
+
+It describes the system **as it is**. Its companion is
+[`pipeline-fsm.json`](pipeline-fsm.json): that document follows one *ticket*
+through its states; this one follows one *container*. They meet at the marker a
+reap produces — a reap is how a stage transition happens when nobody posted a
+marker on the way out.
+
+Read this before changing the zombie sweep, the reconcile passes, the idle
+budgets, or anything that stops an agent. Change the code and this document in
+the same commit.
+
+## The three signals
+
+The machine never asks the agent whether it is alive. It has three signals, and
+every rule below is built from them:
+
+| Signal | Source | What it proves |
+| --- | --- | --- |
+| **Process liveness** | `pgrep -x claude` inside the container, every 5s | The process exists. A *hung* agent looks perfectly healthy here. |
+| **Hook events** | The agent's Claude hooks POST to the daemon (`PreToolUse`, `PostToolUse`, `Notification`, `Stop`, `SessionEnd`) | The agent did something observable, and when. |
+| **Outstanding model request** | The daemon's own proxy: a request sent and not yet answered (`internal/daemon/inflight.go`) | The agent is thinking. No cooperation from the agent required. |
+
+The third exists because the first two together still misjudge a thinking agent:
+extended reasoning emits no hook event and streams no output. Transcript mtime
+and streamed-output heartbeats were both tried and disproven; the proxy's own
+in-flight state replaced them (SC-3074).
+
+Progress is tracked per agent in its own map (`internal/daemon/agentprogress.go`),
+not derived from the event ring — the ring evicts under load and is empty after a
+restart, and losing progress that way kills live work.
+
+## Idle budgets
+
+`AgentProgress.Stalled` (`internal/daemon/agentprogress.go`) is the single
+definition of "hung", and it is two numbers, not one:
+
+| Condition | Budget | Constant |
+| --- | --- | --- |
+| No outstanding work at all | **3 minutes** of silence | `IdleGrace` |
+| Inside a tool call **or** a model request in flight | **30 minutes** of silence | `WorkingIdleGrace` |
+| Waiting on a human (`Notification` — a permission prompt) | **never stalls** | `Blocked` |
+
+Waiting on a local tool call and waiting on the model are the same thing from
+the outside — outstanding work, from two sources — so either earns the generous
+bound. Genuine idleness, with neither, gets the short one. A single fixed
+timeout was wrong in both directions at once: it killed running test suites and
+still made real hangs wait.
+
+## Every condition that ends an agent
+
+### 1. Clean finish — the session ended
+
+**Owner:** `RunAgentCleanup` (`internal/daemon/agentcleanup.go`), subscribed to
+the hook event store.
+
+A `Stop`, `SessionEnd`, or `StopFailure` event for an agent triggers a full
+`Delete` (container stopped and removed, meta deleted) one second later — the
+delay lets claude finish exiting. Events are tracked by monotonic sequence, not
+by agent name: board stage agents reuse the same deterministic name on every
+rebuild, and a name-keyed dedupe leaked the re-run's container and worktree
+(SC-201).
+
+This is the normal path. Everything below is the machine deciding for itself.
+
+### 2. Zombie sweep — claude is gone
+
+**Owner:** `RunAgentZombieSweep` (`internal/daemon/agentzombiesweep.go`), every
+5 seconds.
+
+An agent is reaped when its container is running, it is older than the 10-second
+`zombieGracePeriod`, and `pgrep -x claude` reports nothing. This catches claude
+failing to start, crashing without firing hooks, or a killed tmux pane.
+
+**Spared:** an agent started without a prompt (bare `human agent start NAME`)
+never launches claude at all. It is reaped only once claude has been *observed*
+running for it at least once (`seenClaude`) — otherwise a deliberately idle
+agent dies within seconds of coming up (SC-236). That spare is absolute; it
+survives even the escalation below.
+
+### 3. Zombie sweep — the container is unreachable
+
+**Owner:** same loop.
+
+A liveness check can fail transiently (the container removed between list and
+check), which is tolerated by skipping the tick. But a post-suspend Docker/exec
+disruption fails *persistently*, every tick, and left unbounded it skips the reap
+forever while the board card spins at "reviewing…" (SC-263). After
+`zombieMaxProcessCheckFailures` = **3 consecutive failures** (~15s at the 5s
+interval) the agent is presumed unreachable-and-dead and reaped. A single
+successful check clears the streak.
+
+### 4. Zombie sweep — silence reap (board agents only)
+
+**Owner:** same loop, via `hungBoardAgent`.
+
+claude is *still running* but the agent has been silent past its idle budget
+(§ Idle budgets). Process liveness alone reports such an agent as healthy
+forever, so this is the only rule that can ever catch a hang (SC-1600).
+
+It applies **only to board stage agents** — names of the form
+`board-<KEY>-<stage>`. An interactive agent is deliberately excluded: a human
+thinking between turns looks identical to a hang, and reaping it discards live
+work.
+
+The reap carries its reason out as a sentinel: the synthesized `StopFailure`
+event's `ErrorType` is `reaped-silent:<idle>` (`ReapSilenceErrorType`), which
+routes the exit to the **uncharged** relaunch instead of the charged failure path
+(SC-2447). See § What a reap costs.
+
+### 5. Reconcile — stuck-running card, agent alive but stalled
+
+**Owner:** `reconcileStuckRunning` / `hungLiveAgent`
+(`internal/daemon/board_reconcile.go`), every `BoardReconcileInterval` = 2
+minutes ± 50% jitter.
+
+The durable twin of the silence reap, working from the *card* rather than the
+container. All of these must hold:
+
+- the card derives to a running state, with no active PR review→fix loop;
+- it carries no open `[human:options]` block for its own stage or an earlier one
+  (that is a deliberate human pause, not a hang);
+- its stage has a `*-failed` marker header available;
+- it has sat past `StuckRunningGrace` = **15 minutes**;
+- it passed the `forTakeover` ownership gate — this machine participates in the
+  project, no peer daemon owns the stage, and the branch resolves here (SC-2047);
+- and the stage agent, which *is* alive on this machine, reports stalled.
+
+Then the agent is stopped (a full `DeleteAgent` under a 60s timeout) *before*
+anything relaunches — otherwise two agents work the same stage — and the card is
+reddened with the silence-reap wording.
+
+A stop that fails, or a `stopAgent` that is unwired, leaves the card alone. So
+does an agent the progress probe does not know about: killing live work on absent
+evidence is the one failure this must never risk.
+
+### 6. Reconcile — stuck-running card, agent vanished
+
+Same pass, same preconditions, but no agent for `(key, stage)` is alive at all.
+Nothing is reaped here — the container is already gone. This is the fallback for
+a death the live failure watcher missed (a daemon restart, a dropped event), and
+unlike § 5 it is a genuine unexplained death, so it reds the card and relaunches
+on the **charged** path.
+
+### 7. Reconcile — orphaned on a closed ticket
+
+**Owner:** `reconcileOrphanedAgents` (`internal/daemon/board_reconcile_orphan.go`).
+
+A board agent whose PM key matches no open card, and whose ticket a
+`ClosedTicketProbe` **confirms** is done/closed, is stopped. Such a run would
+otherwise keep working invisibly against a closed ticket — holding its container
+and worktree, posting markers, even pushing commits for work the user called off.
+
+It works from the agent side, so a healthy board costs nothing: an agent matching
+an open card is dismissed without a tracker call. Every uncertainty resolves to
+*leave it running* — an unparseable agent name, a probe error, or a ticket merely
+absent from the open list rather than confirmed closed. Absence is not proof; a
+flaky per-ticket fetch looks the same.
+
+### 8. Close is cancellation
+
+**Owner:** `StopAgentsForPMKey` (`internal/daemon/close_cancel.go`), called from
+the close gate before the ticket transitions.
+
+Closing a ticket from the board reads to the user as "stop this", so it stops
+every live board agent claiming that key, across all stages, within a 90-second
+budget. The close is **gated** on it: if the stop cannot be confirmed for every
+agent — or the liveness probe itself failed — the ticket stays open, and thus
+stays reachable by the reconcile net, rather than closing over a run that refused
+to die.
+
+### 9. Pre-launch teardown of a same-named agent
+
+`Manager.Start` refuses to start over a still-running agent, so the launchers for
+the singleton scan agents (`features`, `findbugs`, `findsecurity`, `mockups-<slug>`)
+delete any prior agent of that name first. This makes a retry after a stale or
+crashed run idempotent.
+
+### 10. A person asks
+
+`human agent stop NAME` runs the same `Manager.Stop` choke point as everything
+above.
+
+## What is never reaped
+
+Collected in one place, because the spares are the load-bearing part:
+
+- **An agent blocked on a permission prompt.** It is waiting for a person; a
+  relaunch discards the question instead of answering it.
+- **An interactive (non-board) agent that is silent.** Only a board stage agent's
+  silence is unambiguous.
+- **An idle-by-design agent** (started with no prompt) that has never been seen
+  running claude.
+- **An agent the progress probe does not know about** — a restarted daemon, or an
+  agent that has not emitted its first event. Unknown is never read as hung.
+- **A card with an open `[human:options]` block** for its own or an earlier stage.
+- **A card in an active PR review→fix loop**, whose half-agents legitimately come
+  and go between rounds.
+- **An outage card** (`BoardOutage`): it is waiting on the substrate, not hung. It
+  is relaunched uncharged each tick until `OutageWaitBound` = **6 hours**, after
+  which it is handed to a person — still uncharged.
+- **Anything on a machine that does not own the stage** (`forTakeover` gate).
+- **Everything, when the liveness list or the closed-ticket probe errors.** A probe
+  blip is not evidence.
+
+## What a reap costs the ticket
+
+| Ending | Charged against `DefaultStageRetries` (=2)? | Bound |
+| --- | --- | --- |
+| Silence reap (§ 4, § 5) | **No** — `relaunchSilenceReap`. The work did not fail; a judgement about the work did (SC-2447). | `MaxSilenceReaps` = 3 relaunches; the 4th posts a give-up marker naming the count and stops. |
+| Genuine death — claude gone, container unreachable, agent vanished (§ 2, § 3, § 6) | **Yes** — `tryRelaunch`. | 2 automatic relaunches per stage, then the card reds for a person. |
+| Outage (substrate unreachable) | **No** — `relaunchOutage`. | `OutageWaitBound` = 6h, then handed to a person. |
+| Needs-person walls (revoked credential, exhausted billing) | **No**, and never auto-relaunched — the next attempt hits the same wall. | — |
+
+Repetition is what gets escalated, not any single stop. A silence reap costs
+nothing precisely so that a *repeated* silence reap is legible as its own
+problem, and `MaxSilenceReaps` is what makes that repetition visible instead of
+hidden. Both give-up markers dedup on a pinned sentinel string so two daemons
+reaching the cap at once do not both post.
+
+## What a reap leaves behind
+
+The teardown choke point is `Manager.stopLocked` (`internal/agent/manager.go`):
+
+1. **Transcript and outcome are persisted first**, before the container (and its
+   in-container `~/.claude/projects` transcript) is destroyed — `PreserveExecutionArtifacts`.
+2. **The container is stopped and removed**, and its devcontainer meta deleted.
+3. **The worktree survives unless the run succeeded.** The gate is positive
+   success, not "did not fail": only a run that posted its handoff has its
+   private worktree removed. A reaped run — and a clean exit that never handed
+   off — *keeps* the worktree beside its execution log for forensics and resume,
+   because a no-handoff exit is precisely the case where uncommitted work exists
+   to lose (SC-731). The kept worktree has its HEAD **detached**, so it stops
+   owning `refs/heads/<branch>` and cannot freeze the shared repo's local branch
+   (SC-2322).
+4. **`outcome.json` records the classification** `DiagnoseFailure` keys off, so
+   the failed marker says what actually broke instead of a generic stage line.
+5. **`output.log` always ends with an exit trailer** (`[human] claude exec exited
+   with code …`), written by the tee when the exec stream EOFs — so an
+   in-container run that dies while its warm container stays up still leaves a
+   diagnosable log rather than a 0-byte void (SC-1688). The tee never overwrites
+   an existing `outcome.json`, so it cannot clobber a `reaped` classification.
+6. **Execution directories are pruned after 90 days** (`execRetentionDays`,
+   `PruneExecutions`).
+
+One asymmetry worth knowing when reading artifacts: the zombie sweep marks the
+meta `StatusFailed` before teardown, so its runs record `reason: "reaped"`. The
+reconcile pass's hung-agent stop goes through `dockerAgentCleaner.DeleteAgent`,
+which does not, so a stage stopped by § 5 records `reason: "completed"` even
+though the machine killed it. The card's marker still says silence reap; the
+run's `outcome.json` does not.
+
+## Timings and constants, in one place
+
+| Constant | Value | Where |
+| --- | --- | --- |
+| `zombieSweepInterval` | 5s | `internal/daemon/agentzombiesweep.go` |
+| `zombieGracePeriod` | 10s | same |
+| `zombieMaxProcessCheckFailures` | 3 (~15s) | same |
+| `zombieReapHardDeadline` | 45s | same |
+| delete timeout inside a reap | 30s | same |
+| `IdleGrace` | 3m | `internal/daemon/agentprogress.go` |
+| `WorkingIdleGrace` | 30m | same |
+| `BoardReconcileInterval` | 2m ± 50% jitter | `internal/daemon/board_reconcile.go` |
+| `StuckRunningGrace` | 15m | same |
+| hung-agent stop timeout | 60s | `cmd/cmddaemon/daemon.go` |
+| close-cancel stop budget | 90s | same |
+| `MaxSilenceReaps` | 3 | `internal/daemon/board_failure.go` |
+| `DefaultStageRetries` | 2 | `internal/daemon/board_retry.go` |
+| `OutageWaitBound` | 6h | `internal/daemon/board_outage.go` |
+| `execRetentionDays` | 90 | `internal/agent/agentlog.go` |
+
+## Why a single reap can never stall the sweep
+
+One sweep goroutine reaps every agent, so a stalled `CopyTranscript` inside
+`DeleteAgent` would otherwise stop every later agent from ever being reaped
+(SC-427). Past `zombieReapHardDeadline` = 45s the reap is abandoned to the
+background — the goroutine keeps its own 30s delete budget and finishes into a
+buffered channel — and the loop advances. The agent's cross-tick memory is
+deliberately left in place so the next tick retries it.
+
+The liveness check has the same property: its exec stream is drained to EOF with
+a watchdog that closes the attachment on context cancellation, so a stalled
+stream cannot park the loop either.
+
+## A reap is a transition
+
+A reaped agent by definition died without emitting the exit hook the board
+watcher listens for. The daemon therefore **synthesizes** a `StopFailure` event
+for it (`cmd/cmddaemon/daemon.go`), so the reap path and the hook-driven exit
+paths converge on one marker-posting code path (SC-206) — otherwise the board
+card spins forever.
+
+That synthesized event is why reaping belongs in the state machine and not
+beside it: the marker it produces is a transition in
+[`pipeline-fsm.json`](pipeline-fsm.json) exactly like one an agent posts for
+itself. A change to a reap condition that changes which marker lands is a change
+to the machine, and both documents have to move together.


### PR DESCRIPTION
Two documents that describe the pipeline **as it is today**, along its two axes: one follows a ticket, one follows a container.

## `docs/pipeline-fsm.json` — the ticket axis

How a ticket moves through the pipeline: **26 states, 38 transitions**. Each transition names the actor that causes it (a user gesture, the daemon, or a skill), the skill that does the work, the marker that records it, and where in the Go code or the agent prompt it is implemented.

The in-container fix run is represented rather than collapsed into one "building" state — preflight, triage, the adversarial challenge, plan, fix and verify are states an item genuinely occupies, grounded in the autofix skill's own steps and the `stage.*` records it writes.

The point: a prompt saying "after X, post Y" defines a transition just as much as the Go code that reads Y. Both are written down here, so a transition that exists in one and not the other shows up as a diff rather than surfacing later as a stuck card.

Verified mechanically before commit: no undeclared states, every marker string appears verbatim in the Go source, every state reachable from `filed`, and no non-terminal state without a way out. Three terminals: `merged`, `nothing-to-do`, `resolved-no-fix`.

## `docs/reaper.md` — the container axis

Every condition under which the machine kills an agent, in one place: the zombie sweep's three rules (claude gone, container persistently unreachable, silence past the idle budget), the reconcile passes (stuck-running with a stalled agent, vanished agent, orphaned on a closed ticket), close-is-cancellation, and the manual paths.

Written around what the machine can actually observe — process liveness, hook events, and the proxy's own outstanding-model-request signal — and around the two idle budgets that follow from it (3 minutes idle, 30 minutes with work in flight). It gives equal weight to what is deliberately **spared**: a blocked agent, an interactive one, an idle-by-design one, an unknown-to-the-probe one, an options-paused card, an outage card. It records what each ending costs the ticket's retry budget (a silence reap is uncharged and bounded at 3; a genuine death is charged against 2) and what survives a reap on disk.

One asymmetry surfaced while writing it and is documented rather than fixed here: the zombie sweep records `outcome.json` `reason: "reaped"`, while the reconcile pass's hung-agent stop goes through a path that does not mark the meta failed, so it records `"completed"` for a run the machine killed.

`CLAUDE.md` gains a "Pipeline state machine" section requiring both documents to be read before planning any pipeline change, and updated in the same commit as the change.

Docs only — no code or config touched.