### PR TITLE
[SC-3785] Tear an agent down when its claude exits, not when a Stop arrives

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -730,7 +730,7 @@ func runDaemonForeground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string,
 		logger.Warn().Err(err).Msg("hook upgrade failed")
 	}
 
-	go daemon.RunAgentCleanup(ctx, ds.srv.HookEvents, &dockerAgentCleaner{}, logger)
+	go daemon.RunAgentCleanup(ctx, ds.srv.HookEvents, &dockerAgentCleaner{}, agentClaudeAlive, logger)
 	hookEvents := ds.srv.HookEvents
 	go daemon.RunAgentZombieSweep(ctx, &dockerAgentSweeper{}, agentProgressWithInflight(hookEvents, inflight), func(agentName string, reason daemon.ReapReason) {
 		// A reaped agent died without firing hooks, so no exit event exists
@@ -4084,6 +4084,22 @@ func closeExecOnContextDone(ctx context.Context, resp devcontainer.ExecAttachRes
 		}
 	}()
 	return func() { close(done) }
+}
+
+// agentClaudeAlive reports whether the named agent's claude process is still
+// running, reusing the zombie sweep's own liveness check so both teardown paths
+// ask the container the same question. A missing meta or an empty container id
+// means there is nothing left to be alive; any other failure is returned so the
+// caller can decide (the cleanup listener treats unreachable as ended, SC-3785).
+func agentClaudeAlive(ctx context.Context, name string) (bool, error) {
+	meta, err := agent.ReadMeta(name)
+	if err != nil {
+		return false, err
+	}
+	if meta.ContainerID == "" {
+		return false, nil
+	}
+	return (&dockerAgentSweeper{}).IsProcessRunning(ctx, meta.ContainerID, "claude")
 }
 
 func (s *dockerAgentSweeper) DeleteAgent(ctx context.Context, name string) error {

--- a/docs/reaper.md
+++ b/docs/reaper.md
@@ -60,11 +60,29 @@ still made real hangs wait.
 the hook event store.
 
 A `Stop`, `SessionEnd`, or `StopFailure` event for an agent triggers a full
-`Delete` (container stopped and removed, meta deleted) one second later — the
-delay lets claude finish exiting. Events are tracked by monotonic sequence, not
-by agent name: board stage agents reuse the same deterministic name on every
-rebuild, and a name-keyed dedupe leaked the re-run's container and worktree
-(SC-201).
+`Delete` (container stopped and removed, meta deleted) — but **only once claude
+has actually exited**. The listener waits for that, polling every
+`cleanupExitPoll` = 1s for up to `cleanupExitWait` = 5 minutes.
+
+The wait is the whole point. An exit hook event carries the *container's* agent
+name, so a subagent's ending is indistinguishable from its parent's — and a
+parent that dispatched a subagent goes on working after it. Acting on the event
+alone destroyed live runs: the container was removed one second later, the 10s
+`ContainerStop` grace expired, and claude was SIGKILLed mid-tool-call, which the
+board then read as "the run stopped before finishing this stage" (SC-3785).
+
+So the event is a prompt to check, not a verdict:
+
+- **claude gone** → tear down, as before.
+- **claude still running when the budget runs out** → the event belonged to
+  somebody else. Leave the run alone; its own ending will arrive later, and a run
+  that instead dies silently is the zombie sweep's to catch.
+- **the agent cannot be probed** → treated as ended. Unreachable is not evidence
+  of a live run, and sparing it would strand containers on any docker hiccup.
+
+Events are tracked by monotonic sequence, not by agent name: board stage agents
+reuse the same deterministic name on every rebuild, and a name-keyed dedupe
+leaked the re-run's container and worktree (SC-201).
 
 This is the normal path. Everything below is the machine deciding for itself.
 
@@ -190,6 +208,8 @@ above.
 
 Collected in one place, because the spares are the load-bearing part:
 
+- **A run whose claude is still running when an exit event names it.** The event
+  was a subagent's; the run keeps working (SC-3785).
 - **An agent blocked on a permission prompt.** It is waiting for a person; a
   relaunch discards the question instead of answering it.
 - **An interactive (non-board) agent that is silent.** Only a board stage agent's
@@ -259,6 +279,9 @@ run's `outcome.json` does not.
 
 | Constant | Value | Where |
 | --- | --- | --- |
+| `cleanupExitPoll` | 1s | `internal/daemon/agentcleanup.go` |
+| `cleanupExitWait` | 5m | same |
+| `cleanupProbeTimeout` | 5s | same |
 | `zombieSweepInterval` | 5s | `internal/daemon/agentzombiesweep.go` |
 | `zombieGracePeriod` | 10s | same |
 | `zombieMaxProcessCheckFailures` | 3 (~15s) | same |

--- a/internal/daemon/agentcleanup.go
+++ b/internal/daemon/agentcleanup.go
@@ -19,9 +19,41 @@ type AgentCleaner interface {
 	StopContainer(ctx context.Context, containerID string) error
 }
 
-// RunAgentCleanup watches for SessionEnd hook events from devcontainer agents
-// and automatically stops the container and removes the worktree.
-func RunAgentCleanup(ctx context.Context, store *HookEventStore, cleaner AgentCleaner, logger zerolog.Logger) {
+// AgentProcessAlive reports whether the named agent's claude process is still
+// running. It is the evidence the cleanup listener needs because an exit hook
+// event does NOT prove the run ended: the events carry the container's agent
+// name, so a subagent's ending is indistinguishable from its parent's, and a
+// parent that dispatched a subagent goes on working after it (SC-3785). An
+// error means the agent could not be reached, which is treated as ended — the
+// same teardown that happened unconditionally before this signal existed.
+type AgentProcessAlive func(ctx context.Context, agentName string) (bool, error)
+
+var (
+	// cleanupExitPoll is how often the teardown re-asks whether claude has
+	// exited. Short: a normal ending must not feel slower than the previous
+	// fixed one-second wait.
+	cleanupExitPoll = 1 * time.Second
+	// cleanupExitWait bounds that wait. Past it the exit event is abandoned
+	// rather than acted on: the run is still going, so it will announce its
+	// real ending later, and a run that instead dies silently is the zombie
+	// sweep's job. Bounding it keeps a long-lived run from holding a goroutine
+	// for its whole life.
+	cleanupExitWait = 5 * time.Minute
+	// cleanupProbeTimeout bounds one liveness probe so a stalled docker exec
+	// cannot park the wait for the whole budget.
+	cleanupProbeTimeout = 5 * time.Second
+)
+
+// RunAgentCleanup watches for exit hook events from devcontainer agents and
+// stops the container and removes the worktree once the run has actually ended.
+//
+// alive is what makes "actually" load-bearing. A Stop event was previously
+// taken as proof the session was over, and the container was destroyed one
+// second later — which SIGKILLed runs that were still working, because a
+// subagent's Stop arrives under the parent's agent name (SC-3785). A nil probe
+// restores that unconditional behaviour (the package's "nil disables"
+// convention), so existing callers keep compiling and behaving as before.
+func RunAgentCleanup(ctx context.Context, store *HookEventStore, cleaner AgentCleaner, alive AgentProcessAlive, logger zerolog.Logger) {
 	if store == nil || cleaner == nil {
 		return
 	}
@@ -50,21 +82,76 @@ func RunAgentCleanup(ctx context.Context, store *HookEventStore, cleaner AgentCl
 				if evt.EventName != "Stop" && evt.EventName != "SessionEnd" && evt.EventName != "StopFailure" {
 					continue
 				}
-				go func(name string) {
-					// Wait for Claude to fully exit before stopping the container.
-					select {
-					case <-time.After(1 * time.Second):
-					case <-ctx.Done():
-						return
-					}
-					logger.Info().Str("agent", name).Msg("auto-cleaning agent after session end")
-					deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-					defer cancel()
-					if err := cleaner.DeleteAgent(deleteCtx, name); err != nil {
-						logger.Warn().Err(err).Str("agent", name).Msg("agent cleanup failed")
-					}
-				}(evt.AgentName)
+				go cleanupAfterExit(ctx, cleaner, alive, evt.AgentName, logger)
 			}
+		}
+	}
+}
+
+// cleanupAfterExit tears one agent down once its claude process is gone. Split
+// out of the watch loop so the wait's branching costs its own function rather
+// than the loop's complexity budget.
+func cleanupAfterExit(ctx context.Context, cleaner AgentCleaner, alive AgentProcessAlive, name string, logger zerolog.Logger) {
+	if !waitForAgentExit(ctx, alive, name, logger) {
+		return
+	}
+	logger.Info().Str("agent", name).Msg("auto-cleaning agent after session end")
+	deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if err := cleaner.DeleteAgent(deleteCtx, name); err != nil {
+		logger.Warn().Err(err).Str("agent", name).Msg("agent cleanup failed")
+	}
+}
+
+// waitForAgentExit blocks until the agent's claude process is gone, and reports
+// whether the caller may tear the agent down.
+//
+// It returns false only for the case this exists to prevent: claude is provably
+// STILL RUNNING when the wait runs out, meaning the exit event did not belong to
+// this run. Everything else — no probe wired, a probe that cannot reach the
+// agent, a cancelled daemon — resolves to teardown or to leaving the loop, never
+// to killing a run that is demonstrably alive.
+func waitForAgentExit(ctx context.Context, alive AgentProcessAlive, name string, logger zerolog.Logger) bool {
+	// The original fixed pause, kept as the first step: claude fires its exit
+	// hook from inside its own process, so it is still running at this instant
+	// even on a perfectly normal ending.
+	select {
+	case <-time.After(cleanupExitPoll):
+	case <-ctx.Done():
+		return false
+	}
+	if alive == nil {
+		return true
+	}
+
+	deadline := time.Now().Add(cleanupExitWait)
+	for {
+		probeCtx, cancel := context.WithTimeout(ctx, cleanupProbeTimeout)
+		running, err := alive(probeCtx, name)
+		cancel()
+		if err != nil {
+			// Unreachable is not the same as alive, and it is not evidence worth
+			// sparing a run over: the agent cannot be talked to, so tear it down
+			// exactly as this listener always did.
+			logger.Debug().Err(err).Str("agent", name).
+				Msg("agent cleanup: cannot probe claude, treating the run as ended")
+			return true
+		}
+		if !running {
+			return true
+		}
+		if time.Now().After(deadline) {
+			// The run outlived the exit event, so the event was somebody else's —
+			// a subagent's. Leave it working; its own ending will arrive later,
+			// and a silent death is the zombie sweep's to catch.
+			logger.Info().Str("agent", name).Dur("waited", cleanupExitWait).
+				Msg("agent cleanup: claude still running past the exit event, leaving the run alone")
+			return false
+		}
+		select {
+		case <-time.After(cleanupExitPoll):
+		case <-ctx.Done():
+			return false
 		}
 	}
 }

