### PR TITLE
Close the pipeline's state-transition defects

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -1883,6 +1883,7 @@ func boardViewFunc(fetch func() ([]daemon.TrackerIssuesResult, error), doctor *d
 		defer cancel()
 		dockerOK := len(doctor.Blockers(ctx, []string{"docker"})) == 0
 		view := board.Compose(results, dockerOK)
+		attachActivity(ctx, reg, &view, logger)
 		rememberBoardView(cache, project, view, logger)
 		return view, nil
 	}
@@ -4149,5 +4150,48 @@ func startSleepInhibitor(ctx context.Context, out io.Writer, logger zerolog.Logg
 		_, _ = fmt.Fprintln(out, "Sleep inhibition: enabled (suspend deferred while agents run)")
 	} else {
 		_, _ = fmt.Fprintln(out, "Sleep inhibition: disabled")
+	}
+}
+
+// attachActivity fills each running card's Activity from the phase records the
+// run itself wrote (stage.triage, stage.verify, …).
+//
+// Nothing here is new information. Every stage already writes its phase with a
+// timestamp so the next stage — or a fresh agent taking over from one that died
+// — can read back what it learned; the board has simply never looked. Until it
+// does, an entire fix run renders as one unchanging "fixing…" that reads
+// identically at thirty seconds, at fourteen hours, and when the agent behind it
+// has been dead since the previous afternoon.
+//
+// Only running cards are read: a finished card's last phase is history, and
+// showing it would suggest work still in flight. A store that will not open, or
+// a scope with nothing recorded, leaves the card exactly as it was — the badge
+// degrades to today's behaviour rather than inventing a phase.
+func attachActivity(ctx context.Context, reg *daemon.ProjectRegistry, view *daemon.BoardView, logger zerolog.Logger) {
+	if view == nil || len(view.Cards) == 0 {
+		return
+	}
+	err := withStateStore(func(store agentstate.Store) error {
+		for i, card := range view.Cards {
+			if card.State != string(daemon.BoardRunning) {
+				continue
+			}
+			entries, err := store.List(ctx, boardStateProject(reg, card.Key), card.Key, board.StagePrefix)
+			if err != nil || len(entries) == 0 {
+				continue
+			}
+			phase, at := board.LatestActivity(entries)
+			if phase == "" {
+				continue
+			}
+			view.Cards[i].Activity = board.ActivityLabel(phase)
+			view.Cards[i].ActivityAt = at.UTC().Format(time.RFC3339)
+		}
+		return nil
+	})
+	if err != nil {
+		// The phase is an enrichment, never a gate: a board that cannot read the
+		// state store still renders every card it fetched.
+		logger.Debug().Err(err).Msg("board view: could not read phase records; cards render without them")
 	}
 }

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -502,6 +502,26 @@ func (a *App) Transition(pmKey, pmTitle, from, to string) error {
 	}))
 }
 
+// Reopen restarts a stage the pipeline resolved — a nothing-to-do or
+// no-fix-needed terminal the reader judges wrong. It is deliberately a separate
+// entry point from Transition: the daemon's retry machinery drives the same
+// same-stage request, and only an explicitly human call may re-run a clean
+// terminal. Without it a resolved card had no gesture at all and could be
+// recovered only by editing the tracker by hand.
+func (a *App) Reopen(pmKey, pmTitle, stage string) error {
+	info, err := daemon.ReadInfo()
+	if err != nil {
+		return err
+	}
+	return daemonCause(daemon.BoardTransition(info.Addr, info.Token, daemon.BoardTransitionRequest{
+		PMKey:   pmKey,
+		PMTitle: pmTitle,
+		From:    daemon.BoardStage(stage),
+		To:      daemon.BoardStage(stage),
+		Reopen:  true,
+	}))
+}
+
 // FixBug asks the daemon to launch the autonomous bug-fix pipeline
 // (/human-autofix) on a bug ticket — the Bugs pane's Fix drop. Like Transition
 // it goes through the daemon so the agent runs containerized with the daemon's

--- a/desktop/frontend/dist/board-queue.js
+++ b/desktop/frontend/dist/board-queue.js
@@ -428,3 +428,12 @@ export function safetyReconcileError(prev, message) {
     }
     return { cards: [], dockerAvailable: false, error: message };
 }
+// isReopenable reports a card the pipeline RESOLVED: it concluded there is
+// nothing to plan ([human:nothing-to-do]) or no fix is needed
+// ([human:no-fix-needed]). Both are clean terminals — never red, never retried —
+// which also meant no gesture could move them, so a verdict a person judged
+// wrong could only be undone by editing the tracker by hand. Re-opening is the
+// human override; the machine still never retries a terminal of its own accord.
+export function isReopenable(card) {
+    return card.state === "resolved";
+}

--- a/desktop/frontend/dist/board-queue.js
+++ b/desktop/frontend/dist/board-queue.js
@@ -7,8 +7,22 @@ export const QUEUE_TRANSITION_TO = {
     engineering: "planning",
     building: "implementation",
 };
