### PR TITLE
[SC-3872] Let an agent ask the machine where it can go, and tell it that it can

### DIFF
--- a/cmd/cmdagentcontext/agent-context.md
+++ b/cmd/cmdagentcontext/agent-context.md
@@ -28,6 +28,13 @@ If a codenav query says the repo is not indexed, the daemon is still building th
 - `human handoff post <KEY>` / `handoff show <KEY>` — the ready-for-review handoff; post derives branch/commits/daemon and verifies the commits are pushed
 - `human commits for <KEY>` — the commits referencing a ticket; `human commits prefix <PM> [<ENG>]` — the canonical commit-subject prefix
 
+## Ask the pipeline what to do next — before you stop and ask a person
+The pipeline is a state machine compiled into `human`, so these answer with no daemon and no credentials:
+- `human fsm next <state>` — every way out of a state: what records it, who causes it, and which are **yours**. Only your own carry a runnable `command`; the rest are listed so you know who you are waiting for. Posting another actor's marker does not advance the item, it puts it somewhere nothing drove it to
+- `human fsm show <state>` — what must hold there, who may act, and `if_nothing_happens` — read that before concluding you are stuck, because most states are recovered by the daemon on a timer
+- `human fsm marker <name>` — what a marker means, where it moves an item, and the fields it requires
+- `human fsm states` / `human fsm constants` — the whole machine; the real budgets (retries, graces, bounds)
+
 ## Pull product context
 - `human notion search "<query>"` — docs, specs, notes
 - `human figma file get <key>` — designs, components, comments

