### PR TITLE
Validate the pipeline state machine as a machine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ Do NOT use a custom tracker status for review signalling — that would require 
 
 A prompt saying "after X, post Y" is a definition of a transition, exactly as much as the Go code that reads Y. Both belong in the document, and a transition that exists in one but not the other is the bug.
 
+**Check it with `make fsm`.** `cmd/fsmcheck` validates the document as a machine — every `dst` and `src` names a declared state, names are unique, nothing is unreachable, no non-terminal state is a trap with no way out, terminal and `reopenable` agree with the edges that exist, every transition names a declared actor and says where it lives (`where:` for Go, `prompt:` for an agent instruction). Errors fail `make check` via `internal/pipelinefsm`; missing prose is a warning. `make fsm-diagram` draws it as a mermaid state diagram. Whether the document is *true of the code* is a separate question the daemon's own conformance test asks (`internal/daemon/pipeline_fsm_doc_test.go`) — a green `make fsm` means the machine holds together, not that it matches.
+
 `docs/reaper.md` is its companion along the other axis: the FSM document follows one ticket, the reaper document follows one container — every condition under which the machine kills an agent (the zombie sweep, the silence reap, the stuck-running and orphan reconcile passes, close-is-cancellation), what it deliberately spares, what the reap costs the ticket's retry budget, and what artifacts it leaves behind. Same rules: read it before changing the sweep, the idle budgets, or any path that stops an agent, and update it in the same commit.
 
 # Daemon

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build fmt fmt-check install test check-test test-integration coverage coverage-check fuzz lint sec secrets check clean upgrade-deps release hooks unhooks desktop desktop-deps desktop-dev desktop-package
+.PHONY: all build fmt fmt-check install test check-test test-integration coverage coverage-check fuzz fsm fsm-diagram lint sec secrets check clean upgrade-deps release hooks unhooks desktop desktop-deps desktop-dev desktop-package
 
 VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
 
@@ -67,6 +67,17 @@ coverage-check: coverage
 fuzz:
 	go test -run=^$$ -fuzz=FuzzSanitizeFTSQuery -fuzztime=30s ./internal/index/...
 	go test -run=^$$ -fuzz=FuzzPeekClientHello -fuzztime=30s ./internal/proxy/...
+
+# fsm validates docs/pipeline-fsm.json as a machine: dangling destinations,
+# unreachable states, states with no way out, undeclared actors. `check` already
+# fails on those through internal/pipelinefsm's own test — this target is for
+# reading the whole list at once while fixing it, warnings included.
+# fsm-diagram draws the machine for a PR or a doc.
+fsm:
+	go run ./cmd/fsmcheck
+
+fsm-diagram:
+	go run ./cmd/fsmcheck -mermaid
 
 # golangci-lint's default set already includes govet and the full staticcheck
 # suite, so the standalone tools would run the same analyses twice.

--- a/cmd/fsmcheck/main.go
+++ b/cmd/fsmcheck/main.go
@@ -1,0 +1,118 @@
+// Command fsmcheck validates docs/pipeline-fsm.json — the pipeline state
+// machine written down.
+//
+// It checks the document against itself: that it is a well-formed machine.
+// Every transition comes from and leads to a state that exists, no two states or
+// transitions share a name, nothing is unreachable, nothing is a trap with no
+// way out, every transition names a declared actor and says where it lives.
+// Whether the document is TRUE of the code is a separate question that needs the
+// code; this answers whether it holds together well enough to be reasoned about
+// at all.
+//
+//	fsmcheck                 # validate the checkout, exit non-zero on findings
+//	fsmcheck -format json    # the same findings, for a tool to read
+//	fsmcheck -mermaid        # draw the machine instead of validating it
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gethuman-sh/human/internal/pipelinefsm"
+)
+
+func main() {
+	root := flag.String("root", "", "repository root (default: the checkout containing the working directory)")
+	format := flag.String("format", "text", "findings format: text or json")
+	diagram := flag.Bool("mermaid", false, "print the machine as a mermaid state diagram instead of checking it")
+	strict := flag.Bool("strict", false, "fail on warnings too, not only on a machine that does not hold together")
+	flag.Parse()
+
+	if err := run(*root, *format, *diagram, *strict); err != nil {
+		fmt.Fprintln(os.Stderr, "fsmcheck:", err)
+		os.Exit(2)
+	}
+}
+
+// run exits 1 when the machine does not hold together and returns an error when
+// the checkout cannot be read (exit 2), so a caller can tell a broken repository
+// from a broken machine.
+func run(root, format string, diagram, strict bool) error {
+	if root == "" {
+		found, err := repoRoot()
+		if err != nil {
+			return err
+		}
+		root = found
+	}
+
+	if diagram {
+		doc, err := pipelinefsm.LoadDocument(root)
+		if err != nil {
+			return err
+		}
+		fmt.Print(pipelinefsm.Mermaid(doc))
+		return nil
+	}
+
+	findings, err := pipelinefsm.Check(root)
+	if err != nil {
+		return err
+	}
+	if err := report(findings, format); err != nil {
+		return err
+	}
+	if failing := pipelinefsm.Errors(findings); failing > 0 || (strict && len(findings) > 0) {
+		os.Exit(1)
+	}
+	return nil
+}
+
+func report(findings []pipelinefsm.Finding, format string) error {
+	switch format {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		// An empty slice, not null: a consumer should see "no findings", not a
+		// missing answer.
+		if findings == nil {
+			findings = []pipelinefsm.Finding{}
+		}
+		return enc.Encode(findings)
+	case "text":
+		if len(findings) == 0 {
+			fmt.Println("docs/pipeline-fsm.json is a well-formed machine")
+			return nil
+		}
+		for _, f := range findings {
+			fmt.Println(f)
+		}
+		errs := pipelinefsm.Errors(findings)
+		fmt.Printf("\n%d error(s), %d warning(s) in docs/pipeline-fsm.json\n", errs, len(findings)-errs)
+		return nil
+	default:
+		return fmt.Errorf("unknown format %q: want text or json", format)
+	}
+}
+
+// repoRoot walks up from the working directory to the checkout that owns it, so
+// the command works from anywhere inside the repo the way git does.
+func repoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no go.mod above the working directory: name the checkout with -root")
+		}
+		dir = parent
+	}
+}

