### PR TITLE
[SC-3849] Ask whether a card can sit where the machine cannot name

### DIFF
--- a/internal/daemon/board_placement_test.go
+++ b/internal/daemon/board_placement_test.go
@@ -1,0 +1,190 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/pipelinefsm"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// The machine describes where an item can BE. The derivation decides where a
+// card actually IS. Nothing has ever compared the two, and they are written
+// independently — so a place a card can sit that the machine does not describe
+// would be invisible in exactly the way the pipeline's stuck-card bugs kept
+// being invisible: not a wrong answer anywhere, just a question nobody asked.
+//
+// This asks it. It drives the real DeriveBoardCard over the real marker
+// vocabulary and collects every (stage, state) placement that comes out, then
+// checks each against the placements the states claim.
+//
+// It is a LOWER BOUND, deliberately and permanently. Threads of one and two
+// markers cannot reach a placement that needs three, so an unclaimed placement
+// found here is real while the absence of one proves nothing. Every count this
+// project has produced from real evidence has had the same shape.
+
+// boardPlacement is one place a card can be.
+type boardPlacement struct {
+	Stage BoardStage `json:"stage"`
+	State BoardState `json:"state"`
+}
+
+func (p boardPlacement) String() string { return string(p.Stage) + "/" + string(p.State) }
+
+// producibleBoardPlacements returns every placement the derivation yields for
+// some thread built out of the marker vocabulary.
+//
+// The vocabulary comes from orderedMarkerSpecs rather than a list written here:
+// a list would be one more thing to keep in step with the markers, which is the
+// drift this whole exercise exists to catch, reproduced inside the check for it.
+func producibleBoardPlacements() map[boardPlacement][]string {
+	found := map[boardPlacement][]string{}
+	record := func(how string, comments []tracker.Comment, status tracker.Category, isIdea bool) {
+		card := DeriveBoardCard(comments, status, isIdea)
+		p := boardPlacement{card.Stage, card.State}
+		if _, seen := found[p]; !seen {
+			found[p] = []string{how}
+		}
+	}
+
+	at := func(n int) time.Time { return time.Unix(int64(1000+n), 0) }
+	body := func(header string) string { return header }
+
+	record("no markers at all", nil, tracker.CategoryUnstarted, false)
+	record("an idea-labelled ticket", nil, tracker.CategoryUnstarted, true)
+	record("a closed ticket", []tracker.Comment{{Body: DeployedHeader, Created: at(0)}}, tracker.CategoryDone, false)
+
+	// Every marker alone, then every ordered pair. The pairs are what reach the
+	// override chain — a decision retiring a running marker, a failure retired by
+	// a later start — which is where the synthesized placements live.
+	headers := make([]string, 0, len(orderedMarkerSpecs))
+	for _, spec := range orderedMarkerSpecs {
+		headers = append(headers, spec.Header)
+	}
+	// The two markers that carry meaning in their BODY, seeded per resumable
+	// stage: an options block and the choice that consumes it are how a card
+	// reaches the paused and queued placements at all.
+	for stage := range optionStages {
+		headers = append(headers,
+			OptionsHeader+"\nstage: "+string(stage)+"\n1: one option",
+			OptionChosenHeader+" 1: one option")
+	}
+
+	for _, first := range headers {
+		record("["+placementHow(first)+"]", []tracker.Comment{{Body: body(first), Created: at(1)}}, tracker.CategoryUnstarted, false)
+		for _, second := range headers {
+			record(placementHow(first)+" then "+placementHow(second), []tracker.Comment{
+				{Body: body(first), Created: at(1)},
+				{Body: body(second), Created: at(2)},
+			}, tracker.CategoryUnstarted, false)
+		}
+	}
+	return found
+}
+
+func placementHow(body string) string {
+	line, _, _ := strings.Cut(body, "\n")
+	return strings.TrimSpace(line)
+}
+
+// placementHow names a thread by its markers, so a finding says what puts a
+// card there rather than only that something does.
+
+// claimedBoardPlacements maps each placement the machine describes to the
+// states claiming it. Several states may claim one placement — that is the blur
+// a marker thread cannot resolve, not a contradiction.
+func claimedBoardPlacements(t *testing.T) map[boardPlacement][]string {
+	t.Helper()
+	doc, err := pipelinefsm.Load()
+	require.NoError(t, err)
+
+	claimed := map[boardPlacement][]string{}
+	for _, s := range doc.States {
+		if s.Board.Stage == "none" {
+			continue
+		}
+		stages := []BoardStage{BoardStage(s.Board.Stage)}
+		if s.Board.Stage == "any" {
+			stages = []BoardStage{BoardBacklog, BoardPlanning, BoardImplementation, BoardVerification, BoardDoneStage}
+		}
+		for _, stage := range stages {
+			p := boardPlacement{stage, BoardState(s.Board.State)}
+			claimed[p] = append(claimed[p], s.Name)
+		}
+	}
+	return claimed
+}
+
+// A placement the document names must be a placement that exists. This is the
+// cheap half and it catches a typo or a stage renamed in the code and not here,
+// which would otherwise make the expensive half below silently pass.
+func TestBoardPlacement_TheMachineNamesRealPlacements(t *testing.T) {
+	doc, err := pipelinefsm.Load()
+	require.NoError(t, err)
+
+	stages := map[string]bool{"any": true, "none": true}
+	for _, s := range []BoardStage{BoardIdeas, BoardBacklog, BoardPlanning, BoardImplementation, BoardVerification, BoardDoneStage, BoardHidden, BoardTicketReview} {
+		stages[string(s)] = true
+	}
+	states := map[string]bool{"none": true}
+	for _, s := range []BoardState{BoardIdle, BoardRunning, BoardDone, BoardFailed, BoardResolved, BoardQueued, BoardOutage} {
+		states[string(s)] = true
+	}
+
+	for _, s := range doc.States {
+		assert.True(t, stages[s.Board.Stage], "%s: board stage %q is not a stage the derivation produces", s.Name, s.Board.Stage)
+		assert.True(t, states[s.Board.State], "%s: board state %q is not a state the derivation produces", s.Name, s.Board.State)
+	}
+}
+
+// TestBoardPlacement_EveryPlacementIsClaimed is the measurement.
+//
+// Recorded against a baseline rather than shipped failing, for the reason the
+// replay baseline gives: a red test cannot be committed, and the finding is
+// worth more written down than shouted. The baseline is compared in BOTH
+// directions, so closing one of these must delete its row, and a new unclaimed
+// placement fails immediately.
+func TestBoardPlacement_EveryPlacementIsClaimed(t *testing.T) {
+	claimed := claimedBoardPlacements(t)
+
+	unclaimed := map[string]string{}
+	for p, hows := range producibleBoardPlacements() {
+		if len(claimed[p]) > 0 {
+			continue
+		}
+		unclaimed[p.String()] = hows[0]
+	}
+
+	var recorded struct {
+		Doc   string `json:"doc"`
+		Bound string `json:"bound"`
+		// Only the keys are compared. The values carry what puts a card there and
+		// what is not known about it, which is the half a reader needs and no
+		// assertion can check.
+		Unclaimed map[string]json.RawMessage `json:"unclaimed"`
+	}
+	raw, err := os.ReadFile("testdata/board-placements.json")
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(raw, &recorded))
+
+	assert.Equal(t, keysOfMap(recorded.Unclaimed), keysOfMap(unclaimed),
+		"the places a card can sit that the machine does not describe have changed — "+
+			"describe the new one in internal/pipelinefsm/pipeline-fsm.json, or record it in "+
+			"testdata/board-placements.json with what puts a card there")
+}
+
+func keysOfMap[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/daemon/testdata/board-placements.json
+++ b/internal/daemon/testdata/board-placements.json
@@ -1,0 +1,27 @@
+{
+  "doc": "Places a card can sit that no state in internal/pipelinefsm/pipeline-fsm.json describes. Found by driving the real DeriveBoardCard over the real marker vocabulary and comparing what comes out against what the machine claims. Recorded rather than fixed: what to do about each is a separate question, and answering it here — by widening the document until nothing is left over — is the move that would make the machine agree with anything.",
+  "bound": "A LOWER BOUND, permanently. The enumeration builds threads of one and two markers, so a placement reachable only from three cannot appear. An entry here is real; an absence proves nothing.",
+  "unclaimed": {
+    "planning/queued": {
+      "reached_by": "[human:options] stage: planning, then [human:option-chosen]",
+      "note": "See implementation/queued — one cause, three stages (optionStages is planning, implementation, verification; the done stage raises its decisions against implementation, so there is no done/queued)."
+    },
+    "implementation/queued": {
+      "reached_by": "[human:options] stage: implementation, then [human:option-chosen]",
+      "note": "A decision is recorded and the stage it named is requeued, but no agent has posted that stage's started marker. BoardQueued exists to stop the stuck-running pass redding a just-decided card (SC-1320) — and it does that by being a state that pass does not look at. Nor does any other: every reconcile pass keys on running, outage, a handoff, a loop, or a container. optionChosenQueued's own doc says a deferred launch can leave a card here indefinitely.",
+      "known": "That a card CAN sit here indefinitely is documented in the code. Whether one ever has is NOT measured — the marker corpus cannot show it, because the evidence of it is the absence of a later marker, which looks exactly like a card that has not got there yet."
+    },
+    "verification/queued": {
+      "reached_by": "[human:options] stage: verification, then [human:option-chosen]",
+      "note": "See implementation/queued."
+    },
+    "hidden/": {
+      "reached_by": "a ticket whose tracker status is done or closed",
+      "note": "Closing a ticket takes it off the board from ANY state, and reaper.md treats close as cancellation — it stops the ticket's agents. So it is a transition out of every state at once, fired from outside the marker bus, recorded in no comment. That is why fifty-nine replayed histories never surfaced it and a state-space enumeration does: the two measurements are blind to different things."
+    },
+    "ideas/": {
+      "reached_by": "a ticket carrying the idea label",
+      "note": "The machine's initial state is `filed`, and idea-to-PM promotion is a label swap rather than a marker, so an idea is arguably before the machine rather than missing from it. Recorded because the enumeration cannot tell 'deliberately outside' from 'left out' — only a person can."
+    }
+  }
+}

--- a/internal/pipelinefsm/doc.go
+++ b/internal/pipelinefsm/doc.go
@@ -101,6 +101,26 @@ type State struct {
 	// Note is what is true of THIS state on top of the inherited rule, so a
 	// deviation can be recorded without restating the rule it deviates from.
 	Note string `json:"note"`
+
+	// Board is where a reader would find an item in this state, as a placement
+	// the code can be asked about rather than a sentence a person reads. It used
+	// to be prose ("Fix, running"), which named frontend columns rather than the
+	// stages the derivation actually produces — so the one question worth asking
+	// of it could not be asked: is there a place a card can be that no state here
+	// describes?
+	Board BoardPlacement `json:"board"`
+}
+
+// BoardPlacement is where a state's item sits on the board: the stage column
+// and the within-stage status the derivation would report for it.
+//
+// Two escape values, both meaning "not one placement": "any" for a state that
+// can be reached from any column (an item does not leave its column to be
+// stopped), and "none" for one the board does not place at all.
+type BoardPlacement struct {
+	Stage string `json:"stage"`
+	State string `json:"state"`
+	Note  string `json:"note,omitempty"`
 }
 
 // StageDefaults carries the shared rules and the prose explaining them. The

--- a/internal/pipelinefsm/pipeline-fsm.json
+++ b/internal/pipelinefsm/pipeline-fsm.json
@@ -30,7 +30,10 @@
     {
       "name": "filed",
       "doc": "The ticket exists. No pipeline activity.",
-      "board": "Backlog",
+      "board": {
+        "stage": "backlog",
+        "state": ""
+      },
       "holds": "The ticket is open and carries no pipeline marker.",
       "who_may_act": [
         "user",
@@ -42,7 +45,10 @@
     {
       "name": "ticket-review",
       "doc": "The pre-planning gate is judging whether solving this ticket solves the problem.",
-      "board": "Backlog, running",
+      "board": {
+        "stage": "backlog",
+        "state": "running"
+      },
       "holds": "The pre-planning gate is running as the FIRST PHASE of the planning dispatch, so the agent that owns it is registered under the planning stage, not this one.",
       "who_may_act": [
         "skill",
@@ -54,7 +60,10 @@
     {
       "name": "ticket-reviewed",
       "doc": "The gate returned a verdict: ready, reframed, superseded, escalated or rejected. The last three are stop decisions.",
-      "board": "Backlog, done",
+      "board": {
+        "stage": "backlog",
+        "state": "done"
+      },
       "holds": "A verdict is recorded with one of five heads.",
       "who_may_act": [
         "skill",
@@ -66,7 +75,10 @@
     {
       "name": "planning",
       "doc": "A planner is exploring the codebase and writing an implementation plan.",
-      "board": "Planning, running",
+      "board": {
+        "stage": "planning",
+        "state": "running"
+      },
       "holds": "A planner owns the stage and [human:planning-started] is the item's newest planning marker.",
       "who_may_act": [
         "skill",
@@ -77,7 +89,10 @@
     {
       "name": "planned",
       "doc": "A plan is attached to the ticket. The item waits for a human to start the build.",
-      "board": "Planning, done",
+      "board": {
+        "stage": "planning",
+        "state": "done"
+      },
       "holds": "A [human:plan] comment is attached and no build has started.",
       "who_may_act": [
         "user"
@@ -88,7 +103,10 @@
     {
       "name": "nothing-to-do",
       "doc": "The planner proved the work is already merged. Clean terminal.",
-      "board": "Planning, resolved",
+      "board": {
+        "stage": "planning",
+        "state": "resolved"
+      },
       "terminal": true,
       "reopenable": true,
       "holds": "The planner established the work is already merged. Clean terminal.",
@@ -101,7 +119,10 @@
     {
       "name": "preflight",
       "doc": "The fix run is resolving what it may do and settling what the evidence can settle, before any work.",
-      "board": "Fix, running",
+      "board": {
+        "stage": "implementation",
+        "state": "running"
+      },
       "holds": "A fix run owns the implementation stage and is resolving what it may do before any work.",
       "who_may_act": [
         "skill",
@@ -112,7 +133,10 @@
     {
       "name": "triaging",
       "doc": "The run is reproducing the report to reach a verdict.",
-      "board": "Fix, running",
+      "board": {
+        "stage": "implementation",
+        "state": "running"
+      },
       "holds": "The run is reproducing the report; the implementation stage is claimed.",
       "who_may_act": [
         "skill",
@@ -123,7 +147,10 @@
     {
       "name": "challenging",
       "doc": "A skeptic is trying to refute a not-a-bug or undetermined verdict before it is acted on.",
-      "board": "Fix, running",
+      "board": {
+        "stage": "implementation",
+        "state": "running"
+      },
       "holds": "A skeptic is trying to refute a not-a-bug or undetermined verdict. It runs ONCE — a verdict that survives is not re-challenged.",
       "who_may_act": [
         "skill",
@@ -134,7 +161,10 @@
     {
       "name": "resolved-no-fix",
       "doc": "The no-fix verdict survived the challenge. Clean terminal — the ticket needs no code change.",
-      "board": "Fix, resolved",
+      "board": {
+        "stage": "implementation",
+        "state": "resolved"
+      },
       "terminal": true,
       "reopenable": true,
       "holds": "The no-fix verdict survived the challenge. Clean terminal — no code change is warranted.",
@@ -147,7 +177,10 @@
     {
       "name": "fix-planning",
       "doc": "The self-planning fix run is producing its own plan.",
-      "board": "Fix, running",
+      "board": {
+        "stage": "implementation",
+        "state": "running"
+      },
       "holds": "The self-planning fix run is writing its own plan, because it entered from a report rather than from a planned ticket.",
       "who_may_act": [
         "skill",
@@ -158,7 +191,10 @@
     {
       "name": "fixing",
       "doc": "A regression test that fails first, then the change that makes it pass.",
-      "board": "Fix, running",
+      "board": {
+        "stage": "implementation",
+        "state": "running"
+      },
       "holds": "A regression test that fails first exists, or is being written, along with the change that makes it pass.",
       "who_may_act": [
         "skill",
@@ -169,7 +205,10 @@
     {
       "name": "verifying",
       "doc": "Proving the test fails before and passes after, on a green suite.",
-      "board": "Fix, running",
+      "board": {
+        "stage": "implementation",
+        "state": "running"
+      },
       "holds": "The fix exists and its fails-before/passes-after evidence is being produced by something other than the code that wrote it.",
       "who_may_act": [
         "skill",
@@ -181,7 +220,10 @@
     {
       "name": "implementing",
       "doc": "A plan executor is carrying out an attached plan (the non-bug path).",
-      "board": "Code, running",
+      "board": {
+        "stage": "implementation",
+        "state": "running"
+      },
       "holds": "A plan executor is carrying out an ATTACHED plan. A launch onto a ticket with no plan is refused before any agent claims the stage.",
       "who_may_act": [
         "skill",
@@ -192,7 +234,10 @@
     {
       "name": "handed-off",
       "doc": "Branch and commits are recorded on the ticket, checked reachable.",
-      "board": "Code, done",
+      "board": {
+        "stage": "implementation",
+        "state": "done"
+      },
       "holds": "Branch and commits are recorded on the ticket AND the commits were verified reachable on the branch before the marker was posted.",
       "who_may_act": [
         "daemon"
@@ -203,7 +248,10 @@
     {
       "name": "in-review",
       "doc": "A reviewer is checking the change against the ticket's acceptance criteria. In a board fix run this happens inline, in the same warm container.",
-      "board": "Review, running",
+      "board": {
+        "stage": "verification",
+        "state": "running"
+      },
       "holds": "A reviewer owns the verification stage and is checking the change against the ticket's acceptance criteria.",
       "who_may_act": [
         "skill",
@@ -214,7 +262,10 @@
     {
       "name": "reviewed",
       "doc": "The review returned a verdict. A failing verdict blocks the deploy and sends the item back to be rebuilt.",
-      "board": "Review, done",
+      "board": {
+        "stage": "verification",
+        "state": "done"
+      },
       "holds": "A verdict is recorded. The board reads the daemon's blocking DECISION, never the verdict string.",
       "who_may_act": [
         "user",
@@ -226,7 +277,10 @@
     {
       "name": "deploying",
       "doc": "The daemon pushed the branch and opened a draft pull request.",
-      "board": "Deploy, running",
+      "board": {
+        "stage": "done",
+        "state": "running"
+      },
       "holds": "The branch is pushed and a DRAFT pull request is open, so a half-reviewed change is not mergeable by anyone.",
       "who_may_act": [
         "daemon"
@@ -236,7 +290,10 @@
     {
       "name": "pr-review",
       "doc": "The machine reviewer is reading the open pull request.",
-      "board": "Deploy, running",
+      "board": {
+        "stage": "done",
+        "state": "running"
+      },
       "holds": "The machine reviewer is reading the open pull request; the newest done-stage marker is a loop-started marker.",
       "who_may_act": [
         "daemon",
@@ -247,7 +304,10 @@
     {
       "name": "pr-fix",
       "doc": "The machine fixer is addressing the review's findings on the local branch.",
-      "board": "Deploy, running",
+      "board": {
+        "stage": "done",
+        "state": "running"
+      },
       "holds": "The machine fixer is committing to the LOCAL branch and never pushing, so the reviewer reads the new commit rather than a stale pushed head.",
       "who_may_act": [
         "daemon"
@@ -257,7 +317,10 @@
     {
       "name": "ci-gate",
       "doc": "Every check must be green before the merge.",
-      "board": "Deploy, running",
+      "board": {
+        "stage": "done",
+        "state": "running"
+      },
       "holds": "The review converged and every check must be green before the merge. If the base moved on, the branch is rebased and CI re-gated on the new head first.",
       "who_may_act": [
         "daemon"
@@ -267,7 +330,10 @@
     {
       "name": "deploy-fixing",
       "doc": "A CI failure or a rebase conflict dispatched the deploy fixer instead of failing the item.",
-      "board": "Deploy, running",
+      "board": {
+        "stage": "done",
+        "state": "running"
+      },
       "holds": "A mechanical failure — red CI or a rebase conflict — dispatched the fixer instead of failing the item. The fixer's container holds no push credentials.",
       "who_may_act": [
         "daemon"
@@ -278,7 +344,10 @@
     {
       "name": "merged",
       "doc": "Merged, branch deleted, ticket closed. The shipping terminal.",
-      "board": "Deploy, done",
+      "board": {
+        "stage": "done",
+        "state": "done"
+      },
       "terminal": true,
       "holds": "Merged, branch deleted, ticket closed. Past the merge, cleanup and closing are best-effort and never fail the item.",
       "who_may_act": [],
@@ -288,7 +357,11 @@
     {
       "name": "awaiting-decision",
       "doc": "The item is parked on a genuine fork. Only a human choosing an answer moves it.",
-      "board": "any column, decision needed",
+      "board": {
+        "stage": "any",
+        "state": "",
+        "note": "Idle in whatever column the card was in, with an open [human:options] block — pauseOnOpenOptions turns running or failed into idle. \"Decision needed\" is not a BoardState; the open block is what distinguishes it."
+      },
       "holds": "An open [human:options] block names this item's own stage, or an earlier stage the answer would rework.",
       "who_may_act": [
         "user"
@@ -299,7 +372,10 @@
     {
       "name": "stopped",
       "doc": "A stage gave up and said why: a spent budget, an unreviewable change, a failed deploy. Needs a human.",
-      "board": "any column, error",
+      "board": {
+        "stage": "any",
+        "state": "failed"
+      },
       "holds": "A stage gave up and the marker says why, naming the blocking condition rather than offering a gesture that cannot work.",
       "who_may_act": [
         "user",
@@ -311,7 +387,10 @@
     {
       "name": "substrate-down",
       "doc": "A stage reported the thing it needs was unreachable. Not a failure — it spends no retry budget and is relaunched when the substrate returns.",
-      "board": "any column, outage",
+      "board": {
+        "stage": "any",
+        "state": "outage"
+      },
       "holds": "A stage reported the thing it needs was unreachable. Nothing about the work is wrong, so it spends no retry budget.",
       "who_may_act": [
         "daemon",
@@ -323,7 +402,11 @@
     {
       "name": "unknown",
       "doc": "The item's own state is unchanged, but the tracker that carries it failed to load, so nothing can be observed about it. It is the only state not derived from the item's markers — it says the board could not look, not that the item moved. Every item on that tracker enters and leaves it together, and it resolves by itself on the next fetch that reads the source.",
-      "board": "not rendered — the board shows a load-failure banner instead of the columns",
+      "board": {
+        "stage": "none",
+        "state": "none",
+        "note": "Not a placement at all. A card whose thread could not be read is marked Degraded and keeps its last-known stage and state, so the board shows an error banner rather than moving it anywhere."
+      },
       "holds": "Nothing about the ITEM is known. Its own state is unchanged; the tracker carrying it failed to load, so every item on that tracker enters and leaves this state together.",
       "who_may_act": [
         "daemon"


### PR DESCRIPTION
A measurement, not a design. No new states, no topology change, nothing decided.

## What it does

The machine says where an item can *be*; `DeriveBoardCard` decides where a card actually *is*. The two are written independently and had never been compared. This drives the real derivation over the real marker vocabulary and checks every placement that comes out against the ones the states claim.

The vocabulary comes from `orderedMarkerSpecs`, not a list in the test — a list would be one more thing to keep in step with the markers, which is the drift this exists to catch, reproduced inside the check for it.

The document's placements were prose (`"Fix, running"`) naming frontend columns rather than derivation stages, and two of those columns are the same stage. Transcribed, not reinterpreted: every state claims exactly what its sentence already claimed.

## What it found

Five unclaimed placements, three causes:

| placement | reached by |
|---|---|
| `planning/queued`, `implementation/queued`, `verification/queued` | a recorded decision whose relaunch has not started |
| `hidden/` | a ticket closed on the tracker |
| `ideas/` | a ticket carrying the idea label |

The `queued` one is the interesting one. `BoardQueued` exists to stop the stuck-running pass redding a just-decided card (SC-1320) — and it does that by being a state that pass does not look at. Nor does any other: every reconcile pass keys on running, outage, a handoff, a loop, or a container. `optionChosenQueued`'s own doc says a deferred launch can leave a card there indefinitely. That a card *can* sit there forever is documented in the code; whether one ever *has* is not measured, and the marker corpus cannot show it — the evidence would be the absence of a later marker, which looks exactly like a card that has not got there yet.

`hidden/` is worth noting for a different reason: closing a ticket takes a card off the board from any state at once, fires from outside the marker bus, and is recorded in no comment. That is why 59 replayed histories never surfaced it and this does. The two measurements are blind to different things.

## What it does not do

Nothing is fixed and nothing is decided. Widening the document until nothing is left over is the one move that would destroy what the answer is worth. Each of the three causes wants a different answer, and the measurement cannot give it.

Recorded as a baseline compared in both directions, so closing one must delete its row and a new unclaimed placement fails immediately. `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)