--- a/cmd/cmdfsm/fsm.go
+++ b/cmd/cmdfsm/fsm.go
@@ -1,0 +1,322 @@
+// Package cmdfsm answers questions about the pipeline state machine the binary
+// carries.
+//
+// Every command here reads compiled-in bytes: no daemon, no credentials, no
+// checkout. That is the point rather than an optimisation — the asker is
+// usually an agent in a container on some other project, and a question it can
+// only ask from the host is a question it cannot ask.
+package cmdfsm
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/marker"
+	"github.com/gethuman-sh/human/internal/pipelinefsm"
+)
+
+// defaultActor is who is asking when nobody says. An agent following a prompt
+// is the overwhelmingly common caller, and it is also the safe default: `skill`
+// owns the fewest edges, so guessing it withholds a command rather than
+// offering one the caller may not use.
+const defaultActor = "skill"
+
+// BuildFSMCmd builds `human fsm`.
+func BuildFSMCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fsm",
+		Short: "Ask the pipeline state machine where an item can go and who may move it",
+		Long: "Ask the pipeline state machine the binary carries.\n\n" +
+			"Answers come from the compiled-in document, so they are the same inside an\n" +
+			"agent container as on the host, and need no daemon and no credentials.",
+	}
+	cmd.AddCommand(buildStatesCmd(), buildShowCmd(), buildNextCmd(), buildMarkerCmd(), buildConstantsCmd())
+	return cmd
+}
+
+// emit writes v as indented JSON. One renderer, so every command has one output
+// shape and one test surface.
+func emit(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	// The commands carry angle-bracket placeholders, and Go escapes those to
+	// <…> by default. A caller pastes the string it was handed, so the
+	// escaped form would reach a shell. Nothing here is ever rendered as HTML.
+	enc.SetEscapeHTML(false)
+	return enc.Encode(v)
+}
+
+// load is the shared entry so a broken compiled-in document fails the same way
+// everywhere rather than once per command.
+func load() (pipelinefsm.Document, error) {
+	doc, err := pipelinefsm.Load()
+	if err != nil {
+		return pipelinefsm.Document{}, errors.WrapWithDetails(err, "reading the compiled-in state machine", "doc", pipelinefsm.DocPath)
+	}
+	return doc, nil
+}
+
+// stateOr fails with the list of states the caller could have named. A wrong
+// state name is the likeliest mistake here, and an error that only says "not
+// found" makes the caller guess a second time.
+func stateOr(doc pipelinefsm.Document, name string) (pipelinefsm.State, error) {
+	s, ok := doc.FindState(name)
+	if !ok {
+		return pipelinefsm.State{}, errors.WithDetails("no such state in the pipeline state machine",
+			"state", name, "known", strings.Join(doc.StateNames(), ", "))
+	}
+	return s, nil
+}
+
+type stateSummary struct {
+	Name       string                     `json:"name"`
+	Doc        string                     `json:"doc,omitempty"`
+	Board      pipelinefsm.BoardPlacement `json:"board"`
+	Terminal   bool                       `json:"terminal,omitempty"`
+	Reopenable bool                       `json:"reopenable,omitempty"`
+}
+
+func buildStatesCmd() *cobra.Command {
+	var stage string
+	cmd := &cobra.Command{
+		Use:   "states",
+		Short: "List every state, with where an item in it sits on the board",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			doc, err := load()
+			if err != nil {
+				return err
+			}
+			out := make([]stateSummary, 0, len(doc.States))
+			for _, s := range doc.States {
+				// "any" and "none" are not stages; a stage filter that matched them
+				// would answer a question the caller did not ask.
+				if stage != "" && s.Board.Stage != stage {
+					continue
+				}
+				out = append(out, stateSummary{s.Name, s.Doc, s.Board, s.Terminal, s.Reopenable})
+			}
+			return emit(cmd.OutOrStdout(), map[string]any{
+				"document_version": doc.Version,
+				"initial":          doc.Initial,
+				"states":           out,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&stage, "stage", "", "Only states whose board stage is this (backlog, planning, implementation, verification, done)")
+	return cmd
+}
+
+func buildShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show STATE",
+		Short: "What must hold in a state, who may act, and what happens if nobody does",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			doc, err := load()
+			if err != nil {
+				return err
+			}
+			s, err := stateOr(doc, args[0])
+			if err != nil {
+				return err
+			}
+			return emit(cmd.OutOrStdout(), map[string]any{
+				"document_version":   doc.Version,
+				"name":               s.Name,
+				"doc":                s.Doc,
+				"board":              s.Board,
+				"terminal":           s.Terminal,
+				"reopenable":         s.Reopenable,
+				"holds":              s.Holds,
+				"who_may_act":        s.WhoMayAct,
+				"stale_when":         s.StaleWhen,
+				"if_nothing_happens": s.IfNothingHappens,
+				"note":               s.Note,
+			})
+		},
+	}
+}
+
+// wayOut is one transition leaving a state, as the caller needs to see it.
+//
+// Yours and Command are the load-bearing pair. A caller sees every way out —
+// that is how it knows what waiting buys it and who it is waiting for — but only
+// its own carry something it can run. An edge with no command is not an edge to
+// improvise: posting its marker yourself puts the item in a state nobody drove
+// it to, which is precisely how [human:deployed] would get posted by an agent
+// that merely finished its work.
+type wayOut struct {
+	Event   string `json:"event"`
+	To      string `json:"to"`
+	Actor   string `json:"actor"`
+	Marker  string `json:"marker,omitempty"`
+	Doc     string `json:"doc,omitempty"`
+	Yours   bool   `json:"yours"`
+	Command string `json:"command,omitempty"`
+
+	// ToIsDerived says To is a placeholder: the real destination is computed
+	// from the marker's body. Reported rather than hidden, so a caller does not
+	// plan around a destination that was never a promise.
+	ToIsDerived bool `json:"to_is_derived,omitempty"`
+
+	// MovesItem is false for an edge that records something without moving the
+	// item. A caller that treats it as progress would wait for a change that is
+	// never coming.
+	MovesItem bool `json:"moves_item"`
+}
+
+func buildNextCmd() *cobra.Command {
+	var actor string
+	cmd := &cobra.Command{
+		Use:   "next STATE",
+		Short: "Every way out of a state: what records it, who causes it, which are yours",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			doc, err := load()
+			if err != nil {
+				return err
+			}
+			s, err := stateOr(doc, args[0])
+			if err != nil {
+				return err
+			}
+			if _, known := doc.Actors[actor]; !known {
+				return errors.WithDetails("no such actor in the pipeline state machine",
+					"actor", actor, "known", strings.Join(actorNames(doc), ", "))
+			}
+			ways := waysOut(doc, s.Name, actor)
+			return emit(cmd.OutOrStdout(), map[string]any{
+				"document_version":   doc.Version,
+				"state":              s.Name,
+				"asking_as":          actor,
+				"who_may_act":        s.WhoMayAct,
+				"if_nothing_happens": s.IfNothingHappens,
+				"ways_out":           ways,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&actor, "actor", defaultActor, "Who is asking (user, daemon, skill) — only this actor's ways out carry a command")
+	return cmd
+}
+
+func actorNames(doc pipelinefsm.Document) []string {
+	out := make([]string, 0, len(doc.Actors))
+	for a := range doc.Actors {
+		out = append(out, a)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// waysOut builds the answer for one state and one asker.
+func waysOut(doc pipelinefsm.Document, state, actor string) []wayOut {
+	events := doc.Out(state)
+	out := make([]wayOut, 0, len(events))
+	for _, e := range events {
+		w := wayOut{
+			Event:       e.Name,
+			To:          e.Dst,
+			Actor:       e.Actor,
+			Marker:      e.Marker,
+			Doc:         e.Doc,
+			Yours:       e.Actor == actor,
+			ToIsDerived: e.DstIsDerived,
+			MovesItem:   e.Moves(),
+		}
+		if w.Yours {
+			w.Command = commandFor(e)
+		}
+		out = append(out, w)
+	}
+	return out
+}
+
+// commandFor is what the caller runs to take an edge it owns.
+//
+// Empty when the edge records no marker (a silent transition has nothing to
+// post) or names several (a per-stage alternation cannot be resolved without
+// knowing the stage, and inventing one would hand back a command for the wrong
+// stage). The required fields come from the marker package rather than being
+// listed here: a marker posted without them is rejected at post time, and
+// telling the caller only half the contract just moves the failure later.
+func commandFor(e pipelinefsm.Event) string {
+	markers := e.Markers()
+	if len(markers) != 1 {
+		return ""
+	}
+	markerType := pipelinefsm.MarkerType(markers[0])
+	cmd := "human marker post <KEY> " + markerType
+	for _, f := range marker.RequiredFields(markerType) {
+		cmd += " --field " + f + "=<" + f + ">"
+	}
+	return cmd
+}
+
+func buildMarkerCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "marker NAME",
+		Short: "What a marker records, and where posting it moves an item",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			doc, err := load()
+			if err != nil {
+				return err
+			}
+			name := pipelinefsm.MarkerType(args[0])
+			uses := doc.MarkerUses(name)
+			listed, dualRole := doc.RecordsContentOnly(name)
+
+			moves := make([]map[string]any, 0, len(uses))
+			for _, e := range uses {
+				moves = append(moves, map[string]any{
+					"event":         e.Name,
+					"from":          e.Src,
+					"to":            e.Dst,
+					"actor":         e.Actor,
+					"to_is_derived": e.DstIsDerived,
+					"doc":           e.Doc,
+				})
+			}
+			if len(uses) == 0 && !listed {
+				return errors.WithDetails("the state machine does not mention this marker",
+					"marker", name, "hint", "human fsm states lists the machine; human marker post accepts open-ended types the machine does not model")
+			}
+			return emit(cmd.OutOrStdout(), map[string]any{
+				"document_version": doc.Version,
+				"marker":           pipelinefsm.MarkerHeader(name),
+				"type":             name,
+				"required_fields":  marker.RequiredFields(name),
+				"moves_an_item":    len(uses) > 0,
+				"moves":            moves,
+				"records_content":  listed,
+				"dual_role":        dualRole,
+			})
+		},
+	}
+}
+
+func buildConstantsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "constants",
+		Short: "The pipeline's real budgets — retries, graces, bounds",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			doc, err := load()
+			if err != nil {
+				return err
+			}
+			if len(doc.Invariants.Constants) == 0 {
+				return fmt.Errorf("the compiled-in state machine declares no constants")
+			}
+			return emit(cmd.OutOrStdout(), map[string]any{
+				"document_version": doc.Version,
+				"constants":        doc.Invariants.Constants,
+			})
+		},
+	}
+}

