### PR TITLE
[SC-3849] Separate what the machine got wrong from what it has outgrown

### DIFF
--- a/docs/pipeline-fsm.json
+++ b/docs/pipeline-fsm.json
@@ -840,13 +840,14 @@
     {
       "name": "launch-refused-no-plan",
       "src": [
-        "implementing"
+        "implementing",
+        "stopped"
       ],
       "dst": "stopped",
       "actor": "daemon",
       "marker": "[human:needs-planning]",
       "where": "board_transition.go refuseIfUnplanned",
-      "doc": "The plan executor was launched on a ticket with no plan, so the launch is refused before any agent claims it. The item surfaces back at planning where a human can start one."
+      "doc": "The plan executor was launched on a ticket with no plan, so the launch is refused before any agent claims it. The item surfaces back at planning where a human can start one. A relaunch attempted on a card that already failed meets the same gate, so the refusal is also a move a stopped card makes onto itself: the plan is still missing, and the card stays exactly as red as it was."
     },
     {
       "name": "source-unreadable",
@@ -992,6 +993,17 @@
       "moves_item": false,
       "where": "internal/claude/embed/human-ticket-reviewer-agent.md",
       "doc": "The gate's verdict inside a planning dispatch. It records why, and deliberately does not end the stage — a stop verdict posts planning's own terminal marker alongside it, and ready/reframed simply carry on. Both are why the verdict moves nothing here."
+    },
+    {
+      "name": "pr-fix-asks",
+      "src": [
+        "pr-fix"
+      ],
+      "dst": "awaiting-decision",
+      "actor": "daemon",
+      "marker": "[human:options]",
+      "where": "internal/daemon/board_transition.go escalatePRLoop — a fixer that ends needing input becomes a decision rather than a red card",
+      "doc": "The PR fixer hit something only a person can settle. Unlike every other stage-asks, the daemon raises this one rather than the agent: the fixer records its need on exit and the loop turns that into the block, naming the implementation stage so choosing rebuilds through the normal chain and re-adopts the still-open draft PR."
     }
   ],
   "ownership": {

--- a/internal/pipelinefsm/replay_test.go
+++ b/internal/pipelinefsm/replay_test.go
@@ -185,6 +185,9 @@ type baseline struct {
 	Violations struct {
 		Kinds map[string]violation `json:"kinds"`
 	} `json:"violations"`
+	Legacy struct {
+		Kinds map[string]int `json:"kinds"`
+	} `json:"legacy"`
 	Unexplained struct {
 		Kinds map[string]int `json:"kinds"`
 	} `json:"unexplained"`
@@ -207,6 +210,9 @@ func (b baseline) refusals() map[string]int {
 		all[k] = v
 	}
 	for k, v := range b.Unexplained.Kinds {
+		all[k] = v
+	}
+	for k, v := range b.Legacy.Kinds {
 		all[k] = v
 	}
 	for k, v := range b.Violations.Kinds {
@@ -257,6 +263,36 @@ func TestReplayCorpus_DisagreementMatchesTheBaseline(t *testing.T) {
 			"fix docs/pipeline-fsm.json, or update testdata/replay-baseline.json if the change is intended")
 	assert.Equal(t, want.Ambiguities.Kinds, ambiguities,
 		"the markers that fit more than one edge have changed")
+}
+
+// The buckets say what to do about a disagreement, so one entry sitting in two
+// of them is two contradictory instructions — and it would go unnoticed, because
+// flattening them for the count silently keeps whichever was merged last.
+func TestReplayBaseline_BucketsAreDisjoint(t *testing.T) {
+	b := loadBaseline(t)
+
+	seen := map[string]string{}
+	for bucket, kinds := range map[string][]string{
+		"undescribed": keysOf(b.Undescribed.Kinds),
+		"unexplained": keysOf(b.Unexplained.Kinds),
+		"legacy":      keysOf(b.Legacy.Kinds),
+		"violations":  keysOf(b.Violations.Kinds),
+	} {
+		for _, k := range kinds {
+			if other, dup := seen[k]; dup {
+				t.Errorf("%s is in both %s and %s — it can only mean one thing", k, other, bucket)
+			}
+			seen[k] = bucket
+		}
+	}
+}
+
+func keysOf[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }
 
 // The violation guard below is only worth anything if Accepts can say yes, so

--- a/internal/pipelinefsm/testdata/replay-baseline.json
+++ b/internal/pipelinefsm/testdata/replay-baseline.json
@@ -3,18 +3,16 @@
   "counting": "Refusals count the FIRST refusal per ticket only. Once replay has lost the thread every later marker is refused too, so a raw total measures how long a history is rather than how wrong the document is. This also means the list is a LOWER BOUND: each entry hides the rest of its own history, so closing one reveals what was behind it.",
   "undescribed": {
     "doc": "The pipeline made a move that is legitimate and simply not written down. Fix the document. These shrink to zero.",
+    "kinds": {}
+  },
+  "legacy": {
+    "doc": "Written by a pipeline that no longer exists. Fix NEITHER side: the document describes the machine as it is, and these histories are evidence about a machine it was. An entry here needs the change that retired the behaviour, and a reason to believe newer histories are clean.",
     "kinds": {
-      "deploy-fix-started@pr-review": 3,
-      "deploy-fix-started@stopped": 1,
-      "deploy-fix-started@implementing": 1,
       "deploy-failed@pr-review": 1,
-      "pr-fix-started@stopped": 1,
-      "pr-review-started@stopped": 1,
-      "needs-planning@stopped": 1,
-      "options@pr-fix": 1,
-      "review-started@in-review": 1
+      "deploy-fix-started@pr-review": 3,
+      "deployed@pr-review": 3
     },
-    "note": "Most of these are one defect: [human:pr-review-failed] records TWO different things — a round's negative verdict, after which the loop dispatches the fixer, and the loop escalating to a stop. The document models only the stop, so every marker the loop posts after a failed round refuses. Same shape as bug-verdict: one marker, two meanings, separable only by the body."
+    "cause": "Before SC-3718 (eca9baf2, 2026-08-05) the PR review loop recorded its starts and its stops but never its passing verdict, so a history from that era leaves the item at pr-review and the next thing it shows is a deploy-stage marker. Of the corpus histories that reached the loop, 7 from before that commit refuse at pr-review and 0 from after it do — which is the reason to believe this is retired rather than merely rarer."
   },
   "violations": {
     "doc": "The pipeline made a move the machine forbids. Fix the CODE. These must never be closed by editing docs/pipeline-fsm.json — the test asserts the machine still refuses each one, so absorbing a violation into the description fails the build. Each names the ticket that owns the fix, so an entry cannot outlive the work silently.",
@@ -95,19 +93,23 @@
   "unexplained": {
     "doc": "Not yet traced to a code path. Do nothing: a single occurrence can be a one-off — a marker posted by hand, an agent killed mid-write — and widening the document on a guess is how a specification becomes a rubber stamp. Each entry leaves here by being explained, in either direction.",
     "kinds": {
-      "deployed@pr-review": 1,
+      "deploy-fix-started@implementing": 1,
+      "deploy-fix-started@stopped": 1,
       "implementation-failed@planning": 2,
       "planning-failed@stopped": 1,
+      "pr-fix-started@stopped": 1,
+      "pr-review-started@stopped": 1,
       "ready-for-review@planned": 1,
       "review-complete@reviewed": 1,
-      "review-started@implementing": 1
+      "review-started@implementing": 1,
+      "review-started@in-review": 1
     }
   },
   "ambiguities": {
     "doc": "Markers that fit several edges leading to different states. Not defects — the header genuinely does not say which move was made, and the answer is in the marker BODY the corpus deliberately does not carry. A NEW ambiguity should fail; these should not.",
     "kinds": {
       "bug-verdict@preflight": 14,
-      "implementation-started@(derived)": 4,
+      "implementation-started@(derived)": 5,
       "implementation-started@stopped": 32,
       "implementation-started@substrate-down": 2
     }


### PR DESCRIPTION
Follow-up to #424/#425. Closes the `undescribed` bucket.

## A fourth bucket: `legacy`

Seven of the remaining disagreements are not disagreements with *this* machine. Before SC-3718 (`eca9baf2`, 2026-08-05) the PR review loop recorded its starts and its stops and never its passing verdict, so a history from that era leaves the item at `pr-review` and the next thing it shows is a deploy-stage marker.

The natural experiment is clean: **of the corpus histories that reached the PR loop, 7 from before that commit refuse at `pr-review` and 0 from after it do.**

Fixing either side would be wrong — widening the document would describe a machine that no longer exists, and changing the code would re-break what SC-3718 fixed. So they go in a bucket that says fix neither, names the commit that retired the behaviour, and carries the before/after count as the reason to believe it.

That the corpus holds evidence about several machines isn't a flaw in it; it's what a record of the past is. It was just invisible while every refusal read as a present-tense defect.

## Two genuine gaps, now described

- **The PR fixer that ends needing input** becomes a decision rather than a red card — and the *daemon* raises that one, unlike every other `stage-asks`, which is why it needs its own transition rather than another source on that one (`escalatePRLoop`).
- **A relaunch attempted on a card that already failed** meets the plan gate exactly as a first launch does, so the refusal is also a move a stopped card makes onto itself.

## State of the baseline

`undescribed` is **empty**. Everything remaining is a violation (9 kinds, owned by SC-3852 / SC-3853), outgrown (3 kinds), or untraced (10 kinds — deliberately untouched).

Buckets are now asserted disjoint: an entry in two of them is two contradictory instructions, and flattening them for the count would silently keep whichever merged last.

Coverage 95.5%, `make check` and `make fsm` green.