### PR TITLE
[SC-3866] Remove the per-tracker credential flags

### DIFF
--- a/cmd/cmdauto/auto_test.go
+++ b/cmd/cmdauto/auto_test.go
@@ -63,8 +63,7 @@ func TestBuildAutoPRCreateCmd_run(t *testing.T) {
 				Forge:    forgegithub.New(srv.URL, "t"),
 			}}, nil
 		},
-		InstanceFromFlags: func(_ *cobra.Command) *tracker.Instance { return nil },
-		AuditLogPath:      func() string { return "" },
+		AuditLogPath: func() string { return "" },
 	}
 
 	root := &cobra.Command{Use: "human"}

--- a/cmd/cmdclickup/clickup.go
+++ b/cmd/cmdclickup/clickup.go
@@ -38,10 +38,6 @@ func resolveClickUpClient(cmd *cobra.Command, deps cmdutil.Deps) (*clickup.Clien
 		return nil, err
 	}
 
-	if inst := deps.InstanceFromFlags(cmd); inst != nil {
-		instances = append(instances, *inst)
-	}
-
 	trackerName, _ := cmd.Root().PersistentFlags().GetString("tracker")
 	instance, err := tracker.ResolveByKind("clickup", instances, trackerName)
 	if err != nil {

--- a/cmd/cmdclickup/clickup_test.go
+++ b/cmd/cmdclickup/clickup_test.go
@@ -31,7 +31,6 @@ func testDeps(srv *httptest.Server, teamID string) cmdutil.Deps {
 				},
 			}, nil
 		},
-		InstanceFromFlags: func(_ *cobra.Command) *tracker.Instance { return nil },
 	}
 }
 

--- a/cmd/cmdprovider/provider_test.go
+++ b/cmd/cmdprovider/provider_test.go
@@ -1061,8 +1061,7 @@ func TestPRCreate_DefaultsRepoFromOrigin(t *testing.T) {
 				Forge:    forgegithub.New(srv.URL, "t"),
 			}}, nil
 		},
-		InstanceFromFlags: func(_ *cobra.Command) *tracker.Instance { return nil },
-		AuditLogPath:      func() string { return "" },
+		AuditLogPath: func() string { return "" },
 	}
 
 	root := &cobra.Command{Use: "human"}
@@ -1100,8 +1099,7 @@ func newTestRoot(mp *mockProvider) (*cobra.Command, cmdutil.Deps) {
 				{Name: "test", Kind: "jira", Provider: mp},
 			}, nil
 		},
-		InstanceFromFlags: func(_ *cobra.Command) *tracker.Instance { return nil },
-		AuditLogPath:      func() string { return "" },
+		AuditLogPath: func() string { return "" },
 	}
 
 	root := &cobra.Command{Use: "human"}
@@ -1408,8 +1406,7 @@ func TestCmd_LoadInstancesError(t *testing.T) {
 		LoadInstances: func(_ string) ([]tracker.Instance, error) {
 			return nil, errors.WithDetails("config error")
 		},
-		InstanceFromFlags: func(_ *cobra.Command) *tracker.Instance { return nil },
-		AuditLogPath:      func() string { return "" },
+		AuditLogPath: func() string { return "" },
 	}
 
 	root := &cobra.Command{Use: "human"}