--- a/cmd/cmdfsm/fsm_test.go
+++ b/cmd/cmdfsm/fsm_test.go
@@ -1,0 +1,224 @@
+package cmdfsm
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/marker"
+	"github.com/gethuman-sh/human/internal/pipelinefsm"
+)
+
+// run executes `human fsm …` against the compiled-in document and decodes the
+// answer. The document is real on purpose: a fixture machine would let these
+// pass while the shipped one answered differently, which is the whole failure
+// this command exists to prevent one level down.
+func run(t *testing.T, args ...string) map[string]any {
+	t.Helper()
+	cmd := BuildFSMCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	require.NoError(t, cmd.Execute(), "human fsm %s: %s", strings.Join(args, " "), out.String())
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got), "output is not JSON: %s", out.String())
+	return got
+}
+
+func runErr(t *testing.T, args ...string) error {
+	t.Helper()
+	cmd := BuildFSMCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+func TestStates_ListsTheWholeMachine(t *testing.T) {
+	doc, err := pipelinefsm.Load()
+	require.NoError(t, err)
+
+	got := run(t, "states")
+
+	assert.Equal(t, doc.Initial, got["initial"])
+	assert.Len(t, got["states"], len(doc.States), "every declared state is listed")
+}
+
+func TestStates_StageFilterNarrowsToThatColumn(t *testing.T) {
+	got := run(t, "states", "--stage", "verification")
+
+	states, ok := got["states"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, states, "the verification stage has states")
+	for _, s := range states {
+		board := s.(map[string]any)["board"].(map[string]any)
+		assert.Equal(t, "verification", board["stage"])
+	}
+}
+
+// A state's answer must carry the inherited liveness rule, not an empty field
+// and a pointer to a stage default the caller would have to resolve itself.
+func TestShow_ResolvesTheInheritedRule(t *testing.T) {
+	doc, err := pipelinefsm.Load()
+	require.NoError(t, err)
+	var inheriting string
+	for _, s := range doc.States {
+		if s.Inherits != "" {
+			inheriting = s.Name
+			break
+		}
+	}
+	require.NotEmpty(t, inheriting, "the document has a state that inherits its rule")
+
+	got := run(t, "show", inheriting)
+
+	assert.NotEmpty(t, got["stale_when"], "%s: the inherited rule is resolved, not left blank", inheriting)
+	assert.NotEmpty(t, got["if_nothing_happens"], "%s: same for what happens if nobody acts", inheriting)
+}
+
+func TestShow_UnknownStateNamesTheOnesThatExist(t *testing.T) {
+	err := runErr(t, "show", "not-a-state")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no such state")
+}
+
+// THE guard. An agent is shown every way out — that is how it knows who it is
+// waiting for — but is handed a runnable command only for its own. Without this
+// an agent that merely finished its work could post [human:deployed] and put the
+// item in a state nothing drove it to.
+func TestNext_OnlyTheAskersOwnWaysOutCarryACommand(t *testing.T) {
+	doc, err := pipelinefsm.Load()
+	require.NoError(t, err)
+
+	for actor := range doc.Actors {
+		for _, state := range doc.StateNames() {
+			for _, w := range waysOut(doc, state, actor) {
+				if w.Actor == actor {
+					assert.True(t, w.Yours, "%s/%s: %s is this actor's own edge", actor, state, w.Event)
+					continue
+				}
+				assert.False(t, w.Yours, "%s/%s: %s belongs to %s", actor, state, w.Event, w.Actor)
+				assert.Empty(t, w.Command,
+					"%s/%s: %s belongs to %s and must carry no way to take it",
+					actor, state, w.Event, w.Actor)
+			}
+		}
+	}
+}
+
+// The command handed to a caller must carry every field its marker requires.
+// Telling a caller half the contract only moves the failure to post time.
+//
+// It deliberately does NOT assert the type is in marker.KnownTypes(): that list
+// is the types with a VALIDATION CONTRACT, and several real markers
+// (pr-review-passed, pr-review-started, pr-started) are open-ended — postable,
+// carried by daemon constants, contract-free. Asserting against it here would
+// fail on correct commands. That the document's markers are real is already
+// guarded, against the right list, by the daemon's own conformance test.
+func TestNext_EveryCommandIsCompleteAndPostable(t *testing.T) {
+	doc, err := pipelinefsm.Load()
+	require.NoError(t, err)
+
+	checked := 0
+	for actor := range doc.Actors {
+		for _, state := range doc.StateNames() {
+			for _, w := range waysOut(doc, state, actor) {
+				if w.Command == "" {
+					continue
+				}
+				checked++
+				fields := strings.Fields(w.Command)
+				require.GreaterOrEqual(t, len(fields), 5, "%s: %q", w.Event, w.Command)
+				markerType := fields[4]
+				for _, required := range marker.RequiredFields(markerType) {
+					assert.Contains(t, w.Command, "--field "+required+"=",
+						"%s: %q omits the %q field that %s requires", w.Event, w.Command, required, markerType)
+				}
+			}
+		}
+	}
+	assert.Positive(t, checked, "some edges do carry commands, or this test proves nothing")
+}
+
+// An alternation names a different marker per stage; a static answer cannot pick
+// one, and picking wrong would hand back a command for another stage.
+func TestNext_NoCommandForAMarkerThatVariesByStage(t *testing.T) {
+	doc, err := pipelinefsm.Load()
+	require.NoError(t, err)
+
+	for _, e := range doc.Events {
+		if len(e.Markers()) > 1 {
+			assert.Empty(t, commandFor(e), "%s records several markers; no single command is correct", e.Name)
+		}
+	}
+}
+
+func TestNext_RejectsAnActorTheMachineDoesNotDeclare(t *testing.T) {
+	err := runErr(t, "next", "planning", "--actor", "nobody")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no such actor")
+}
+
+func TestMarker_ReportsWhereItMovesAnItem(t *testing.T) {
+	got := run(t, "marker", "deployed")
+
+	assert.Equal(t, "[human:deployed]", got["marker"])
+	assert.Equal(t, true, got["moves_an_item"])
+	assert.NotEmpty(t, got["moves"])
+	assert.Contains(t, got["required_fields"], "pr", "the caller is told what the marker requires")
+}
+
+// Either form of the name answers, because a caller says it the way it posts it
+// and the document writes it the way it appears on a ticket.
+func TestMarker_AcceptsEitherForm(t *testing.T) {
+	assert.Equal(t, run(t, "marker", "deployed"), run(t, "marker", "[human:deployed]"))
+}
+
+// A dual-role marker must not be reported as merely decorative: it moves an item
+// from some states and records content from others, and an agent told only the
+// second half would think posting it is free.
+func TestMarker_DualRoleReportsBothHalves(t *testing.T) {
+	got := run(t, "marker", "plan")
+
+	assert.Equal(t, true, got["records_content"])
+	assert.Equal(t, true, got["moves_an_item"])
+	assert.NotEmpty(t, got["dual_role"], "and says why it is both")
+}
+
+func TestMarker_UnknownIsAnErrorRatherThanAnEmptyAnswer(t *testing.T) {
+	err := runErr(t, "marker", "not-a-marker")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not mention this marker")
+}
+
+func TestConstants_CarriesTheBudgetsTheProseRefersToByName(t *testing.T) {
+	got := run(t, "constants")
+
+	constants, ok := got["constants"].(map[string]any)
+	require.True(t, ok)
+	for _, name := range []string{"DefaultStageRetries", "StuckRunningGrace", "MaxSilenceReaps"} {
+		assert.Contains(t, constants, name)
+	}
+}
+
+// The placeholders must survive as typed. Go's JSON encoder escapes angle
+// brackets by default, and a caller pastes what it is handed.
+func TestCommandPlaceholdersAreNotHTMLEscaped(t *testing.T) {
+	cmd := BuildFSMCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"next", "implementing"})
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, out.String(), "<KEY>")
+	assert.NotContains(t, out.String(), "\\u003c", "the escaped form must not reach a caller")
+}