--- a/docs/pipeline-fsm.json
+++ b/docs/pipeline-fsm.json
@@ -683,7 +683,8 @@
       "dst": "unknown",
       "actor": "daemon",
       "where": "internal/board/gate.go PMRoleNotice; internal/board/compose.go",
-      "doc": "The tracker instance failed to load — an unreachable credential store, a config error. Every item it carries becomes unobservable at once, so this is a property of the fetch rather than of any one ticket. It resolves by itself when the source is reachable again; nothing about the item changed."
+      "doc": "The tracker instance failed to load — an unreachable credential store, a config error. Every item it carries becomes unobservable at once, so this is a property of the fetch rather than of any one ticket. It resolves by itself when the source is reachable again; nothing about the item changed.",
+      "moves_item": false
     },
     {
       "name": "source-readable-again",
@@ -694,7 +695,8 @@
       "actor": "daemon",
       "where": "internal/board/compose.go — the next fetch that resolves a PM-role result",
       "doc": "The source came back and the item's real state is re-derived from its markers — it returns to whatever they say, not to `filed`. The single dst here is a topological placeholder: this machine has one destination per transition and the true one is computed. Nothing about the item changed while it was unobservable.",
-      "dst_is_derived": true
+      "dst_is_derived": true,
+      "moves_item": false
     },
     {
       "name": "reopen-planning",

--- a/internal/daemon/pipeline_fsm_doc_test.go
+++ b/internal/daemon/pipeline_fsm_doc_test.go
@@ -13,10 +13,14 @@ import (
 )
 
 // docs/pipeline-fsm.json is the written-down machine. These tests are what stop
-// it drifting from the code, which is the failure that produced every defect it
-// describes: a marker the prompts post that the daemon has never been told
-// about, a state named in one place and not the other, a transition that exists
-// in the prose and nowhere else.
+// it drifting from the CODE: a marker the prompts post that the daemon has never
+// been told about, a marker string no constant carries.
+//
+// Whether the document is a well-formed machine at all — dangling destinations,
+// unreachable states, states with no way out — is a question about the document
+// alone, and lives in internal/pipelinefsm (and the fsmcheck command). Two
+// questions, two checks: this one needs the daemon's constants and so has to live
+// here; that one needs nothing but the file and so should not.
 //
 // Kept as a test rather than a separate tool so `make check` runs it and a
 // change to the machine cannot merge without the description following it.
@@ -47,63 +51,6 @@ func loadFSMDoc(t *testing.T) fsmDoc {
 	require.NotEmpty(t, doc.States)
 	require.NotEmpty(t, doc.Events)
 	return doc
-}
-
-// Topology has to hold on its own terms: a transition may not come from or lead
-// to a state nobody declared, and no two transitions may share a name (the name
-// is the alphabet, and a duplicate silently shadows one of them).
-func TestPipelineFSM_TopologyIsSound(t *testing.T) {
-	doc := loadFSMDoc(t)
-	states := map[string]bool{}
-	for _, s := range doc.States {
-		require.False(t, states[s.Name], "duplicate state %q", s.Name)
-		states[s.Name] = true
-	}
-	require.True(t, states[doc.Initial], "the initial state %q must be declared", doc.Initial)
-
-	seen := map[string]bool{}
-	for _, e := range doc.Events {
-		require.NotEmpty(t, e.Name, "every transition needs a name")
-		require.False(t, seen[e.Name], "duplicate transition name %q", e.Name)
-		seen[e.Name] = true
-		require.NotEmpty(t, e.Src, "%s: a transition needs at least one source", e.Name)
-		require.True(t, states[e.Dst], "%s: dst %q is not a declared state", e.Name, e.Dst)
-		for _, s := range e.Src {
-			require.True(t, states[s], "%s: src %q is not a declared state", e.Name, s)
-		}
-	}
-}
-
-// Every state must be reachable and every non-terminal state must have a way
-// out. A state nothing reaches is dead description; a non-terminal state with no
-// exit is a trap the machine can enter and never leave.
-func TestPipelineFSM_NoUnreachableStatesAndNoDeadEnds(t *testing.T) {
-	doc := loadFSMDoc(t)
-
-	reached := map[string]bool{doc.Initial: true}
-	for range doc.States {
-		for _, e := range doc.Events {
-			for _, s := range e.Src {
-				if reached[s] {
-					reached[e.Dst] = true
-				}
-			}
-		}
-	}
-	exits := map[string]bool{}
-	for _, e := range doc.Events {
-		for _, s := range e.Src {
-			if e.Dst != s {
-				exits[s] = true
-			}
-		}
-	}
-	for _, s := range doc.States {
-		require.True(t, reached[s.Name], "state %q is unreachable from %q", s.Name, doc.Initial)
-		if !s.Terminal {
-			require.True(t, exits[s.Name], "state %q is not terminal and has no way out", s.Name)
-		}
-	}
 }
 
 // Marker strings in the document must be real. Checked against the daemon's own

--- a/internal/pipelinefsm/check.go
+++ b/internal/pipelinefsm/check.go
@@ -1,0 +1,336 @@
+package pipelinefsm
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Rule names the check that produced a finding, so a failure says which
+// guarantee broke rather than only that something did.
+type Rule string
+
+const (
+	RuleSchema       Rule = "schema"        // the fields a machine needs are present and non-empty
+	RuleTopology     Rule = "topology"      // src/dst name declared states; names are unique
+	RuleReachability Rule = "reachability"  // every state is reachable, every non-terminal has an exit
+	RuleTerminal     Rule = "terminal"      // terminal and reopenable agree with the edges that exist
+	RuleActor        Rule = "actor"         // every transition names a declared actor
+	RuleMarkerSyntax Rule = "marker-syntax" // a marker is written the way a marker is written
+	RuleDescribed    Rule = "described"     // a transition says what it means and where it lives
+)
+
+// Severity separates a machine that does not hold together from one that holds
+// together but is under-described. Both are worth reporting and only the first
+// should stop a build: an unreachable state or a dangling dst makes the document
+// unusable for the reasoning it exists to support, while a transition missing
+// its sentence of prose is a gap to fill, not a wrong answer.
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+)
+
+// Finding is one way the document fails to be a well-formed machine.
+type Finding struct {
+	Rule     Rule     `json:"rule"`
+	Severity Severity `json:"severity"`
+	Subject  string   `json:"subject"` // the transition or state at fault
+	Message  string   `json:"message"`
+}
+
+func (f Finding) String() string {
+	return fmt.Sprintf("%-7s %-14s %-28s %s", f.Severity, f.Rule, f.Subject, f.Message)
+}
+
+// Errors counts the findings severe enough to fail a build.
+func Errors(findings []Finding) int {
+	n := 0
+	for _, f := range findings {
+		if f.Severity == SeverityError {
+			n++
+		}
+	}
+	return n
+}
+
+// markerPrefix is what makes a string a marker header.
+const markerPrefix = "[human:"
+
+// Validate runs every rule and returns ALL findings, sorted.
+//
+// All of them on purpose. The hand-written tests this grew out of used require,
+// so the first disagreement hid the rest and each fix revealed one more. A
+// document that has drifted has usually drifted in several places at once — that
+// is what drift is — so the useful output is the whole list.
+func Validate(doc Document) []Finding {
+	var findings []Finding
+	findings = append(findings, checkSchema(doc)...)
+	findings = append(findings, checkTopology(doc)...)
+	findings = append(findings, checkReachability(doc)...)
+	findings = append(findings, checkTerminals(doc)...)
+	findings = append(findings, checkActors(doc)...)
+	findings = append(findings, checkMarkerSyntax(doc)...)
+	findings = append(findings, checkDescribed(doc)...)
+
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].Severity != findings[j].Severity {
+			return findings[i].Severity < findings[j].Severity // error before warning
+		}
+		if findings[i].Rule != findings[j].Rule {
+			return findings[i].Rule < findings[j].Rule
+		}
+		if findings[i].Subject != findings[j].Subject {
+			return findings[i].Subject < findings[j].Subject
+		}
+		return findings[i].Message < findings[j].Message
+	})
+	return findings
+}
+
+// Check validates the document in a repository root.
+func Check(root string) ([]Finding, error) {
+	doc, err := LoadDocument(root)
+	if err != nil {
+		return nil, err
+	}
+	return Validate(doc), nil
+}
+
+// checkSchema requires the fields without which the rest is not a machine.
+func checkSchema(doc Document) []Finding {
+	var findings []Finding
+	if doc.Version <= 0 {
+		findings = append(findings, Finding{RuleSchema, SeverityError, "version", "is missing — the machine must declare its schema version"})
+	}
+	for _, missing := range []struct{ field, value string }{
+		{"describes", doc.Describes},
+		{"item", doc.Item},
+		{"initial", doc.Initial},
+	} {
+		if strings.TrimSpace(missing.value) == "" {
+			findings = append(findings, Finding{RuleSchema, SeverityError, missing.field, "is empty — the machine must declare it"})
+		}
+	}
+	if len(doc.States) == 0 {
+		findings = append(findings, Finding{RuleSchema, SeverityError, "states", "the machine declares no states"})
+	}
+	if len(doc.Events) == 0 {
+		findings = append(findings, Finding{RuleSchema, SeverityError, "events", "the machine declares no transitions"})
+	}
+	if len(doc.Actors) == 0 {
+		findings = append(findings, Finding{RuleSchema, SeverityError, "actors", "the machine declares no actors"})
+	}
+
+	for i, s := range doc.States {
+		if strings.TrimSpace(s.Name) == "" {
+			findings = append(findings, Finding{RuleSchema, SeverityError, fmt.Sprintf("states[%d]", i), "a state has no name"})
+		}
+	}
+	for i, e := range doc.Events {
+		if strings.TrimSpace(e.Name) == "" {
+			findings = append(findings, Finding{RuleSchema, SeverityError, fmt.Sprintf("events[%d]", i), "a transition has no name"})
+		}
+	}
+	return findings
+}
+
+// checkDescribed is the completeness pass: a state that does not say what it
+// means, or a transition that says neither what it means nor where it lives, is
+// a row in a table rather than a description. Warnings, not errors — the machine
+// still holds together, and a build that goes red over a missing sentence
+// teaches people to stop adding transitions rather than to describe them.
+func checkDescribed(doc Document) []Finding {
+	var findings []Finding
+	for _, s := range doc.States {
+		if s.Name != "" && strings.TrimSpace(s.Doc) == "" {
+			findings = append(findings, Finding{RuleDescribed, SeverityWarning, s.Name, "a state should say what it means"})
+		}
+	}
+	for _, e := range doc.Events {
+		if e.Name == "" {
+			continue
+		}
+		if strings.TrimSpace(e.Doc) == "" {
+			findings = append(findings, Finding{RuleDescribed, SeverityWarning, e.Name, "a transition should say what it means"})
+		}
+		if strings.TrimSpace(e.Implementation()) == "" {
+			findings = append(findings, Finding{RuleDescribed, SeverityWarning, e.Name, "a transition should say where it is implemented (where: or prompt:)"})
+		}
+	}
+	return findings
+}
+
+// checkTopology holds the graph to its own terms: a transition may not come from
+// or lead to a state nobody declared, and no two may share a name — the name is
+// the alphabet, and a duplicate silently shadows one of them.
+func checkTopology(doc Document) []Finding {
+	var findings []Finding
+	states := map[string]bool{}
+	for _, s := range doc.States {
+		if states[s.Name] {
+			findings = append(findings, Finding{RuleTopology, SeverityError, s.Name, "declared twice as a state"})
+		}
+		states[s.Name] = true
+	}
+	if doc.Initial != "" && !states[doc.Initial] {
+		findings = append(findings, Finding{RuleTopology, SeverityError, doc.Initial, "the initial state is not declared"})
+	}
+
+	seen := map[string]bool{}
+	for _, e := range doc.Events {
+		if e.Name != "" && seen[e.Name] {
+			findings = append(findings, Finding{RuleTopology, SeverityError, e.Name, "declared twice as a transition"})
+		}
+		seen[e.Name] = true
+
+		if len(e.Src) == 0 {
+			findings = append(findings, Finding{RuleTopology, SeverityError, e.Name, "a transition needs at least one source"})
+		}
+		if !states[e.Dst] {
+			findings = append(findings, Finding{RuleTopology, SeverityError, e.Name, fmt.Sprintf("dst %q is not a declared state", e.Dst)})
+		}
+		fromSeen := map[string]bool{}
+		for _, src := range e.Src {
+			if !states[src] {
+				findings = append(findings, Finding{RuleTopology, SeverityError, e.Name, fmt.Sprintf("src %q is not a declared state", src)})
+			}
+			if fromSeen[src] {
+				findings = append(findings, Finding{RuleTopology, SeverityError, e.Name, fmt.Sprintf("src %q is listed twice", src)})
+			}
+			fromSeen[src] = true
+		}
+	}
+	return findings
+}
+
+// checkReachability finds description nobody can reach and states nobody can
+// leave. An unreachable state is documentation of something that cannot happen;
+// a non-terminal state with no exit is a trap the machine can enter and never
+// leave, which is the shape of every stuck card this document was written for.
+func checkReachability(doc Document) []Finding {
+	reached := map[string]bool{doc.Initial: true}
+	for range doc.States { // a fixpoint: |states| rounds always suffice
+		for _, e := range doc.Events {
+			for _, src := range e.Src {
+				if reached[src] {
+					reached[e.Dst] = true
+				}
+			}
+		}
+	}
+
+	var findings []Finding
+	for _, s := range doc.States {
+		if !reached[s.Name] {
+			findings = append(findings, Finding{RuleReachability, SeverityError, s.Name, fmt.Sprintf("unreachable from %q", doc.Initial)})
+		}
+		if !s.Terminal && !hasExit(doc, s.Name) {
+			findings = append(findings, Finding{RuleReachability, SeverityError, s.Name, "not terminal and has no way out"})
+		}
+	}
+	return findings
+}
+
+// checkTerminals holds the two terminal fields to the edges that actually exist.
+// A terminal state the machine can leave is a contradiction unless the document
+// says a person may overrule it, and a reopenable state that is not terminal is
+// a field with nothing to mean.
+func checkTerminals(doc Document) []Finding {
+	var findings []Finding
+	for _, s := range doc.States {
+		switch {
+		case s.Reopenable && !s.Terminal:
+			findings = append(findings, Finding{RuleTerminal, SeverityError, s.Name, "reopenable but not terminal — there is nothing to reopen"})
+		case s.Terminal && movingExit(doc, s.Name) && !s.Reopenable:
+			findings = append(findings, Finding{RuleTerminal, SeverityError, s.Name, "terminal but a transition moves the item out of it — mark it reopenable or stop calling it terminal"})
+		case s.Terminal && s.Reopenable && !movingExit(doc, s.Name):
+			findings = append(findings, Finding{RuleTerminal, SeverityError, s.Name, "reopenable but no transition leaves it — the way back is not described"})
+		}
+	}
+	return findings
+}
+
+// hasExit reports whether any transition leads out of the state to a different
+// one. A self-loop is not a way out.
+func hasExit(doc Document, state string) bool {
+	return leavesState(doc, state, false)
+}
+
+// movingExit is the stricter question the terminal rule asks: is there a way out
+// that moves the ITEM. The two differ because an observability edge leaves every
+// state, terminals included — a tracker that fails to load makes every item
+// unobservable without any of them moving — and counting that as a way out of a
+// terminal would make "terminal" impossible to declare truthfully.
+func movingExit(doc Document, state string) bool {
+	return leavesState(doc, state, true)
+}
+
+func leavesState(doc Document, state string, onlyMoving bool) bool {
+	for _, e := range doc.Events {
+		if e.Dst == state || (onlyMoving && !e.Moves()) {
+			continue
+		}
+		for _, src := range e.Src {
+			if src == state {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// checkActors requires every transition to name an actor the document declares.
+// Who causes a transition is half of what the machine says: it is the difference
+// between something the pipeline does to an item and something only a person can
+// do, and an actor invented in one entry is a distinction quietly lost.
+func checkActors(doc Document) []Finding {
+	var findings []Finding
+	for _, e := range doc.Events {
+		if strings.TrimSpace(e.Actor) == "" {
+			findings = append(findings, Finding{RuleActor, SeverityError, e.Name, "a transition must name the actor that causes it"})
+			continue
+		}
+		if _, ok := doc.Actors[e.Actor]; !ok {
+			findings = append(findings, Finding{RuleActor, SeverityError, e.Name, fmt.Sprintf("actor %q is not declared", e.Actor)})
+		}
+	}
+	return findings
+}
+
+// checkMarkerSyntax checks the shape of a marker, not its existence — whether
+// the daemon defines it is a question about the code. A marker that is not
+// written as one is still a document bug: it will not match anything a reader
+// greps for in a real comment thread.
+func checkMarkerSyntax(doc Document) []Finding {
+	var findings []Finding
+	for _, e := range doc.Events {
+		if strings.TrimSpace(e.Marker) == "" {
+			continue // a transition need not be recorded by a marker
+		}
+		for _, m := range e.Markers() {
+			if !strings.HasPrefix(m, markerPrefix) || !strings.HasSuffix(m, "]") || len(m) <= len(markerPrefix)+1 {
+				findings = append(findings, Finding{RuleMarkerSyntax, SeverityError, e.Name, fmt.Sprintf("marker %q is not written as [human:…]", m)})
+			}
+		}
+	}
+	return findings
+}
+
+// splitMarkers separates the alternatives of a marker field. Alternatives are
+// written "a | b" and mean one transition recorded by a different marker per
+// stage.
+func splitMarkers(field string) []string {
+	if strings.TrimSpace(field) == "" {
+		return nil
+	}
+	parts := strings.Split(field, "|")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}

--- a/internal/pipelinefsm/check_test.go
+++ b/internal/pipelinefsm/check_test.go
@@ -1,0 +1,316 @@
+package pipelinefsm_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/pipelinefsm"
+)
+
+// A minimal well-formed machine. Each test mutates one thing about it, so a
+// finding can only come from the mutation — the alternative is a checker that
+// passes because it never really looked.
+const soundMachine = `{
+  "version": 1,
+  "describes": "commit abc1234",
+  "item": "a ticket",
+  "initial": "filed",
+  "actors": {"daemon": "the host process", "user": "a person"},
+  "states": [
+    {"name": "filed", "doc": "the ticket exists"},
+    {"name": "working", "doc": "an agent is on it"},
+    {"name": "done", "doc": "shipped", "terminal": true}
+  ],
+  "events": [
+    {"name": "start", "src": ["filed"], "dst": "working", "actor": "daemon",
+     "marker": "[human:started]", "where": "board.go", "doc": "work begins"},
+    {"name": "finish", "src": ["working"], "dst": "done", "actor": "daemon",
+     "marker": "[human:deployed]", "where": "deploy.go", "doc": "work ends"}
+  ]
+}`
+
+func validate(t *testing.T, machine string) []pipelinefsm.Finding {
+	t.Helper()
+	doc, err := pipelinefsm.ParseDocument([]byte(machine))
+	require.NoError(t, err)
+	return pipelinefsm.Validate(doc)
+}
+
+// mutate edits the machine as JSON so a test reads as the change it makes rather
+// than as a wall of literal.
+func mutate(t *testing.T, edit func(m map[string]any)) string {
+	t.Helper()
+	var m map[string]any
+	require.NoError(t, json.Unmarshal([]byte(soundMachine), &m))
+	edit(m)
+	out, err := json.Marshal(m)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func events(t *testing.T, m map[string]any) []any {
+	t.Helper()
+	return m["events"].([]any)
+}
+
+func states(t *testing.T, m map[string]any) []any {
+	t.Helper()
+	return m["states"].([]any)
+}
+
+// findingFor returns the first finding of a rule, so a test asserts on the rule
+// it is about and not on the order findings happen to sort in.
+func findingFor(findings []pipelinefsm.Finding, rule pipelinefsm.Rule) (pipelinefsm.Finding, bool) {
+	for _, f := range findings {
+		if f.Rule == rule {
+			return f, true
+		}
+	}
+	return pipelinefsm.Finding{}, false
+}
+
+func requireFinding(t *testing.T, findings []pipelinefsm.Finding, rule pipelinefsm.Rule, subject string) pipelinefsm.Finding {
+	t.Helper()
+	f, ok := findingFor(findings, rule)
+	require.True(t, ok, "expected a %q finding, got %v", rule, findings)
+	assert.Equal(t, subject, f.Subject)
+	return f
+}
+
+func TestValidate_ASoundMachineHasNothingToSay(t *testing.T) {
+	assert.Empty(t, validate(t, soundMachine))
+}
+
+// The rule the whole thing exists for: a transition that leads somewhere nobody
+// declared. It reads as a legal edge and is a dangling pointer.
+func TestValidate_DstMustBeADeclaredState(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		events(t, m)[1].(map[string]any)["dst"] = "shipped"
+	})
+	f := requireFinding(t, validate(t, machine), pipelinefsm.RuleTopology, "finish")
+	assert.Equal(t, pipelinefsm.SeverityError, f.Severity)
+	assert.Contains(t, f.Message, `dst "shipped" is not a declared state`)
+}
+
+func TestValidate_SrcMustBeADeclaredState(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		events(t, m)[0].(map[string]any)["src"] = []any{"drafted"}
+	})
+	f := requireFinding(t, validate(t, machine), pipelinefsm.RuleTopology, "start")
+	assert.Contains(t, f.Message, `src "drafted" is not a declared state`)
+}
+
+// A duplicate name silently shadows one of the two: the machine keeps working
+// and one transition stops existing.
+func TestValidate_TransitionNamesAreUnique(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		events(t, m)[1].(map[string]any)["name"] = "start"
+	})
+	f := requireFinding(t, validate(t, machine), pipelinefsm.RuleTopology, "start")
+	assert.Contains(t, f.Message, "declared twice as a transition")
+}
+
+func TestValidate_StateNamesAreUnique(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		states(t, m)[1].(map[string]any)["name"] = "filed"
+	})
+	f := requireFinding(t, validate(t, machine), pipelinefsm.RuleTopology, "filed")
+	assert.Contains(t, f.Message, "declared twice as a state")
+}
+
+func TestValidate_TheInitialStateMustExist(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) { m["initial"] = "drafted" })
+	f := requireFinding(t, validate(t, machine), pipelinefsm.RuleTopology, "drafted")
+	assert.Contains(t, f.Message, "the initial state is not declared")
+}
+
+func TestValidate_ASourceListedTwiceIsAMistake(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		events(t, m)[0].(map[string]any)["src"] = []any{"filed", "filed"}
+	})
+	f := requireFinding(t, validate(t, machine), pipelinefsm.RuleTopology, "start")
+	assert.Contains(t, f.Message, `src "filed" is listed twice`)
+}
+
+// Description of something that cannot happen.
+func TestValidate_EveryStateMustBeReachable(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		m["states"] = append(states(t, m), map[string]any{"name": "orphan", "doc": "nothing reaches this", "terminal": true})
+	})
+	f := requireFinding(t, validate(t, machine), pipelinefsm.RuleReachability, "orphan")
+	assert.Contains(t, f.Message, `unreachable from "filed"`)
+}
+
+// The shape of every stuck card the document was written for: a state the
+// machine can enter and never leave.
+func TestValidate_ANonTerminalStateNeedsAWayOut(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		states(t, m)[2].(map[string]any)["terminal"] = false
+	})
+	f := requireFinding(t, validate(t, machine), pipelinefsm.RuleReachability, "done")
+	assert.Contains(t, f.Message, "no way out")
+}
+
+// A self-loop is not a way out — it is the stuck state drawn as a circle.
+func TestValidate_ASelfLoopIsNotAWayOut(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		states(t, m)[2].(map[string]any)["terminal"] = false
+		m["events"] = append(events(t, m), map[string]any{
+			"name": "retry-done", "src": []any{"done"}, "dst": "done",
+			"actor": "daemon", "where": "deploy.go", "doc": "tries again",
+		})
+	})
+	f := requireFinding(t, validate(t, machine), pipelinefsm.RuleReachability, "done")
+	assert.Contains(t, f.Message, "no way out")
+}
+
+func TestValidate_ATerminalWithAWayOutMustSayItIsReopenable(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		m["events"] = append(events(t, m), map[string]any{
+			"name": "reopen", "src": []any{"done"}, "dst": "working",
+			"actor": "user", "where": "board.go", "doc": "a person overrules it",
+		})
+	})
+	f := requireFinding(t, validate(t, machine), pipelinefsm.RuleTerminal, "done")
+	assert.Contains(t, f.Message, "mark it reopenable")
+}
+
+func TestValidate_AReopenableTerminalWithAWayOutIsFine(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		states(t, m)[2].(map[string]any)["reopenable"] = true
+		m["events"] = append(events(t, m), map[string]any{
+			"name": "reopen", "src": []any{"done"}, "dst": "working",
+			"actor": "user", "where": "board.go", "doc": "a person overrules it",
+		})
+	})
+	assert.Empty(t, validate(t, machine))
+}
+
+func TestValidate_AReopenableTerminalWithNoWayBackIsAnEmptyPromise(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		states(t, m)[2].(map[string]any)["reopenable"] = true
+	})
+	f := requireFinding(t, validate(t, machine), pipelinefsm.RuleTerminal, "done")
+	assert.Contains(t, f.Message, "the way back is not described")
+}
+
+func TestValidate_ReopenableOnANonTerminalMeansNothing(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		states(t, m)[1].(map[string]any)["reopenable"] = true
+	})
+	f := requireFinding(t, validate(t, machine), pipelinefsm.RuleTerminal, "working")
+	assert.Contains(t, f.Message, "there is nothing to reopen")
+}
+
+// An edge that does not move the item leaves every state including a terminal —
+// a tracker that fails to load makes every item unobservable without any of them
+// moving. Counting that as a way out would make "terminal" undeclarable.
+func TestValidate_ANonMovingEdgeDoesNotContradictATerminal(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		m["states"] = append(states(t, m), map[string]any{"name": "unobservable", "doc": "the source could not be read"})
+		m["events"] = append(events(t, m),
+			map[string]any{
+				"name": "source-unreadable", "src": []any{"filed", "working", "done"}, "dst": "unobservable",
+				"actor": "daemon", "where": "compose.go", "doc": "the tracker failed to load", "moves_item": false,
+			},
+			map[string]any{
+				"name": "source-readable-again", "src": []any{"unobservable"}, "dst": "filed",
+				"actor": "daemon", "where": "compose.go", "doc": "the source came back", "moves_item": false,
+			})
+	})
+	assert.Empty(t, validate(t, machine))
+}
+
+func TestValidate_EveryTransitionNamesADeclaredActor(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		events(t, m)[0].(map[string]any)["actor"] = "robot"
+	})
+	f := requireFinding(t, validate(t, machine), pipelinefsm.RuleActor, "start")
+	assert.Contains(t, f.Message, `actor "robot" is not declared`)
+}
+
+func TestValidate_ATransitionWithNoActorIsIncomplete(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		delete(events(t, m)[0].(map[string]any), "actor")
+	})
+	f := requireFinding(t, validate(t, machine), pipelinefsm.RuleActor, "start")
+	assert.Contains(t, f.Message, "must name the actor")
+}
+
+func TestValidate_AMarkerMustBeWrittenAsOne(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		events(t, m)[0].(map[string]any)["marker"] = "started"
+	})
+	f := requireFinding(t, validate(t, machine), pipelinefsm.RuleMarkerSyntax, "start")
+	assert.Contains(t, f.Message, "is not written as [human:")
+}
+
+// One transition may be recorded by a different marker per stage; every
+// alternative is checked, not just the first.
+func TestValidate_EveryMarkerAlternativeIsChecked(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		events(t, m)[0].(map[string]any)["marker"] = "[human:started] | oops"
+	})
+	f := requireFinding(t, validate(t, machine), pipelinefsm.RuleMarkerSyntax, "start")
+	assert.Contains(t, f.Message, `"oops"`)
+}
+
+func TestValidate_ATransitionNeedNotHaveAMarker(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		delete(events(t, m)[0].(map[string]any), "marker")
+	})
+	assert.Empty(t, validate(t, machine))
+}
+
+func TestValidate_MissingTopLevelFieldsAreErrors(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		delete(m, "version")
+		delete(m, "describes")
+		delete(m, "actors")
+	})
+	findings := validate(t, machine)
+	subjects := map[string]bool{}
+	for _, f := range findings {
+		if f.Rule == pipelinefsm.RuleSchema {
+			subjects[f.Subject] = true
+		}
+	}
+	assert.True(t, subjects["version"], "a machine must declare its schema version")
+	assert.True(t, subjects["describes"], "a machine must say what it describes")
+	assert.True(t, subjects["actors"], "a machine must declare its actors")
+}
+
+// Prose gaps are warnings: the machine still holds together, and a build that
+// goes red over a missing sentence teaches people to stop adding transitions
+// rather than to describe them.
+func TestValidate_AnUndescribedTransitionWarnsRatherThanFails(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		delete(events(t, m)[0].(map[string]any), "doc")
+		delete(events(t, m)[0].(map[string]any), "where")
+	})
+	findings := validate(t, machine)
+	require.NotEmpty(t, findings)
+	assert.Zero(t, pipelinefsm.Errors(findings), "an under-described machine is not a broken one")
+	for _, f := range findings {
+		assert.Equal(t, pipelinefsm.SeverityWarning, f.Severity)
+	}
+}
+
+// A transition implemented in a prompt is as real as one implemented in Go:
+// "after X, post Y" defines an edge whether or not a compiler ever sees it.
+func TestValidate_APromptCountsAsSayingWhereATransitionLives(t *testing.T) {
+	machine := mutate(t, func(m map[string]any) {
+		e := events(t, m)[0].(map[string]any)
+		delete(e, "where")
+		e["prompt"] = "human-planner-agent.md"
+	})
+	assert.Empty(t, validate(t, machine))
+}
+
+func TestParseDocument_RejectsNonsense(t *testing.T) {
+	_, err := pipelinefsm.ParseDocument([]byte("not json"))
+	require.Error(t, err)
+}