--- a/cmd/cmdutil/instances.go
+++ b/cmd/cmdutil/instances.go
@@ -6,11 +6,8 @@ import (
 	"path/filepath"
 
 	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
 
 	"github.com/gethuman-sh/human/internal/config"
-	"github.com/gethuman-sh/human/internal/forge"
-	forgegithub "github.com/gethuman-sh/human/internal/forge/github"
 	"github.com/gethuman-sh/human/internal/knowledge/notion"
 	"github.com/gethuman-sh/human/internal/recall"
 	"github.com/gethuman-sh/human/internal/tracker"
@@ -148,96 +145,6 @@ func LoadAllInstancesTolerant(dir string, lookup config.EnvLookup, resolver *vau
 		all = append(all, instances...)
 	}
 	return all, failures
-}
-
-// InstanceFromFlags builds a tracker instance from root persistent flags,
-// returning nil when insufficient flags are provided.
-func InstanceFromFlags(cmd *cobra.Command) *tracker.Instance {
-	getFlag := func(name string) string {
-		v, _ := cmd.Root().PersistentFlags().GetString(name)
-		return v
-	}
-
-	if inst := instanceFromJiraFlags(getFlag); inst != nil {
-		return inst
-	}
-	if inst := instanceFromAzureFlags(getFlag); inst != nil {
-		return inst
-	}
-
-	// Simple token-based providers: token flag, url flag, default URL, kind,
-	// tracker constructor, and an optional forge constructor for backends that
-	// also host pull requests (GitHub).
-	type simpleProvider struct {
-		tokenFlag  string
-		urlFlag    string
-		defaultURL string
-		kind       string
-		newClient  func(url, token string) tracker.Provider
-		newForge   func(url, token string) forge.Forge
-	}
-	simpleProviders := []simpleProvider{
-		{"github-token", "github-url", "https://api.github.com", "github", func(u, t string) tracker.Provider { return github.New(u, t) }, func(u, t string) forge.Forge { return forgegithub.New(u, t) }},
-		{"gitlab-token", "gitlab-url", "https://gitlab.com", "gitlab", func(u, t string) tracker.Provider { return gitlab.New(u, t) }, nil},
-		{"linear-token", "linear-url", "https://api.linear.app", "linear", func(u, t string) tracker.Provider { return linear.New(u, t) }, nil},
-		{"shortcut-token", "shortcut-url", "https://api.app.shortcut.com", "shortcut", func(u, t string) tracker.Provider { return shortcut.New(u, t) }, nil},
-		{"clickup-token", "clickup-url", "https://api.clickup.com", "clickup", func(u, t string) tracker.Provider { return clickup.New(u, t, "") }, nil},
-	}
-	for _, sp := range simpleProviders {
-		token := getFlag(sp.tokenFlag)
-		if token == "" {
-			continue
-		}
-		url := getFlag(sp.urlFlag)
-		if url == "" {
-			url = sp.defaultURL
-		}
-		inst := &tracker.Instance{
-			Kind:     sp.kind,
-			URL:      url,
-			Provider: sp.newClient(url, token),
-		}
-		if sp.newForge != nil {
-			inst.Forge = sp.newForge(url, token)
-		}
-		return inst
-	}
-
-	return nil
-}
-
-// instanceFromJiraFlags builds a Jira instance from flags, or returns nil.
-func instanceFromJiraFlags(getFlag func(string) string) *tracker.Instance {
-	jiraURL := getFlag("jira-url")
-	jiraUser := getFlag("jira-user")
-	jiraKey := getFlag("jira-key")
-	if jiraURL == "" || jiraUser == "" || jiraKey == "" {
-		return nil
-	}
-	return &tracker.Instance{
-		Kind:     "jira",
-		URL:      jiraURL,
-		User:     jiraUser,
-		Provider: jira.New(jiraURL, jiraUser, jiraKey),
-	}
-}
-
-// instanceFromAzureFlags builds an Azure DevOps instance from flags, or returns nil.
-func instanceFromAzureFlags(getFlag func(string) string) *tracker.Instance {
-	azureToken := getFlag("azure-token")
-	azureOrg := getFlag("azure-org")
-	if azureToken == "" || azureOrg == "" {
-		return nil
-	}
-	url := getFlag("azure-url")
-	if url == "" {
-		url = "https://dev.azure.com"
-	}
-	return &tracker.Instance{
-		Kind:     "azuredevops",
-		URL:      url,
-		Provider: azuredevops.New(url, azureOrg, azureToken),
-	}
 }
 
 // LoadNotionIndexInstances loads Notion instances and converts them

--- a/cmd/cmdutil/origin_test.go
+++ b/cmd/cmdutil/origin_test.go
@@ -33,8 +33,7 @@ func githubDeps() Deps {
 				Forge:    forgegithub.New("https://api.github.com", "t"),
 			}}, nil
 		},
-		InstanceFromFlags: func(_ *cobra.Command) *tracker.Instance { return nil },
-		AuditLogPath:      func() string { return "" },
+		AuditLogPath: func() string { return "" },
 	}
 }
 