--- a/internal/claude/embed/human-bug-fixer-agent.md
+++ b/internal/claude/embed/human-bug-fixer-agent.md
@@ -74,6 +74,8 @@ Infrastructure trouble — a dead container, a network blip, a runner that never
 
 <!-- human:include stage-lease stage=fix -->
 
+<!-- human:include fsm state=preflight -->
+
 <!-- human:include exit-contract -->
 
 ## Principles

--- a/internal/claude/embed/human-bug-triage-agent.md
+++ b/internal/claude/embed/human-bug-triage-agent.md
@@ -121,4 +121,6 @@ EOF
 
 <!-- human:include stage-lease stage=triage -->
 
+<!-- human:include fsm state=triaging -->
+
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-deploy-fixer-agent.md
+++ b/internal/claude/embed/human-deploy-fixer-agent.md
@@ -76,4 +76,6 @@ Do NOT use `AskUserQuestion` — you cannot interact with a human.
 
 <!-- human:include stage-lease stage=deploy-fix -->
 
+<!-- human:include fsm state=deploy-fixing -->
+
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-executor-agent.md
+++ b/internal/claude/embed/human-executor-agent.md
@@ -154,6 +154,8 @@ Infrastructure trouble is never a real attempt — it is a `retryable` ending, n
 
 <!-- human:include stage-lease stage=implementation -->
 