--- a/internal/pipelinefsm/doc.go
+++ b/internal/pipelinefsm/doc.go
@@ -1,0 +1,132 @@
+// Package pipelinefsm validates docs/pipeline-fsm.json — the written-down
+// pipeline state machine.
+//
+// This checks the document against ITSELF: that it is a well-formed machine.
+// Every transition comes from and leads to a state that exists, no two states or
+// transitions share a name, nothing is unreachable, nothing is a trap you can
+// enter and never leave, every transition names an actor the document declares
+// and says where it is implemented.
+//
+// That is a narrower job than "is the document true", and deliberately so. A
+// description can be perfectly consistent and still describe the wrong system;
+// catching that needs the code, and it is a different check. What this catches
+// is the failure that comes first and costs the most to debug later: a machine
+// that does not hold together, where a transition points at a state nobody
+// declared or a state has no way out, so the document cannot be reasoned about
+// at all — the thing it exists to make possible.
+package pipelinefsm
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gethuman-sh/human/errors"
+)
+
+// DocPath is the document's location relative to the repository root.
+const DocPath = "docs/pipeline-fsm.json"
+
+// Document is the written machine.
+//
+// A PARTIAL view on purpose: the file carries prose annotations this package has
+// no opinion about (runs, prompt, guard, state_key, …) and Go's decoder drops
+// unknown fields, so the document can grow annotations without this type
+// changing. What is modelled here is exactly what can be checked.
+type Document struct {
+	Version   int               `json:"version"`
+	Describes string            `json:"describes"`
+	Item      string            `json:"item"`
+	Initial   string            `json:"initial"`
+	Actors    map[string]string `json:"actors"`
+	States    []State           `json:"states"`
+	Events    []Event           `json:"events"`
+}
+
+// State is one state an item can be in.
+type State struct {
+	Name string `json:"name"`
+	Doc  string `json:"doc"`
+
+	// Terminal marks a state the machine may come to rest in, which is what
+	// exempts it from needing a way out.
+	Terminal bool `json:"terminal"`
+
+	// Reopenable marks a terminal a person may overrule. It is the ONLY reason a
+	// terminal state may have an outgoing transition, so the two fields have to
+	// agree: a terminal with an exit and no reopenable is either mislabelled or
+	// describes a way out nobody meant to offer.
+	Reopenable bool `json:"reopenable"`
+}
+
+// Event is one transition. Name, Src and Dst are the looplab/fsm shape on
+// purpose: the document stays loadable by that library if we ever want the
+// machine executable rather than merely described.
+type Event struct {
+	Name   string   `json:"name"`
+	Src    []string `json:"src"`
+	Dst    string   `json:"dst"`
+	Actor  string   `json:"actor"`
+	Marker string   `json:"marker"`
+	Doc    string   `json:"doc"`
+
+	// Where and Prompt are the two ways a transition says where it is
+	// implemented, and a transition needs one of them. Which one is not a
+	// detail: `where` is Go, `prompt` is an agent instruction, and a transition
+	// that lives in a prompt is exactly as real as one that lives in code —
+	// "after X, post Y" defines an edge whether a compiler ever sees it.
+	Where  string `json:"where"`
+	Prompt string `json:"prompt"`
+
+	// DstIsDerived says the true destination is computed rather than fixed, so
+	// Dst is a topological placeholder.
+	DstIsDerived bool `json:"dst_is_derived"`
+
+	// MovesItem is false for a transition that changes something OTHER than where
+	// the item is in the pipeline — an observability edge, a gate that reports
+	// "not yet" without moving anything. Absent means true, so the ordinary case
+	// needs no annotation. It is why a terminal state can carry an outgoing edge
+	// without being a contradiction.
+	MovesItem *bool `json:"moves_item"`
+}
+
+// Moves reports whether the transition changes the item's place in the pipeline.
+func (e Event) Moves() bool {
+	return e.MovesItem == nil || *e.MovesItem
+}
+
+// Implementation names where the transition lives, in code or in a prompt.
+func (e Event) Implementation() string {
+	if strings.TrimSpace(e.Where) != "" {
+		return e.Where
+	}
+	return e.Prompt
+}
+
+// Markers splits a transition's marker field, which may name several
+// alternatives ("[human:a] | [human:b]") when one transition is recorded by a
+// different marker per stage.
+func (e Event) Markers() []string {
+	return splitMarkers(e.Marker)
+}
+
+// LoadDocument reads the machine from a repository root.
+func LoadDocument(root string) (Document, error) {
+	path := filepath.Join(root, filepath.FromSlash(DocPath))
+	raw, err := os.ReadFile(path) // #nosec G304 -- a path the operator names, in their own checkout
+	if err != nil {
+		return Document{}, errors.WrapWithDetails(err, "reading the pipeline machine", "path", path)
+	}
+	return ParseDocument(raw)
+}
+
+// ParseDocument decodes the machine. Split from LoadDocument so the rules can be
+// exercised on a document held in memory.
+func ParseDocument(raw []byte) (Document, error) {
+	var doc Document
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return Document{}, errors.WrapWithDetails(err, "parsing the pipeline machine")
+	}
+	return doc, nil
+}