--- a/cmd/cmdutil/resolve.go
+++ b/cmd/cmdutil/resolve.go
@@ -37,7 +37,6 @@ import (
 type Deps struct {
 	LoadInstances       func(dir string) ([]tracker.Instance, error)
 	LoadInstancesCtx    func(ctx context.Context, dir string) ([]tracker.Instance, error)
-	InstanceFromFlags   func(cmd *cobra.Command) *tracker.Instance
 	AuditLogPath        func() string
 	DestructiveLogPath  func() string
 	DestructiveNotifier func(ctx context.Context) tracker.DestructiveNotifier // returns nil if no notification configured; ctx carries per-request env
@@ -48,7 +47,6 @@ func DefaultDeps() Deps {
 	return Deps{
 		LoadInstances:       LoadAllInstances,
 		LoadInstancesCtx:    LoadAllInstancesCtx,
-		InstanceFromFlags:   InstanceFromFlags,
 		AuditLogPath:        AuditLogPath,
 		DestructiveLogPath:  DestructiveLogPath,
 		DestructiveNotifier: loadDestructiveNotifier,
@@ -63,17 +61,13 @@ type AutoResult struct {
 	Cleanup  func()
 }
 
-// ResolveProvider loads instances, applies CLI flag overrides, and resolves
-// the provider for the given kind using the tracker name from persistent flags.
+// ResolveProvider loads the configured instances and resolves the provider for
+// the given kind using the tracker name from persistent flags.
 func ResolveProvider(cmd *cobra.Command, kind string, deps Deps) (tracker.Provider, func(), error) {
 	ctx := cmdContext(cmd)
 	instances, err := loadInstancesCtx(ctx, deps)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	if inst := deps.InstanceFromFlags(cmd); inst != nil {
-		instances = append(instances, *inst)
 	}
 
 	trackerName, _ := cmd.Root().PersistentFlags().GetString("tracker")
@@ -116,10 +110,6 @@ func ResolveForge(cmd *cobra.Command, kind string, deps Deps) (forge.Forge, erro
 	instances, err := loadInstancesCtx(ctx, deps)
 	if err != nil {
 		return nil, err
-	}
-
-	if inst := deps.InstanceFromFlags(cmd); inst != nil {
-		instances = append(instances, *inst)
 	}
 
 	trackerName, _ := cmd.Root().PersistentFlags().GetString("tracker")
@@ -182,8 +172,8 @@ func OriginRepo(cmd *cobra.Command) (string, error) {
 	return repo, nil
 }
 
-// ResolveAutoProvider loads all instances, applies flag overrides, and resolves
-// the provider without requiring a fixed kind. It uses tracker.Resolve for
+// ResolveAutoProvider loads all instances and resolves the provider without
+// requiring a fixed kind. It uses tracker.Resolve for
 // auto-detection and falls back to FindTracker + ResolveByKind for ambiguous
 // get commands.
 //
@@ -210,10 +200,6 @@ func resolveFromURL(ctx context.Context, cmd *cobra.Command, rawURL string, deps
 	instances, err := loadInstancesCtx(ctx, deps)
 	if err != nil {
 		return nil, err
-	}
-
-	if inst := deps.InstanceFromFlags(cmd); inst != nil {
-		instances = append(instances, *inst)
 	}
 
 	if instance := matchInstanceByKindAndURL(instances, parsed.Kind, parsed.BaseURL); instance != nil {
@@ -246,10 +232,6 @@ func resolveFromKey(ctx context.Context, cmd *cobra.Command, keyHint string, all
 	instances, err := loadInstancesCtx(ctx, deps)
 	if err != nil {
 		return nil, err
-	}
-
-	if inst := deps.InstanceFromFlags(cmd); inst != nil {
-		instances = append(instances, *inst)
 	}
 
 	trackerName, _ := cmd.Root().PersistentFlags().GetString("tracker")

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -95,10 +95,15 @@ human tracker list
 
 Each setting is resolved in priority order (highest wins):
 
-1. **CLI flags** (e.g. `--jira-url`)
-2. **Global env vars** (e.g. `JIRA_URL`)
-3. **Per-instance env vars** (e.g. `JIRA_WORK_URL` — name uppercased)
-4. **`.humanconfig.yaml`** — selected entry fills remaining gaps
+1. **Global env vars** (e.g. `JIRA_URL`)
+2. **Per-instance env vars** (e.g. `JIRA_WORK_URL` — name uppercased)
+3. **`.humanconfig.yaml`** — selected entry fills remaining gaps
+
+There are no per-tracker credential flags. Credentials arrive through the env
+convention above or `.humanconfig.yaml` (which can hold `1pw://` and `gh://`
+vault references) — one mechanism that works for every tracker, so adding a
+tracker never means adding flags. Use `--tracker <name>` to pick between
+configured instances.
 
 | Tracker | Env prefix | Settings | Default URL |
 |---------|-----------|----------|-------------|

--- a/internal/audit/emit.go
+++ b/internal/audit/emit.go
@@ -3,8 +3,6 @@ package audit
 import (
 	"strings"
 	"time"
-
-	"github.com/gethuman-sh/human/internal/cliflags"
 )
 
 // DecisionFromEnv reads the at-decision-time context an agent harness forwards
@@ -42,10 +40,16 @@ func BuildEvent(now time.Time, op MutatingOp, outcome Outcome, dc DecisionContex
 }
 
 // stripCredentials removes secret-bearing tokens from args so the audit trail
-// stays safe to review and share. It drops any value-flag token and the value
-// that follows it, plus the inline "--*-token=" / "--*-key=" forms. The
-// shared cliflags.ValueFlags set keeps this aligned with the detector and
-// client-side forwarding.
+// stays safe to review and share. It drops any credential-named flag and the
+// value that follows it, plus the inline "--*-token=" / "--*-key=" forms.
+//
+// Recognition is by NAME SHAPE, not by a list of known flags. It used to key on
+// cliflags.ValueFlags, which conflated two unrelated questions: that set exists
+// so a value token cannot shift positional indices past the destructive-command
+// detector, and it shrank to just --tracker when the per-tracker credential
+// flags were removed. Redaction must not shrink with it — an unrecognised flag
+// should be redacted, never logged, so anything credential-shaped is dropped
+// whether or not the CLI declares it.
 func stripCredentials(args []string) []string {
 	if len(args) == 0 {
 		return nil
@@ -53,7 +57,7 @@ func stripCredentials(args []string) []string {
 	out := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
 		a := args[i]
-		if cliflags.ValueFlags[a] {
+		if isCredentialFlagName(a) {
 			i++ // also skip the value token that carries the secret
 			continue
 		}
@@ -68,13 +72,34 @@ func stripCredentials(args []string) []string {
 	return out
 }
 
-// isInlineCredential reports whether a is an inline "--<x>-token=…" or
-// "--<x>-key=…" flag carrying a secret value in the same token.
+// credentialSuffixes name the flag endings that carry a secret value.
+var credentialSuffixes = []string{"-token", "-key", "-secret", "-password"}
+
+// isCredentialFlagName reports whether a is a "--…-token"-style flag whose
+// value arrives as the next argument.
+func isCredentialFlagName(a string) bool {
+	if !strings.HasPrefix(a, "-") || strings.Contains(a, "=") {
+		return false
+	}
+	for _, s := range credentialSuffixes {
+		if strings.HasSuffix(a, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// isInlineCredential reports whether a is an inline "--<x>-token=…" style flag
+// carrying a secret value in the same token.
 func isInlineCredential(a string) bool {
 	before, _, ok := strings.Cut(a, "=")
 	if !ok {
 		return false
 	}
-	name := before
-	return strings.HasSuffix(name, "-token") || strings.HasSuffix(name, "-key")
+	for _, s := range credentialSuffixes {
+		if strings.HasSuffix(before, s) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/audit/event_test.go
+++ b/internal/audit/event_test.go
@@ -50,6 +50,23 @@ func TestDecisionFromEnv(t *testing.T) {
 	assert.Equal(t, "implementing the plan", dc.Rationale)
 }
 
+// Redaction keys on the flag NAME SHAPE, not on a list of flags the CLI
+// declares, so a credential-shaped flag nobody enumerated is still kept out of
+// the audit trail. --made-up-token is deliberately not a real flag.
+func TestBuildEventStripsUndeclaredCredentialFlags(t *testing.T) {
+	args := []string{"jira", "issue", "delete", "KAN-1", "--made-up-token", "SECRET", "--other-password=TOPSECRET"}
+	op := MutatingOp{Operation: "delete", TrackerKind: "jira", Key: "KAN-1"}
+	e, err := BuildEvent(time.Now(), op, OutcomeSuccess, DecisionContext{}, args)
+	require.NoError(t, err)
+
+	for _, a := range e.Data.Args {
+		assert.NotContains(t, a, "SECRET")
+		assert.NotContains(t, a, "TOPSECRET")
+	}
+	assert.Contains(t, e.Data.Args, "delete")
+	assert.Contains(t, e.Data.Args, "KAN-1")
+}
+
 func TestBuildEventStripsCredentials(t *testing.T) {
 	args := []string{"jira", "issue", "delete", "KAN-1", "--jira-key", "SECRET", "--linear-token=TOPSECRET"}
 	op := MutatingOp{Operation: "delete", TrackerKind: "jira", Key: "KAN-1"}

--- a/internal/cliflags/cliflags.go
+++ b/internal/cliflags/cliflags.go
@@ -12,21 +12,5 @@ package cliflags
 //
 // Keep this in sync with PersistentFlags() in newRootCmd.
 var ValueFlags = map[string]bool{
-	"--tracker":        true,
-	"--jira-key":       true,
-	"--jira-url":       true,
-	"--jira-user":      true,
-	"--github-token":   true,
-	"--github-url":     true,
-	"--gitlab-token":   true,
-	"--gitlab-url":     true,
-	"--linear-token":   true,
-	"--linear-url":     true,
-	"--azure-token":    true,
-	"--azure-url":      true,
-	"--azure-org":      true,
-	"--shortcut-token": true,
-	"--shortcut-url":   true,
-	"--clickup-token":  true,
-	"--clickup-url":    true,
+	"--tracker": true,
 }

--- a/main.go
+++ b/main.go
@@ -165,29 +165,13 @@ Configure trackers and tools in .humanconfig.yaml or pass credentials via flags/
 	pf.Bool("yes", false, "Skip interactive confirmation for destructive operations")
 	_ = pf.MarkHidden("yes")
 
-	// Credential flags — functional but hidden from help (use env vars or .humanconfig).
-	credFlags := []struct{ name, env, help string }{
-		{"jira-key", "JIRA_KEY", "Jira API token"},
-		{"jira-url", "JIRA_URL", "Jira base URL"},
-		{"jira-user", "JIRA_USER", "Jira user email"},
-		{"github-token", "GITHUB_TOKEN", "GitHub personal access token"},
-		{"github-url", "GITHUB_URL", "GitHub API base URL"},
-		{"gitlab-token", "GITLAB_TOKEN", "GitLab private token"},
-		{"gitlab-url", "GITLAB_URL", "GitLab base URL"},
-		{"linear-token", "LINEAR_TOKEN", "Linear API key"},
-		{"linear-url", "LINEAR_URL", "Linear API base URL"},
-		{"azure-token", "AZURE_TOKEN", "Azure DevOps PAT token"},
-		{"azure-url", "AZURE_URL", "Azure DevOps base URL"},
-		{"azure-org", "AZURE_ORG", "Azure DevOps organization"},
-		{"shortcut-token", "SHORTCUT_TOKEN", "Shortcut API token"},
-		{"shortcut-url", "SHORTCUT_URL", "Shortcut API base URL"},
-		{"clickup-token", "CLICKUP_TOKEN", "ClickUp personal API token"},
-		{"clickup-url", "CLICKUP_URL", "ClickUp API base URL"},
-	}
-	for _, f := range credFlags {
-		pf.String(f.name, os.Getenv(f.env), f.help)
-		_ = pf.MarkHidden(f.name)
-	}
+	// Credentials come from .humanconfig (with vault refs) or the
+	// <KIND>_<NAME>_TOKEN env convention the config loaders already read — one
+	// mechanism that needs no per-provider code. The hidden per-tracker
+	// --<kind>-token/--<kind>-url flags that used to sit here were a second,
+	// provider-specific implementation of the same thing, and a URL flag paired
+	// with a credential is a redirection primitive the daemon should not accept
+	// over its socket at all. Adding a tracker must not mean adding flags.
 
 	// --- Command groups ---
 	rootCmd.AddGroup(

--- a/main_test.go
+++ b/main_test.go
@@ -824,14 +824,23 @@ func TestRootCmd_defaultShowsHelp(t *testing.T) {
 	assert.Contains(t, buf.String(), "human")
 }
 
-// --- instanceFromFlags tests ---
+// --- credential flag removal ---
 
-func TestInstanceFromFlags_noFlags(t *testing.T) {
-	cmd := newRootCmd()
-	cmd.SetArgs([]string{})
-	_ = cmd.Execute()
-	inst := cmdutil.InstanceFromFlags(cmd)
-	assert.Nil(t, inst)
+// Credentials resolve from .humanconfig and the <KIND>_<NAME>_TOKEN convention,
+// which needs no per-provider code. Re-adding a --<kind>-token/--<kind>-url pair
+// would restore a second, provider-specific path to building a tracker instance
+// — and a URL flag beside a credential is a redirection primitive that a
+// forwarded daemon request must not be able to set. Adding a tracker must not
+// mean adding flags, so this asserts the whole shape is gone rather than naming
+// the sixteen flags that used to be here.
+func TestRootCmd_hasNoPerTrackerCredentialFlags(t *testing.T) {
+	pf := newRootCmd().PersistentFlags()
+	for _, kind := range []string{"jira", "github", "gitlab", "linear", "azure", "shortcut", "clickup"} {
+		for _, suffix := range []string{"token", "url", "key", "user", "org"} {
+			name := kind + "-" + suffix
+			assert.Nil(t, pf.Lookup(name), "per-tracker credential flag --%s must not exist", name)
+		}
+	}
 }
 
 // --- tracker find tests ---
@@ -904,8 +913,6 @@ func TestIsLocalSubcommand(t *testing.T) {
 		// Space-separated value-taking flags must be skipped over (C-LOGIC-025).
 		{[]string{"--tracker", "work", "daemon", "stop"}, true},
 		{[]string{"--tracker=work", "daemon", "stop"}, true},
-		{[]string{"--github-token", "ghp_xx", "install"}, true},
-		{[]string{"--clickup-token", "X", "index"}, true},
 		{[]string{"--tracker", "work", "init"}, true},
 		// Tracker-forwarded commands should stay forwarded even with space flags.
 		{[]string{"--tracker", "work", "jira", "issue", "get", "KAN-1"}, false},


### PR DESCRIPTION
Removes the sixteen hidden `--<kind>-token` / `--<kind>-url` persistent flags and the flag-to-instance construction behind them.

## Why

Credentials already resolve from `.humanconfig` (with `1pw://` and `gh://` vault refs) and the `<KIND>_<NAME>_TOKEN` env convention — driven by the config schema, no per-provider Go code. The flags were a second implementation of the same thing, spread across three lists that had to be edited together for each new tracker:

- `main.go` — the `credFlags` table
- `cmd/cmdutil/instances.go` — `simpleProviders`, plus hand-written special cases for Jira (url+user+key) and Azure (org)
- `internal/cliflags` — `ValueFlags`

A URL flag standing beside a credential flag is also a redirection primitive, and args reach the daemon from agent containers. Today that is defanged by resolution order (config instances load first and `ResolveByKind` returns `filtered[0]`, so a flag-built instance only wins when nothing of that kind is configured) — but that is an incidental property, not a decision. Deleting the flags removes ad-hoc tracker-instance injection over the daemon socket as a category.

## Dependents checked

| Kind | Result |
|---|---|
| shipped agent prompts (`internal/claude/embed/`) | none — examined, unchanged |
| CI / Makefile / scripts | none — examined, unchanged |
| docs | `docs/documentation.md` — examined, changed |
| Go callers of `InstanceFromFlags` | 5 call sites + `Deps` field — examined, changed |
| consumers of `cliflags.ValueFlags` | 2, with **different purposes** — see below |

`ValueFlags` had two consumers answering unrelated questions: positional-index correctness for the destructive-command detector, and secret redaction in `internal/audit`. Shrinking the set is right for the first and wrong for the second, so the first commit decouples redaction onto a name-shape predicate before the second commit shrinks the set. Redaction now also covers credential-shaped flags nobody enumerated, which is stricter than before.

## Behaviour change

`human --github-token ghp_x github issue list` no longer works. `GITHUB_<NAME>_TOKEN=… human github issue list` covers that case and is the path the docs teach. `--tracker <name>` still selects between configured instances.

## Verification

`make check` green. Two failures in `cmd/cmddaemon` (`TestReadDeployFixExit_readsField`, `TestStageExitClass_SettlesOnDelayedReport`) are **pre-existing on main** — verified by stashing this branch's changes and re-running — and are unrelated `StageExit` vs `string` assertions. Note that `make check` runs `go list ./... | grep -v /cmd/`, so no `cmd/` package is covered by the gate at all; worth a separate look.