+<!-- human:include fsm state=implementing -->
+
 <!-- human:include exit-contract -->
 
 ## Completion invariant

--- a/internal/claude/embed/human-planner-agent.md
+++ b/internal/claude/embed/human-planner-agent.md
@@ -187,4 +187,6 @@ Do NOT use `AskUserQuestion` — you cannot interact with the user. Either retur
 
 <!-- human:include stage-lease stage=planning -->
 
+<!-- human:include fsm state=planning -->
+
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-pr-fixer-agent.md
+++ b/internal/claude/embed/human-pr-fixer-agent.md
@@ -76,4 +76,6 @@ Do NOT use `AskUserQuestion` — you cannot interact with a human.
 
 <!-- human:include stage-lease stage=pr-fix -->
 
+<!-- human:include fsm state=pr-fix -->
+
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-pr-reviewer-agent.md
+++ b/internal/claude/embed/human-pr-reviewer-agent.md
@@ -102,4 +102,6 @@ Do NOT use `AskUserQuestion` — you cannot interact with a human. Humans review
 
 <!-- human:include stage-lease stage=pr-review -->
 
+<!-- human:include fsm state=pr-review -->
+
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-reviewer-agent.md
+++ b/internal/claude/embed/human-reviewer-agent.md
@@ -195,4 +195,6 @@ Use `unreviewable` only when the code itself could not be obtained (branch unrea
 
 <!-- human:include stage-lease stage=review -->
 
+<!-- human:include fsm state=in-review -->
+
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-security-triage-agent.md
+++ b/internal/claude/embed/human-security-triage-agent.md
@@ -132,4 +132,6 @@ EOF
 
 <!-- human:include stage-lease stage=triage -->
 
+<!-- human:include fsm state=triaging -->
+
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/shared/fsm.md
+++ b/internal/claude/embed/shared/fsm.md
@@ -1,0 +1,39 @@
+## Ask the machine before you stop
+
+The pipeline you are running inside is a state machine, written down and compiled
+into `human`. Ask it. It needs no daemon and no credentials, so it answers the
+same in your container as on the host:
+
+```sh
+human fsm next <STATE>       # every way out: what records it, who causes it, which are YOURS
+human fsm show <STATE>       # what must hold here, who may act, what happens if nobody does
+human fsm marker <name>      # what a marker means, where it moves an item, what it requires
+human fsm constants          # the real budgets — retries, graces, bounds
+```
+
+You are normally in **`<STATE>`**. A run that has moved on is in a different one;
+`human fsm states` lists them all, and each carries a `holds` saying what is true
+of an item sitting there.
+
+**Only a way out marked `"yours": true` carries a `command`.** That is the whole
+point of asking. The others are listed so you can see what waiting buys you and
+who you are waiting for — the daemon, or a person — but you may not take them.
+Posting another actor's marker does not advance the item; it puts it in a state
+nobody drove it to, and the machine will then be reasoning about a run that never
+happened.
+
+Two rules follow, and they are not style:
+
+- **Never invent a marker or a field.** The `command` a way out gives you is
+  complete, including every field that marker requires. A marker missing a
+  required field is rejected, and a marker you made up is worse — it is accepted
+  and means nothing.
+- **Before you raise `[human:options]`, check `next` for an edge you already
+  own.** A decision block stops the pipeline and waits for a person, so it is the
+  escape hatch, not a way of being careful. Raise it for a genuine fork only —
+  something the evidence cannot settle and you are not entitled to choose.
+
+If nothing looks like your way out, read `if_nothing_happens` before concluding
+you are stuck. Most states are recovered by the daemon on a timer, and the field
+says which one and how long — waiting is often the correct action, and it is not
+the same as being blocked.

--- a/internal/claude/fsm_fragment_test.go
+++ b/internal/claude/fsm_fragment_test.go
@@ -1,0 +1,87 @@
+package claude
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/pipelinefsm"
+)
+
+var fsmIncludeRe = regexp.MustCompile(`human:include fsm state=([a-z0-9-]+)`)
+
+// A prompt telling an agent "you are in <state>" is only useful while that state
+// exists. Rename or drop one in the machine and the include silently starts
+// naming nothing — the agent would then run `human fsm next <gone>`, get an
+// error, and fall back to the guessing this fragment exists to replace.
+func TestFSMFragment_EveryPromptNamesADeclaredState(t *testing.T) {
+	doc, err := pipelinefsm.Load()
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir("embed")
+	require.NoError(t, err)
+
+	found := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join("embed", e.Name()))
+		require.NoError(t, err)
+		for _, m := range fsmIncludeRe.FindAllStringSubmatch(string(body), -1) {
+			found++
+			_, ok := doc.FindState(m[1])
+			assert.True(t, ok, "%s: includes the fsm fragment for state %q, which the machine does not declare (known: %s)",
+				e.Name(), m[1], strings.Join(doc.StateNames(), ", "))
+		}
+	}
+	assert.Positive(t, found, "some prompt carries the fragment, or this test proves nothing")
+}
+
+// The rule the stage-lease include already follows: every agent the board can
+// launch carries it. An agent that can be launched is an agent that can get
+// stuck, and one that was never told it may ask will stop and ask a person
+// instead — the outcome the whole pipeline exists to avoid.
+func TestFSMFragment_EveryBoardLaunchedAgentCarriesIt(t *testing.T) {
+	entries, err := os.ReadDir("embed")
+	require.NoError(t, err)
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join("embed", e.Name()))
+		require.NoError(t, err)
+		// The stage-lease include is the existing marker of "the board can launch
+		// this", so the two sets are kept identical by construction rather than by
+		// a second list here that would drift from it.
+		if !strings.Contains(string(body), "human:include stage-lease") {
+			continue
+		}
+		assert.Regexp(t, fsmIncludeRe, string(body),
+			"%s is board-launched but is never told it can ask the machine", e.Name())
+	}
+}
+
+// The fragment must not ship a usable example state, for the reason stage-lease
+// learned the hard way: nine prompts copied its worked example instead of
+// substituting their own, and every one of them was then wrong.
+func TestFSMFragment_CarriesNoUsableExampleState(t *testing.T) {
+	doc, err := pipelinefsm.Load()
+	require.NoError(t, err)
+
+	body, err := os.ReadFile(filepath.Join("embed", "shared", "fsm.md"))
+	require.NoError(t, err)
+	text := string(body)
+
+	assert.Contains(t, text, "<STATE>", "the placeholder is what the include binds")
+	for _, name := range doc.StateNames() {
+		assert.NotContains(t, text, "fsm next "+name,
+			"the fragment shows %q as a worked example, which prompts copy verbatim", name)
+	}
+}