--- a/internal/pipelinefsm/machine_test.go
+++ b/internal/pipelinefsm/machine_test.go
@@ -1,0 +1,85 @@
+package pipelinefsm_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/pipelinefsm"
+)
+
+// repoRoot is this package's distance to the checkout.
+const repoRoot = "../.."
+
+// The real machine, checked on every `make check`. This is the point of the
+// package: a transition added with a dst nobody declared, or a state with no way
+// out, fails the build rather than waiting to mislead whoever plans the next
+// pipeline change against it.
+func TestTheShippedMachineHoldsTogether(t *testing.T) {
+	findings, err := pipelinefsm.Check(repoRoot)
+	require.NoError(t, err)
+
+	var errs []string
+	for _, f := range findings {
+		if f.Severity == pipelinefsm.SeverityError {
+			errs = append(errs, f.String())
+		}
+	}
+	assert.Empty(t, errs, "docs/pipeline-fsm.json is not a well-formed machine:\n%s", strings.Join(errs, "\n"))
+}
+
+func TestMermaid_DrawsEveryEdgeAndBothEnds(t *testing.T) {
+	doc, err := pipelinefsm.LoadDocument(repoRoot)
+	require.NoError(t, err)
+
+	diagram := pipelinefsm.Mermaid(doc)
+	assert.True(t, strings.HasPrefix(diagram, "stateDiagram-v2\n"))
+	assert.Contains(t, diagram, "[*] --> "+strings.ReplaceAll(doc.Initial, "-", "_"))
+
+	edges := 0
+	for _, e := range doc.Events {
+		edges += len(e.Src)
+	}
+	terminals := 0
+	for _, s := range doc.States {
+		if s.Terminal {
+			terminals++
+		}
+	}
+	// One line per (src, transition) pair, one per terminal, one for the entry,
+	// one for the header.
+	assert.Equal(t, edges+terminals+2, len(strings.Split(strings.TrimRight(diagram, "\n"), "\n")))
+
+	// Hyphens are mermaid's arrow, so a state name carrying one must not reach
+	// the diagram raw.
+	for _, line := range strings.Split(diagram, "\n") {
+		before, _, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+		assert.NotContains(t, strings.TrimSpace(strings.ReplaceAll(before, "-->", "")), "-",
+			"a state name reached the diagram unescaped: %s", line)
+	}
+}
+
+func TestMermaid_LabelsAnEdgeWithItsMarker(t *testing.T) {
+	doc, err := pipelinefsm.ParseDocument([]byte(soundMachine))
+	require.NoError(t, err)
+	assert.Contains(t, pipelinefsm.Mermaid(doc), "start [human:started]")
+}
+
+// A transition recorded by a different marker per stage cannot name one of them
+// in the label without being wrong about the others.
+func TestMermaid_SaysWhenTheMarkerIsPerStage(t *testing.T) {
+	doc := pipelinefsm.Document{
+		Initial: "a",
+		States:  []pipelinefsm.State{{Name: "a"}, {Name: "b", Terminal: true}},
+		Events: []pipelinefsm.Event{{
+			Name: "down", Src: []string{"a"}, Dst: "b",
+			Marker: "[human:planning-outage] | [human:deploy-outage]",
+		}},
+	}
+	assert.Contains(t, pipelinefsm.Mermaid(doc), "down (per-stage marker)")
+}

