### PR TITLE
[SC-3849] Let a marker be both, but only on purpose

### DIFF
--- a/internal/pipelinefsm/check.go
+++ b/internal/pipelinefsm/check.go
@@ -19,6 +19,7 @@ const (
 	RuleMarkerSyntax Rule = "marker-syntax" // a marker is written the way a marker is written
 	RuleDescribed    Rule = "described"     // a transition says what it means and where it lives
 	RuleInvariant    Rule = "invariant"     // a state says what holds, who may act, and what happens if nobody does
+	RuleDualRole     Rule = "dual-role"     // a marker that both moves an item and records content says so on purpose
 )
 
 // Severity separates a machine that does not hold together from one that holds
@@ -75,6 +76,7 @@ func Validate(doc Document) []Finding {
 	findings = append(findings, checkMarkerSyntax(doc)...)
 	findings = append(findings, checkDescribed(doc)...)
 	findings = append(findings, checkInvariants(doc)...)
+	findings = append(findings, checkDualRole(doc)...)
 
 	sort.Slice(findings, func(i, j int) bool {
 		if findings[i].Severity != findings[j].Severity {
@@ -436,6 +438,42 @@ func checkMarkerSyntax(doc Document) []Finding {
 			if !strings.HasPrefix(m, markerPrefix) || !strings.HasSuffix(m, "]") || len(m) <= len(markerPrefix)+1 {
 				findings = append(findings, Finding{RuleMarkerSyntax, SeverityError, e.Name, fmt.Sprintf("marker %q is not written as [human:…]", m)})
 			}
+		}
+	}
+	return findings
+}
+
+// checkDualRole holds the line between a deliberate overlap and an accidental
+// one.
+//
+// A marker may legitimately be a transition from one state and a record of
+// content from another — [human:plan] is both — and the flat marker list cannot
+// express that, so the overlap has to be allowed. What must not be allowed is an
+// overlap nobody meant: a marker added to a transition while it still sits in
+// the unclassified list is a marker replay will silently absorb wherever no edge
+// happens to exist, which hides real disagreements rather than recording them.
+// Declaring it costs a sentence and turns silence into a decision.
+func checkDualRole(doc Document) []Finding {
+	var findings []Finding
+	transitions := map[string]bool{}
+	for _, e := range doc.Events {
+		for _, m := range e.Markers() {
+			transitions[strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(m), markerPrefix), "]")] = true
+		}
+	}
+	unclassified := map[string]bool{}
+	for _, m := range doc.Unclassified.Markers {
+		unclassified[m] = true
+		if transitions[m] && strings.TrimSpace(doc.Unclassified.DualRole[m]) == "" {
+			findings = append(findings, Finding{RuleDualRole, SeverityError, m,
+				"is declared both as a transition marker and as recording no movement, with no dual_role entry saying why — " +
+					"either it is one or the other, or the overlap is deliberate and needs a reason"})
+		}
+	}
+	for m := range doc.Unclassified.DualRole {
+		if !transitions[m] || !unclassified[m] {
+			findings = append(findings, Finding{RuleDualRole, SeverityWarning, m,
+				"has a dual_role reason but is no longer both a transition marker and unclassified — the reason outlived what it explained"})
 		}
 	}
 	return findings

--- a/internal/pipelinefsm/doc.go
+++ b/internal/pipelinefsm/doc.go
@@ -240,4 +240,16 @@ func ParseDocument(raw []byte) (Document, error) {
 // "this marker moves nothing" from "this marker is missing from the machine".
 type Unclassified struct {
 	Markers []string `json:"markers"`
+
+	// DualRole names the markers that are deliberately BOTH — a transition from
+	// some states and a record of content from others — and says why for each.
+	//
+	// The overlap looks like a contradiction and is not one. [human:plan] moves
+	// a self-planning fix run from fix-planning to fixing, and records content
+	// when a planner attaches a plan to a ticket that is not going anywhere yet.
+	// The list of markers has no way to say "here but not there", so without this
+	// field the choice is between a document that contradicts itself and one that
+	// is wrong. Declaring the overlap makes it visible and, more to the point,
+	// makes an UNdeclared overlap an error rather than an accident.
+	DualRole map[string]string `json:"dual_role,omitempty"`
 }

--- a/internal/pipelinefsm/pipeline-fsm.json
+++ b/internal/pipelinefsm/pipeline-fsm.json
@@ -24,7 +24,11 @@
       "fix-summary",
       "claim",
       "stage-wait"
-    ]
+    ],
+    "dual_role": {
+      "plan": "A transition inside a self-planning fix run (fix-plan-written: fix-planning to fixing, the run writing the plan it is about to carry out) and a record of content everywhere else, where a planner attaches a plan to a ticket that does not move until [human:plan-ready]. Measured on the 59-history corpus: dropping it from this list turns 21 histories' plan markers into refusals, 16 of them at `filed` or `planning` where nothing moved. The overlap is what keeps those 16 from being reported as defects.",
+      "bug-verdict": "A transition out of triaging — to fix-planning on a confirmed bug, to challenging on a not-a-bug, which is why the corpus records bug-verdict@preflight as a known ambiguity rather than a defect — and a record of content when it lands anywhere else. Dropping it from this list adds 2 refusals at `implementing`."
+    }
   },
   "states": [
     {


### PR DESCRIPTION
`plan` and `bug-verdict` were declared as transitions **and** in `unclassified_markers` ("deliberately not transitions"). I've had that written down since the first corpus run as a checker rule to add: *a marker must not be both*.

**That rule would have been wrong.** The corpus says so:

| change | effect |
|---|---|
| drop `plan` from the unclassified list | 21 histories' `plan` markers become refusals — 16 at `filed` or `planning` |
| drop `bug-verdict` | 2 more, at `implementing` |
| both | clean replays fall 8 → 3 |

Those 16 are a planner attaching a plan to a ticket that does not move until `[human:plan-ready]`. Nothing moved; reporting them as defects would be the document lying about the pipeline to satisfy its own rule.

The overlap is not a mistake. It is the document compensating for a flat marker list that cannot say *"a transition here, content there"* — `[human:plan]` moves a self-planning fix run from `fix-planning` to `fixing`, and records content everywhere else.

## So the check inverts

The overlap stays and becomes deliberate. Each such marker carries a `dual_role` reason, and an overlap **without** one is the error — because a marker added to a transition while it still sits in the unclassified list is one replay will silently absorb wherever no edge happens to exist, hiding disagreements instead of recording them. A reason that outlives the overlap it explains is a warning, so the explanations cannot rot in place.

Both directions verified: the error fires on exactly the two, the warning fires on an injected stale entry.

## What did not change

The corpus is byte-identical before and after — 8 clean replays, the same 22 refusal kinds. This changes what the document can be *asked*, not what it says.

`make fsm` and `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)