### PR TITLE
[SC-3849] Name the ticket that owns each violation

### DIFF
--- a/internal/pipelinefsm/testdata/replay-baseline.json
+++ b/internal/pipelinefsm/testdata/replay-baseline.json
@@ -1,7 +1,6 @@
 {
   "doc": "Every disagreement the corpus demonstrates between the written machine and the pipeline that produced these histories, sorted by what should happen about it. The sorting is the point: a refusal is a question — the machine says this move should not happen, and either the machine is wrong or the pipeline is — and answering it the lazy way, by widening the document until nothing objects, would destroy the only thing the document is for.",
   "counting": "Refusals count the FIRST refusal per ticket only. Once replay has lost the thread every later marker is refused too, so a raw total measures how long a history is rather than how wrong the document is. This also means the list is a LOWER BOUND: each entry hides the rest of its own history, so closing one reveals what was behind it.",
-
   "undescribed": {
     "doc": "The pipeline made a move that is legitimate and simply not written down. Fix the document. These shrink to zero.",
     "kinds": {
@@ -17,50 +16,82 @@
     },
     "note": "Most of these are one defect: [human:pr-review-failed] records TWO different things — a round's negative verdict, after which the loop dispatches the fixer, and the loop escalating to a stop. The document models only the stop, so every marker the loop posts after a failed round refuses. Same shape as bug-verdict: one marker, two meanings, separable only by the body."
   },
-
   "violations": {
-    "doc": "The pipeline made a move the machine forbids. Fix the CODE. These must never be closed by editing docs/pipeline-fsm.json — the test asserts the machine still refuses each one, so absorbing a violation into the description fails the build.",
+    "doc": "The pipeline made a move the machine forbids. Fix the CODE. These must never be closed by editing docs/pipeline-fsm.json — the test asserts the machine still refuses each one, so absorbing a violation into the description fails the build. Each names the ticket that owns the fix, so an entry cannot outlive the work silently.",
     "kinds": {
       "deployed@filed": {
         "count": 15,
         "why": "human deploy <KEY> --branch merges without the ticket entering the state machine at all: no started marker, no review, no PR loop. The card goes Backlog to Done and nothing describes the move. RunDeploy reads a branch straight from the flag and calls deployEngine (cmd/cmddeploy/deploy.go).",
-        "evidence": ["SC-3282"]
+        "ticket": "SC-3852",
+        "evidence": [
+          "SC-3282"
+        ]
       },
       "deployed@stopped": {
         "count": 2,
         "why": "The same bypass, onto a card that had already failed.",
-        "evidence": ["SC-2804"]
+        "evidence": [
+          "SC-2804"
+        ],
+        "ticket": "SC-3852"
       },
-      "deployed@planned": {"count": 1, "why": "The same bypass, onto a card holding an unstarted plan.", "evidence": []},
-      "deploy-failed@filed": {"count": 1, "why": "The same bypass, failing.", "evidence": ["SC-3497"]},
+      "deployed@planned": {
+        "count": 1,
+        "why": "The same bypass, onto a card holding an unstarted plan.",
+        "ticket": "SC-3852",
+        "evidence": []
+      },
+      "deploy-failed@filed": {
+        "count": 1,
+        "why": "The same bypass, failing.",
+        "ticket": "SC-3852",
+        "evidence": [
+          "SC-3497"
+        ]
+      },
       "deployed@awaiting-decision": {
         "count": 1,
         "why": "Merged while an options block was open — the one state nothing is allowed to move, because the machine has explicitly said only a person can answer.",
-        "evidence": ["SC-3295"]
+        "evidence": [
+          "SC-3295"
+        ],
+        "ticket": "SC-3852"
       },
       "plan-ready@stopped": {
         "count": 3,
         "why": "The planner posted its plan after the watcher had declared it dead. Work continuing past a stop, with no relaunch in between.",
-        "evidence": ["SC-2910", "SC-3305"]
+        "ticket": "SC-3853",
+        "evidence": [
+          "SC-2910",
+          "SC-3305"
+        ]
       },
       "review-complete@stopped": {
         "count": 3,
         "why": "The reviewer posted its verdict after review-failed. Same race.",
-        "evidence": ["SC-1655"]
+        "ticket": "SC-3853",
+        "evidence": [
+          "SC-1655"
+        ]
       },
       "ready-for-review@stopped": {
         "count": 3,
         "why": "The run handed off after implementation-failed. Same race.",
-        "evidence": ["SC-2005"]
+        "ticket": "SC-3853",
+        "evidence": [
+          "SC-2005"
+        ]
       },
       "implementation-failed@stopped": {
         "count": 1,
         "why": "Two failure markers for one ending, with no relaunch between them: the skill posts its own terminal marker when the budget is spent AND the daemon's exit watcher posts one when the agent leaves.",
-        "evidence": ["SC-3024"]
+        "evidence": [
+          "SC-3024"
+        ],
+        "ticket": "none yet — one history, and the two posters are known but which fired is not"
       }
     }
   },
-
   "unexplained": {
     "doc": "Not yet traced to a code path. Do nothing: a single occurrence can be a one-off — a marker posted by hand, an agent killed mid-write — and widening the document on a guess is how a specification becomes a rubber stamp. Each entry leaves here by being explained, in either direction.",
     "kinds": {
@@ -72,7 +103,6 @@
       "review-started@implementing": 1
     }
   },
-
   "ambiguities": {
     "doc": "Markers that fit several edges leading to different states. Not defects — the header genuinely does not say which move was made, and the answer is in the marker BODY the corpus deliberately does not carry. A NEW ambiguity should fail; these should not.",
     "kinds": {


### PR DESCRIPTION
Follow-up to #424. The `violations` bucket now names the ticket that owns each fix — SC-3852 for the deploy bypass (17 histories), SC-3853 for results arriving after a stop (9). An entry that names no work is a note someone has to re-derive before acting on it.

`implementation-failed@stopped` names no ticket on purpose: one history is not enough to say which of its two known posters fired.