--- a/internal/daemon/agentcleanup_test.go
+++ b/internal/daemon/agentcleanup_test.go
@@ -2,7 +2,9 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -63,7 +65,7 @@ func TestRunAgentCleanup_ReusedNameSecondExitCleansAgain(t *testing.T) {
 	cleaner := newCountingCleaner()
 
 	ctx := t.Context()
-	go RunAgentCleanup(ctx, store, cleaner, zerolog.Nop())
+	go RunAgentCleanup(ctx, store, cleaner, nil, zerolog.Nop())
 	time.Sleep(50 * time.Millisecond)
 
 	name := "board-201-implementation"
@@ -98,7 +100,7 @@ func TestRunAgentCleanup_StopEvent(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		RunAgentCleanup(ctx, store, cleaner, logger)
+		RunAgentCleanup(ctx, store, cleaner, nil, logger)
 		close(done)
 	}()
 
@@ -130,7 +132,7 @@ func TestRunAgentCleanup_SessionEndEvent(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		RunAgentCleanup(ctx, store, cleaner, logger)
+		RunAgentCleanup(ctx, store, cleaner, nil, logger)
 		close(done)
 	}()
 
@@ -160,7 +162,7 @@ func TestRunAgentCleanup_IgnoresNonAgentEvents(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		RunAgentCleanup(ctx, store, cleaner, logger)
+		RunAgentCleanup(ctx, store, cleaner, nil, logger)
 		close(done)
 	}()
 
@@ -178,4 +180,91 @@ func TestRunAgentCleanup_IgnoresNonAgentEvents(t *testing.T) {
 	<-done
 
 	assert.Empty(t, cleaner.deleted)
+}
+
+// shrinkCleanupWait makes the exit wait test-fast and restores it afterwards,
+// so a regression test costs milliseconds rather than the production budget.
+func shrinkCleanupWait(t *testing.T, wait time.Duration) {
+	t.Helper()
+	poll, w := cleanupExitPoll, cleanupExitWait
+	cleanupExitPoll, cleanupExitWait = 5*time.Millisecond, wait
+	t.Cleanup(func() { cleanupExitPoll, cleanupExitWait = poll, w })
+}
+
+// SC-3785: an exit hook event names the CONTAINER's agent, so a subagent's Stop
+// is indistinguishable from its parent's. Tearing the container down on that
+// event SIGKILLed runs that were still working. A run whose claude is provably
+// still running must be left alone.
+func TestRunAgentCleanup_LeavesRunAliveWhenClaudeStillRunning(t *testing.T) {
+	shrinkCleanupWait(t, 50*time.Millisecond)
+	store := NewHookEventStore()
+	cleaner := &mockCleaner{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	alive := func(context.Context, string) (bool, error) { return true, nil }
+	go RunAgentCleanup(ctx, store, cleaner, alive, zerolog.Nop())
+	time.Sleep(50 * time.Millisecond)
+
+	store.Append(hookevents.Event{EventName: "Stop", AgentName: "board-3785-verification", Timestamp: time.Now()})
+
+	time.Sleep(500 * time.Millisecond)
+	assert.Empty(t, cleaner.deleted, "a run whose claude is still running must not be torn down by somebody else's Stop")
+}
+
+// The other half of the same contract: once claude really is gone, the teardown
+// still happens — the wait defers cleanup, it does not cancel it.
+func TestRunAgentCleanup_DeletesOnceClaudeExits(t *testing.T) {
+	shrinkCleanupWait(t, 5*time.Second)
+	store := NewHookEventStore()
+	cleaner := newCountingCleaner()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var probes int32
+	alive := func(context.Context, string) (bool, error) {
+		// Alive for the first two probes, gone after — the shape of a run that
+		// takes a moment to unwind after firing its exit hook.
+		return atomic.AddInt32(&probes, 1) <= 2, nil
+	}
+	go RunAgentCleanup(ctx, store, cleaner, alive, zerolog.Nop())
+	time.Sleep(50 * time.Millisecond)
+
+	store.Append(hookevents.Event{EventName: "Stop", AgentName: "board-3785-implementation", Timestamp: time.Now()})
+
+	select {
+	case got := <-cleaner.ch:
+		assert.Equal(t, "board-3785-implementation", got)
+	case <-time.After(4 * time.Second):
+		t.Fatal("teardown must still happen once claude has exited")
+	}
+}
+
+// An agent that cannot be probed is not evidence of a live run — the container
+// is unreachable — so teardown proceeds exactly as it did before the probe
+// existed. Sparing it would strand containers whenever docker hiccups.
+func TestRunAgentCleanup_ProbeErrorTearsDown(t *testing.T) {
+	shrinkCleanupWait(t, 5*time.Second)
+	store := NewHookEventStore()
+	cleaner := newCountingCleaner()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	alive := func(context.Context, string) (bool, error) {
+		return false, errors.New("no such container")
+	}
+	go RunAgentCleanup(ctx, store, cleaner, alive, zerolog.Nop())
+	time.Sleep(50 * time.Millisecond)
+
+	store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: "board-3785-planning", Timestamp: time.Now()})
+
+	select {
+	case got := <-cleaner.ch:
+		assert.Equal(t, "board-3785-planning", got)
+	case <-time.After(4 * time.Second):
+		t.Fatal("an unreachable agent must still be cleaned up")
+	}
 }