--- a/internal/claude/includes.go
+++ b/internal/claude/includes.go
@@ -54,6 +54,21 @@ var outcomeNotMechanismFragment []byte
 //go:embed embed/shared/dependents.md
 var dependentsFragment []byte
 
+// The machine an agent runs inside was written down and invisible to it: no
+// prompt mentioned pipeline-fsm.json, so every agent decided what to post, and
+// whether it was stuck, from its own prompt alone. This fragment is the half of
+// `human fsm` that changes behaviour — the commands only make asking possible.
+//
+// The state is a REQUIRED argument for the reason stage-lease's is: the answer
+// an agent needs is about the state it is actually in, and a fragment carrying
+// an example state would be copied. It names the state an agent normally
+// occupies rather than a stage, because stages are a coarser vocabulary that
+// cannot answer "what may I post next" — and note it is NOT the lease scope,
+// which is a third vocabulary again (`fix`, `pr-fix`, `triage`).
+//
+//go:embed embed/shared/fsm.md
+var fsmFragment []byte
+
 // sharedFragments are prompt blocks that must read identically in every skill
 // and agent that carries them. Keeping one copy here and substituting it at
 // install time is what stops twenty prompts from drifting apart, which is how
@@ -65,6 +80,7 @@ var sharedFragments = map[string][]byte{
 	"build-gate":            buildGateFragment,
 	"outcome-not-mechanism": outcomeNotMechanismFragment,
 	"dependents":            dependentsFragment,
+	"fsm":                   fsmFragment,
 }
 
 // fragmentArgs names the arguments each shared fragment requires. A fragment