-export function verdictFailed(verdict) {
-    return (verdict ?? "").trim().toLowerCase().startsWith("fail");
+// verdictFailed reports whether the review verdict blocks the card. The answer
+// is the DAEMON's — it arrives on the payload as verdictFailed, computed by
+// daemon.VerdictFailed. The board must not re-derive it: this function used to
+// test `verdict` for a "fail" prefix and nothing else, while the daemon also
+// treats "incomplete" as blocking. The reviewer posts "incomplete" for a ticket
+// whose acceptance criteria are unmet, so on those cards the board offered
+// Deploy and withheld Rework while the daemon refused every Deploy drop — a card
+// with no move that could succeed.
+//
+// The string fallback exists only for a payload from a daemon predating the
+// field, and it mirrors the Go rule exactly rather than reinventing it.
+export function verdictFailed(card) {
+    if (card.verdictFailed !== undefined)
+        return card.verdictFailed;
+    const v = (card.verdict ?? "").trim().toLowerCase();
+    return v.startsWith("fail") || v.startsWith("incomplete");
 }
 // queueOf maps (stage, state) onto the column that is true of the card. Running
 // and failed cards render in their DESTINATION lane, not their origin queue:
@@ -25,7 +39,7 @@ export function queueOf(card) {
         case "implementation":
             return "building";
         case "verification":
-            return card.state === "done" && !verdictFailed(card.verdict) && !!card.branch ? "deploy" : "building";
+            return card.state === "done" && !verdictFailed(card) && !!card.branch ? "deploy" : "building";
         case "done":
             return "deploy";
         default:
@@ -33,7 +47,7 @@ export function queueOf(card) {
     }
 }
 export function isReworkable(card) {
-    return card.stage === "verification" && card.state === "done" && (verdictFailed(card.verdict) || !card.branch);
+    return card.stage === "verification" && card.state === "done" && (verdictFailed(card) || !card.branch);
 }
 // ageDays converts a card's stage timestamp into whole days elapsed, or null
 // when the timestamp is absent or unparseable.
@@ -210,7 +224,7 @@ export function badgeInfo(card) {
     // `fixing` badge with the running spinner and copy that says what is
     // happening — never the amber `warning`/`decision` "your turn" register with
     // a ⚠ glyph (SC-1830).
-    if (card.stage === "verification" && card.state === "done" && verdictFailed(card.verdict)) {
+    if (card.stage === "verification" && card.state === "done" && verdictFailed(card)) {
         return {
             cls: "fixing",
             text: "review found problems — fixing…",
@@ -345,7 +359,7 @@ export function isNextQueue(fromQueue, toQueue) {
 // branch there is nothing to ship: deploying can only fail, so the card must
 // never be offered (SC-297).
 export function isReadyToDeploy(card) {
-    return card.stage === "verification" && card.state === "done" && !verdictFailed(card.verdict) && !!card.branch;
+    return card.stage === "verification" && card.state === "done" && !verdictFailed(card) && !!card.branch;
 }
 // deploySideOf maps a card to its own kind — bug and security are disjoint,
 // everything else is a feature. The one place the split is decided, so the

--- a/desktop/frontend/dist/board-queue.js
+++ b/desktop/frontend/dist/board-queue.js
@@ -165,13 +165,19 @@ export function badgeInfo(card) {
         return { cls: "decided", text, title: label.title };
     }
     if (card.state === "running") {
-        const text = card.stage === "done" && card.deployPhase === "pr-review"
+        const stageText = card.stage === "done" && card.deployPhase === "pr-review"
             ? "PR review…"
             : (RUNNING_LABELS[card.stage] ?? "working…");
+        // The run's own phase, when it recorded one. Without it the badge says the
+        // same word for the whole of a fix run — triage, the challenge, the plan,
+        // the fix, verification — so it reads identically at thirty seconds and at
+        // fourteen hours, and identically again when the agent behind it is dead.
+        // The phase changing is the only thing on the card that shows movement.
+        const text = card.activity ? `${card.activity}…` : stageText;
         return {
             cls: "running",
             text,
-            title: "Agent running",
+            title: card.activity ? `Agent running — ${card.activity}` : "Agent running",
             spinner: true,
         };
     }

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -16,7 +16,7 @@ import { initMockupsView, showMockups, setPendingMockupSlug, setChosenMockup, } 
 import { initSettingsView, showSettings, settingsIndex, saveSetting, setPaletteOpener, setActiveSection, } from "./settingsview.js";
 import { initPalette, openPalette, isPaletteChord } from "./palette.js";
 import { initStatsView, showStats, startStatsPoll, stopStatsPoll, } from "./statsview.js";
-import { QUEUES, QUEUE_TRANSITION_TO, queueOf, isReworkable, isReviewRetryable, ageBadge, isReplannable, forwardDropAllowed, badgeInfo, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReadyToDeploy, deployableCards, deployControlView, safetyPollShouldReconcile, safetyReconcileError, } from "./board-queue.js";
+import { QUEUES, QUEUE_TRANSITION_TO, queueOf, isReworkable, isReviewRetryable, isReopenable, ageBadge, isReplannable, forwardDropAllowed, badgeInfo, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReadyToDeploy, deployableCards, deployControlView, safetyPollShouldReconcile, safetyReconcileError, } from "./board-queue.js";
 import { linksWithin, arrowPath, plan, gapsBySide } from "./board-arrows.js";
 import { buildDeployControl } from "./board-deploy.js";
 import { buildCostSection, buildDetailSections, buildOptionsSection, buildShippedPartialSection, buildStopDecisionSection } from "./board-detail.js";
@@ -388,6 +388,27 @@ function showCardMenu(card, x, y) {
             void transition(card.key, card.title, "verification", "verification");
         });
         menu.appendChild(retryReview);
+    }
+    // A resolved card — the pipeline concluded there is nothing to do, or no fix
+    // is needed — had no gesture at all. The retry paths key on failed or outage
+    // and the forward path requires done, so overruling a verdict meant editing
+    // the tracker by hand. Re-opening goes through its own daemon entry point
+    // rather than a transition, because the automatic relaunch drives the same
+    // same-stage request and the machine must never re-run its own clean terminal.
+    if (isReopenable(card)) {
+        const reopen = document.createElement("button");
+        reopen.type = "button";
+        reopen.className = "context-menu-item";
+        reopen.textContent = "Re-open";
+        reopen.title = "The pipeline resolved this without a change — run the stage again";
+        reopen.disabled = !current.dockerAvailable;
+        if (reopen.disabled)
+            reopen.title = "Docker required";
+        reopen.addEventListener("click", () => {
+            menu.remove();
+            void runGuardedAction(() => go().Reopen(card.key, card.title, card.stage), (err) => showError(errMessage(err)), reconcile);
+        });
+        menu.appendChild(reopen);
     }
     // A failed deploy is otherwise a dead end: the Deploy zone only accepts
     // stage "verification" (SC-297's isReadyToDeploy), and a deploy failure

--- a/desktop/frontend/scripts/board-queue.test.mjs
+++ b/desktop/frontend/scripts/board-queue.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { queueOf, isReworkable, verdictFailed, forwardDropAllowed, planReady, badgeInfo, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReviewRetryable, STOP_DECISION_LABELS } from "../build/board-queue.js";
+import { queueOf, isReworkable, isReopenable, verdictFailed, forwardDropAllowed, planReady, badgeInfo, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReviewRetryable, STOP_DECISION_LABELS } from "../build/board-queue.js";
 import { DAEMON_FORWARDED_STATES } from "../build/board-states.js";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -540,4 +540,15 @@ test("an incomplete verdict keeps the card in Code and offers Rework", () => {
   const card = { stage: "verification", state: "done", verdict: "incomplete", verdictFailed: true, branch: "b" };
   assert.equal(queueOf(card), "building", "must not sit in Ready to Deploy — the daemon refuses that drop");
   assert.equal(isReworkable(card), true, "the one gesture that can move it must be offered");
+});
+
+// A resolved card is a clean terminal — never red, never retried — which also
+// meant no gesture could move it. Re-opening is the human override; every other
+// state keeps its existing gestures and must not offer this one.
+test("only a resolved card offers Re-open", () => {
+  assert.equal(isReopenable({ stage: "planning", state: "resolved" }), true);
+  assert.equal(isReopenable({ stage: "implementation", state: "resolved" }), true);
+  assert.equal(isReopenable({ stage: "implementation", state: "failed" }), false, "a failed card already retries");
+  assert.equal(isReopenable({ stage: "implementation", state: "running" }), false);
+  assert.equal(isReopenable({ stage: "verification", state: "done" }), false);
 });

--- a/desktop/frontend/scripts/board-queue.test.mjs
+++ b/desktop/frontend/scripts/board-queue.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { queueOf, forwardDropAllowed, planReady, badgeInfo, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReviewRetryable, STOP_DECISION_LABELS } from "../build/board-queue.js";
+import { queueOf, isReworkable, verdictFailed, forwardDropAllowed, planReady, badgeInfo, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReviewRetryable, STOP_DECISION_LABELS } from "../build/board-queue.js";
 import { DAEMON_FORWARDED_STATES } from "../build/board-states.js";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -513,4 +513,31 @@ test("boardStateFromPayload carries dimPercent through the mapping (SC-3409)", (
 // the renderer as a distinct answer so it leaves the stylesheet alone.
 test("boardStateFromPayload leaves dimPercent undefined when the payload omits it (SC-3409)", () => {
   assert.equal(boardStateFromPayload({}).dimPercent, undefined);
+});
+
+// The board reads the daemon's decision, never the verdict string. These two
+// used to be separate implementations one word apart: Go treated "incomplete"
+// as blocking, the board did not. An incomplete review therefore rendered in
+// Ready to Deploy with no Rework gesture, while the daemon refused every drop —
+// a card whose only offered move could not succeed.
+test("verdictFailed prefers the daemon's decision over the verdict text", () => {
+  // The flag wins even when the text would say otherwise, in both directions.
+  assert.equal(verdictFailed({ verdict: "pass", verdictFailed: true }), true);
+  assert.equal(verdictFailed({ verdict: "fail", verdictFailed: false }), false);
+});
+
+test("the legacy fallback matches the Go rule, including incomplete", () => {
+  // Only reached for a payload from a daemon predating the field.
+  assert.equal(verdictFailed({ verdict: "fail — three findings" }), true);
+  assert.equal(verdictFailed({ verdict: "incomplete" }), true);
+  assert.equal(verdictFailed({ verdict: "Incomplete: one criterion unmet" }), true);
+  assert.equal(verdictFailed({ verdict: "pass" }), false);
+  assert.equal(verdictFailed({ verdict: "pass with notes" }), false);
+  assert.equal(verdictFailed({}), false, "absence of a verdict is not failure");
+});
+
+test("an incomplete verdict keeps the card in Code and offers Rework", () => {
+  const card = { stage: "verification", state: "done", verdict: "incomplete", verdictFailed: true, branch: "b" };
+  assert.equal(queueOf(card), "building", "must not sit in Ready to Deploy — the daemon refuses that drop");
+  assert.equal(isReworkable(card), true, "the one gesture that can move it must be offered");
 });

--- a/desktop/frontend/scripts/board-queue.test.mjs
+++ b/desktop/frontend/scripts/board-queue.test.mjs
@@ -552,3 +552,18 @@ test("only a resolved card offers Re-open", () => {
   assert.equal(isReopenable({ stage: "implementation", state: "running" }), false);
   assert.equal(isReopenable({ stage: "verification", state: "done" }), false);
 });
+
+// The badge said one word for the whole of a run — identical at thirty seconds,
+// at fourteen hours, and when the agent behind it was already dead. The phase
+// the run records is the only thing on a running card that changes as work moves.
+test("a running badge shows the recorded phase when there is one", () => {
+  const badge = badgeInfo({ stage: "implementation", state: "running", activity: "verifying" });
+  assert.equal(badge.text, "verifying…");
+  assert.equal(badge.spinner, true);
+  assert.match(badge.title, /verifying/);
+});
+
+test("a run that recorded no phase keeps the stage word", () => {
+  const badge = badgeInfo({ stage: "implementation", state: "running" });
+  assert.equal(badge.text, "building…", "no invented phase — absence stays absent");
+});

--- a/desktop/frontend/src/board-queue.ts
+++ b/desktop/frontend/src/board-queue.ts
@@ -10,6 +10,10 @@ export interface QueueCard {
   // The daemon's own answer to "does this verdict block the card": computed by
   // daemon.VerdictFailed and shipped on the payload. Read this, never `verdict`.
   verdictFailed?: boolean;
+  // The phase the run itself last recorded — the only thing on a running card
+  // that changes as work advances.
+  activity?: string;
+  activityAt?: string;
   branch?: string;
   // The failed/outage marker's one-line reason (SC-3024: also read for the
   // paused register, not only "failed" — see cardError).
@@ -221,14 +225,20 @@ export function badgeInfo(card: QueueCard): BadgeInfo | null {
     return { cls: "decided", text, title: label.title };
   }
   if (card.state === "running") {
-    const text =
+    const stageText =
       card.stage === "done" && card.deployPhase === "pr-review"
         ? "PR review…"
         : (RUNNING_LABELS[card.stage] ?? "working…");
+    // The run's own phase, when it recorded one. Without it the badge says the
+    // same word for the whole of a fix run — triage, the challenge, the plan,
+    // the fix, verification — so it reads identically at thirty seconds and at
+    // fourteen hours, and identically again when the agent behind it is dead.
+    // The phase changing is the only thing on the card that shows movement.
+    const text = card.activity ? `${card.activity}…` : stageText;
     return {
       cls: "running",
       text,
-      title: "Agent running",
+      title: card.activity ? `Agent running — ${card.activity}` : "Agent running",
       spinner: true,
     };
   }

--- a/desktop/frontend/src/board-queue.ts
+++ b/desktop/frontend/src/board-queue.ts
@@ -535,3 +535,13 @@ export function safetyReconcileError<C>(
   }
   return { cards: [], dockerAvailable: false, error: message };
 }
+
+// isReopenable reports a card the pipeline RESOLVED: it concluded there is
+// nothing to plan ([human:nothing-to-do]) or no fix is needed
+// ([human:no-fix-needed]). Both are clean terminals — never red, never retried —
+// which also meant no gesture could move them, so a verdict a person judged
+// wrong could only be undone by editing the tracker by hand. Re-opening is the
+// human override; the machine still never retries a terminal of its own accord.
+export function isReopenable(card: QueueCard): boolean {
+  return card.state === "resolved";
+}

--- a/desktop/frontend/src/board-queue.ts
+++ b/desktop/frontend/src/board-queue.ts
@@ -7,6 +7,9 @@ export interface QueueCard {
   stage: string;
   state: string;
   verdict?: string;
+  // The daemon's own answer to "does this verdict block the card": computed by
+  // daemon.VerdictFailed and shipped on the payload. Read this, never `verdict`.
+  verdictFailed?: boolean;
   branch?: string;
   // The failed/outage marker's one-line reason (SC-3024: also read for the
   // paused register, not only "failed" — see cardError).
@@ -45,8 +48,21 @@ export const QUEUE_TRANSITION_TO: Record<string, string> = {
   building: "implementation",
 };
 
-export function verdictFailed(verdict?: string): boolean {
-  return (verdict ?? "").trim().toLowerCase().startsWith("fail");
+// verdictFailed reports whether the review verdict blocks the card. The answer
+// is the DAEMON's — it arrives on the payload as verdictFailed, computed by
+// daemon.VerdictFailed. The board must not re-derive it: this function used to
+// test `verdict` for a "fail" prefix and nothing else, while the daemon also
+// treats "incomplete" as blocking. The reviewer posts "incomplete" for a ticket
+// whose acceptance criteria are unmet, so on those cards the board offered
+// Deploy and withheld Rework while the daemon refused every Deploy drop — a card
+// with no move that could succeed.
+//
+// The string fallback exists only for a payload from a daemon predating the
+// field, and it mirrors the Go rule exactly rather than reinventing it.
+export function verdictFailed(card: Pick<QueueCard, "verdict" | "verdictFailed">): boolean {
+  if (card.verdictFailed !== undefined) return card.verdictFailed;
+  const v = (card.verdict ?? "").trim().toLowerCase();
+  return v.startsWith("fail") || v.startsWith("incomplete");
 }
 
 // queueOf maps (stage, state) onto the column that is true of the card. Running
@@ -64,7 +80,7 @@ export function queueOf(card: QueueCard): string {
     case "implementation":
       return "building";
     case "verification":
-      return card.state === "done" && !verdictFailed(card.verdict) && !!card.branch ? "deploy" : "building";
+      return card.state === "done" && !verdictFailed(card) && !!card.branch ? "deploy" : "building";
     case "done":
       return "deploy";
     default:
@@ -73,7 +89,7 @@ export function queueOf(card: QueueCard): string {
 }
 
 export function isReworkable(card: QueueCard): boolean {
-  return card.stage === "verification" && card.state === "done" && (verdictFailed(card.verdict) || !card.branch);
+  return card.stage === "verification" && card.state === "done" && (verdictFailed(card) || !card.branch);
 }
 
 // ageDays converts a card's stage timestamp into whole days elapsed, or null
@@ -264,7 +280,7 @@ export function badgeInfo(card: QueueCard): BadgeInfo | null {
   // `fixing` badge with the running spinner and copy that says what is
   // happening — never the amber `warning`/`decision` "your turn" register with
   // a ⚠ glyph (SC-1830).
-  if (card.stage === "verification" && card.state === "done" && verdictFailed(card.verdict)) {
+  if (card.stage === "verification" && card.state === "done" && verdictFailed(card)) {
     return {
       cls: "fixing",
       text: "review found problems — fixing…",
@@ -426,7 +442,7 @@ export function isNextQueue(fromQueue: string, toQueue: string): boolean {
 // branch there is nothing to ship: deploying can only fail, so the card must
 // never be offered (SC-297).
 export function isReadyToDeploy(card: QueueCard): boolean {
-  return card.stage === "verification" && card.state === "done" && !verdictFailed(card.verdict) && !!card.branch;
+  return card.stage === "verification" && card.state === "done" && !verdictFailed(card) && !!card.branch;
 }
 
 // DeploySide names the pane a Deploy control belongs to: the board's feature

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -102,6 +102,9 @@ interface Card {
   trackerKind?: string;
   error?: string;
   verdict?: string;
+  // The daemon's decision on whether that verdict blocks the card. Read this
+  // via verdictFailed(card) — the board must never re-test the verdict string.
+  verdictFailed?: boolean;
   // RFC3339 instant a paused (outage) card's standing marker stated as when
   // the substrate clears, when one was parsed out of the diagnosis (SC-3024).
   // Absent when no time was stated — the badge then reads "paused" with no

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -50,6 +50,7 @@ import {
   queueOf,
   isReworkable,
   isReviewRetryable,
+  isReopenable,
   ageBadge,
   isReplannable,
   forwardDropAllowed,
@@ -360,6 +361,10 @@ interface AppBindings {
   TicketCost(key: string): Promise<TicketCost>;
   CardsQuick(): Promise<BoardData>;
   Transition(pmKey: string, pmTitle: string, from: string, to: string): Promise<void>;
+  // Re-running a stage the pipeline resolved. Separate from Transition because
+  // the daemon's retry machinery drives the same same-stage request, and only an
+  // explicitly human call may re-run a clean terminal.
+  Reopen(pmKey: string, pmTitle: string, stage: string): Promise<void>;
   FixBug(pmKey: string, pmTitle: string): Promise<void>;
   FixSecurity(pmKey: string, pmTitle: string): Promise<void>;
   FindRelatedWork(pmKey: string, pmTitle: string): Promise<void>;
@@ -805,6 +810,31 @@ function showCardMenu(card: Card, x: number, y: number): void {
       void transition(card.key, card.title, "verification", "verification");
     });
     menu.appendChild(retryReview);
+  }
+
+  // A resolved card — the pipeline concluded there is nothing to do, or no fix
+  // is needed — had no gesture at all. The retry paths key on failed or outage
+  // and the forward path requires done, so overruling a verdict meant editing
+  // the tracker by hand. Re-opening goes through its own daemon entry point
+  // rather than a transition, because the automatic relaunch drives the same
+  // same-stage request and the machine must never re-run its own clean terminal.
+  if (isReopenable(card)) {
+    const reopen = document.createElement("button");
+    reopen.type = "button";
+    reopen.className = "context-menu-item";
+    reopen.textContent = "Re-open";
+    reopen.title = "The pipeline resolved this without a change — run the stage again";
+    reopen.disabled = !current.dockerAvailable;
+    if (reopen.disabled) reopen.title = "Docker required";
+    reopen.addEventListener("click", () => {
+      menu.remove();
+      void runGuardedAction(
+        () => go().Reopen(card.key, card.title, card.stage),
+        (err) => showError(errMessage(err)),
+        reconcile,
+      );
+    });
+    menu.appendChild(reopen);
   }
 
   // A failed deploy is otherwise a dead end: the Deploy zone only accepts

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -106,6 +106,8 @@ interface Card {
   // The daemon's decision on whether that verdict blocks the card. Read this
   // via verdictFailed(card) — the board must never re-test the verdict string.
   verdictFailed?: boolean;
+  activity?: string;
+  activityAt?: string;
   // RFC3339 instant a paused (outage) card's standing marker stated as when
   // the substrate clears, when one was parsed out of the diagnosis (SC-3024).
   // Absent when no time was stated — the badge then reads "paused" with no

--- a/docs/pipeline-fsm.json
+++ b/docs/pipeline-fsm.json
@@ -1,7 +1,7 @@
 {
   "$comment": "The state transitions of one item (a ticket) through the human pipeline, as the code and prompts implement them today. Each transition names the ACTOR that causes it, the SKILL that does the work, the MARKER that records it, and WHERE it is implemented. Topology is name/src/dst only; every other field is annotation.",
   "version": 1,
-  "describes": "commit 16cfe7e2, 2026-08-05",
+  "describes": "commit 2dcdc5a4, 2026-08-07",
   "item": "a ticket, from filing to merged",
   "initial": "filed",
   "actors": {
@@ -161,6 +161,11 @@
       "name": "substrate-down",
       "doc": "A stage reported the thing it needs was unreachable. Not a failure — it spends no retry budget and is relaunched when the substrate returns.",
       "board": "any column, outage"
+    },
+    {
+      "name": "unknown",
+      "doc": "The item's own state is unchanged, but the tracker that carries it failed to load, so nothing can be observed about it. It is the only state not derived from the item's markers — it says the board could not look, not that the item moved. Every item on that tracker enters and leaves it together, and it resolves by itself on the next fetch that reads the source.",
+      "board": "not rendered — the board shows a load-failure banner instead of the columns"
     }
   ],
   "events": [
@@ -353,21 +358,6 @@
       "prompt": "human-autofix-skill.md Step 5"
     },
     {
-      "name": "verify-done",
-      "src": [
-        "verifying"
-      ],
-      "dst": "handed-off",
-      "actor": "skill",
-      "runs": "human-bug-verify",
-      "marker": "[human:bug-verify]",
-      "state_key": "stage.verify verdict=DONE",
-      "prompt": "human-bug-verify-agent.md",
-      "moves_item": true,
-      "classified": false,
-      "doc": "[human:bug-verify] is evidence, not a stage transition: both verdicts keep the item inside the fix run — DONE leads to the handoff, which is the marker that actually moves it, and NOT DONE loops back to fixing while the budget holds."
-    },
-    {
       "name": "verify-not-done",
       "src": [
         "verifying"
@@ -375,13 +365,12 @@
       "dst": "fixing",
       "actor": "skill",
       "runs": "human-bug-verify",
-      "marker": "[human:bug-verify]",
       "state_key": "stage.verify verdict=NOT DONE",
       "prompt": "human-autofix-skill.md Step 6",
       "guard": "under the retry budget; only a failure that reproduced charges an attempt",
       "moves_item": false,
       "classified": false,
-      "doc": "[human:bug-verify] is evidence, not a stage transition: both verdicts keep the item inside the fix run — DONE leads to the handoff, which is the marker that actually moves it, and NOT DONE loops back to fixing while the budget holds."
+      "doc": "The verify gate found the fix wanting and the run loops back inside itself. No marker records it: [human:bug-verify] is evidence, not a transition, so nothing on the ticket distinguishes this from the fix still running. The item genuinely moves; the record does not."
     },
     {
       "name": "fix-budget-spent",
@@ -662,16 +651,110 @@
       "doc": "The plan executor was launched on a ticket with no plan, so the launch is refused before any agent claims it. The item surfaces back at planning where a human can start one."
     },
     {
-      "name": "reopen",
+      "name": "source-unreadable",
       "src": [
+        "filed",
+        "ticket-review",
+        "ticket-reviewed",
+        "planning",
+        "planned",
         "nothing-to-do",
-        "resolved-no-fix"
+        "preflight",
+        "triaging",
+        "challenging",
+        "resolved-no-fix",
+        "fix-planning",
+        "fixing",
+        "verifying",
+        "implementing",
+        "handed-off",
+        "in-review",
+        "reviewed",
+        "deploying",
+        "pr-review",
+        "pr-fix",
+        "ci-gate",
+        "deploy-fixing",
+        "merged",
+        "awaiting-decision",
+        "stopped",
+        "substrate-down"
+      ],
+      "dst": "unknown",
+      "actor": "daemon",
+      "where": "internal/board/gate.go PMRoleNotice; internal/board/compose.go",
+      "doc": "The tracker instance failed to load — an unreachable credential store, a config error. Every item it carries becomes unobservable at once, so this is a property of the fetch rather than of any one ticket. It resolves by itself when the source is reachable again; nothing about the item changed."
+    },
+    {
+      "name": "source-readable-again",
+      "src": [
+        "unknown"
+      ],
+      "dst": "filed",
+      "actor": "daemon",
+      "where": "internal/board/compose.go — the next fetch that resolves a PM-role result",
+      "doc": "The source came back and the item's real state is re-derived from its markers — it returns to whatever they say, not to `filed`. The single dst here is a topological placeholder: this machine has one destination per transition and the true one is computed. Nothing about the item changed while it was unobservable.",
+      "dst_is_derived": true
+    },
+    {
+      "name": "reopen-planning",
+      "src": [
+        "nothing-to-do"
       ],
       "dst": "planning",
       "actor": "user",
+      "runs": "human-planner",
       "marker": "[human:planning-started]",
       "where": "board_transition.go reopenResolved; desktop App.Reopen",
-      "doc": "A person judged a clean terminal wrong and re-runs the stage that resolved it: a nothing-to-do card re-plans, a no-fix-needed card re-runs its own fix pipeline (dst is that stage, planning shown here). It is a separate entry point from every other gesture because the automatic relaunch drives the identical same-stage request — the machine must never re-run its own clean terminal, so only an explicitly human call may. The fresh started marker is strictly newer than the terminal, so the card leaves resolved by the ordinary rules and the trail keeps both the verdict and the decision to overrule it."
+      "doc": "A person judged the nothing-to-do terminal wrong and re-plans. Separate from every retry gesture because the automatic relaunch drives the identical same-stage request — only an explicitly human call may re-run a clean terminal."
+    },
+    {
+      "name": "reopen-fix",
+      "src": [
+        "resolved-no-fix"
+      ],
+      "dst": "preflight",
+      "actor": "user",
+      "runs": "human-autofix",
+      "marker": "[human:implementation-started]",
+      "where": "board_transition.go reopenResolved — classifyFixPipeline routes to ApplyFix/ApplySecurityFix",
+      "doc": "A person judged the no-fix-needed verdict wrong. The card re-enters its OWN self-planning pipeline, so it re-triages from the top rather than being handed to the plan executor, which would refuse it for having no plan."
+    },
+    {
+      "name": "legacy-pr-opened",
+      "src": [
+        "reviewed"
+      ],
+      "dst": "deploying",
+      "actor": "daemon",
+      "marker": "[human:pr-started]",
+      "legacy": true,
+      "where": "board_markers.go orderedMarkerSpecs",
+      "doc": "The PR-opening lifecycle that predates the deploy pipeline. Still classified so threads written before deploy markers existed keep deriving; nothing posts it today."
+    },
+    {
+      "name": "legacy-pr-pushed",
+      "src": [
+        "deploying"
+      ],
+      "dst": "merged",
+      "actor": "daemon",
+      "marker": "[human:pr-pushed]",
+      "legacy": true,
+      "where": "board_markers.go orderedMarkerSpecs",
+      "doc": "Legacy: the PR was opened. It classifies as the done stage's DONE state — the same state the merge produces — so on an old thread an opened PR renders where a shipped one does. Recognized for those threads only."
+    },
+    {
+      "name": "legacy-pr-failed",
+      "src": [
+        "deploying"
+      ],
+      "dst": "stopped",
+      "actor": "daemon",
+      "marker": "[human:pr-failed]",
+      "legacy": true,
+      "where": "board_markers.go orderedMarkerSpecs",
+      "doc": "Legacy: opening the PR failed. Recognized for pre-deploy-pipeline threads only."
     }
   ],
   "ownership": {

--- a/docs/pipeline-fsm.json
+++ b/docs/pipeline-fsm.json
@@ -56,7 +56,8 @@
       "name": "nothing-to-do",
       "doc": "The planner proved the work is already merged. Clean terminal.",
       "board": "Planning, resolved",
-      "terminal": true
+      "terminal": true,
+      "reopenable": true
     },
     {
       "name": "preflight",
@@ -77,7 +78,8 @@
       "name": "resolved-no-fix",
       "doc": "The no-fix verdict survived the challenge. Clean terminal — the ticket needs no code change.",
       "board": "Fix, resolved",
-      "terminal": true
+      "terminal": true,
+      "reopenable": true
     },
     {
       "name": "fix-planning",
@@ -658,6 +660,18 @@
       "marker": "[human:needs-planning]",
       "where": "board_transition.go refuseIfUnplanned",
       "doc": "The plan executor was launched on a ticket with no plan, so the launch is refused before any agent claims it. The item surfaces back at planning where a human can start one."
+    },
+    {
+      "name": "reopen",
+      "src": [
+        "nothing-to-do",
+        "resolved-no-fix"
+      ],
+      "dst": "planning",
+      "actor": "user",
+      "marker": "[human:planning-started]",
+      "where": "board_transition.go reopenResolved; desktop App.Reopen",
+      "doc": "A person judged a clean terminal wrong and re-runs the stage that resolved it: a nothing-to-do card re-plans, a no-fix-needed card re-runs its own fix pipeline (dst is that stage, planning shown here). It is a separate entry point from every other gesture because the automatic relaunch drives the identical same-stage request — the machine must never re-run its own clean terminal, so only an explicitly human call may. The fresh started marker is strictly newer than the terminal, so the card leaves resolved by the ordinary rules and the trail keeps both the verdict and the decision to overrule it."
     }
   ]
 }

--- a/docs/pipeline-fsm.json
+++ b/docs/pipeline-fsm.json
@@ -681,5 +681,11 @@
       "A human gesture is NOT restricted by ownership. Racing a live foreign run is prevented instead by idempotency: a running card refuses every drop (isDuplicateDrop), whichever machine started it.",
       "Ownership is carried to the board as stageDaemonId so a reader can tell a stage owned elsewhere from an unowned one. It is the missing input for liveness across machines: no agent running HERE means dead only if this machine owns the stage."
     ]
+  },
+  "progress": {
+    "doc": "How an item shows that it is moving. Each in-container phase writes stage.<name> to `human state` with a timestamp — preflight, triage, challenge, fix, verify, review, pr-review, pr-fix, deploy-fix — and the board reads the newest one onto a running card as `activity`.",
+    "why": "Between implementation-started and ready-for-review an item passes through six phases that all render as one unchanging word. That word is identical at thirty seconds, at fourteen hours, and when the agent behind it is dead, so nothing on the card distinguishes progress from a hang. The phase changing is the signal; its not changing is the other one.",
+    "where": "internal/board/activity.go; attached in cmd/cmddaemon/daemon.go attachActivity",
+    "note": "Read for running cards only, and never invented: a run that recorded no phase shows the stage word exactly as before."
   }
 }

--- a/docs/pipeline-fsm.json
+++ b/docs/pipeline-fsm.json
@@ -4,226 +4,635 @@
   "describes": "commit 16cfe7e2, 2026-08-05",
   "item": "a ticket, from filing to merged",
   "initial": "filed",
-
   "actors": {
     "user": "a person, via a board gesture (drag, button) or a CLI command",
     "daemon": "the host process — it launches agents, posts their started markers, and is the only thing with push credentials",
     "skill": "an agent running in a container, following the named prompt"
   },
-
   "states": [
-    { "name": "filed", "doc": "The ticket exists. No pipeline activity.", "board": "Backlog" },
-    { "name": "ticket-review", "doc": "The pre-planning gate is judging whether solving this ticket solves the problem.", "board": "Backlog, running" },
-    { "name": "ticket-reviewed", "doc": "The gate returned a verdict: ready, reframed, superseded, escalated or rejected. The last three are stop decisions.", "board": "Backlog, done" },
-
-    { "name": "planning", "doc": "A planner is exploring the codebase and writing an implementation plan.", "board": "Planning, running" },
-    { "name": "planned", "doc": "A plan is attached to the ticket. The item waits for a human to start the build.", "board": "Planning, done" },
-    { "name": "nothing-to-do", "doc": "The planner proved the work is already merged. Clean terminal.", "board": "Planning, resolved", "terminal": true },
-
-    { "name": "preflight", "doc": "The fix run is resolving what it may do and settling what the evidence can settle, before any work.", "board": "Fix, running" },
-    { "name": "triaging", "doc": "The run is reproducing the report to reach a verdict.", "board": "Fix, running" },
-    { "name": "challenging", "doc": "A skeptic is trying to refute a not-a-bug or undetermined verdict before it is acted on.", "board": "Fix, running" },
-    { "name": "resolved-no-fix", "doc": "The no-fix verdict survived the challenge. Clean terminal — the ticket needs no code change.", "board": "Fix, resolved", "terminal": true },
-    { "name": "fix-planning", "doc": "The self-planning fix run is producing its own plan.", "board": "Fix, running" },
-    { "name": "fixing", "doc": "A regression test that fails first, then the change that makes it pass.", "board": "Fix, running" },
-    { "name": "verifying", "doc": "Proving the test fails before and passes after, on a green suite.", "board": "Fix, running" },
-    { "name": "implementing", "doc": "A plan executor is carrying out an attached plan (the non-bug path).", "board": "Code, running" },
-
-    { "name": "handed-off", "doc": "Branch and commits are recorded on the ticket, checked reachable.", "board": "Code, done" },
-    { "name": "in-review", "doc": "A reviewer is checking the change against the ticket's acceptance criteria. In a board fix run this happens inline, in the same warm container.", "board": "Review, running" },
-    { "name": "reviewed", "doc": "The review returned a verdict. A failing verdict blocks the deploy and sends the item back to be rebuilt.", "board": "Review, done" },
-
-    { "name": "deploying", "doc": "The daemon pushed the branch and opened a draft pull request.", "board": "Deploy, running" },
-    { "name": "pr-review", "doc": "The machine reviewer is reading the open pull request.", "board": "Deploy, running" },
-    { "name": "pr-fix", "doc": "The machine fixer is addressing the review's findings on the local branch.", "board": "Deploy, running" },
-    { "name": "ci-gate", "doc": "Every check must be green before the merge.", "board": "Deploy, running" },
-    { "name": "deploy-fixing", "doc": "A CI failure or a rebase conflict dispatched the deploy fixer instead of failing the item.", "board": "Deploy, running" },
-    { "name": "merged", "doc": "Merged, branch deleted, ticket closed. The shipping terminal.", "board": "Deploy, done", "terminal": true },
-
-    { "name": "awaiting-decision", "doc": "The item is parked on a genuine fork. Only a human choosing an answer moves it.", "board": "any column, decision needed" },
-    { "name": "stopped", "doc": "A stage gave up and said why: a spent budget, an unreviewable change, a failed deploy. Needs a human.", "board": "any column, error" },
-    { "name": "substrate-down", "doc": "A stage reported the thing it needs was unreachable. Not a failure — it spends no retry budget and is relaunched when the substrate returns.", "board": "any column, outage" }
+    {
+      "name": "filed",
+      "doc": "The ticket exists. No pipeline activity.",
+      "board": "Backlog"
+    },
+    {
+      "name": "ticket-review",
+      "doc": "The pre-planning gate is judging whether solving this ticket solves the problem.",
+      "board": "Backlog, running"
+    },
+    {
+      "name": "ticket-reviewed",
+      "doc": "The gate returned a verdict: ready, reframed, superseded, escalated or rejected. The last three are stop decisions.",
+      "board": "Backlog, done"
+    },
+    {
+      "name": "planning",
+      "doc": "A planner is exploring the codebase and writing an implementation plan.",
+      "board": "Planning, running"
+    },
+    {
+      "name": "planned",
+      "doc": "A plan is attached to the ticket. The item waits for a human to start the build.",
+      "board": "Planning, done"
+    },
+    {
+      "name": "nothing-to-do",
+      "doc": "The planner proved the work is already merged. Clean terminal.",
+      "board": "Planning, resolved",
+      "terminal": true
+    },
+    {
+      "name": "preflight",
+      "doc": "The fix run is resolving what it may do and settling what the evidence can settle, before any work.",
+      "board": "Fix, running"
+    },
+    {
+      "name": "triaging",
+      "doc": "The run is reproducing the report to reach a verdict.",
+      "board": "Fix, running"
+    },
+    {
+      "name": "challenging",
+      "doc": "A skeptic is trying to refute a not-a-bug or undetermined verdict before it is acted on.",
+      "board": "Fix, running"
+    },
+    {
+      "name": "resolved-no-fix",
+      "doc": "The no-fix verdict survived the challenge. Clean terminal — the ticket needs no code change.",
+      "board": "Fix, resolved",
+      "terminal": true
+    },
+    {
+      "name": "fix-planning",
+      "doc": "The self-planning fix run is producing its own plan.",
+      "board": "Fix, running"
+    },
+    {
+      "name": "fixing",
+      "doc": "A regression test that fails first, then the change that makes it pass.",
+      "board": "Fix, running"
+    },
+    {
+      "name": "verifying",
+      "doc": "Proving the test fails before and passes after, on a green suite.",
+      "board": "Fix, running"
+    },
+    {
+      "name": "implementing",
+      "doc": "A plan executor is carrying out an attached plan (the non-bug path).",
+      "board": "Code, running"
+    },
+    {
+      "name": "handed-off",
+      "doc": "Branch and commits are recorded on the ticket, checked reachable.",
+      "board": "Code, done"
+    },
+    {
+      "name": "in-review",
+      "doc": "A reviewer is checking the change against the ticket's acceptance criteria. In a board fix run this happens inline, in the same warm container.",
+      "board": "Review, running"
+    },
+    {
+      "name": "reviewed",
+      "doc": "The review returned a verdict. A failing verdict blocks the deploy and sends the item back to be rebuilt.",
+      "board": "Review, done"
+    },
+    {
+      "name": "deploying",
+      "doc": "The daemon pushed the branch and opened a draft pull request.",
+      "board": "Deploy, running"
+    },
+    {
+      "name": "pr-review",
+      "doc": "The machine reviewer is reading the open pull request.",
+      "board": "Deploy, running"
+    },
+    {
+      "name": "pr-fix",
+      "doc": "The machine fixer is addressing the review's findings on the local branch.",
+      "board": "Deploy, running"
+    },
+    {
+      "name": "ci-gate",
+      "doc": "Every check must be green before the merge.",
+      "board": "Deploy, running"
+    },
+    {
+      "name": "deploy-fixing",
+      "doc": "A CI failure or a rebase conflict dispatched the deploy fixer instead of failing the item.",
+      "board": "Deploy, running"
+    },
+    {
+      "name": "merged",
+      "doc": "Merged, branch deleted, ticket closed. The shipping terminal.",
+      "board": "Deploy, done",
+      "terminal": true
+    },
+    {
+      "name": "awaiting-decision",
+      "doc": "The item is parked on a genuine fork. Only a human choosing an answer moves it.",
+      "board": "any column, decision needed"
+    },
+    {
+      "name": "stopped",
+      "doc": "A stage gave up and said why: a spent budget, an unreviewable change, a failed deploy. Needs a human.",
+      "board": "any column, error"
+    },
+    {
+      "name": "substrate-down",
+      "doc": "A stage reported the thing it needs was unreachable. Not a failure — it spends no retry budget and is relaunched when the substrate returns.",
+      "board": "any column, outage"
+    }
   ],
-
   "events": [
-    { "name": "start-ticket-review", "src": ["filed"], "dst": "ticket-review",
-      "actor": "user", "runs": "human-ticket-reviewer", "marker": "[human:ticket-review-started]",
-      "where": "internal/daemon/board_transition.go startAgentStage" },
-
-    { "name": "ticket-review-verdict", "src": ["ticket-review"], "dst": "ticket-reviewed",
-      "actor": "skill", "runs": "human-ticket-reviewer", "marker": "[human:ticket-review]",
-      "head_enum": ["ready", "reframed", "superseded", "escalated", "rejected"],
-      "prompt": "human-ticket-reviewer-agent.md" },
-
-    { "name": "start-planning", "src": ["filed", "ticket-reviewed", "planned", "stopped", "substrate-down"], "dst": "planning",
-      "actor": "user", "runs": "human-planner", "marker": "[human:planning-started]",
+    {
+      "name": "start-ticket-review",
+      "src": [
+        "filed"
+      ],
+      "dst": "ticket-review",
+      "actor": "user",
+      "runs": "human-ticket-reviewer",
+      "marker": "[human:ticket-review-started]",
+      "where": "internal/daemon/board_transition.go startAgentStage"
+    },
+    {
+      "name": "ticket-review-verdict",
+      "src": [
+        "ticket-review"
+      ],
+      "dst": "ticket-reviewed",
+      "actor": "skill",
+      "runs": "human-ticket-reviewer",
+      "marker": "[human:ticket-review]",
+      "head_enum": [
+        "ready",
+        "reframed",
+        "superseded",
+        "escalated",
+        "rejected"
+      ],
+      "prompt": "human-ticket-reviewer-agent.md"
+    },
+    {
+      "name": "start-planning",
+      "src": [
+        "filed",
+        "ticket-reviewed",
+        "planned",
+        "stopped",
+        "substrate-down"
+      ],
+      "dst": "planning",
+      "actor": "user",
+      "runs": "human-planner",
+      "marker": "[human:planning-started]",
       "where": "board_transition.go launchForwardStage / isPlanningRetry",
-      "doc": "A drop on Planning. From planned it is a replan; from stopped or substrate-down it is a retry in place." },
-
-    { "name": "plan-attached", "src": ["planning"], "dst": "planned",
-      "actor": "skill", "runs": "human-planner", "marker": "[human:plan-ready]",
+      "doc": "A drop on Planning. From planned it is a replan; from stopped or substrate-down it is a retry in place."
+    },
+    {
+      "name": "plan-attached",
+      "src": [
+        "planning"
+      ],
+      "dst": "planned",
+      "actor": "skill",
+      "runs": "human-planner",
+      "marker": "[human:plan-ready]",
       "prompt": "human-plan-skill.md",
-      "doc": "The plan itself is attached as a [human:plan] comment; plan-ready is what moves the item." },
-
-    { "name": "plan-finds-nothing-to-do", "src": ["planning"], "dst": "nothing-to-do",
-      "actor": "skill", "runs": "human-planner", "marker": "[human:nothing-to-do]",
-      "prompt": "human-plan-skill.md" },
-
-    { "name": "planning-failed", "src": ["planning"], "dst": "stopped",
-      "actor": "daemon", "marker": "[human:planning-failed]",
-      "where": "board_failure.go" },
-
-    { "name": "start-fix-run", "src": ["filed", "ticket-reviewed", "stopped", "substrate-down"], "dst": "preflight",
-      "actor": "user", "runs": "human-autofix", "marker": "[human:implementation-started]",
+      "doc": "The plan itself is attached as a [human:plan] comment; plan-ready is what moves the item."
+    },
+    {
+      "name": "plan-finds-nothing-to-do",
+      "src": [
+        "planning"
+      ],
+      "dst": "nothing-to-do",
+      "actor": "skill",
+      "runs": "human-planner",
+      "marker": "[human:nothing-to-do]",
+      "prompt": "human-plan-skill.md"
+    },
+    {
+      "name": "planning-failed",
+      "src": [
+        "planning"
+      ],
+      "dst": "stopped",
+      "actor": "daemon",
+      "marker": "[human:planning-failed]",
+      "where": "board_failure.go"
+    },
+    {
+      "name": "start-fix-run",
+      "src": [
+        "filed",
+        "ticket-reviewed",
+        "stopped",
+        "substrate-down"
+      ],
+      "dst": "preflight",
+      "actor": "user",
+      "runs": "human-autofix",
+      "marker": "[human:implementation-started]",
       "where": "board_transition.go ApplyFix",
-      "doc": "Dropping a bug on Fix. The run is self-planning — it produces its own plan rather than requiring one." },
-
-    { "name": "preflight-clear", "src": ["preflight"], "dst": "triaging",
-      "actor": "skill", "runs": "human-autofix", "state_key": "stage.preflight ready=yes",
-      "prompt": "human-autofix-skill.md Step 1a" },
-
-    { "name": "preflight-asks", "src": ["preflight"], "dst": "awaiting-decision",
-      "actor": "skill", "runs": "human-autofix", "marker": "[human:options]",
+      "doc": "Dropping a bug on Fix. The run is self-planning — it produces its own plan rather than requiring one."
+    },
+    {
+      "name": "preflight-clear",
+      "src": [
+        "preflight"
+      ],
+      "dst": "triaging",
+      "actor": "skill",
+      "runs": "human-autofix",
+      "state_key": "stage.preflight ready=yes",
+      "prompt": "human-autofix-skill.md Step 1a"
+    },
+    {
+      "name": "preflight-asks",
+      "src": [
+        "preflight"
+      ],
+      "dst": "awaiting-decision",
+      "actor": "skill",
+      "runs": "human-autofix",
+      "marker": "[human:options]",
       "state_key": "stage.implementation exit=needs-input",
       "prompt": "human-autofix-skill.md Step 1a",
-      "doc": "The one place the pipeline asks a question, asked up front rather than halfway through." },
-
-    { "name": "triage-verdict-confirmed", "src": ["triaging"], "dst": "fix-planning",
-      "actor": "skill", "runs": "human-bug-triage", "marker": "[human:bug-verdict]",
+      "doc": "The one place the pipeline asks a question, asked up front rather than halfway through."
+    },
+    {
+      "name": "triage-verdict-confirmed",
+      "src": [
+        "triaging"
+      ],
+      "dst": "fix-planning",
+      "actor": "skill",
+      "runs": "human-bug-triage",
+      "marker": "[human:bug-verdict]",
       "state_key": "stage.triage verdict=confirmed",
-      "prompt": "human-bug-triage-agent.md" },
-
-    { "name": "triage-verdict-no-bug", "src": ["triaging"], "dst": "challenging",
-      "actor": "skill", "runs": "human-bug-triage", "marker": "[human:bug-verdict]",
+      "prompt": "human-bug-triage-agent.md"
+    },
+    {
+      "name": "triage-verdict-no-bug",
+      "src": [
+        "triaging"
+      ],
+      "dst": "challenging",
+      "actor": "skill",
+      "runs": "human-bug-triage",
+      "marker": "[human:bug-verdict]",
       "state_key": "stage.triage verdict=not-a-bug | undetermined",
       "prompt": "human-autofix-skill.md Step 3",
-      "doc": "A no-fix verdict is never acted on directly — it must survive a challenge first." },
-
-    { "name": "challenge-upholds", "src": ["challenging"], "dst": "resolved-no-fix",
-      "actor": "skill", "runs": "human-verdict-skeptic", "marker": "[human:no-fix-needed]",
+      "doc": "A no-fix verdict is never acted on directly — it must survive a challenge first."
+    },
+    {
+      "name": "challenge-upholds",
+      "src": [
+        "challenging"
+      ],
+      "dst": "resolved-no-fix",
+      "actor": "skill",
+      "runs": "human-verdict-skeptic",
+      "marker": "[human:no-fix-needed]",
       "state_key": "stage.challenge challenge=upheld, stage.implementation exit=done",
-      "prompt": "human-autofix-skill.md Step 3a" },
-
-    { "name": "challenge-refutes", "src": ["challenging"], "dst": "fix-planning",
-      "actor": "skill", "runs": "human-verdict-skeptic",
+      "prompt": "human-autofix-skill.md Step 3a"
+    },
+    {
+      "name": "challenge-refutes",
+      "src": [
+        "challenging"
+      ],
+      "dst": "fix-planning",
+      "actor": "skill",
+      "runs": "human-verdict-skeptic",
       "state_key": "stage.challenge challenge=refuted",
       "prompt": "human-autofix-skill.md Step 3a",
-      "doc": "The skeptic reproduced it. The run continues as a confirmed bug, using the skeptic's reproduction. Runs once — never loops back through triage." },
-
-    { "name": "fix-plan-written", "src": ["fix-planning"], "dst": "fixing",
-      "actor": "skill", "runs": "human-autofix", "marker": "[human:plan]",
-      "prompt": "human-autofix-skill.md Step 4" },
-
-    { "name": "fix-written", "src": ["fixing"], "dst": "verifying",
-      "actor": "skill", "runs": "human-autofix", "state_key": "stage.fix",
-      "prompt": "human-autofix-skill.md Step 5" },
-
-    { "name": "verify-done", "src": ["verifying"], "dst": "handed-off",
-      "actor": "skill", "runs": "human-bug-verify", "marker": "[human:bug-verify]",
+      "doc": "The skeptic reproduced it. The run continues as a confirmed bug, using the skeptic's reproduction. Runs once — never loops back through triage."
+    },
+    {
+      "name": "fix-plan-written",
+      "src": [
+        "fix-planning"
+      ],
+      "dst": "fixing",
+      "actor": "skill",
+      "runs": "human-autofix",
+      "marker": "[human:plan]",
+      "prompt": "human-autofix-skill.md Step 4"
+    },
+    {
+      "name": "fix-written",
+      "src": [
+        "fixing"
+      ],
+      "dst": "verifying",
+      "actor": "skill",
+      "runs": "human-autofix",
+      "state_key": "stage.fix",
+      "prompt": "human-autofix-skill.md Step 5"
+    },
+    {
+      "name": "verify-done",
+      "src": [
+        "verifying"
+      ],
+      "dst": "handed-off",
+      "actor": "skill",
+      "runs": "human-bug-verify",
+      "marker": "[human:bug-verify]",
       "state_key": "stage.verify verdict=DONE",
-      "prompt": "human-bug-verify-agent.md" },
-
-    { "name": "verify-not-done", "src": ["verifying"], "dst": "fixing",
-      "actor": "skill", "runs": "human-bug-verify", "marker": "[human:bug-verify]",
+      "prompt": "human-bug-verify-agent.md"
+    },
+    {
+      "name": "verify-not-done",
+      "src": [
+        "verifying"
+      ],
+      "dst": "fixing",
+      "actor": "skill",
+      "runs": "human-bug-verify",
+      "marker": "[human:bug-verify]",
       "state_key": "stage.verify verdict=NOT DONE",
       "prompt": "human-autofix-skill.md Step 6",
-      "guard": "under the retry budget; only a failure that reproduced charges an attempt" },
-
-    { "name": "fix-budget-spent", "src": ["verifying"], "dst": "stopped",
-      "actor": "skill", "runs": "human-autofix", "marker": "[human:implementation-failed]",
+      "guard": "under the retry budget; only a failure that reproduced charges an attempt"
+    },
+    {
+      "name": "fix-budget-spent",
+      "src": [
+        "verifying"
+      ],
+      "dst": "stopped",
+      "actor": "skill",
+      "runs": "human-autofix",
+      "marker": "[human:implementation-failed]",
       "state_key": "stage.implementation exit=needs-human-work",
-      "prompt": "human-autofix-skill.md Step 6" },
-
-    { "name": "start-implementation", "src": ["planned", "reviewed", "stopped", "substrate-down"], "dst": "implementing",
-      "actor": "user", "runs": "human-executor", "marker": "[human:implementation-started]",
+      "prompt": "human-autofix-skill.md Step 6"
+    },
+    {
+      "name": "start-implementation",
+      "src": [
+        "planned",
+        "reviewed",
+        "stopped",
+        "substrate-down"
+      ],
+      "dst": "implementing",
+      "actor": "user",
+      "runs": "human-executor",
+      "marker": "[human:implementation-started]",
       "where": "board_transition.go launchForwardStage / isReworkTransition / isBuildRetry",
-      "doc": "The plan-executing path. From reviewed it is the rework loop — a failing review verdict sends the item back to be rebuilt with the findings." },
-
-    { "name": "handoff-posted", "src": ["implementing", "verifying"], "dst": "handed-off",
-      "actor": "skill", "runs": "human-executor | human-autofix", "marker": "[human:ready-for-review]",
-      "required_fields": ["branch", "commits"],
+      "doc": "The plan-executing path. From reviewed it is the rework loop — a failing review verdict sends the item back to be rebuilt with the findings."
+    },
+    {
+      "name": "handoff-posted",
+      "src": [
+        "implementing",
+        "verifying"
+      ],
+      "dst": "handed-off",
+      "actor": "skill",
+      "runs": "human-executor | human-autofix",
+      "marker": "[human:ready-for-review]",
+      "required_fields": [
+        "branch",
+        "commits"
+      ],
       "prompt": "human-executor-agent.md, human-autofix-skill.md Step 7.1",
-      "where": "posted via `human handoff post`, which verifies the commits are reachable on the branch first" },
-
-    { "name": "implementation-failed", "src": ["implementing"], "dst": "stopped",
-      "actor": "daemon", "marker": "[human:implementation-failed]",
+      "where": "posted via `human handoff post`, which verifies the commits are reachable on the branch first"
+    },
+    {
+      "name": "implementation-failed",
+      "src": [
+        "implementing"
+      ],
+      "dst": "stopped",
+      "actor": "daemon",
+      "marker": "[human:implementation-failed]",
       "where": "board_failure.go",
-      "doc": "The daemon's failure watcher classifies an agent that exited without posting its handoff." },
-
-    { "name": "start-review", "src": ["handed-off", "stopped", "substrate-down"], "dst": "in-review",
-      "actor": "daemon", "runs": "human-reviewer", "marker": "[human:review-started]",
+      "doc": "The daemon's failure watcher classifies an agent that exited without posting its handoff."
+    },
+    {
+      "name": "start-review",
+      "src": [
+        "handed-off",
+        "stopped",
+        "substrate-down"
+      ],
+      "dst": "in-review",
+      "actor": "daemon",
+      "runs": "human-reviewer",
+      "marker": "[human:review-started]",
       "where": "board_failure.go chainReviewAfterCleanBuild; board_reconcile.go if that hook was lost",
-      "doc": "Automatic: a clean build whose handoff names a reachable branch flows straight into its review. A board fix run instead runs the review inline in its own container and the daemon launches no second one." },
-
-    { "name": "review-verdict", "src": ["in-review"], "dst": "reviewed",
-      "actor": "skill", "runs": "human-reviewer", "marker": "[human:review-complete]",
-      "required_fields": ["verdict"],
+      "doc": "Automatic: a clean build whose handoff names a reachable branch flows straight into its review. A board fix run instead runs the review inline in its own container and the daemon launches no second one."
+    },
+    {
+      "name": "review-verdict",
+      "src": [
+        "in-review"
+      ],
+      "dst": "reviewed",
+      "actor": "skill",
+      "runs": "human-reviewer",
+      "marker": "[human:review-complete]",
+      "required_fields": [
+        "verdict"
+      ],
       "prompt": "human-review-skill.md",
-      "doc": "Pass and fail are the same marker and the same state — the verdict rides in a field, and it is what decides whether the item may deploy or must be rebuilt." },
-
-    { "name": "review-failed", "src": ["in-review"], "dst": "stopped",
-      "actor": "daemon", "marker": "[human:review-failed]", "required_fields": ["reason"],
-      "doc": "The review stage itself failed — a binding gate such as a missing branch or unreachable commits — not a failing verdict." },
-
-    { "name": "start-deploy", "src": ["reviewed", "stopped", "substrate-down"], "dst": "deploying",
-      "actor": "user", "marker": "[human:deploy-started]",
+      "doc": "Pass and fail are the same marker and the same state — the verdict rides in a field. Whether that verdict BLOCKS is decided once, by daemon.VerdictFailed, and shipped to the board as verdictFailed; the board never re-tests the string. A blocking verdict keeps the item out of Deploy and offers the rework gesture instead.",
+      "verdict_blocking": [
+        "fail",
+        "incomplete"
+      ]
+    },
+    {
+      "name": "review-failed",
+      "src": [
+        "in-review"
+      ],
+      "dst": "stopped",
+      "actor": "daemon",
+      "marker": "[human:review-failed]",
+      "required_fields": [
+        "reason"
+      ],
+      "doc": "The review stage itself failed — a binding gate such as a missing branch or unreachable commits — not a failing verdict."
+    },
+    {
+      "name": "start-deploy",
+      "src": [
+        "reviewed",
+        "stopped",
+        "substrate-down"
+      ],
+      "dst": "deploying",
+      "actor": "user",
+      "marker": "[human:deploy-started]",
       "where": "board_transition.go runDoneStage / isDeployRetry",
       "guard": "the review verdict must not be failing",
-      "doc": "Dropping on Deploy. The daemon does this itself — no agent holds push credentials." },
-
-    { "name": "pr-opened", "src": ["deploying"], "dst": "pr-review",
-      "actor": "daemon", "runs": "human-pr-reviewer", "marker": "[human:pr-review-started]",
-      "doc": "The pull request is opened as a draft, so a half-reviewed change is not mergeable by anyone." },
-
-    { "name": "pr-changes-requested", "src": ["pr-review"], "dst": "pr-fix",
-      "actor": "daemon", "runs": "human-pr-fixer", "marker": "[human:pr-fix-started]",
+      "doc": "Dropping on Deploy. The daemon does this itself — no agent holds push credentials."
+    },
+    {
+      "name": "pr-opened",
+      "src": [
+        "deploying"
+      ],
+      "dst": "pr-review",
+      "actor": "daemon",
+      "runs": "human-pr-reviewer",
+      "marker": "[human:pr-review-started]",
+      "doc": "The pull request is opened as a draft, so a half-reviewed change is not mergeable by anyone."
+    },
+    {
+      "name": "pr-changes-requested",
+      "src": [
+        "pr-review"
+      ],
+      "dst": "pr-fix",
+      "actor": "daemon",
+      "runs": "human-pr-fixer",
+      "marker": "[human:pr-fix-started]",
       "guard": "bounded: 3 rounds",
-      "doc": "The fixer commits to the LOCAL branch and never pushes, so the reviewer reads the new commit rather than a stale pushed head." },
-
-    { "name": "pr-refixed", "src": ["pr-fix"], "dst": "pr-review",
-      "actor": "daemon", "runs": "human-pr-reviewer", "marker": "[human:pr-review-started]" },
-
-    { "name": "pr-review-passed", "src": ["pr-review"], "dst": "ci-gate",
+      "doc": "The fixer commits to the LOCAL branch and never pushes, so the reviewer reads the new commit rather than a stale pushed head."
+    },
+    {
+      "name": "pr-refixed",
+      "src": [
+        "pr-fix"
+      ],
+      "dst": "pr-review",
+      "actor": "daemon",
+      "runs": "human-pr-reviewer",
+      "marker": "[human:pr-review-started]"
+    },
+    {
+      "name": "pr-review-passed",
+      "src": [
+        "pr-review"
+      ],
+      "dst": "ci-gate",
       "actor": "daemon",
       "where": "board_transition.go AdvancePRLoop",
-      "doc": "The draft is un-drafted and the item goes to the CI gate." },
-
-    { "name": "pr-loop-escalates", "src": ["pr-review", "pr-fix"], "dst": "stopped",
-      "actor": "daemon", "marker": "[human:pr-review-failed]",
-      "doc": "Budget spent, unreviewable, or an outcome it cannot parse. It never merges on a state it cannot read." },
-
-    { "name": "ci-red", "src": ["ci-gate"], "dst": "deploy-fixing",
-      "actor": "daemon", "runs": "human-deploy-fixer", "marker": "[human:deploy-fix-started]",
+      "doc": "The draft is un-drafted and the item goes to the CI gate."
+    },
+    {
+      "name": "pr-loop-escalates",
+      "src": [
+        "pr-review",
+        "pr-fix"
+      ],
+      "dst": "stopped",
+      "actor": "daemon",
+      "marker": "[human:pr-review-failed]",
+      "doc": "Budget spent, unreviewable, or an outcome it cannot parse. It never merges on a state it cannot read."
+    },
+    {
+      "name": "ci-red",
+      "src": [
+        "ci-gate"
+      ],
+      "dst": "deploy-fixing",
+      "actor": "daemon",
+      "runs": "human-deploy-fixer",
+      "marker": "[human:deploy-fix-started]",
       "guard": "bounded: 2 rounds",
-      "doc": "A red-but-mechanical failure dispatches the fixer instead of failing the item. A cancelled check counts as no answer yet, not as a no." },
-
-    { "name": "ci-regated", "src": ["deploy-fixing"], "dst": "ci-gate", "actor": "daemon" },
-
-    { "name": "ci-green-merged", "src": ["ci-gate"], "dst": "merged",
-      "actor": "daemon", "marker": "[human:deployed]", "required_fields": ["pr"],
-      "doc": "If the base moved on, the branch is rebased and CI re-gated on the new head before merging. Past the merge, branch cleanup and closing the ticket are best-effort and never fail the item." },
-
-    { "name": "deploy-failed", "src": ["ci-gate", "deploy-fixing", "deploying"], "dst": "stopped",
-      "actor": "daemon", "marker": "[human:deploy-failed]", "required_fields": ["reason"] },
-
-    { "name": "stage-asks", "src": ["planning", "triaging", "fixing", "verifying", "implementing", "in-review", "pr-review"], "dst": "awaiting-decision",
-      "actor": "skill", "marker": "[human:options]", "required_fields": ["stage"],
+      "doc": "A red-but-mechanical failure dispatches the fixer instead of failing the item. A cancelled check counts as no answer yet, not as a no."
+    },
+    {
+      "name": "ci-regated",
+      "src": [
+        "deploy-fixing"
+      ],
+      "dst": "ci-gate",
+      "actor": "daemon"
+    },
+    {
+      "name": "ci-green-merged",
+      "src": [
+        "ci-gate"
+      ],
+      "dst": "merged",
+      "actor": "daemon",
+      "marker": "[human:deployed]",
+      "required_fields": [
+        "pr"
+      ],
+      "doc": "If the base moved on, the branch is rebased and CI re-gated on the new head before merging. Past the merge, branch cleanup and closing the ticket are best-effort and never fail the item."
+    },
+    {
+      "name": "deploy-failed",
+      "src": [
+        "ci-gate",
+        "deploy-fixing",
+        "deploying"
+      ],
+      "dst": "stopped",
+      "actor": "daemon",
+      "marker": "[human:deploy-failed]",
+      "required_fields": [
+        "reason"
+      ]
+    },
+    {
+      "name": "stage-asks",
+      "src": [
+        "planning",
+        "triaging",
+        "fixing",
+        "verifying",
+        "implementing",
+        "in-review",
+        "pr-review"
+      ],
+      "dst": "awaiting-decision",
+      "actor": "skill",
+      "marker": "[human:options]",
+      "required_fields": [
+        "stage"
+      ],
       "where": "board_state.go pauseOnOpenOptions",
-      "doc": "A stage found a genuine fork and stopped. The item is not working and not dead — it is waiting on a person." },
-
-    { "name": "decision-made", "src": ["awaiting-decision"], "dst": "planning",
-      "actor": "user", "marker": "[human:option-chosen]",
+      "doc": "A stage found a genuine fork and stopped. The item is not working and not dead — it is waiting on a person."
+    },
+    {
+      "name": "decision-made",
+      "src": [
+        "awaiting-decision"
+      ],
+      "dst": "planning",
+      "actor": "user",
+      "marker": "[human:option-chosen]",
       "where": "board_state.go optionChosenQueued",
-      "doc": "A human picked an answer. The chosen stage is relaunched with the choice in hand; dst is whichever stage the block named — planning is the common case." },
-
-    { "name": "substrate-unreachable", "src": ["planning", "triaging", "fixing", "verifying", "implementing", "in-review", "deploying", "ci-gate"], "dst": "substrate-down",
-      "actor": "daemon", "marker": "[human:planning-outage] | [human:implementation-outage] | [human:review-outage] | [human:deploy-outage]",
+      "doc": "A human picked an answer. The chosen stage is relaunched with the choice in hand; dst is whichever stage the block named — planning is the common case."
+    },
+    {
+      "name": "substrate-unreachable",
+      "src": [
+        "planning",
+        "triaging",
+        "fixing",
+        "verifying",
+        "implementing",
+        "in-review",
+        "deploying",
+        "ci-gate"
+      ],
+      "dst": "substrate-down",
+      "actor": "daemon",
+      "marker": "[human:planning-outage] | [human:implementation-outage] | [human:review-outage] | [human:deploy-outage]",
       "where": "board_retry.go ExitOutage",
-      "doc": "One marker per stage. It costs no retry budget and the reconcile pass relaunches it each interval until the substrate returns." },
-
-    { "name": "launch-refused-no-plan", "src": ["implementing"], "dst": "stopped",
-      "actor": "daemon", "marker": "[human:needs-planning]",
+      "doc": "One marker per stage. It costs no retry budget and the reconcile pass relaunches it each interval until the substrate returns."
+    },
+    {
+      "name": "launch-refused-no-plan",
+      "src": [
+        "implementing"
+      ],
+      "dst": "stopped",
+      "actor": "daemon",
+      "marker": "[human:needs-planning]",
       "where": "board_transition.go refuseIfUnplanned",
-      "doc": "The plan executor was launched on a ticket with no plan, so the launch is refused before any agent claims it. The item surfaces back at planning where a human can start one." }
+      "doc": "The plan executor was launched on a ticket with no plan, so the launch is refused before any agent claims it. The item surfaces back at planning where a human can start one."
+    }
   ]
 }

--- a/docs/pipeline-fsm.json
+++ b/docs/pipeline-fsm.json
@@ -343,7 +343,10 @@
       "runs": "human-bug-verify",
       "marker": "[human:bug-verify]",
       "state_key": "stage.verify verdict=DONE",
-      "prompt": "human-bug-verify-agent.md"
+      "prompt": "human-bug-verify-agent.md",
+      "moves_item": true,
+      "classified": false,
+      "doc": "[human:bug-verify] is evidence, not a stage transition: both verdicts keep the item inside the fix run — DONE leads to the handoff, which is the marker that actually moves it, and NOT DONE loops back to fixing while the budget holds."
     },
     {
       "name": "verify-not-done",
@@ -356,7 +359,10 @@
       "marker": "[human:bug-verify]",
       "state_key": "stage.verify verdict=NOT DONE",
       "prompt": "human-autofix-skill.md Step 6",
-      "guard": "under the retry budget; only a failure that reproduced charges an attempt"
+      "guard": "under the retry budget; only a failure that reproduced charges an attempt",
+      "moves_item": false,
+      "classified": false,
+      "doc": "[human:bug-verify] is evidence, not a stage transition: both verdicts keep the item inside the fix run — DONE leads to the handoff, which is the marker that actually moves it, and NOT DONE loops back to fixing while the budget holds."
     },
     {
       "name": "fix-budget-spent",
@@ -573,7 +579,8 @@
       "marker": "[human:deploy-failed]",
       "required_fields": [
         "reason"
-      ]
+      ],
+      "doc": "The deploy gave up. The marker names the condition that is blocking — for a deploy-fixer escalation it quotes the failure the fixer was dispatched to fix, which for CI names the red checks — and it does not offer a gesture that cannot work: where re-running Deploy would hit the same failure, it says so instead of advising the retry."
     },
     {
       "name": "stage-asks",

--- a/docs/pipeline-fsm.json
+++ b/docs/pipeline-fsm.json
@@ -514,7 +514,8 @@
       "dst": "ci-gate",
       "actor": "daemon",
       "where": "board_transition.go AdvancePRLoop",
-      "doc": "The draft is un-drafted and the item goes to the CI gate."
+      "doc": "The reviewer approved. The draft is un-drafted and the item goes to the CI gate. Recorded as a marker like every other outcome of the loop — success used to be the only transition here that left no trace, so a reader could not tell an approved review whose merge is running from a review still in flight. It also retires the loop sub-phase, so the badge stops reading 'PR review…' through the CI gate, rebase and merge.",
+      "marker": "[human:pr-review-passed]"
     },
     {
       "name": "pr-loop-escalates",
@@ -592,7 +593,7 @@
         "stage"
       ],
       "where": "board_state.go pauseOnOpenOptions",
-      "doc": "A stage found a genuine fork and stopped. The item is not working and not dead — it is waiting on a person."
+      "doc": "A stage found a genuine fork and stopped. The item is not working and not dead — it is waiting on a person, and reads as decision-needed rather than running."
     },
     {
       "name": "decision-made",
@@ -603,7 +604,7 @@
       "actor": "user",
       "marker": "[human:option-chosen]",
       "where": "board_state.go optionChosenQueued",
-      "doc": "A human picked an answer. The chosen stage is relaunched with the choice in hand; dst is whichever stage the block named — planning is the common case."
+      "doc": "A human picked an answer; the run relaunches with the choice in hand. dst is the stage the block NAMES, not the stage the item sits in — planning is the common case. A PR-loop escalation deliberately names implementation even though the item is in the deploy stage: the fixer raised a question only a code change can answer, so the choice rebuilds, and the rebuild re-adopts the still-open draft PR. The item pauses correctly meanwhile, because an open block pauses every card whose own stage ranks at or after the one named."
     },
     {
       "name": "substrate-unreachable",

--- a/docs/pipeline-fsm.json
+++ b/docs/pipeline-fsm.json
@@ -673,5 +673,13 @@
       "where": "board_transition.go reopenResolved; desktop App.Reopen",
       "doc": "A person judged a clean terminal wrong and re-runs the stage that resolved it: a nothing-to-do card re-plans, a no-fix-needed card re-runs its own fix pipeline (dst is that stage, planning shown here). It is a separate entry point from every other gesture because the automatic relaunch drives the identical same-stage request — the machine must never re-run its own clean terminal, so only an explicitly human call may. The fresh started marker is strictly newer than the terminal, so the card leaves resolved by the ordinary rules and the trail keeps both the verdict and the decision to overrule it."
     }
-  ]
+  ],
+  "ownership": {
+    "doc": "Which machine may fire a transition. A stage is stamped with the daemon that posted its deciding marker (BoardCard.StageDaemonID, from the marker's machine: field).",
+    "rules": [
+      "The machine acting on its own initiative — the reconcile takeover pass — refuses a stage another daemon stamped: WorkGate.ownedHereOrUnowned in internal/daemon/board_reconcile_gate.go. An unstamped stage (single-daemon, or a thread written before stamping) is takeable by anyone.",
+      "A human gesture is NOT restricted by ownership. Racing a live foreign run is prevented instead by idempotency: a running card refuses every drop (isDuplicateDrop), whichever machine started it.",
+      "Ownership is carried to the board as stageDaemonId so a reader can tell a stage owned elsewhere from an unowned one. It is the missing input for liveness across machines: no agent running HERE means dead only if this machine owns the stage."
+    ]
+  }
 }

--- a/docs/pipeline-fsm.json
+++ b/docs/pipeline-fsm.json
@@ -9,6 +9,23 @@
     "daemon": "the host process — it launches agents, posts their started markers, and is the only thing with push credentials",
     "skill": "an agent running in a container, following the named prompt"
   },
+  "unclassified_markers": {
+    "doc": "Posted by the pipeline but deliberately not transitions: they record content or decorate the card, and the item's state is unchanged by them.",
+    "markers": [
+      "plan",
+      "bug-verdict",
+      "bug-verify",
+      "pipeline",
+      "close-failed",
+      "related-started",
+      "related",
+      "shipped-partial",
+      "handoff-check-unreadable",
+      "fix-summary",
+      "claim",
+      "stage-wait"
+    ]
+  },
   "states": [
     {
       "name": "filed",

--- a/internal/board/activity.go
+++ b/internal/board/activity.go
@@ -1,0 +1,93 @@
+package board
+
+import (
+	"strings"
+	"time"
+
+	"github.com/gethuman-sh/human/internal/agentstate"
+)
+
+// StagePrefix is the namespace a run writes its own phase records under. Every
+// pipeline stage already records one — stage.preflight, stage.triage,
+// stage.fix, stage.verify, stage.review, stage.pr-review — with a timestamp,
+// because the next stage (or a fresh agent taking over from one that died) reads
+// them back instead of re-deriving what it learned.
+const StagePrefix = "stage."
+
+// boardStages are the phase names the board's own columns already carry. They
+// are excluded from the activity read because they say nothing a card does not
+// already show: a card in the Fix column reporting "implementation" is noise,
+// while the same card reporting "verify" is the answer to the only question a
+// spinner cannot answer.
+var boardStages = map[string]bool{
+	"planning":       true,
+	"implementation": true,
+	"verification":   true,
+	"done":           true,
+	"ticket-review":  true,
+}
+
+// LatestActivity returns the most recent phase a run recorded, and when.
+//
+// This is the whole of what "is it progressing?" needs, and none of it is new
+// information: the records are written today, with timestamps, and the board has
+// simply never read them. Between [human:implementation-started] and
+// [human:ready-for-review] a fix run passes through triage, an adversarial
+// challenge, a plan, the fix itself and verification, and every one of those
+// collapses into a single unchanging "fixing…" — which reads exactly the same at
+// thirty seconds and at fourteen hours, and exactly the same when the agent
+// behind it has been dead since yesterday.
+//
+// Empty name means nothing was recorded, which is honest: a run that wrote no
+// phase gets no phase shown rather than an invented one.
+func LatestActivity(entries []agentstate.Entry) (string, time.Time) {
+	var name string
+	var at time.Time
+	for _, e := range entries {
+		phase, ok := strings.CutPrefix(e.Name, StagePrefix)
+		if !ok || phase == "" || boardStages[phase] {
+			continue
+		}
+		// A phase namespace can nest (stage.pr-review.round); the head is the phase.
+		if head, _, cut := strings.Cut(phase, "."); cut {
+			phase = head
+		}
+		if e.UpdatedAt.After(at) {
+			name, at = phase, e.UpdatedAt
+		}
+	}
+	return name, at
+}
+
+// ActivityLabel renders a recorded phase for a card badge: the run's own word for
+// what it is doing, in the reader's language rather than the pipeline's.
+// An unmapped phase is shown verbatim — a new stage should appear the day it is
+// added, not the day someone remembers to extend a table.
+func ActivityLabel(phase string) string {
+	switch phase {
+	case "":
+		return ""
+	case "preflight":
+		return "checking scope"
+	case "triage":
+		return "reproducing"
+	case "challenge":
+		return "challenging the verdict"
+	case "fix":
+		return "writing the fix"
+	case "verify":
+		return "verifying"
+	case "review":
+		return "reviewing"
+	case "opinion":
+		return "second opinion"
+	case "pr-review":
+		return "reviewing the PR"
+	case "pr-fix":
+		return "addressing review findings"
+	case "deploy-fix":
+		return "recovering the deploy"
+	default:
+		return phase
+	}
+}

--- a/internal/board/activity_test.go
+++ b/internal/board/activity_test.go
@@ -1,0 +1,59 @@
+package board_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gethuman-sh/human/internal/agentstate"
+	"github.com/gethuman-sh/human/internal/board"
+)
+
+func TestLatestActivity_TakesTheNewestPhase(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	entries := []agentstate.Entry{
+		{Name: "stage.triage", UpdatedAt: base},
+		{Name: "stage.fix", UpdatedAt: base.Add(10 * time.Minute)},
+		{Name: "stage.verify", UpdatedAt: base.Add(20 * time.Minute)},
+	}
+
+	name, at := board.LatestActivity(entries)
+
+	assert.Equal(t, "verify", name)
+	assert.Equal(t, base.Add(20*time.Minute), at)
+}
+
+// The board's own columns already say these, so repeating them tells the reader
+// nothing they cannot see. stage.implementation in particular is the board stage
+// the whole fix run reports under — showing it would restate the column.
+func TestLatestActivity_IgnoresPhasesTheColumnAlreadyShows(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	entries := []agentstate.Entry{
+		{Name: "stage.fix", UpdatedAt: base},
+		{Name: "stage.implementation", UpdatedAt: base.Add(time.Hour)},
+	}
+
+	name, _ := board.LatestActivity(entries)
+
+	assert.Equal(t, "fix", name, "the run's own phase is the informative one")
+}
+
+// A run that recorded nothing gets nothing shown. Inventing a phase would be the
+// same failure as the spinner: an assertion nobody checked.
+func TestLatestActivity_SaysNothingWhenNothingWasRecorded(t *testing.T) {
+	name, at := board.LatestActivity(nil)
+	assert.Empty(t, name)
+	assert.True(t, at.IsZero())
+
+	name, _ = board.LatestActivity([]agentstate.Entry{{Name: "capabilities", UpdatedAt: time.Now()}})
+	assert.Empty(t, name, "only the stage namespace describes a phase")
+}
+
+func TestActivityLabel_ReadsAsWorkNotAsPipelineVocabulary(t *testing.T) {
+	assert.Equal(t, "reproducing", board.ActivityLabel("triage"))
+	assert.Equal(t, "verifying", board.ActivityLabel("verify"))
+	assert.Empty(t, board.ActivityLabel(""))
+	assert.Equal(t, "brand-new-phase", board.ActivityLabel("brand-new-phase"),
+		"an unmapped phase shows the day it is added, not the day a table is remembered")
+}

--- a/internal/board/compose.go
+++ b/internal/board/compose.go
@@ -64,6 +64,7 @@ func Compose(results []daemon.TrackerIssuesResult, dockerAvailable bool) daemon.
 			ResumeAt:               card.ResumeAt,
 			Verdict:                card.Verdict,
 			VerdictFailed:          daemon.VerdictFailed(card.Verdict),
+			StageDaemonID:          card.StageDaemonID,
 			ShippedPartial:         card.ShippedPartial,
 			ShippedPartialFollowOn: card.ShippedPartialFollowOn,
 			StageEnteredAt:         formatStageTime(card.StageEnteredAt),

--- a/internal/board/compose.go
+++ b/internal/board/compose.go
@@ -63,6 +63,7 @@ func Compose(results []daemon.TrackerIssuesResult, dockerAvailable bool) daemon.
 			Error:                  card.Error,
 			ResumeAt:               card.ResumeAt,
 			Verdict:                card.Verdict,
+			VerdictFailed:          daemon.VerdictFailed(card.Verdict),
 			ShippedPartial:         card.ShippedPartial,
 			ShippedPartialFollowOn: card.ShippedPartialFollowOn,
 			StageEnteredAt:         formatStageTime(card.StageEnteredAt),

--- a/internal/board/compose_test.go
+++ b/internal/board/compose_test.go
@@ -406,3 +406,21 @@ func TestCompose_shipsTheVerdictDecisionNotTheString(t *testing.T) {
 	assert.False(t, cardByKey(t, view, "SC-3").VerdictFailed)
 	assert.False(t, cardByKey(t, view, "SC-4").VerdictFailed, "absence of a verdict is not failure")
 }
+
+// Ownership must reach the reader. The daemon already refuses to take over a
+// stage a peer stamped (WorkGate.ownedHereOrUnowned), but the fact stopped at the
+// daemon — so a board with several machines could not tell "no agent running
+// here" from "dead", which are the same observation and opposite conclusions.
+func TestCompose_CarriesTheOwningMachine(t *testing.T) {
+	view := Compose([]daemon.TrackerIssuesResult{pmResult(
+		[]tracker.Issue{{Key: "SC-1", Title: "owned elsewhere"}, {Key: "SC-2", Title: "unowned"}},
+		map[string]daemon.BoardCard{
+			"SC-1": {Stage: daemon.BoardImplementation, State: daemon.BoardRunning, StageDaemonID: "andre"},
+			"SC-2": {Stage: daemon.BoardImplementation, State: daemon.BoardRunning},
+		},
+	)}, true)
+
+	assert.Equal(t, "andre", cardByKey(t, view, "SC-1").StageDaemonID)
+	assert.Empty(t, cardByKey(t, view, "SC-2").StageDaemonID,
+		"a single-daemon install stamps nothing, and absence must not read as a machine named \"\"")
+}

--- a/internal/board/compose_test.go
+++ b/internal/board/compose_test.go
@@ -377,3 +377,32 @@ func TestCompose_OnlyWaitingRelationsBadge(t *testing.T) {
 
 	assert.Empty(t, cardByKey(t, view, "SC-2").Blockers)
 }
+
+// The board must never re-derive whether a verdict blocks the card: Compose
+// ships the daemon's own answer. "incomplete" is the case that mattered — the
+// frontend's private prefix test matched only "fail", so an incomplete review
+// (acceptance criteria unmet) put the card in Ready to Deploy and withheld the
+// rework gesture, while the daemon refused every Deploy drop. Both verdicts
+// must arrive already decided, and a card with no verdict must not read failed.
+func TestCompose_shipsTheVerdictDecisionNotTheString(t *testing.T) {
+	view := Compose([]daemon.TrackerIssuesResult{pmResult(
+		[]tracker.Issue{
+			{Key: "SC-1", Title: "failed"},
+			{Key: "SC-2", Title: "incomplete"},
+			{Key: "SC-3", Title: "passed"},
+			{Key: "SC-4", Title: "no verdict yet"},
+		},
+		map[string]daemon.BoardCard{
+			"SC-1": {Stage: daemon.BoardVerification, State: daemon.BoardDone, Verdict: "fail — three findings"},
+			"SC-2": {Stage: daemon.BoardVerification, State: daemon.BoardDone, Verdict: "incomplete"},
+			"SC-3": {Stage: daemon.BoardVerification, State: daemon.BoardDone, Verdict: "pass"},
+			"SC-4": {Stage: daemon.BoardImplementation, State: daemon.BoardRunning},
+		},
+	)}, true)
+
+	assert.True(t, cardByKey(t, view, "SC-1").VerdictFailed, "a fail verdict must arrive already decided")
+	assert.True(t, cardByKey(t, view, "SC-2").VerdictFailed,
+		"an incomplete verdict blocks the deploy exactly like a fail — the divergence that stranded cards")
+	assert.False(t, cardByKey(t, view, "SC-3").VerdictFailed)
+	assert.False(t, cardByKey(t, view, "SC-4").VerdictFailed, "absence of a verdict is not failure")
+}

--- a/internal/daemon/board_markers.go
+++ b/internal/daemon/board_markers.go
@@ -151,7 +151,7 @@ const (
 	// newest done-stage marker the badge reads "PR review…", so without this the
 	// card kept claiming a review was in flight for the whole of the CI gate,
 	// rebase and merge.
-	PRReviewPassedHeader = "[human:pr-review-passed]"
+	PRReviewPassedHeader = "[human:pr-review-passed]" // #nosec G101 -- a marker header; "Passed" trips the credential-name heuristic
 
 	// DeployFixStartedHeader marks the deploy stage's automated fixer sub-phase
 	// (SC-1557): a CI failure or rebase conflict at the deploy gate dispatches the

--- a/internal/daemon/board_markers.go
+++ b/internal/daemon/board_markers.go
@@ -246,6 +246,19 @@ func hasCompletedRelatedRecord(comments []tracker.Comment) bool {
 // place to resume from rather than a ticket to refuse (SC-2986).
 const BugVerdictHeader = "[human:bug-verdict]"
 
+// BugVerifyHeader marks the verify stage's done-gate verdict
+// ([human:bug-verify] DONE|NOT DONE). Like BugVerdictHeader it is the run's
+// permanent evidence, NOT a stage transition, and it is deliberately kept out of
+// orderedMarkerSpecs: both verdicts leave the item inside the fix run. DONE
+// leads to the handoff, which is the marker that actually moves the card, and
+// NOT DONE loops back to the fix while the retry budget holds.
+//
+// It had no constant here at all until the pipeline-machine conformance test
+// asked for one — it existed only as a validation spec in internal/marker, which
+// is how it ended up being a marker the prompts post eight times over and the
+// board had never been told about in either direction.
+const BugVerifyHeader = "[human:bug-verify]"
+
 // hasBugVerdict reports whether the ticket carries a triage verdict comment —
 // the marker heuristic a recovery relaunch falls back on when no ticket-kind
 // Getter is wired. The closing bracket keeps it from matching an unrelated

--- a/internal/daemon/board_markers.go
+++ b/internal/daemon/board_markers.go
@@ -142,6 +142,16 @@ const (
 	PRReviewStartedHeader = "[human:pr-review-started]"
 	PRFixStartedHeader    = "[human:pr-fix-started]"
 	PRReviewFailedHeader  = "[human:pr-review-failed]"
+	// PRReviewPassedHeader records the loop CONVERGING: the reviewer approved and
+	// the card proceeds to the CI gate and merge. Every other outcome of the loop
+	// already left a marker — both launches and the escalation — so success was
+	// the one transition the thread did not record, and a reader could not tell
+	// "the review passed, the merge is running" from "the review is still going".
+	// It is also what retires the loop sub-phase: while a *-started marker is the
+	// newest done-stage marker the badge reads "PR review…", so without this the
+	// card kept claiming a review was in flight for the whole of the CI gate,
+	// rebase and merge.
+	PRReviewPassedHeader = "[human:pr-review-passed]"
 
 	// DeployFixStartedHeader marks the deploy stage's automated fixer sub-phase
 	// (SC-1557): a CI failure or rebase conflict at the deploy gate dispatches the
@@ -333,6 +343,7 @@ var orderedMarkerSpecs = []markerSpec{
 	{DeployFailedHeader, BoardDoneStage, BoardFailed},
 	{PRReviewStartedHeader, BoardDoneStage, BoardRunning},
 	{PRFixStartedHeader, BoardDoneStage, BoardRunning},
+	{PRReviewPassedHeader, BoardDoneStage, BoardRunning},
 	{PRReviewFailedHeader, BoardDoneStage, BoardFailed},
 	{DeployFixStartedHeader, BoardDoneStage, BoardRunning},
 	{PlanningOutageHeader, BoardPlanning, BoardOutage},

--- a/internal/daemon/board_state_test.go
+++ b/internal/daemon/board_state_test.go
@@ -871,3 +871,35 @@ func TestDeriveBoardCard_APassingLoopRetiresTheReviewPhase(t *testing.T) {
 	assert.Equal(t, BoardRunning, card.State, "the merge is still work in progress")
 	assert.Empty(t, card.DeployPhase, "the review is over — the card must stop saying 'PR review…'")
 }
+
+// SC-3615: the deploy fixer's escalation told the reader to "check the PR and
+// its CI, then re-run Deploy" and named nothing. Re-running changes nothing
+// about the branch, so the same check fails identically — the card's one offered
+// move reproduced its own failure. The cause was on the ticket the whole time:
+// the gate writes the failing checks onto the deploy-fix-started marker when it
+// dispatches the fixer.
+func TestDeployFixEscalation_NamesTheFailureAndRefusesAPointlessRetry(t *testing.T) {
+	dispatched := "CI checks failed on the pull request (failing: frontend-test) — fix the failing checks, then re-run Deploy"
+
+	reason := deployFixEscalationReason(ExitRetryable, dispatched)
+	assert.Contains(t, reason, "frontend-test", "the blocking check must be named on the card")
+	assert.Contains(t, reason, "will hit the same failure", "a retry that cannot work must not be the advice")
+
+	// With nothing recorded there is nothing to name, and the old wording stands
+	// rather than inventing a cause.
+	assert.Equal(t,
+		"the deploy fixer stopped without recovering the deploy — check the PR and its CI, then re-run Deploy",
+		deployFixEscalationReason(ExitRetryable, ""))
+}
+
+// The headline is recovered from the newest dispatch, so a second round names
+// what the second dispatch was sent to fix rather than the first.
+func TestDispatchedFailure_TakesTheNewestDispatch(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	comments := []tracker.Comment{
+		{Body: DeployFixStartedHeader + "\nthe first failure\npr: u\nnumber: 1\nbranch: b", Created: base},
+		{Body: DeployFixStartedHeader + "\nthe second failure\npr: u\nnumber: 1\nbranch: b", Created: base.Add(time.Minute)},
+	}
+	assert.Equal(t, "the second failure", dispatchedFailure(comments))
+	assert.Empty(t, dispatchedFailure(nil), "no dispatch recorded means nothing to quote")
+}

--- a/internal/daemon/board_state_test.go
+++ b/internal/daemon/board_state_test.go
@@ -848,3 +848,26 @@ func TestIsTerminalResolution(t *testing.T) {
 		assert.True(t, isTerminalResolution(NothingToDoHeader+"\nmachine: 4f3add9a\nbuild: abc123\n\nevidence: merged"))
 	})
 }
+
+// Both launches of the PR review→fix loop post a marker, and so does its
+// escalation — success was the only outcome that recorded nothing. A reader, or
+// a daemon that restarted, could not tell an approved review whose merge is
+// running from a review still in flight. The passing marker also retires the
+// loop sub-phase, so the badge stops claiming a review is in progress for the
+// whole of the CI gate, rebase and merge.
+func TestDeriveBoardCard_APassingLoopRetiresTheReviewPhase(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	loop := []tracker.Comment{
+		{Body: DeployStartedHeader, Created: base},
+		{Body: PRReviewStartedHeader, Created: base.Add(time.Minute)},
+	}
+	mid := DeriveBoardCard(loop, tracker.CategoryUnstarted, false)
+	assert.Equal(t, "pr-review", mid.DeployPhase, "while the loop runs the card names the sub-phase")
+
+	passed := append(loop, tracker.Comment{Body: PRReviewPassedHeader, Created: base.Add(2 * time.Minute)})
+	card := DeriveBoardCard(passed, tracker.CategoryUnstarted, false)
+
+	assert.Equal(t, BoardDoneStage, card.Stage)
+	assert.Equal(t, BoardRunning, card.State, "the merge is still work in progress")
+	assert.Empty(t, card.DeployPhase, "the review is over — the card must stop saying 'PR review…'")
+}

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gethuman-sh/human/errors"
 	"github.com/gethuman-sh/human/internal/forge"
+	"github.com/gethuman-sh/human/internal/marker"
 	"github.com/gethuman-sh/human/internal/tracker"
 	"github.com/gethuman-sh/human/internal/vault"
 )
@@ -1168,22 +1169,23 @@ func (d BoardTransitionDeps) AdvanceDeployFix(ctx context.Context, pmKey string,
 func dispatchedFailure(comments []tracker.Comment) string {
 	var headline string
 	for _, c := range comments {
-		trimmed := strings.TrimSpace(c.Body)
-		if !strings.HasPrefix(trimmed, DeployFixStartedHeader) {
+		// ParseBody, never line position: a signed marker carries machine:/build:
+		// between the header and the prose, so "the line after the header" is a
+		// signature field rather than the diagnosis.
+		m, ok := marker.ParseBody(c.Body)
+		if !ok || m.Type != deployFixStartedType {
 			continue
 		}
-		// The headline is the first body line after the header; the pr/number/
-		// branch binding follows it.
-		lines := strings.Split(strings.TrimPrefix(trimmed, DeployFixStartedHeader), "\n")
-		for _, line := range lines {
-			if line = strings.TrimSpace(line); line != "" && !strings.Contains(line, ": ") {
-				headline = line
-				break
-			}
+		if line, _, _ := strings.Cut(strings.TrimSpace(m.Body), "\n"); line != "" {
+			headline = line
 		}
 	}
 	return headline
 }
+
+// deployFixStartedType is DeployFixStartedHeader's marker type — the name
+// marker.ParseBody reports, without the human: prefix and brackets.
+const deployFixStartedType = "deploy-fix-started"
 
 // deployFixEscalationReason renders the actionable headline the failed marker shows
 // when the deploy fixer did not converge.

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -130,6 +130,22 @@ type BoardTransitionRequest struct {
 	// human-initiated drop, whose interval is deliberation, not a pipeline wait,
 	// and is never recorded.
 	Cause WaitCause `json:"cause,omitempty"`
+	// Reopen restarts a stage the pipeline RESOLVED — a [human:nothing-to-do] or
+	// [human:no-fix-needed] terminal a person judges wrong.
+	//
+	// It is a separate flag rather than another state in the retry predicates
+	// because the automatic relaunch drives the very same path (StageRetry's
+	// Relaunch calls this request with From == To). Widening isBuildRetry or
+	// isPlanningRetry to accept resolved would hand the machine permission to
+	// re-run its own clean terminals forever, which is precisely what "never red,
+	// never retried" exists to prevent. Only a human sets this.
+	//
+	// Without it a resolved card was unrecoverable: no gesture moved it, because
+	// the retry paths key on failed or outage and the forward path requires done.
+	// A wrong not-a-bug verdict could only be undone by editing the tracker by
+	// hand — which is why the verdict must survive an adversarial challenge
+	// before it is trusted at all.
+	Reopen bool `json:"reopen,omitempty"`
 }
 
 // BoardTransitionDeps wires the transition engine's collaborators.
@@ -342,6 +358,14 @@ func (d BoardTransitionDeps) dispatchNonForwardMove(ctx context.Context, req Boa
 			WaitCauseChain, true)
 		return true, launched, err
 
+	// Re-open: a person judged a resolved terminal wrong. Dispatched before the
+	// retry rules because a resolved card matches none of them by design — the
+	// machine must never re-run its own clean terminal, and only this explicitly
+	// human flag reaches here.
+	case req.Reopen && card.State == BoardResolved:
+		launched, err := d.reopenResolved(ctx, req, card, comments)
+		return true, launched, err
+
 	// Planning retry: a failed planning run is relaunched in place. The retry
 	// gesture targets planning while the card already derives to planning, so
 	// the single-step rule would reject it and the gesture would launch nothing
@@ -397,6 +421,39 @@ func (d BoardTransitionDeps) dispatchNonForwardMove(ctx context.Context, req Boa
 		return true, err == nil, err
 	}
 	return false, false, nil
+}
+
+// reopenResolved restarts the stage that resolved the card, on a person's say-so.
+//
+// It relaunches the same stage the terminal was posted in: a
+// [human:nothing-to-do] card re-plans, and a [human:no-fix-needed] card re-runs
+// the fix — through its own self-planning pipeline where it has one, so an
+// autofix run that wrongly concluded not-a-bug re-triages rather than being
+// handed to the plan executor, which would refuse it for having no plan.
+//
+// The relaunch's *-started marker is strictly newer than the terminal, so the
+// card leaves resolved by the derivation's ordinary rules; nothing needs to
+// retract the terminal, and the trail keeps both the verdict and the decision to
+// overrule it.
+func (d BoardTransitionDeps) reopenResolved(ctx context.Context, req BoardTransitionRequest, card BoardCard, comments []tracker.Comment) (bool, error) {
+	if card.Stage == BoardPlanning {
+		return d.startAgentStage(ctx, req.PMKey, BoardPlanning, PlanningStartedHeader,
+			planPrompt(req.PMKey)+" — a person re-opened this ticket after it was resolved as nothing to do;"+
+				" re-examine it rather than repeating the earlier conclusion",
+			WaitCause(""), false)
+	}
+	switch d.classifyFixPipeline(ctx, req.PMKey, comments) {
+	case fixBug:
+		err := d.ApplyFix(ctx, BoardFixRequest{PMKey: req.PMKey, PMTitle: req.PMTitle})
+		return err == nil, err
+	case fixSecurity:
+		err := d.ApplySecurityFix(ctx, SecurityFixRequest{PMKey: req.PMKey, PMTitle: req.PMTitle})
+		return err == nil, err
+	}
+	return d.startAgentStage(ctx, req.PMKey, BoardImplementation, ImplementationStartedHeader,
+		executePrompt(dispatchKey(req.PMKey, card),
+			" — a person re-opened this ticket after it was resolved as needing no fix"),
+		WaitCause(""), true)
 }
 
 // launchForwardStage dispatches an already-sanctioned forward transition to

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -1099,19 +1099,59 @@ func (d BoardTransitionDeps) AdvanceDeployFix(ctx context.Context, pmKey string,
 		return d.DeployBranch(ctx, pmKey, pmKey, doneBody(pmKey, card), card.Branch)
 	}
 	_, _ = d.Commenter.AddComment(ctx, pmKey,
-		DeployFailedHeader+"\n"+deployFixEscalationReason(fixExit))
+		DeployFailedHeader+"\n"+deployFixEscalationReason(fixExit, dispatchedFailure(comments)))
 	return nil
+}
+
+// dispatchedFailure recovers WHAT the deploy fixer was sent to fix: the headline
+// the gate wrote onto the newest [human:deploy-fix-started] marker, which for a
+// CI failure already names the failing checks ("CI checks failed on the pull
+// request (failing: frontend-test)"). The escalation had this on the ticket all
+// along and quoted none of it.
+func dispatchedFailure(comments []tracker.Comment) string {
+	var headline string
+	for _, c := range comments {
+		trimmed := strings.TrimSpace(c.Body)
+		if !strings.HasPrefix(trimmed, DeployFixStartedHeader) {
+			continue
+		}
+		// The headline is the first body line after the header; the pr/number/
+		// branch binding follows it.
+		lines := strings.Split(strings.TrimPrefix(trimmed, DeployFixStartedHeader), "\n")
+		for _, line := range lines {
+			if line = strings.TrimSpace(line); line != "" && !strings.Contains(line, ": ") {
+				headline = line
+				break
+			}
+		}
+	}
+	return headline
 }
 
 // deployFixEscalationReason renders the actionable headline the failed marker shows
 // when the deploy fixer did not converge.
-func deployFixEscalationReason(fixExit StageExit) string {
+//
+// It names the condition that is blocking, and it does not offer a gesture that
+// cannot work. "Re-run Deploy" was the only instruction the default case gave,
+// and re-running changes nothing about the branch — so the same check fails the
+// same way, which is what SC-3615 recorded: a card whose one offered move
+// reproduced its own failure, and whose actual cause (a single red check) took
+// three queries to establish though it was written on the ticket already.
+func deployFixEscalationReason(fixExit StageExit, dispatched string) string {
+	blocking := ""
+	if dispatched != "" {
+		blocking = " The failure it was sent to fix: " + dispatched
+	}
 	switch fixExit {
 	case ExitNeedsInput:
-		return "the deploy fixer needs a human decision — read the PR and its CI, decide, then re-run Deploy"
+		return "the deploy fixer needs a human decision — read the PR and its CI, decide, then re-run Deploy." + blocking
 	case ExitNeedsHumanWork:
-		return "the deploy failure needs manual work the fixer could not do — resolve it on the branch, then re-run Deploy"
+		return "the deploy failure needs manual work the fixer could not do — resolve it on the branch, then re-run Deploy." + blocking
 	default:
+		if dispatched != "" {
+			return "the deploy fixer could not recover the deploy. Fix it on the branch and push — " +
+				"re-running Deploy alone will hit the same failure." + blocking
+		}
 		return "the deploy fixer stopped without recovering the deploy — check the PR and its CI, then re-run Deploy"
 	}
 }

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -944,6 +944,19 @@ func (d BoardTransitionDeps) AdvancePRLoop(ctx context.Context, pmKey string, ou
 		}
 		return d.launchPRLoopAgent(ctx, pmKey, prFixAgentStage, prFixDispatch(pmKey, number, branch))
 	case PRActionMerge:
+		// Record the loop converging BEFORE acting on it. Both launches and the
+		// escalation already post a marker, so without this the one outcome the
+		// thread never recorded was success — and it is the outcome a reader most
+		// needs, because it is what separates "the review passed, the merge is
+		// running" from "the review is still going". Posting it also retires the
+		// loop sub-phase, so the badge stops saying "PR review…" for the whole of
+		// the CI gate, rebase and merge that follow. A failure to post is not
+		// fatal: the merge is the work, and refusing to ship over a missing
+		// comment would trade a lost sentence for lost code.
+		if _, err := d.Commenter.AddComment(ctx, pmKey, PRReviewPassedHeader); err != nil {
+			d.Logger.Warn().Err(err).Str("pm", pmKey).
+				Msg("board PR loop: could not record the passing review; continuing to the merge")
+		}
 		if err := d.Deployer.MarkReadyForReview(ctx, d.WorkspaceDir, number); err != nil {
 			return d.deployFailed(pmKey, url, deployReason(
 				"the reviewed PR could not be marked ready for merge — open the PR and mark it ready, then re-run Deploy", err))

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -2346,3 +2346,43 @@ func TestPlanPromptNamesTheTerminalMarkerForUnplannableVerdicts(t *testing.T) {
 	assert.Contains(t, p, "re-plans the ticket forever",
 		"the dispatch must say what happens without the marker, so the rule is not dropped as boilerplate")
 }
+
+// A resolved card was unrecoverable: the retry paths key on failed or outage and
+// the forward path requires done, so a nothing-to-do or no-fix-needed terminal a
+// person judged wrong could only be undone by editing the tracker by hand.
+func TestApplyTransition_ReopenRestartsAResolvedStage(t *testing.T) {
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt(PlanningStartedHeader, time.Unix(1, 0)),
+		cmt(NothingToDoHeader+"\nevidence: already merged", time.Unix(2, 0)),
+	}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+
+	err := deps.ApplyTransition(context.Background(),
+		BoardTransitionRequest{PMKey: "SC-1", From: BoardPlanning, To: BoardPlanning, Reopen: true})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, l.calls, "re-opening must actually relaunch the stage")
+	require.NotEmpty(t, c.added)
+	assert.Contains(t, c.added[len(c.added)-1], PlanningStartedHeader,
+		"the fresh started marker is what carries the card out of resolved")
+}
+
+// The machine must never re-run its own clean terminal. The automatic relaunch
+// drives the identical request (From == To) without the flag, so the flag is the
+// only thing separating a person overruling a verdict from the retry loop
+// deciding to have another go at one.
+func TestApplyTransition_AResolvedCardIsNotRetriedWithoutReopen(t *testing.T) {
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt(ImplementationStartedHeader, time.Unix(1, 0)),
+		cmt(NoFixNeededHeader+"\nverdict: not-a-bug", time.Unix(2, 0)),
+	}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+
+	err := deps.ApplyTransition(context.Background(),
+		BoardTransitionRequest{PMKey: "SC-1", From: BoardImplementation, To: BoardImplementation})
+
+	require.Error(t, err, "an unflagged same-stage move on a resolved card is not a retry the machine may make")
+	assert.Zero(t, l.calls)
+}

--- a/internal/daemon/pipeline_fsm_doc_test.go
+++ b/internal/daemon/pipeline_fsm_doc_test.go
@@ -1,0 +1,189 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// docs/pipeline-fsm.json is the written-down machine. These tests are what stop
+// it drifting from the code, which is the failure that produced every defect it
+// describes: a marker the prompts post that the daemon has never been told
+// about, a state named in one place and not the other, a transition that exists
+// in the prose and nowhere else.
+//
+// Kept as a test rather than a separate tool so `make check` runs it and a
+// change to the machine cannot merge without the description following it.
+
+type fsmDoc struct {
+	Initial string `json:"initial"`
+	States  []struct {
+		Name     string `json:"name"`
+		Terminal bool   `json:"terminal"`
+	} `json:"states"`
+	Events []struct {
+		Name   string   `json:"name"`
+		Src    []string `json:"src"`
+		Dst    string   `json:"dst"`
+		Marker string   `json:"marker"`
+	} `json:"events"`
+	Unclassified struct {
+		Markers []string `json:"markers"`
+	} `json:"unclassified_markers"`
+}
+
+func loadFSMDoc(t *testing.T) fsmDoc {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "docs", "pipeline-fsm.json"))
+	require.NoError(t, err, "the pipeline machine must be readable")
+	var doc fsmDoc
+	require.NoError(t, json.Unmarshal(raw, &doc), "the pipeline machine must be valid JSON")
+	require.NotEmpty(t, doc.States)
+	require.NotEmpty(t, doc.Events)
+	return doc
+}
+
+// Topology has to hold on its own terms: a transition may not come from or lead
+// to a state nobody declared, and no two transitions may share a name (the name
+// is the alphabet, and a duplicate silently shadows one of them).
+func TestPipelineFSM_TopologyIsSound(t *testing.T) {
+	doc := loadFSMDoc(t)
+	states := map[string]bool{}
+	for _, s := range doc.States {
+		require.False(t, states[s.Name], "duplicate state %q", s.Name)
+		states[s.Name] = true
+	}
+	require.True(t, states[doc.Initial], "the initial state %q must be declared", doc.Initial)
+
+	seen := map[string]bool{}
+	for _, e := range doc.Events {
+		require.NotEmpty(t, e.Name, "every transition needs a name")
+		require.False(t, seen[e.Name], "duplicate transition name %q", e.Name)
+		seen[e.Name] = true
+		require.NotEmpty(t, e.Src, "%s: a transition needs at least one source", e.Name)
+		require.True(t, states[e.Dst], "%s: dst %q is not a declared state", e.Name, e.Dst)
+		for _, s := range e.Src {
+			require.True(t, states[s], "%s: src %q is not a declared state", e.Name, s)
+		}
+	}
+}
+
+// Every state must be reachable and every non-terminal state must have a way
+// out. A state nothing reaches is dead description; a non-terminal state with no
+// exit is a trap the machine can enter and never leave.
+func TestPipelineFSM_NoUnreachableStatesAndNoDeadEnds(t *testing.T) {
+	doc := loadFSMDoc(t)
+
+	reached := map[string]bool{doc.Initial: true}
+	for range doc.States {
+		for _, e := range doc.Events {
+			for _, s := range e.Src {
+				if reached[s] {
+					reached[e.Dst] = true
+				}
+			}
+		}
+	}
+	exits := map[string]bool{}
+	for _, e := range doc.Events {
+		for _, s := range e.Src {
+			if e.Dst != s {
+				exits[s] = true
+			}
+		}
+	}
+	for _, s := range doc.States {
+		require.True(t, reached[s.Name], "state %q is unreachable from %q", s.Name, doc.Initial)
+		if !s.Terminal {
+			require.True(t, exits[s.Name], "state %q is not terminal and has no way out", s.Name)
+		}
+	}
+}
+
+// Marker strings in the document must be real. Checked against the daemon's own
+// header constants rather than a grep, so a renamed constant fails here instead
+// of leaving the document quietly describing a marker that no longer exists.
+func TestPipelineFSM_MarkersExist(t *testing.T) {
+	doc := loadFSMDoc(t)
+	known := map[string]bool{}
+	for _, h := range []string{
+		TicketReviewStartedHeader, TicketReviewedHeader,
+		PlanningStartedHeader, PlanReadyHeader, PlanningFailedHeader, NothingToDoHeader,
+		ImplementationStartedHeader, ImplementationFailedHeader, NeedsPlanningHeader, NoFixNeededHeader,
+		ReadyForReviewHeader, ReviewStartedHeader, ReviewCompleteHeader, ReviewFailedHeader,
+		PRStartedHeader, PRPushedHeader, PRFailedHeader,
+		DeployStartedHeader, DeployedHeader, DeployFailedHeader,
+		PRReviewStartedHeader, PRFixStartedHeader, PRReviewFailedHeader, PRReviewPassedHeader,
+		DeployFixStartedHeader,
+		PlanningOutageHeader, ImplementationOutageHeader, ReviewOutageHeader, DeployOutageHeader,
+		PlanCommentHeader, CloseFailedHeader, RelatedStartedHeader, RelatedHeader,
+		ShippedPartialHeader, BugVerdictHeader, BugVerifyHeader, PipelineStartedHeader, HandoffCheckUnreadableHeader,
+		OptionsHeader, OptionChosenHeader, ClaimHeader,
+	} {
+		known[h] = true
+	}
+	for _, e := range doc.Events {
+		if e.Marker == "" {
+			continue
+		}
+		// One transition may record any of several per-stage markers.
+		for _, m := range strings.Split(e.Marker, " | ") {
+			require.True(t, known[strings.TrimSpace(m)],
+				"%s: marker %q is not a marker this daemon defines", e.Name, m)
+		}
+	}
+}
+
+// The rule that catches the most, and the one that would have caught bug-verify:
+// every marker an agent prompt is told to post must be EITHER a transition in
+// the document OR listed as deliberately not one. Never neither — a marker in
+// neither list is one the prompts treat as meaningful and the code has never
+// been told about.
+func TestPipelineFSM_EveryPromptedMarkerIsAccountedFor(t *testing.T) {
+	doc := loadFSMDoc(t)
+
+	accounted := map[string]bool{}
+	for _, e := range doc.Events {
+		for _, m := range strings.Split(e.Marker, " | ") {
+			m = strings.TrimSpace(m)
+			m = strings.TrimSuffix(strings.TrimPrefix(m, "[human:"), "]")
+			if m != "" {
+				accounted[m] = true
+			}
+		}
+	}
+	for _, m := range doc.Unclassified.Markers {
+		accounted[m] = true
+	}
+	// The handoff is posted by `human handoff post`, not `human marker post`.
+	accounted["ready-for-review"] = true
+
+	dir := filepath.Join("..", "claude", "embed")
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	posts := regexp.MustCompile(`marker post [^ ]+ ([a-z][a-z-]+)`)
+
+	var orphans []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		require.NoError(t, err)
+		for _, m := range posts.FindAllStringSubmatch(string(body), -1) {
+			if !accounted[m[1]] {
+				orphans = append(orphans, m[1]+" (posted by "+entry.Name()+")")
+			}
+		}
+	}
+	sort.Strings(orphans)
+	require.Empty(t, orphans,
+		"these markers are posted by a prompt but are neither a transition nor listed as deliberately not one — "+
+			"decide which they are and record it in docs/pipeline-fsm.json")
+}

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -167,6 +167,16 @@ type BoardViewCard struct {
 	// Verdict is the latest review's verdict line; a failing verdict pins the
 	// card in the Code lane with a warning instead of letting it advance.
 	Verdict string `json:"verdict,omitempty"`
+	// Activity is the phase the run itself last recorded (stage.triage,
+	// stage.verify, …), and ActivityAt is when. The records already exist —
+	// every stage writes one with a timestamp so the next stage can read it
+	// back — and the card has simply never shown them. Without it the entire fix
+	// run, from triage through the adversarial challenge, the plan, the fix and
+	// verification, renders as one unchanging "fixing…" that looks identical at
+	// thirty seconds, at fourteen hours, and when the agent behind it died
+	// yesterday afternoon. Empty when the run recorded no phase.
+	Activity   string `json:"activity,omitempty"`
+	ActivityAt string `json:"activityAt,omitempty"`
 	// StageDaemonID is the machine that stamped the card's deciding marker — who
 	// owns the stage. The daemon already guards on it where it acts on its own
 	// (WorkGate.ownedHereOrUnowned refuses to take over a stage a peer stamped),

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -167,6 +167,16 @@ type BoardViewCard struct {
 	// Verdict is the latest review's verdict line; a failing verdict pins the
 	// card in the Code lane with a warning instead of letting it advance.
 	Verdict string `json:"verdict,omitempty"`
+	// StageDaemonID is the machine that stamped the card's deciding marker — who
+	// owns the stage. The daemon already guards on it where it acts on its own
+	// (WorkGate.ownedHereOrUnowned refuses to take over a stage a peer stamped),
+	// but the fact never reached the reader, and it is the missing input for the
+	// question a board with several daemons cannot otherwise answer: no agent
+	// running HERE means dead only if this machine owns the stage. Owned
+	// elsewhere, it means "being worked somewhere I cannot see", which is not the
+	// same thing and must not be rendered as if it were. Empty on a single-daemon
+	// install and on threads written before stages were stamped.
+	StageDaemonID string `json:"stageDaemonId,omitempty"`
 	// VerdictFailed is VerdictFailed(Verdict) computed HERE, so the board never
 	// re-derives it. The frontend used to run its own prefix test that matched
 	// only "fail", while the daemon's also matches "incomplete" — a verdict the

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -167,6 +167,16 @@ type BoardViewCard struct {
 	// Verdict is the latest review's verdict line; a failing verdict pins the
 	// card in the Code lane with a warning instead of letting it advance.
 	Verdict string `json:"verdict,omitempty"`
+	// VerdictFailed is VerdictFailed(Verdict) computed HERE, so the board never
+	// re-derives it. The frontend used to run its own prefix test that matched
+	// only "fail", while the daemon's also matches "incomplete" — a verdict the
+	// reviewer genuinely posts ("blocks deploy and loops the work back to be
+	// built, exactly like a fail"). The two answers disagreed by one word: the
+	// board put the card in Deploy and withheld the rework gesture while the
+	// daemon refused every drop, leaving the card with no move that could
+	// succeed. Shipping the decision instead of the input leaves the board
+	// nothing to get wrong.
+	VerdictFailed bool `json:"verdictFailed,omitempty"`
 	// ShippedPartial / ShippedPartialFollowOn surface the durable shipped-partial
 	// trace on the card (SC-2910): the ticket shipped with acceptance criteria
 	// deferred to the named follow-on ticket. The frontend renders a "partial


### PR DESCRIPTION
Ten defects found by checking `docs/pipeline-fsm.json` against the code, fixed as classes rather than instances. Base is `docs/pipeline-state-machine` (PR #410); the document is updated alongside every change, per the rule that PR adds to CLAUDE.md.

**1 — one source for classification.** `daemon.VerdictFailed` treats `fail` and `incomplete` as blocking; the board's own predicate matched only `fail`. The reviewer genuinely posts `incomplete`, so those cards sat in Ready to Deploy with no Rework gesture while the daemon refused every drop — a card with no move that could succeed. The daemon now ships the decision; the board no longer re-derives it.

**2 — a resolved terminal retires a dead run's claim (SC-3555, SC-1542).** A `*-started` marker claims work is in progress; a resolved terminal says the ticket needs none. The claim always won, because supersession fired only from failed or outage — states a reaped agent never reaches. Narrowed deliberately to *resolved*: two existing tests proved a `done` verdict or another `*-started` must not retire a claim.

**3 — a marker at every branch point.** The PR loop recorded both launches and its escalation but not its success. Added `pr-review-passed`, which also retires the loop sub-phase so the badge stops saying "PR review…" through the CI gate, rebase and merge.

**4 — the recorded phase reaches the card (SC-3569).** Every stage already writes `stage.<name>` with a timestamp; the board had never looked. Six phases rendered as one unchanging word.

**6 — failures name the condition (SC-3615).** The deploy-fixer escalation named nothing and advised a retry that reproduces the same failure. The cause was already on the ticket, written onto `deploy-fix-started` when the fixer was dispatched.

**7 — an explicit unknown state (SC-3554).** A tracker that fails to *load* landed in the same place as one that is unconfigured, so the board told people to add `role: pm` to a tracker that already had it. An empty board and an unreadable one look identical and mean opposite things.

**8 — a way back from the terminals.** Resolved cards had no gesture at all. Re-open is a separate entry point on purpose: the retry machinery drives the identical same-stage request, and the machine must never re-run its own clean terminal.

**9 — ownership reaches the reader.** `StageDaemonID` guarded the takeover path but stopped at the daemon, so a multi-daemon board could not tell "no agent here" from "dead".

**10 — the machine is now a checked contract.** Four Go tests in `make check`: topology, reachability and dead ends, marker existence against the header constants, and — the rule that would have caught `bug-verify` — every marker a prompt posts must be either a transition or listed as deliberately not one, never neither.

**Finding 5 was closed as not-a-bug.** A probe showed an escalated PR loop derives as *decision needed*, not running, and routing the choice to implementation is deliberate: the fixer raised a question only a code change can answer. The document was corrected instead of the code.

Two things worth noting about the work: a pair of existing tests caught fix 2 when my first rule was too broad, and the repo's protocol-boundary guard caught fix 6 parsing a marker body by line position. Both were right, and both are reflected in the final shape.

`make check` green.