### PR DESCRIPTION
Board cards kept reddening with "the run stopped before finishing this stage" for runs that were demonstrably still working.

## What was happening

`board-SC-3569-verification`, run `0ac39c4a`, 2026-08-05:

```
10:11:44Z  PreToolUse Agent → SubagentStart
10:11:52Z  Stop                      ← 8s after dispatching a subagent
10:11:54Z  PreToolUse Bash           ← still working
10:12:01Z  PreToolUse/PostToolUse Bash
10:12:05Z  StopFailure               ← SIGKILL landed
```

Exit hook events carry the *container's* agent name, so a subagent's ending is indistinguishable from its parent's. `RunAgentCleanup` took any `Stop` as proof the session was over and deleted the agent one second later; `ContainerStop`'s 10s grace then expired and claude was SIGKILLed — the `exit code: 137` recorded in that run's `output.log`, and the generic red on the card.

Not rare and not new: 13 runs since 2026-07-22 have tool calls continuing after a `Stop` (board-1184, 1388, 1559 ×2, 1616, SC-1857, SC-1957, SC-2042, SC-2405, SC-3030, SC-3305, SC-637, SC-3569).

## The change

The event becomes a prompt to check, not a verdict. Teardown waits for claude to actually exit, polling every second to a 5-minute bound:

- **claude gone** → tear down, as before.
- **still running at the bound** → the event was somebody else's. Leave the run alone; its own ending arrives later, and a run that dies silently is already the zombie sweep's job.
- **cannot be probed** → tear down. Unreachable is not evidence of a live run, and sparing it would strand containers on any docker hiccup.

The probe reuses the zombie sweep's own `IsProcessRunning`, so both teardown paths ask the container the same question. A nil probe restores the old unconditional behaviour, per the package's "nil disables" convention.

## Tests

Three regression tests in `internal/daemon/agentcleanup_test.go`. The first fails without the fix (verified: `Should be empty, but was [board-3785-verification]`):

- a run whose claude is still running is not torn down by somebody else's Stop
- teardown still happens once claude has exited (the wait defers, it does not cancel)
- an unprobeable agent still tears down

`make check` green.

## Not covered

The sibling red — "the PR reviewer stopped before recording a verdict" — is a different consumer (the PR loop's verdict path) and is not fixed here. One verified instance of it, `board-SC-3581-prreview`, ended with the reviewer's subagent dispatch failing after 12 minutes and claude exiting 0 with "The reviewer dispatch was interrupted, so no review ran and no verdict was recorded."