--- a/internal/pipelinefsm/mermaid.go
+++ b/internal/pipelinefsm/mermaid.go
@@ -1,0 +1,51 @@
+package pipelinefsm
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Mermaid draws the machine as a state diagram.
+//
+// Drawing it was half the reason for writing the machine down: a list of
+// transitions is checkable but not readable, and the questions people actually
+// ask of a pipeline — where can this card go from here, what leads to a stuck
+// state, is there a way out — are shape questions. Mermaid because it renders in
+// the places this gets read: a pull request, an artifact, the docs.
+func Mermaid(doc Document) string {
+	var b strings.Builder
+	b.WriteString("stateDiagram-v2\n")
+	fmt.Fprintf(&b, "    [*] --> %s\n", id(doc.Initial))
+
+	for _, e := range doc.Events {
+		for _, src := range e.Src {
+			fmt.Fprintf(&b, "    %s --> %s: %s\n", id(src), id(e.Dst), label(e))
+		}
+	}
+	for _, s := range doc.States {
+		if s.Terminal {
+			fmt.Fprintf(&b, "    %s --> [*]\n", id(s.Name))
+		}
+	}
+	return b.String()
+}
+
+// id makes a state name safe as a mermaid identifier. The names carry hyphens,
+// which mermaid reads as part of an arrow.
+func id(state string) string {
+	return strings.ReplaceAll(state, "-", "_")
+}
+
+// label names the transition and, where one exists, the marker that records it —
+// the marker is the thing a reader greps for when they are looking at a real
+// ticket's comment thread and asking which edge it took.
+func label(e Event) string {
+	markers := e.Markers()
+	if len(markers) == 0 {
+		return e.Name
+	}
+	if len(markers) > 1 {
+		return e.Name + " (per-stage marker)"
+	}
+	return e.Name + " " + markers[0]
+}