@@ -75,6 +91,7 @@ var sharedFragments = map[string][]byte{
 // choose for itself.
 var fragmentArgs = map[string][]string{
 	"stage-lease": {"stage"},
+	"fsm":         {"state"},
 }
 
 // includePattern matches a whole-line include directive, with optional

--- a/internal/marker/marker.go
+++ b/internal/marker/marker.go
@@ -147,6 +147,24 @@ func KnownTypes() []string {
 	return types
 }
 
+// RequiredFields lists the field lines a marker type must carry, sorted. Empty
+// for a type with no contract and for an unknown one, which is the same answer
+// Validate gives them.
+//
+// Exported so something telling a caller HOW to post a marker can read the
+// contract instead of restating it. A second list of required fields would be
+// wrong the first time a field is added here, and wrong silently: the caller
+// would build a command that post-time validation then rejects.
+func RequiredFields(markerType string) []string {
+	s, known := specs[markerType]
+	if !known || len(s.required) == 0 {
+		return nil
+	}
+	out := append([]string(nil), s.required...)
+	sort.Strings(out)
+	return out
+}
+
 // Validate checks m against its type's contract. Unknown types pass — only a
 // syntactically valid type name is required.
 func Validate(m Marker) error {

--- a/internal/pipelinefsm/doc.go
+++ b/internal/pipelinefsm/doc.go
@@ -57,6 +57,26 @@ type Document struct {
 	StageDefaults StageDefaults `json:"stage_defaults"`
 
 	Unclassified Unclassified `json:"unclassified_markers"`
+
+	// Invariants carries the budgets the states' prose refers to by name.
+	// Modelled so a caller can be told the number instead of the name: a plan or
+	// an agent that reads "past the budget it waits for a person" and has to
+	// guess what the budget is will guess, and a guessed budget is how the same
+	// timing bug gets rediscovered under a new number.
+	Invariants Invariants `json:"invariants"`
+}
+
+// Invariants is the document's block of cross-cutting facts: the named budgets
+// and the fields every state carries.
+type Invariants struct {
+	Doc string `json:"doc"`
+
+	// Constants maps a budget's name to its value and where it lives, e.g.
+	// "StuckRunningGrace" -> "15m — how long a running card is left alone …".
+	Constants map[string]string `json:"constants"`
+
+	// Fields documents what each per-state invariant means.
+	Fields map[string]string `json:"fields"`
 }
 
 // ResolvedStates returns every state with its inherited fields filled in.

--- a/internal/pipelinefsm/query.go
+++ b/internal/pipelinefsm/query.go
@@ -1,0 +1,105 @@
+package pipelinefsm
+
+import (
+	"sort"
+	"strings"
+)
+
+// The questions something INSIDE the pipeline asks: where am I, where can I go,
+// what does this marker do. They live here rather than in the command that
+// prints them because the answers are document logic and there will be more
+// than one asker — a command today, a per-ticket lookup later — and two readings
+// of the same document is the drift this package exists to prevent.
+
+// FindState returns the named state with its inherited liveness rule filled in.
+// Resolved rather than raw: a caller asking what happens if nothing happens must
+// get the rule that applies, not an empty field and a pointer to a stage default
+// it would then have to look up and apply itself.
+func (d Document) FindState(name string) (State, bool) {
+	for _, s := range d.States {
+		if s.Name == name {
+			return s.Resolve(d.StageDefaults), true
+		}
+	}
+	return State{}, false
+}
+
+// StateNames lists every declared state, sorted, for an error that has to say
+// what the caller could have asked for instead.
+func (d Document) StateNames() []string {
+	out := make([]string, 0, len(d.States))
+	for _, s := range d.States {
+		out = append(out, s.Name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Out returns the transitions that leave a state — the ways out, in document
+// order so the common path reads first.
+func (d Document) Out(state string) []Event {
+	var out []Event
+	for _, e := range d.Events {
+		for _, src := range e.Src {
+			if src == state {
+				out = append(out, e)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// MarkerType strips the [human:…] wrapper, and leaves a bare type alone.
+//
+// Three forms of the same name are in play: a caller says it the way it posts it
+// (`plan-ready`), the transition table writes it the way it appears on a ticket
+// (`[human:plan-ready]`), and the unclassified list uses the bare form. One of
+// them has to convert. Doing it here means no caller has to know which form a
+// given field happens to use, which is the kind of detail that otherwise gets
+// half-remembered at three call sites.
+func MarkerType(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "[human:")
+	return strings.TrimSuffix(s, "]")
+}
+
+// MarkerHeader is the inverse: the form a marker takes on a ticket.
+func MarkerHeader(markerType string) string {
+	return "[human:" + MarkerType(markerType) + "]"
+}
+
+// MarkerUses returns the transitions that record a marker, named in either
+// form. The document writes one transition's per-stage alternatives as
+// "[human:a] | [human:b]", so a lookup has to match a member rather than the
+// whole field.
+func (d Document) MarkerUses(marker string) []Event {
+	want := MarkerType(marker)
+	var out []Event
+	for _, e := range d.Events {
+		for _, m := range e.Markers() {
+			if MarkerType(m) == want {
+				out = append(out, e)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// RecordsContentOnly reports whether the document declares a marker as one that
+// deliberately does not move an item, and why if it says.
+//
+// The second return is the dual-role note, present only for a marker that is
+// BOTH — a transition from some states and a record from others. A caller that
+// treats "listed here" as "never a transition" would be wrong about those, which
+// is exactly the confusion the dual_role block was added to make visible.
+func (d Document) RecordsContentOnly(marker string) (listed bool, dualRole string) {
+	want := MarkerType(marker)
+	for _, m := range d.Unclassified.Markers {
+		if MarkerType(m) == want {
+			return true, d.Unclassified.DualRole[want]
+		}
+	}
+	return false, ""
+}

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gethuman-sh/human/cmd/cmddeploy"
 	"github.com/gethuman-sh/human/cmd/cmddoctor"
 	"github.com/gethuman-sh/human/cmd/cmdfigma"
+	"github.com/gethuman-sh/human/cmd/cmdfsm"
 	"github.com/gethuman-sh/human/cmd/cmdhandoff"
 	"github.com/gethuman-sh/human/cmd/cmdindex"
 	"github.com/gethuman-sh/human/cmd/cmdinit"
@@ -384,6 +385,10 @@ Configure trackers and tools in .humanconfig.yaml or pass credentials via flags/
 	codenavCmd.GroupID = "utility"
 	rootCmd.AddCommand(codenavCmd)
 
+	fsmCmd := cmdfsm.BuildFSMCmd()
+	fsmCmd.GroupID = "utility"
+	rootCmd.AddCommand(fsmCmd)
+
 	agentContextCmd := cmdagentcontext.BuildAgentContextCmd()
 	agentContextCmd.GroupID = "utility"
 	rootCmd.AddCommand(agentContextCmd)
@@ -596,6 +601,12 @@ var localSubcommands = map[string]bool{
 	// Describes the caller's own checkout and environment — the one thing the
 	// daemon cannot see on its behalf.
 	"capabilities": true,
+	// Answers from the machine compiled into THIS binary. Forwarding it would
+	// make the one caller it exists for — an agent in a container, on a project
+	// whose daemon it cannot reach — unable to ask, and would answer from the
+	// daemon's build rather than the asker's, so two binaries at different
+	// versions would silently disagree about which document they quoted.
+	"fsm": true,
 	// bug/security create call the daemon's bug-create/security-create route
 	// directly (like the desktop board buttons); they must not be forwarded, or
 	// the RunE would open a reentrant connection back into the daemon.


### PR DESCRIPTION
The pipeline's state machine has been written down and compiled into the binary for a while, and nothing running inside the pipeline could ask it anything. An agent decided what to post, and whether it was stuck, from its own prompt alone.

### The commands

`human fsm states | show | next | marker | constants`, answering from the compiled-in document.

Registered as a **local** subcommand, which is the point rather than an optimisation. The caller it exists for is an agent in a container on a project whose daemon it cannot reach, so a forwarded command is one it cannot ask — and a forwarded answer would come from the daemon's build rather than the asker's, so two binaries at different versions would silently disagree about which document they were quoting.

**The load-bearing rule is in `next`:** an edge carries a runnable `command` only when its actor is the asker (default `skill`). Every other way out is still listed — that is how an agent knows what waiting buys it and who it is waiting for — but with no way to take it. Without that, an agent that merely finished its work could post `[human:deployed]` and put the item somewhere nothing drove it to. A test drives every (actor, state) pair in the machine to hold it.

The command carries the marker's required fields, read from the marker package rather than restated. A second list would be wrong the first time a field is added, and wrong silently: the caller would build a command that post-time validation then rejects. Two edges deliberately carry none — a silent transition has no marker, and a per-stage alternation cannot be resolved without knowing the stage.

### The half that changes behaviour

Commands nobody is told about change nothing. All nine board-launched agents now carry one shared fragment telling them to ask before they stop and ask a person, plus the session-start brief so an agent carrying no fragment still knows the commands exist.

Membership reuses the stage-lease include as the test, so the two sets are identical by construction rather than by a second list that would drift. The state is a required argument for the reason stage-lease's is — nine prompts once copied its worked example instead of substituting their own — so the fragment ships no usable example state, and a test fails if one appears.

**Worth flagging:** I was going to reuse the `stage=` argument the lease include already carries. That would have been wrong — lease scopes (`fix`, `pr-fix`, `triage`) are a different vocabulary from board stages, which are different again from state names. A test now checks every state named in a prompt is one the machine declares, so a renamed state fails the build instead of sending an agent to ask about something gone.

### Also

`Document` gains the `invariants` block, which was in the JSON and unmodelled, so `constants` can tell a caller the number instead of the name its prose refers to.

One test assumption of mine was wrong and is recorded as such: `marker.KnownTypes()` is the types with a *validation contract*, and several real markers (`pr-review-passed`, `pr-review-started`, `pr-started`) are open-ended. Asserting against that list failed on correct commands.

`make check` green, rebased on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)