### PR TITLE
[SC-3849] Measure the depth the placement bound was only assuming

### DIFF
--- a/internal/daemon/board_placement_test.go
+++ b/internal/daemon/board_placement_test.go
@@ -25,10 +25,18 @@ import (
 // vocabulary and collects every (stage, state) placement that comes out, then
 // checks each against the placements the states claim.
 //
-// It is a LOWER BOUND, deliberately and permanently. Threads of one and two
-// markers cannot reach a placement that needs three, so an unclaimed placement
-// found here is real while the absence of one proves nothing. Every count this
-// project has produced from real evidence has had the same shape.
+// It is a LOWER BOUND — an unclaimed placement found here is real, while the
+// absence of one proves nothing. Every count this project has produced from real
+// evidence has had the same shape.
+//
+// What that bound is NOT limited by any more is thread DEPTH. This used to
+// enumerate pairs and disclaim placements needing three; measured, the set
+// saturates at two — threes add none, and a one-off probe to four added none
+// either. Threes are enumerated anyway, cheaply, so the depth the caveat used to
+// worry about is covered by the guard rather than argued about in a comment.
+// What still bounds it is marker SHAPE: each header is seeded with one body, and
+// the options block with one stage-and-count, so a placement that needs a
+// particular body cannot appear.
 
 // boardPlacement is one place a card can be.
 type boardPlacement struct {
@@ -61,9 +69,12 @@ func producibleBoardPlacements() map[boardPlacement][]string {
 	record("an idea-labelled ticket", nil, tracker.CategoryUnstarted, true)
 	record("a closed ticket", []tracker.Comment{{Body: DeployedHeader, Created: at(0)}}, tracker.CategoryDone, false)
 
-	// Every marker alone, then every ordered pair. The pairs are what reach the
-	// override chain — a decision retiring a running marker, a failure retired by
-	// a later start — which is where the synthesized placements live.
+	// Every marker alone, then every ordered pair, then every ordered triple. The
+	// pairs are what reach the override chain — a decision retiring a running
+	// marker, a failure retired by a later start — which is where the synthesized
+	// placements live. The triples reach nothing further today; they are here so
+	// that a change which makes a third marker matter fails this test instead of
+	// quietly widening what the enumeration cannot see.
 	headers := make([]string, 0, len(orderedMarkerSpecs))
 	for _, spec := range orderedMarkerSpecs {
 		headers = append(headers, spec.Header)
@@ -84,6 +95,14 @@ func producibleBoardPlacements() map[boardPlacement][]string {
 				{Body: body(first), Created: at(1)},
 				{Body: body(second), Created: at(2)},
 			}, tracker.CategoryUnstarted, false)
+			for _, third := range headers {
+				record(placementHow(first)+" then "+placementHow(second)+" then "+placementHow(third),
+					[]tracker.Comment{
+						{Body: body(first), Created: at(1)},
+						{Body: body(second), Created: at(2)},
+						{Body: body(third), Created: at(3)},
+					}, tracker.CategoryUnstarted, false)
+			}
 		}
 	}
 	return found

--- a/internal/daemon/testdata/board-placements.json
+++ b/internal/daemon/testdata/board-placements.json
@@ -1,6 +1,6 @@
 {
   "doc": "Places a card can sit that no state in internal/pipelinefsm/pipeline-fsm.json describes. Found by driving the real DeriveBoardCard over the real marker vocabulary and comparing what comes out against what the machine claims. Recorded rather than fixed: what to do about each is a separate question, and answering it here — by widening the document until nothing is left over — is the move that would make the machine agree with anything.",
-  "bound": "A LOWER BOUND, permanently. The enumeration builds threads of one and two markers, so a placement reachable only from three cannot appear. An entry here is real; an absence proves nothing.",
+  "bound": "A LOWER BOUND. An entry here is real; an absence proves nothing. What no longer bounds it is thread DEPTH: this said a placement reachable only from three markers could not appear, and that was an assumption. Measured 2026-08-09 — the placement set saturates at two. All 36^3 ordered triples yield the same 27 placements pairs do, and a one-off probe of all 36^4 quadruples added none either; triples are now enumerated by the shipped check so a change that makes a third marker matter fails it. What still bounds it is marker SHAPE: every header is seeded with one body and the options block with one stage-and-count, so a placement that needs a particular body cannot appear.",
   "unclaimed": {
     "planning/queued": {
       "reached_by": "[human:options] stage: planning, then [human:option-chosen]",
@@ -26,7 +26,9 @@
     },
     "ideas/": {
       "reached_by": "a ticket carrying the idea label",
-      "note": "The machine's initial state is `filed`, and idea-to-PM promotion is a label swap rather than a marker, so an idea is arguably before the machine rather than missing from it. Recorded because the enumeration cannot tell 'deliberately outside' from 'left out' — only a person can."
+      "note": "The machine's initial state is `filed`, and idea-to-PM promotion is a label swap rather than a marker, so an idea is arguably before the machine rather than missing from it. Recorded because the enumeration cannot tell 'deliberately outside' from 'left out' — only a person can.",
+      "known": "Read in code 2026-08-09, three facts. (1) Promotion posts NO marker: RunIdeaPromote (cmd/cmdauto/semantic.go) is one EditIssue with RemoveLabels and nothing else, so ideas -> filed is invisible to the marker bus in exactly the way close is — which is why replaying markers can never see this edge, and why it took a state-space enumeration to surface it. (2) Membership is the label and only the label: DeriveBoardCard returns the Ideas stage before it looks at a single comment, deliberately (board_state.go), so an idea-labelled ticket that somehow carries pipeline markers renders as an idea and its real pipeline position is hidden. (3) The word `idea` appears NOWHERE in pipeline-fsm.json, while `filed` claims board (backlog, \"\") unconditionally — so for an idea-labelled ticket that state's `holds` is satisfied and its `board` is wrong.",
+      "not_known": "How often (2) actually happens — whether any idea-labelled ticket carries pipeline markers, which is the number that would say if the hiding is theoretical or real. It needs the label on every ticket, which the local replay corpus does not record (it stores key and markers only) and the tracker was vault-locked when this was written. This is the one of the three still unmeasured against real tickets."
     }
   }
 }


### PR DESCRIPTION
The board-placement enumeration built threads of one and two markers and disclaimed, permanently and in a comment, any placement that needed three. That was an assumption sitting inside a measurement.

**Measured:** the placement set saturates at two. All 36^3 ordered triples yield the same 27 placements the pairs do; a one-off probe of all 36^4 quadruples added none either. Triples now run in the shipped check (0.3s), so a change that makes a third marker matter fails here rather than quietly widening what the enumeration cannot see.

Still a lower bound, for a reason now stated accurately: every header is seeded with one body and the options block with one stage-and-count, so a placement needing a particular body cannot appear. Depth is no longer part of that caveat.

Also records what reading the code settles about the `ideas` entry — none of it decides the open question:
- promotion posts **no marker** (`RunIdeaPromote` is one label edit), so `ideas -> filed` is invisible to the marker bus exactly as close is, which is why only a state-space enumeration could surface it;
- membership is the label alone, checked before any comment, so an idea-labelled ticket carrying markers has its real pipeline position hidden;
- the document never says the word, while `filed` claims board `(backlog, "")` unconditionally.

How often the second case happens stays unmeasured: it needs per-ticket labels, which the replay corpus does not store.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)