### PR DESCRIPTION
`docs/pipeline-fsm.json` is the pipeline written down. It was checked for parse-ability and for marker existence, but nothing checked that it holds together as a machine — a `dst` naming a state nobody declared reads as a legal edge, and a state with no way out reads as a state.

`internal/pipelinefsm` + `cmd/fsmcheck` (`make fsm`) validate it against itself and report every finding at once:

| severity | rule | catches |
|---|---|---|
| error | topology | dangling `src`/`dst`, duplicate state or transition names, a source listed twice |
| error | reachability | unreachable states; a non-terminal state with no way out (a self-loop does not count) |
| error | terminal | `terminal`/`reopenable` disagreeing with the edges that exist |
| error | actor | a transition naming an actor the document does not declare |
| error | marker-syntax | a marker not written as `[human:…]` |
| warning | described | a state or transition with no prose, or no `where:`/`prompt:` |

Errors fail `make check` through the package's own test; warnings do not, because a build that reds over a missing sentence teaches people to stop adding transitions rather than to describe them. `make fsm-diagram` renders the machine as mermaid.

Whether the document is *true of the code* is a separate question, and it stays where it needs the daemon's constants — `internal/daemon/pipeline_fsm_doc_test.go` keeps the marker rules and loses the topology ones it now duplicates.

**Two findings were real, and the document answers them:**
- a transition implemented in a prompt is as real as one in Go, so `where:` and `prompt:` both count as saying where it lives
- an observability edge leaves every state including the terminals, so the two source-readability transitions are `moves_item: false` and `merged` can call itself terminal truthfully

Current state of the shipped document: **0 errors, 22 warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)