### PR TITLE
[SC-3872] Let an agent ask where its ticket is, and tell it that it can

### DIFF
--- a/cmd/cmdagentcontext/agent-context.md
+++ b/cmd/cmdagentcontext/agent-context.md
@@ -28,6 +28,13 @@ If a codenav query says the repo is not indexed, the daemon is still building th
 - `human handoff post <KEY>` / `handoff show <KEY>` — the ready-for-review handoff; post derives branch/commits/daemon and verifies the commits are pushed
 - `human commits for <KEY>` — the commits referencing a ticket; `human commits prefix <PM> [<ENG>]` — the canonical commit-subject prefix
 
+## Ask the pipeline what to do next — before you stop and ask a person
+The pipeline is a state machine compiled into `human`, so these answer with no daemon and no credentials:
+- `human fsm next <state>` — every way out of a state: what records it, who causes it, and which are **yours**. Only your own carry a runnable `command`; the rest are listed so you know who you are waiting for. Posting another actor's marker does not advance the item, it puts it somewhere nothing drove it to
+- `human fsm show <state>` — what must hold there, who may act, and `if_nothing_happens` — read that before concluding you are stuck, because most states are recovered by the daemon on a timer
+- `human fsm marker <name>` — what a marker means, where it moves an item, and the fields it requires
+- `human fsm states` / `human fsm constants` — the whole machine; the real budgets (retries, graces, bounds)
+
 ## Pull product context
 - `human notion search "<query>"` — docs, specs, notes
 - `human figma file get <key>` — designs, components, comments

--- a/cmd/cmdbug/bug.go
+++ b/cmd/cmdbug/bug.go
@@ -6,7 +6,6 @@ package cmdbug
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -104,27 +103,9 @@ func RunSecurityCreate(out io.Writer, title, description string) error {
 // A package var so tests can point it at an unreachable address.
 var dockerHostFallbackAddr = fmt.Sprintf("%s:%d", daemon.DockerHost, daemon.DefaultPort)
 
-// resolveDaemon locates the running daemon: env vars first, then the info file,
-// then the host.docker.internal fallback so the command works inside a
-// devcontainer. Mirrors main.discoverDaemon. Returns a clear error when no
-// daemon is reachable, since it holds the tracker credentials and .humanconfig.
+// resolveDaemon delegates to the daemon package's discovery. Kept as a thin
+// local name so the call sites read the same, with one implementation of the
+// order behind it.
 func resolveDaemon() (addr, token string, err error) {
-	addr = os.Getenv("HUMAN_DAEMON_ADDR")
-	token = os.Getenv("HUMAN_DAEMON_TOKEN")
-
-	info, readErr := daemon.ReadInfo()
-	if token == "" && readErr == nil {
-		token = info.Token
-	}
-	if addr != "" {
-		return addr, token, nil
-	}
-	if readErr == nil && info.IsReachable() {
-		return info.Addr, token, nil
-	}
-	fallback := daemon.DaemonInfo{Addr: dockerHostFallbackAddr}
-	if fallback.IsReachable() {
-		return fallback.Addr, token, nil
-	}
-	return "", "", errors.WithDetails("human daemon not reachable — start it with `human daemon start` (it holds the tracker credentials and resolves the configured PM group)")
+	return daemon.ResolveDaemon()
 }

--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -462,18 +462,25 @@ func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, de
 		BoardSecurityFixer: securityFixerFunc(projectRegistry, vaultResolver, daemonID, logger, launchGate, agentIPs),
 		BoardOptioner:      boardOptionerFunc(projectRegistry, vaultResolver, daemonID, logger, launchGate, agentIPs),
 		BugCreator:         bugCreatorFunc(projectRegistry, vaultResolver, relateLauncherFunc(projectRegistry, daemonID)),
-		SecurityCreator:    securityCreatorFunc(projectRegistry, vaultResolver),
-		CloseTicketer:      closeTicketerFunc(projectRegistry, vaultResolver, liveBoardAgents, (&dockerAgentCleaner{}).DeleteAgent, logger),
-		FeaturesGenerator:  featuresGeneratorFunc(projectRegistry),
-		FindbugsRunner:     findbugsRunnerFunc(projectRegistry),
-		RelateLauncher:     relateLauncherFunc(projectRegistry, daemonID),
-		SecurityRunner:     securityRunnerFunc(projectRegistry),
-		MockupsCreator:     mockupsCreatorFunc(projectRegistry),
-		VariationsCreator:  variationsCreatorFunc(projectRegistry),
-		MockupChooser:      mockupChooserFunc(projectRegistry),
-		MockupPruner:       mockupPrunerFunc(projectRegistry),
-		Ideation:           ideationEngine(projectRegistry, vaultResolver, hookStore, ideationStore, logger),
-		LeaseChecker:       leaseChecker,
+		WhereComments:      whereCommentsFunc(projectRegistry, vaultResolver),
+		WhereAttempts: func(pmKey string, stage daemon.BoardStage) (int, error) {
+			// The READ-ONLY twin of the retry path's counter. bumpStageRetries
+			// increments as it reads, so wiring it here would spend a ticket's
+			// budget every time an agent asked where it was.
+			return readStageRetries(context.Background(), boardStateProject(projectRegistry, pmKey), pmKey, stage)
+		},
+		SecurityCreator:   securityCreatorFunc(projectRegistry, vaultResolver),
+		CloseTicketer:     closeTicketerFunc(projectRegistry, vaultResolver, liveBoardAgents, (&dockerAgentCleaner{}).DeleteAgent, logger),
+		FeaturesGenerator: featuresGeneratorFunc(projectRegistry),
+		FindbugsRunner:    findbugsRunnerFunc(projectRegistry),
+		RelateLauncher:    relateLauncherFunc(projectRegistry, daemonID),
+		SecurityRunner:    securityRunnerFunc(projectRegistry),
+		MockupsCreator:    mockupsCreatorFunc(projectRegistry),
+		VariationsCreator: variationsCreatorFunc(projectRegistry),
+		MockupChooser:     mockupChooserFunc(projectRegistry),
+		MockupPruner:      mockupPrunerFunc(projectRegistry),
+		Ideation:          ideationEngine(projectRegistry, vaultResolver, hookStore, ideationStore, logger),
+		LeaseChecker:      leaseChecker,
 	}
 
 	// Bring back a chat the previous process was in the middle of, before the
@@ -4213,5 +4220,47 @@ func attachActivity(ctx context.Context, reg *daemon.ProjectRegistry, view *daem
 		// The phase is an enrichment, never a gate: a board that cannot read the
 		// state store still renders every card it fetched.
 		logger.Debug().Err(err).Msg("board view: could not read phase records; cards render without them")
+	}
+}
+
+// whereCommentsFunc loads one ticket's thread for the fsm-where route: the
+// comments the placement is derived from, plus the status and idea label that
+// take an item off the board entirely.
+//
+// Modelled on issueGetterFunc rather than sharing it, because that path builds
+// the desktop panel's extras and caches them; a question about where an item is
+// must read the thread as it stands now.
+func whereCommentsFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver) daemon.WhereCommentReader {
+	return func(key string) ([]tracker.Comment, tracker.Category, bool, error) {
+		entry, err := reg.EntryForKey(key)
+		if err != nil {
+			return nil, "", false, err
+		}
+		instances, err := cmdutil.LoadAllInstancesWithResolver(entry.Dir, entry.EnvLookup(), resolver)
+		if err != nil {
+			return nil, "", false, err
+		}
+		inst, err := tracker.Resolve("", instances, key)
+		if err != nil {
+			return nil, "", false, err
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		issue, err := inst.Provider.GetIssue(ctx, key)
+		if err != nil {
+			return nil, "", false, err
+		}
+		lister, ok := inst.Provider.(tracker.Commenter)
+		if !ok {
+			return nil, issue.StatusType, issue.IsIdea(), nil
+		}
+		comments, err := lister.ListComments(ctx, key)
+		if err != nil {
+			// The thread is what the placement is derived from, so an unreadable
+			// one must fail rather than answer "backlog, nothing here" — that
+			// would be a confident wrong answer where none is much cheaper.
+			return nil, "", false, err
+		}
+		return comments, issue.StatusType, issue.IsIdea(), nil
 	}
 }

--- a/cmd/cmddaemon/stageretry.go
+++ b/cmd/cmddaemon/stageretry.go
@@ -3,6 +3,8 @@ package cmddaemon
 import (
 	"context"
 	"encoding/json"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -126,4 +128,27 @@ func decStageRetries(ctx context.Context, project, pmKey string, stage daemon.Bo
 			agentstate.Meta{Agent: "daemon-board-retry"})
 		return err
 	})
+}
+
+// readStageRetries reports how many automatic relaunches a stage has already
+// spent, WITHOUT bumping the counter.
+//
+// It exists because bumpStageRetries — the only other reader — increments as it
+// reads. That is correct for the retry path and catastrophic for a question:
+// `human fsm where` would spend a ticket's budget every time an agent asked
+// where it was, and the budget would run out because someone looked at it. An
+// absent or unparseable counter reads as zero, the same as never retried.
+func readStageRetries(ctx context.Context, project, pmKey string, stage daemon.BoardStage) (int, error) {
+	var n int
+	err := withStateStore(func(store agentstate.Store) error {
+		entry, err := store.Get(ctx, project, pmKey, retryCounterName(stage))
+		if err != nil {
+			return err
+		}
+		if parsed, convErr := strconv.Atoi(strings.TrimSpace(entry.Value)); convErr == nil {
+			n = parsed
+		}
+		return nil
+	})
+	return n, err
 }

--- a/cmd/cmdfsm/fsm.go
+++ b/cmd/cmdfsm/fsm.go
@@ -1,0 +1,160 @@
+// Package cmdfsm lets something inside the pipeline ask the state machine where
+// it is and what it may do.
+//
+// `where` is the command with the value, and the shape of everything else
+// follows from why: the one fact an agent reliably has is its own ticket key. It
+// does not know which state it is in — that is what it is asking — so a surface
+// that made it name a state first would answer only the question it could
+// already answer. `marker` and `constants` are here because they are likewise
+// answerable from what an agent holds: the marker it is about to post, and no
+// context at all.
+package cmdfsm
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/daemon"
+	"github.com/gethuman-sh/human/internal/marker"
+	"github.com/gethuman-sh/human/internal/pipelinefsm"
+)
+
+// defaultActor is who is asking when nobody says. An agent following a prompt is
+// the overwhelmingly common caller, and it is the safe default: `skill` owns the
+// fewest edges, so guessing it withholds a command rather than offering one the
+// caller may not use.
+const defaultActor = "skill"
+
+// resolveDaemon is swapped in tests. `where` is the only subcommand that needs a
+// daemon; the rest read the compiled-in document and work in any container.
+var resolveDaemon = daemon.ResolveDaemon
+
+// BuildFSMCmd builds `human fsm`.
+func BuildFSMCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fsm",
+		Short: "Ask the pipeline state machine where an item is and who may move it",
+		Long: "Ask the pipeline state machine.\n\n" +
+			"`where` needs the running daemon, because where an item IS depends on its\n" +
+			"agents' liveness and its spent retries, which only the daemon holds. The\n" +
+			"others read the machine compiled into this binary and work anywhere.",
+	}
+	cmd.AddCommand(buildWhereCmd(), buildMarkerCmd(), buildConstantsCmd())
+	return cmd
+}
+
+// emit writes v as indented JSON. One renderer, so every answer has one shape
+// and one test surface.
+func emit(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	// The commands carry angle-bracket placeholders, and Go escapes those by
+	// default. A caller pastes the string it was handed, so the escaped form
+	// would reach a shell. Nothing here is ever rendered as HTML.
+	enc.SetEscapeHTML(false)
+	return enc.Encode(v)
+}
+
+func load() (pipelinefsm.Document, error) {
+	doc, err := pipelinefsm.Load()
+	if err != nil {
+		return pipelinefsm.Document{}, errors.WrapWithDetails(err, "reading the compiled-in state machine", "doc", pipelinefsm.DocPath)
+	}
+	return doc, nil
+}
+
+func buildWhereCmd() *cobra.Command {
+	var actor string
+	cmd := &cobra.Command{
+		Use:   "where KEY",
+		Short: "Where an item is, what holds there, and which ways out are yours",
+		Long: "Report where a ticket is in the pipeline: the state it is in, what must be\n" +
+			"true while it sits there, who may move it, what happens if nobody does, and\n" +
+			"every way out — with a runnable command only for the ways out that are yours.\n\n" +
+			"When the evidence cannot identify a single state, the candidates are listed\n" +
+			"with the reason. That is deliberate: acting on a state you are not in means\n" +
+			"taking an edge you do not own.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			addr, token, err := resolveDaemon()
+			if err != nil {
+				return err
+			}
+			report, err := daemon.FSMWhere(addr, token, daemon.WhereRequest{Key: args[0], Actor: actor})
+			if err != nil {
+				return err
+			}
+			return emit(cmd.OutOrStdout(), report)
+		},
+	}
+	cmd.Flags().StringVar(&actor, "actor", defaultActor, "Who is asking (user, daemon, skill) — only this actor's ways out carry a command")
+	return cmd
+}
+
+func buildMarkerCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "marker NAME",
+		Short: "What a marker records, where posting it moves an item, what it requires",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			doc, err := load()
+			if err != nil {
+				return err
+			}
+			name := pipelinefsm.MarkerType(args[0])
+			uses := doc.MarkerUses(name)
+			listed, dualRole := doc.RecordsContentOnly(name)
+			if len(uses) == 0 && !listed {
+				return errors.WithDetails("the state machine does not mention this marker",
+					"marker", name,
+					"hint", "human marker post also accepts open-ended types the machine does not model")
+			}
+
+			moves := make([]map[string]any, 0, len(uses))
+			for _, e := range uses {
+				moves = append(moves, map[string]any{
+					"event":         e.Name,
+					"from":          e.Src,
+					"to":            e.Dst,
+					"actor":         e.Actor,
+					"to_is_derived": e.DstIsDerived,
+					"doc":           e.Doc,
+				})
+			}
+			return emit(cmd.OutOrStdout(), map[string]any{
+				"document_version": doc.Version,
+				"marker":           pipelinefsm.MarkerHeader(name),
+				"type":             name,
+				"required_fields":  marker.RequiredFields(name),
+				"moves_an_item":    len(uses) > 0,
+				"moves":            moves,
+				"records_content":  listed,
+				"dual_role":        dualRole,
+			})
+		},
+	}
+}
+
+func buildConstantsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "constants",
+		Short: "The pipeline's real budgets — retries, graces, bounds",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			doc, err := load()
+			if err != nil {
+				return err
+			}
+			if len(doc.Invariants.Constants) == 0 {
+				return fmt.Errorf("the compiled-in state machine declares no constants")
+			}
+			return emit(cmd.OutOrStdout(), map[string]any{
+				"document_version": doc.Version,
+				"constants":        doc.Invariants.Constants,
+			})
+		},
+	}
+}

--- a/cmd/cmdfsm/fsm_test.go
+++ b/cmd/cmdfsm/fsm_test.go
@@ -1,0 +1,101 @@
+package cmdfsm
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func run(t *testing.T, args ...string) map[string]any {
+	t.Helper()
+	cmd := BuildFSMCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	require.NoError(t, cmd.Execute(), "human fsm %s: %s", strings.Join(args, " "), out.String())
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got), "output is not JSON: %s", out.String())
+	return got
+}
+
+func runErr(t *testing.T, args ...string) error {
+	t.Helper()
+	cmd := BuildFSMCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+func TestMarker_ReportsWhereItMovesAnItem(t *testing.T) {
+	got := run(t, "marker", "deployed")
+
+	assert.Equal(t, "[human:deployed]", got["marker"])
+	assert.Equal(t, true, got["moves_an_item"])
+	assert.NotEmpty(t, got["moves"])
+	assert.Contains(t, got["required_fields"], "pr", "the caller is told what the marker requires")
+}
+
+// Either form answers: a caller says a marker the way it posts it, and the
+// document writes it the way it appears on a ticket.
+func TestMarker_AcceptsEitherForm(t *testing.T) {
+	assert.Equal(t, run(t, "marker", "deployed"), run(t, "marker", "[human:deployed]"))
+}
+
+// A dual-role marker must not read as merely decorative: it moves an item from
+// some states and records content from others, and an agent told only the second
+// half would think posting it is free.
+func TestMarker_DualRoleReportsBothHalves(t *testing.T) {
+	got := run(t, "marker", "plan")
+
+	assert.Equal(t, true, got["records_content"])
+	assert.Equal(t, true, got["moves_an_item"])
+	assert.NotEmpty(t, got["dual_role"], "and says why it is both")
+}
+
+func TestMarker_UnknownIsAnErrorRatherThanAnEmptyAnswer(t *testing.T) {
+	err := runErr(t, "marker", "not-a-marker")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not mention this marker")
+}
+
+func TestConstants_CarriesTheBudgetsTheProseRefersToByName(t *testing.T) {
+	got := run(t, "constants")
+
+	constants, ok := got["constants"].(map[string]any)
+	require.True(t, ok)
+	for _, name := range []string{"DefaultStageRetries", "StuckRunningGrace", "MaxSilenceReaps"} {
+		assert.Contains(t, constants, name)
+	}
+}
+
+// where needs the daemon, and says so plainly rather than failing obscurely: it
+// is the one subcommand that cannot answer from the compiled-in document alone.
+func TestWhere_SaysSoWhenNoDaemonIsReachable(t *testing.T) {
+	original := resolveDaemon
+	t.Cleanup(func() { resolveDaemon = original })
+	resolveDaemon = func() (string, string, error) {
+		return "", "", assert.AnError
+	}
+
+	err := runErr(t, "where", "SC-1")
+
+	require.Error(t, err)
+}
+
+// The placeholders in a command must survive as typed. Go's JSON encoder escapes
+// angle brackets by default, and a caller pastes what it is handed.
+func TestEmitDoesNotHTMLEscapePlaceholders(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, emit(&out, map[string]string{"command": "human marker post <KEY> plan-ready"}))
+
+	assert.Contains(t, out.String(), "<KEY>")
+	assert.NotContains(t, out.String(), "\\u003c", "the escaped form must not reach a caller")
+}

--- a/internal/claude/embed/human-bug-fixer-agent.md
+++ b/internal/claude/embed/human-bug-fixer-agent.md
@@ -74,6 +74,8 @@ Infrastructure trouble — a dead container, a network blip, a runner that never
 
 <!-- human:include stage-lease stage=fix -->
 
+<!-- human:include fsm -->
+
 <!-- human:include exit-contract -->
 
 ## Principles

--- a/internal/claude/embed/human-bug-triage-agent.md
+++ b/internal/claude/embed/human-bug-triage-agent.md
@@ -121,4 +121,6 @@ EOF
 
 <!-- human:include stage-lease stage=triage -->
 
+<!-- human:include fsm -->
+
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-deploy-fixer-agent.md
+++ b/internal/claude/embed/human-deploy-fixer-agent.md
@@ -76,4 +76,6 @@ Do NOT use `AskUserQuestion` — you cannot interact with a human.
 
 <!-- human:include stage-lease stage=deploy-fix -->
 
+<!-- human:include fsm -->
+
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-executor-agent.md
+++ b/internal/claude/embed/human-executor-agent.md
@@ -154,6 +154,8 @@ Infrastructure trouble is never a real attempt — it is a `retryable` ending, n
 
 <!-- human:include stage-lease stage=implementation -->
 
+<!-- human:include fsm -->
+
 <!-- human:include exit-contract -->
 
 ## Completion invariant

--- a/internal/claude/embed/human-planner-agent.md
+++ b/internal/claude/embed/human-planner-agent.md
@@ -187,4 +187,6 @@ Do NOT use `AskUserQuestion` — you cannot interact with the user. Either retur
 
 <!-- human:include stage-lease stage=planning -->
 
+<!-- human:include fsm -->
+
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-pr-fixer-agent.md
+++ b/internal/claude/embed/human-pr-fixer-agent.md
@@ -76,4 +76,6 @@ Do NOT use `AskUserQuestion` — you cannot interact with a human.
 
 <!-- human:include stage-lease stage=pr-fix -->
 
+<!-- human:include fsm -->
+
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-pr-reviewer-agent.md
+++ b/internal/claude/embed/human-pr-reviewer-agent.md
@@ -102,4 +102,6 @@ Do NOT use `AskUserQuestion` — you cannot interact with a human. Humans review
 
 <!-- human:include stage-lease stage=pr-review -->
 
+<!-- human:include fsm -->
+
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-reviewer-agent.md
+++ b/internal/claude/embed/human-reviewer-agent.md
@@ -195,4 +195,6 @@ Use `unreviewable` only when the code itself could not be obtained (branch unrea
 
 <!-- human:include stage-lease stage=review -->
 
+<!-- human:include fsm -->
+
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/human-security-triage-agent.md
+++ b/internal/claude/embed/human-security-triage-agent.md
@@ -132,4 +132,6 @@ EOF
 
 <!-- human:include stage-lease stage=triage -->
 
+<!-- human:include fsm -->
+
 <!-- human:include exit-contract -->

--- a/internal/claude/embed/shared/fsm.md
+++ b/internal/claude/embed/shared/fsm.md
@@ -1,0 +1,41 @@
+## Ask the machine before you stop
+
+The pipeline you are running inside is a state machine, and `human` can answer
+questions about it. Ask it rather than guessing what to post, and rather than
+stopping to ask a person:
+
+```sh
+human fsm where <TICKET_KEY>   # where this item is, and every way out — with a command for the ones that are YOURS
+human fsm marker <name>        # what a marker records, where it moves an item, what fields it requires
+human fsm constants            # the real budgets: retries, graces, bounds
+```
+
+`where` is the one to reach for. You know your ticket key; you do not need to
+know which state you are in, because that is what it tells you — along with what
+must be true while an item sits there, who may move it, and what happens if
+nobody does.
+
+**Only a way out marked `"yours": true` carries a `command`.** That is the point
+of asking. The rest are listed so you can see what waiting buys you and who you
+are waiting for — the daemon, or a person — but they are not yours to take.
+Posting another actor's marker does not advance the item; it puts it in a state
+nobody drove it to, and everything downstream then reasons about a run that never
+happened.
+
+Three rules follow, and none of them is style:
+
+- **Never invent a marker or a field.** The `command` you are given is complete,
+  including every field that marker requires. A marker missing a required field
+  is rejected; a marker you made up is worse, because it is accepted and means
+  nothing.
+- **Read `if_nothing_happens` before concluding you are stuck.** Most states are
+  recovered by the daemon on a timer, and the field says which one and how long.
+  Waiting is often the correct action and is not the same as being blocked.
+- **Before you raise `[human:options]`, check your own ways out.** A decision
+  block stops the pipeline and waits for a person, so it is the escape hatch, not
+  a way of being careful. Raise it only for a genuine fork — something the
+  evidence cannot settle and that you are not entitled to choose.
+
+If `where` reports `candidates` rather than a single `state`, it could not tell
+which phase you are in from the ticket alone. Pick the one whose `holds`
+describes your run, and use that one's ways out — not the union of all of them.

--- a/internal/claude/fsm_fragment_test.go
+++ b/internal/claude/fsm_fragment_test.go
@@ -1,0 +1,92 @@
+package claude
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/pipelinefsm"
+)
+
+func promptBodies(t *testing.T) map[string]string {
+	t.Helper()
+	entries, err := os.ReadDir("embed")
+	require.NoError(t, err)
+	out := map[string]string{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join("embed", e.Name()))
+		require.NoError(t, err)
+		out[e.Name()] = string(body)
+	}
+	return out
+}
+
+// The rule the stage-lease include already establishes: every agent the board
+// can launch carries it. An agent that can be launched is an agent that can get
+// stuck, and one never told it may ask will stop and ask a person instead —
+// the outcome the pipeline exists to avoid.
+func TestFSMFragment_EveryBoardLaunchedAgentCarriesIt(t *testing.T) {
+	found := 0
+	for name, body := range promptBodies(t) {
+		// The stage-lease include is the existing marker of "the board can launch
+		// this", so the two sets stay identical by construction rather than by a
+		// second list here that would drift from it.
+		if !strings.Contains(body, "human:include stage-lease") {
+			continue
+		}
+		found++
+		assert.Contains(t, body, "<!-- human:include fsm -->",
+			"%s is board-launched but is never told it can ask the machine", name)
+	}
+	assert.Positive(t, found, "some prompt is board-launched, or this test proves nothing")
+}
+
+// The fragment takes no argument, and that must stay true.
+//
+// An earlier draft bound each prompt to the state its agent normally occupies.
+// The premise was wrong — an agent knows its ticket key and not its state, which
+// is the thing it is asking — and it was wrong in practice on the first try: the
+// bug fixer was bound to `preflight` when it is `fixing`, and a test that only
+// checked the state EXISTED could not catch it. A binding that cannot be
+// verified against the run it describes should not exist.
+func TestFSMFragment_TakesNoStateArgument(t *testing.T) {
+	assert.NotContains(t, fragmentArgs, "fsm",
+		"the fsm fragment must take no argument — a prompt cannot know the state its run will be in")
+
+	for name, body := range promptBodies(t) {
+		assert.NotContains(t, body, "human:include fsm state=",
+			"%s binds the fragment to a state; ask with the ticket key instead", name)
+	}
+}
+
+// The fragment must point at the command that answers from what an agent holds.
+func TestFSMFragment_PointsAtWhere(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("embed", "shared", "fsm.md"))
+	require.NoError(t, err)
+	text := string(body)
+
+	assert.Contains(t, text, "human fsm where", "where is the command with the value")
+	assert.Contains(t, text, `"yours": true`,
+		"the rule that stops an agent taking an edge it does not own must be stated")
+}
+
+// A state named in the fragment's prose must exist, or it sends an agent to ask
+// about something the machine no longer has.
+func TestFSMFragment_NamesNoStaleState(t *testing.T) {
+	doc, err := pipelinefsm.Load()
+	require.NoError(t, err)
+	body, err := os.ReadFile(filepath.Join("embed", "shared", "fsm.md"))
+	require.NoError(t, err)
+
+	for _, name := range doc.StateNames() {
+		assert.NotContains(t, string(body), "fsm where "+name,
+			"the fragment shows %q where a ticket key belongs", name)
+	}
+}

--- a/internal/claude/includes.go
+++ b/internal/claude/includes.go
@@ -54,6 +54,21 @@ var outcomeNotMechanismFragment []byte
 //go:embed embed/shared/dependents.md
 var dependentsFragment []byte
 
+// The machine an agent runs inside was written down and invisible to it: no
+// prompt mentioned it, so every agent decided what to post, and whether it was
+// stuck, from its own prompt alone. This fragment is the half of `human fsm`
+// that changes behaviour — the commands only make asking possible.
+//
+// It takes NO argument, and that is the design rather than an omission. An
+// earlier draft bound each prompt to the state its agent normally occupies, so
+// the agent could ask about that state. Wrong premise: an agent knows its ticket
+// key and not its state — the state is what it is asking — and a prompt-bound
+// state is stale the moment a run moves on, which the fix run does five times.
+// `where <KEY>` asks with the fact the agent actually holds.
+//
+//go:embed embed/shared/fsm.md
+var fsmFragment []byte
+
 // sharedFragments are prompt blocks that must read identically in every skill
 // and agent that carries them. Keeping one copy here and substituting it at
 // install time is what stops twenty prompts from drifting apart, which is how
@@ -65,6 +80,7 @@ var sharedFragments = map[string][]byte{
 	"build-gate":            buildGateFragment,
 	"outcome-not-mechanism": outcomeNotMechanismFragment,
 	"dependents":            dependentsFragment,
+	"fsm":                   fsmFragment,
 }
 
 // fragmentArgs names the arguments each shared fragment requires. A fragment

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -937,3 +937,51 @@ func selectedEnv() map[string]string {
 	}
 	return env
 }
+
+// FSMWhere asks the daemon where one ticket is in the pipeline. A route rather
+// than a forwarded command because the answer needs the daemon's own liveness
+// records and retry counters, which a forwarded cobra command has no handle to.
+func FSMWhere(addr, token string, req WhereRequest) (WhereReport, error) {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return WhereReport{}, errors.WrapWithDetails(err, "marshaling fsm-where request")
+	}
+	out, err := RunRemoteCapture(addr, token, []string{"fsm-where", string(data)})
+	if err != nil {
+		return WhereReport{}, err
+	}
+	var resp WhereReport
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return WhereReport{}, errors.WrapWithDetails(err, "invalid fsm-where JSON")
+	}
+	return resp, nil
+}
+
+// ResolveDaemon locates the running daemon: env first, then the info file, then
+// the host.docker.internal fallback so a command works from inside a
+// devcontainer.
+//
+// Exported and living here because more than one command needs it and the
+// daemon package is what knows how a daemon is found. A second copy in a command
+// package is how the discovery order drifts, and a command that looks in a
+// different order finds a different daemon.
+func ResolveDaemon() (addr, token string, err error) {
+	addr = os.Getenv("HUMAN_DAEMON_ADDR")
+	token = os.Getenv("HUMAN_DAEMON_TOKEN")
+
+	info, readErr := ReadInfo()
+	if token == "" && readErr == nil {
+		token = info.Token
+	}
+	if addr != "" {
+		return addr, token, nil
+	}
+	if readErr == nil && info.IsReachable() {
+		return info.Addr, token, nil
+	}
+	fallback := DaemonInfo{Addr: fmt.Sprintf("%s:%d", DockerHost, DefaultPort)}
+	if fallback.IsReachable() {
+		return fallback.Addr, token, nil
+	}
+	return "", "", errors.WithDetails("human daemon not reachable — start it with `human daemon start` (it holds the tracker credentials and resolves the configured PM group)")
+}

--- a/internal/daemon/fsm_where.go
+++ b/internal/daemon/fsm_where.go
@@ -1,0 +1,261 @@
+package daemon
+
+import (
+	"strings"
+	"time"
+
+	"github.com/gethuman-sh/human/internal/pipelinefsm"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// WhereReport answers "where is this item, and what may I do about it" for one
+// ticket. It is the answer an agent can actually ask for, because the one thing
+// an agent always knows is its own key.
+type WhereReport struct {
+	Key             string `json:"key"`
+	DocumentVersion int    `json:"document_version"`
+
+	// Board is where the derivation puts the card. It is the ground truth here:
+	// the derivation never refuses, so this is always answerable even when the
+	// machine has no name for the result.
+	Board WhereBoard `json:"board"`
+
+	// State is the single state the item is in, when the evidence identifies
+	// one. Empty when it does not, in which case Candidates carries what it
+	// could be and Why says what stopped it narrowing further. Reporting
+	// nothing is better than reporting the wrong one: an agent that acts on a
+	// state it is not in takes an edge it does not own.
+	State      string       `json:"state,omitempty"`
+	Candidates []WhereState `json:"candidates,omitempty"`
+	Why        string       `json:"why,omitempty"`
+
+	// Agent is the liveness of the stage's agent, read from the daemon's own
+	// records rather than recomputed. A second implementation of "is it alive"
+	// is the exact defect class the machine document exists to prevent.
+	Agent *WhereAgent `json:"agent,omitempty"`
+
+	// Budget is what the item has already spent of its automatic relaunches.
+	Budget *WhereBudget `json:"budget,omitempty"`
+}
+
+// WhereBoard is the derived placement.
+type WhereBoard struct {
+	Stage string `json:"stage"`
+	State string `json:"state"`
+}
+
+// WhereState is one state the item may be in, with everything needed to decide
+// what to do about it.
+type WhereState struct {
+	Name             string               `json:"name"`
+	Doc              string               `json:"doc,omitempty"`
+	Holds            string               `json:"holds,omitempty"`
+	WhoMayAct        []string             `json:"who_may_act,omitempty"`
+	StaleWhen        string               `json:"stale_when,omitempty"`
+	IfNothingHappens string               `json:"if_nothing_happens,omitempty"`
+	WaysOut          []pipelinefsm.WayOut `json:"ways_out"`
+}
+
+// WhereAgent reports the stage agent's liveness.
+type WhereAgent struct {
+	Name string `json:"name"`
+	// Known is false when the daemon has no record — it restarted, or the agent
+	// has yet to emit anything. Reported rather than folded into "not alive",
+	// because absent evidence and evidence of absence lead to opposite actions.
+	Known           bool   `json:"known"`
+	LastEventAt     string `json:"last_event_at,omitempty"`
+	IdleSeconds     int    `json:"idle_seconds,omitempty"`
+	Stalled         bool   `json:"stalled"`
+	InsideTool      bool   `json:"inside_tool,omitempty"`
+	OutstandingCall bool   `json:"outstanding_model_request,omitempty"`
+	Blocked         bool   `json:"blocked,omitempty"`
+}
+
+// WhereBudget is the automatic-relaunch budget for the item's current stage.
+type WhereBudget struct {
+	Kind  string `json:"kind"`
+	Spent int    `json:"spent"`
+	Of    int    `json:"of"`
+}
+
+// WhereDeps are the daemon-held facts a report needs beyond the ticket's own
+// comments. Each is optional: a missing one drops its section rather than
+// failing the answer, because "where am I" is still worth answering when only
+// the liveness record is unavailable.
+type WhereDeps struct {
+	// Progress reports the last sign of life from an agent, nil-safe.
+	Progress AgentProgressProbe
+	// Attempts reads how many automatic relaunches a stage has already spent.
+	// It must READ ONLY — StageRetry.Attempts increments, and a question must
+	// never spend the budget it is asking about.
+	Attempts func(pmKey string, stage BoardStage) (int, error)
+	// MaxAttempts is the cap those attempts are counted against.
+	MaxAttempts int
+	// Now is injected so the staleness answer is testable.
+	Now time.Time
+}
+
+// BuildWhere resolves one ticket's position. Pure given its inputs.
+func BuildWhere(doc pipelinefsm.Document, key string, comments []tracker.Comment, status tracker.Category, isIdea bool, actor string, deps WhereDeps) WhereReport {
+	card := DeriveBoardCard(comments, status, isIdea)
+	report := WhereReport{
+		Key:             key,
+		DocumentVersion: doc.Version,
+		Board:           WhereBoard{string(card.Stage), string(card.State)},
+	}
+
+	states, why := statesFor(doc, card, comments)
+	report.Why = why
+	for _, s := range states {
+		report.Candidates = append(report.Candidates, WhereState{
+			Name:             s.Name,
+			Doc:              s.Doc,
+			Holds:            s.Holds,
+			WhoMayAct:        s.WhoMayAct,
+			StaleWhen:        s.StaleWhen,
+			IfNothingHappens: s.IfNothingHappens,
+			WaysOut:          doc.WaysOut(s.Name, actor),
+		})
+	}
+	if len(states) == 1 {
+		report.State = states[0].Name
+	}
+
+	report.Agent = whereAgent(key, card, deps)
+	report.Budget = whereBudget(key, card, deps)
+	return report
+}
+
+// statesFor names the state an item is in, or every state it could be in.
+//
+// The board placement decides it outright for sixteen of the eighteen
+// placements the machine declares. Two are genuinely many-to-one —
+// implementation/running covers seven states and done/running five — because
+// the board shows that a stage is running while the machine distinguishes the
+// phases inside it. Those are narrowed by the newest marker in the winning
+// stage, which is the record of which phase last reported.
+func statesFor(doc pipelinefsm.Document, card BoardCard, comments []tracker.Comment) ([]pipelinefsm.State, string) {
+	// An open decision is identified by the block, not by the placement. The
+	// document says so itself — "decision needed" is not a board state, and
+	// pauseOnOpenOptions turns running or failed into idle — so an item parked on
+	// a fork is indistinguishable by placement from one that is merely idle.
+	// Checked first because that idleness is what it shares with `filed`.
+	if _, open := openOptionsBlock(comments); open {
+		if s, ok := doc.FindState("awaiting-decision"); ok {
+			return []pipelinefsm.State{s}, ""
+		}
+	}
+
+	// A within-stage state that any column can carry is matched on the state
+	// alone: an item does not leave its column to be stopped, queued or waiting
+	// on the substrate, so its stage says nothing about which of those it is in.
+	//
+	// Only for a state that SAYS something. The empty state is idle, which every
+	// column has and which distinguishes nothing — matching on it would answer
+	// "awaiting-decision" for every quiet card, including a closed one.
+	if card.State != "" {
+		if anyStage := doc.StatesAtAnyStage(string(card.State)); len(anyStage) > 0 {
+			return anyStage, ""
+		}
+	}
+
+	candidates := doc.StatesAtPlacement(string(card.Stage), string(card.State))
+	switch len(candidates) {
+	case 0:
+		return nil, "no state in the machine describes the board placement " +
+			string(card.Stage) + "/" + string(card.State) +
+			" — the item is somewhere the machine cannot name, which is a gap in the document rather than in the item"
+	case 1:
+		return candidates, ""
+	}
+
+	// Narrow by the marker that last reported inside the winning stage: it names
+	// the phase that recorded, where the placement only names the stage.
+	_, latest := latestStateInStage(comments, card.Stage)
+	header := markerHeaderOf(latest.Body)
+	if header == "" {
+		return candidates, "the board says the " + string(card.Stage) +
+			" stage is running; nothing narrows which phase of it, so every phase is listed"
+	}
+	narrowed := intersectByName(candidates, doc.StatesEnteredBy(header))
+	if len(narrowed) == 0 {
+		return candidates, "the newest " + string(card.Stage) + " marker (" + header +
+			") does not lead to any phase the placement allows, so every phase is listed"
+	}
+	if len(narrowed) == 1 {
+		return narrowed, ""
+	}
+	return narrowed, "the newest " + string(card.Stage) + " marker (" + header +
+		") is posted by more than one phase, so the ones it could be are listed"
+}
+
+// markerHeaderOf extracts the [human:…] header from a comment body.
+func markerHeaderOf(body string) string {
+	line, _, _ := strings.Cut(strings.TrimSpace(body), "\n")
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, "[human:") {
+		return ""
+	}
+	end := strings.Index(line, "]")
+	if end < 0 {
+		return ""
+	}
+	return line[:end+1]
+}
+
+// intersectByName keeps the candidates the narrowing evidence also allows.
+func intersectByName(candidates, allowed []pipelinefsm.State) []pipelinefsm.State {
+	permitted := make(map[string]bool, len(allowed))
+	for _, s := range allowed {
+		permitted[s.Name] = true
+	}
+	var out []pipelinefsm.State
+	for _, s := range candidates {
+		if permitted[s.Name] {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// whereAgent reads liveness from the daemon's own progress record. It never
+// recomputes staleness: AgentProgress.Stalled already holds the rule, including
+// that a blocked agent is waiting for a person rather than hung.
+func whereAgent(key string, card BoardCard, deps WhereDeps) *WhereAgent {
+	if deps.Progress == nil || card.Stage == "" {
+		return nil
+	}
+	name := agentNameFor(key, card.Stage)
+	p, ok := deps.Progress(name)
+	if !ok {
+		return &WhereAgent{Name: name, Known: false}
+	}
+	stalled, idle := p.Stalled(deps.Now)
+	return &WhereAgent{
+		Name:            name,
+		Known:           true,
+		LastEventAt:     p.LastEventAt.UTC().Format(time.RFC3339),
+		IdleSeconds:     int(idle.Seconds()),
+		Stalled:         stalled,
+		InsideTool:      p.InsideTool,
+		OutstandingCall: p.OutstandingModelRequest,
+		Blocked:         p.Blocked,
+	}
+}
+
+// whereBudget reports what the stage has already spent. Read-only by contract:
+// the caller supplies a reader, never StageRetry.Attempts, which increments.
+func whereBudget(key string, card BoardCard, deps WhereDeps) *WhereBudget {
+	if deps.Attempts == nil || card.Stage == "" {
+		return nil
+	}
+	spent, err := deps.Attempts(key, card.Stage)
+	if err != nil {
+		return nil
+	}
+	max := deps.MaxAttempts
+	if max <= 0 {
+		max = DefaultStageRetries
+	}
+	return &WhereBudget{Kind: "stage_retries", Spent: spent, Of: max}
+}

--- a/internal/daemon/fsm_where_route.go
+++ b/internal/daemon/fsm_where_route.go
@@ -1,0 +1,91 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/gethuman-sh/human/internal/pipelinefsm"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// WhereRequest is the fsm-where wire payload.
+type WhereRequest struct {
+	Key string `json:"key"`
+	// Actor is who is asking. Only this actor's ways out come back with a
+	// runnable command, so defaulting matters: `skill` owns the fewest edges, and
+	// guessing it withholds a command rather than offering one the caller may not
+	// use.
+	Actor string `json:"actor,omitempty"`
+}
+
+// WhereCommentReader loads one ticket's comment thread and status. Injected so
+// the route stays a shaping step and the tracker fan-out stays where every
+// other route already keeps it.
+type WhereCommentReader func(key string) (comments []tracker.Comment, status tracker.Category, isIdea bool, err error)
+
+// handleFSMWhere answers where one ticket is. One JSON arg, mirroring the other
+// routes.
+func (s *Server) handleFSMWhere(conn net.Conn, args []string) {
+	if s.WhereComments == nil {
+		s.writeError(conn, "the daemon cannot read this project's tickets, so it cannot say where one is", 1)
+		return
+	}
+	if len(args) != 1 {
+		s.writeError(conn, "fsm-where requires one JSON arg", 1)
+		return
+	}
+	var req WhereRequest
+	if err := json.Unmarshal([]byte(args[0]), &req); err != nil {
+		s.writeError(conn, "invalid fsm-where request: "+err.Error(), 1)
+		return
+	}
+	if strings.TrimSpace(req.Key) == "" {
+		s.writeError(conn, "fsm-where needs a ticket key", 1)
+		return
+	}
+	actor := req.Actor
+	if actor == "" {
+		actor = "skill"
+	}
+
+	doc, err := pipelinefsm.Load()
+	if err != nil {
+		s.writeError(conn, err.Error(), 1)
+		return
+	}
+	if _, known := doc.Actors[actor]; !known {
+		s.writeError(conn, "no such actor in the pipeline state machine: "+actor, 1)
+		return
+	}
+
+	comments, status, isIdea, err := s.WhereComments(req.Key)
+	if err != nil {
+		s.writeError(conn, err.Error(), 1)
+		return
+	}
+
+	report := BuildWhere(doc, req.Key, comments, status, isIdea, actor, WhereDeps{
+		Progress: s.whereProgress(),
+		Attempts: s.WhereAttempts,
+		Now:      time.Now(),
+	})
+	data, err := json.Marshal(report)
+	if err != nil {
+		s.writeError(conn, err.Error(), 1)
+		return
+	}
+	resp := Response{Stdout: string(data) + "\n"}
+	_ = json.NewEncoder(conn).Encode(resp)
+}
+
+// whereProgress adapts the hook store to the probe the report wants, and is nil
+// when nothing is recorded — an answer without a liveness section beats an
+// answer that invents one.
+func (s *Server) whereProgress() AgentProgressProbe {
+	if s.HookEvents == nil {
+		return nil
+	}
+	return s.HookEvents.AgentProgress
+}

--- a/internal/daemon/fsm_where_route_test.go
+++ b/internal/daemon/fsm_where_route_test.go
@@ -1,0 +1,96 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+func whereServer(reader WhereCommentReader) *Server {
+	return &Server{Logger: zerolog.Nop(), WhereComments: reader}
+}
+
+func whereRequest(t *testing.T, srv *Server, req WhereRequest) Response {
+	t.Helper()
+	arg, err := json.Marshal(req)
+	require.NoError(t, err)
+	return captureHandlerResponse(t, func(conn net.Conn) {
+		srv.handleFSMWhere(conn, []string{string(arg)})
+	})
+}
+
+func TestFSMWhereRoute_AnswersForATicket(t *testing.T) {
+	srv := whereServer(func(string) ([]tracker.Comment, tracker.Category, bool, error) {
+		return []tracker.Comment{cmt(PlanReadyHeader, time.Unix(1000, 0))}, tracker.CategoryUnstarted, false, nil
+	})
+
+	resp := whereRequest(t, srv, WhereRequest{Key: "SC-1"})
+
+	require.Equal(t, 0, resp.ExitCode, resp.Stderr)
+	var report WhereReport
+	require.NoError(t, json.Unmarshal([]byte(resp.Stdout), &report))
+	assert.Equal(t, "SC-1", report.Key)
+	assert.Equal(t, "planned", report.State)
+	assert.Positive(t, report.DocumentVersion)
+}
+
+// The default asker is the one that owns the fewest edges, so an unstated actor
+// withholds a command rather than offering one the caller may not use.
+func TestFSMWhereRoute_DefaultsToTheSkillActor(t *testing.T) {
+	srv := whereServer(func(string) ([]tracker.Comment, tracker.Category, bool, error) {
+		return []tracker.Comment{cmt(ImplementationStartedHeader, time.Unix(1000, 0))}, tracker.CategoryUnstarted, false, nil
+	})
+
+	stated := whereRequest(t, srv, WhereRequest{Key: "SC-1", Actor: "skill"})
+	unstated := whereRequest(t, srv, WhereRequest{Key: "SC-1"})
+
+	assert.Equal(t, stated.Stdout, unstated.Stdout)
+}
+
+func TestFSMWhereRoute_RejectsAnActorTheMachineDoesNotDeclare(t *testing.T) {
+	srv := whereServer(func(string) ([]tracker.Comment, tracker.Category, bool, error) {
+		return nil, tracker.CategoryUnstarted, false, nil
+	})
+
+	resp := whereRequest(t, srv, WhereRequest{Key: "SC-1", Actor: "robot"})
+
+	assert.NotEqual(t, 0, resp.ExitCode)
+	assert.Contains(t, resp.Stderr, "no such actor")
+}
+
+func TestFSMWhereRoute_NeedsAKey(t *testing.T) {
+	srv := whereServer(func(string) ([]tracker.Comment, tracker.Category, bool, error) {
+		return nil, tracker.CategoryUnstarted, false, nil
+	})
+
+	resp := whereRequest(t, srv, WhereRequest{})
+
+	assert.NotEqual(t, 0, resp.ExitCode)
+	assert.Contains(t, resp.Stderr, "needs a ticket key")
+}
+
+// An unreadable thread must fail rather than answer "backlog, nothing here" —
+// a confident wrong answer where none is far cheaper.
+func TestFSMWhereRoute_FailsWhenTheThreadCannotBeRead(t *testing.T) {
+	srv := whereServer(func(string) ([]tracker.Comment, tracker.Category, bool, error) {
+		return nil, "", false, assert.AnError
+	})
+
+	resp := whereRequest(t, srv, WhereRequest{Key: "SC-1"})
+
+	assert.NotEqual(t, 0, resp.ExitCode)
+}
+
+func TestFSMWhereRoute_DisabledWithoutAReader(t *testing.T) {
+	resp := whereRequest(t, &Server{Logger: zerolog.Nop()}, WhereRequest{Key: "SC-1"})
+
+	assert.NotEqual(t, 0, resp.ExitCode)
+	assert.Contains(t, resp.Stderr, "cannot read")
+}

--- a/internal/daemon/fsm_where_test.go
+++ b/internal/daemon/fsm_where_test.go
@@ -1,0 +1,183 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/pipelinefsm"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+func whereDoc(t *testing.T) pipelinefsm.Document {
+	t.Helper()
+	doc, err := pipelinefsm.Load()
+	require.NoError(t, err)
+	return doc
+}
+
+func whereOf(t *testing.T, comments []tracker.Comment, actor string) WhereReport {
+	t.Helper()
+	return BuildWhere(whereDoc(t), "SC-1", comments, tracker.CategoryUnstarted, false, actor,
+		WhereDeps{Now: time.Unix(10_000, 0)})
+}
+
+// The ordinary case: one placement, one state, named outright.
+func TestWhere_NamesTheStateWhenThePlacementIsUnambiguous(t *testing.T) {
+	report := whereOf(t, []tracker.Comment{
+		cmt(PlanReadyHeader, time.Unix(1000, 0)),
+	}, "user")
+
+	assert.Equal(t, "planned", report.State)
+	assert.Empty(t, report.Why, "nothing had to be explained away")
+	require.Len(t, report.Candidates, 1)
+	assert.NotEmpty(t, report.Candidates[0].IfNothingHappens)
+}
+
+// THE guard, carried over from the command: an asker sees every way out, and
+// only its own carry something it can run. Without it an agent that merely
+// finished its work could post [human:deployed].
+func TestWhere_OnlyTheAskersOwnWaysOutCarryACommand(t *testing.T) {
+	doc := whereDoc(t)
+	for actor := range doc.Actors {
+		report := BuildWhere(doc, "SC-1", []tracker.Comment{
+			cmt(ReadyForReviewHeader, time.Unix(1000, 0)),
+		}, tracker.CategoryUnstarted, false, actor, WhereDeps{Now: time.Unix(10_000, 0)})
+
+		require.NotEmpty(t, report.Candidates)
+		for _, c := range report.Candidates {
+			for _, w := range c.WaysOut {
+				if w.Actor == actor {
+					assert.True(t, w.Yours, "%s: %s is this actor's own edge", actor, w.Event)
+					continue
+				}
+				assert.False(t, w.Yours)
+				assert.Empty(t, w.Command,
+					"%s: %s belongs to %s and must carry no way to take it", actor, w.Event, w.Actor)
+			}
+		}
+	}
+}
+
+// implementation/running covers seven states. The newest marker in the stage
+// names which phase reported, so the answer narrows rather than listing all
+// seven.
+func TestWhere_NarrowsABlurredPlacementByTheNewestMarker(t *testing.T) {
+	report := whereOf(t, []tracker.Comment{
+		cmt(ImplementationStartedHeader, time.Unix(1000, 0)),
+		cmt(BugVerdictHeader+" confirmed", time.Unix(2000, 0)),
+	}, "skill")
+
+	assert.Equal(t, BoardImplementation, BoardStage(report.Board.Stage))
+	assert.Equal(t, BoardRunning, BoardState(report.Board.State))
+	assert.NotEmpty(t, report.Candidates)
+	assert.Less(t, len(report.Candidates), 7, "the newest marker narrowed the seven phases")
+}
+
+// When it genuinely cannot tell, it says so and lists the candidates rather than
+// picking one. Reporting the wrong state is worse than reporting several: an
+// agent acting on a state it is not in takes an edge it does not own.
+func TestWhere_ListsCandidatesWithAReasonRatherThanGuessing(t *testing.T) {
+	report := whereOf(t, []tracker.Comment{
+		cmt(ImplementationStartedHeader, time.Unix(1000, 0)),
+	}, "skill")
+
+	if report.State != "" {
+		return // narrowed to one; nothing to explain
+	}
+	assert.Greater(t, len(report.Candidates), 1)
+	assert.NotEmpty(t, report.Why, "an unresolved answer must say what stopped it resolving")
+}
+
+// A state any column can carry is matched on the state alone — an item does not
+// leave its column to be stopped.
+func TestWhere_ResolvesTheColumnIndependentStates(t *testing.T) {
+	report := whereOf(t, []tracker.Comment{
+		cmt(ImplementationStartedHeader, time.Unix(1000, 0)),
+		cmt(ImplementationFailedHeader+"\nreason: x", time.Unix(2000, 0)),
+	}, "user")
+
+	assert.Equal(t, "stopped", report.State)
+}
+
+// A closed ticket has no state in the machine. It must say that plainly instead
+// of naming one, which is the honest half of the gap the document still carries.
+func TestWhere_SaysWhenNoStateDescribesThePlacement(t *testing.T) {
+	report := BuildWhere(whereDoc(t), "SC-1",
+		[]tracker.Comment{cmt(DeployedHeader, time.Unix(1000, 0))},
+		tracker.CategoryDone, false, "skill", WhereDeps{Now: time.Unix(10_000, 0)})
+
+	assert.Equal(t, string(BoardHidden), report.Board.Stage)
+	assert.Empty(t, report.State)
+	assert.Empty(t, report.Candidates)
+	assert.Contains(t, report.Why, "no state in the machine describes")
+}
+
+// Liveness is read from the daemon's own record, never recomputed. A blocked
+// agent is waiting for a person, not hung, and Stalled already holds that rule.
+func TestWhere_ReportsLivenessFromTheDaemonsOwnRecord(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	deps := WhereDeps{
+		Now: now,
+		Progress: func(string) (AgentProgress, bool) {
+			return AgentProgress{LastEventAt: now.Add(-time.Hour), Blocked: true}, true
+		},
+	}
+	report := BuildWhere(whereDoc(t), "SC-1",
+		[]tracker.Comment{cmt(ImplementationStartedHeader, time.Unix(1000, 0))},
+		tracker.CategoryUnstarted, false, "skill", deps)
+
+	require.NotNil(t, report.Agent)
+	assert.True(t, report.Agent.Known)
+	assert.True(t, report.Agent.Blocked)
+	assert.False(t, report.Agent.Stalled, "an agent waiting on a person is not hung")
+}
+
+// An unknown agent is reported as unknown rather than as dead: absent evidence
+// and evidence of absence lead to opposite actions.
+func TestWhere_DistinguishesNoRecordFromNotAlive(t *testing.T) {
+	deps := WhereDeps{
+		Now:      time.Unix(10_000, 0),
+		Progress: func(string) (AgentProgress, bool) { return AgentProgress{}, false },
+	}
+	report := BuildWhere(whereDoc(t), "SC-1",
+		[]tracker.Comment{cmt(ImplementationStartedHeader, time.Unix(1000, 0))},
+		tracker.CategoryUnstarted, false, "skill", deps)
+
+	require.NotNil(t, report.Agent)
+	assert.False(t, report.Agent.Known)
+}
+
+// Asking where an item is must never spend the budget being asked about. The
+// deps take a READER; StageRetry.Attempts increments and must never be wired
+// here.
+func TestWhere_ReadingTheBudgetDoesNotSpendIt(t *testing.T) {
+	reads := 0
+	deps := WhereDeps{
+		Now:         time.Unix(10_000, 0),
+		MaxAttempts: 2,
+		Attempts:    func(string, BoardStage) (int, error) { reads++; return 1, nil },
+	}
+	comments := []tracker.Comment{cmt(ImplementationStartedHeader, time.Unix(1000, 0))}
+
+	first := BuildWhere(whereDoc(t), "SC-1", comments, tracker.CategoryUnstarted, false, "skill", deps)
+	second := BuildWhere(whereDoc(t), "SC-1", comments, tracker.CategoryUnstarted, false, "skill", deps)
+
+	require.NotNil(t, first.Budget)
+	assert.Equal(t, 1, first.Budget.Spent)
+	assert.Equal(t, 2, first.Budget.Of)
+	assert.Equal(t, first.Budget.Spent, second.Budget.Spent, "asking twice reports the same, unspent, count")
+	assert.Equal(t, 2, reads)
+}
+
+// A missing dependency drops its section rather than failing the answer: where
+// an item is stays worth knowing when only the liveness record is unavailable.
+func TestWhere_AnswersWithoutTheOptionalSections(t *testing.T) {
+	report := whereOf(t, []tracker.Comment{cmt(PlanReadyHeader, time.Unix(1000, 0))}, "user")
+
+	assert.Equal(t, "planned", report.State)
+	assert.Nil(t, report.Agent)
+	assert.Nil(t, report.Budget)
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -110,6 +110,13 @@ type Server struct {
 	// BugCreator files a defect ticket on the PM tracker for the Bugs pane's
 	// + dialog. nil disables the bug-create route.
 	BugCreator func(req BugCreateRequest) (BugCreateResponse, error)
+	// WhereComments loads one ticket's thread for the fsm-where route. nil
+	// disables it.
+	WhereComments WhereCommentReader
+	// WhereAttempts reads how many automatic relaunches a stage has already
+	// spent, for the same route. It must READ ONLY: StageRetry.Attempts
+	// increments, and a question must never spend the budget it asks about.
+	WhereAttempts func(pmKey string, stage BoardStage) (int, error)
 	// SecurityCreator files a security ticket on the PM tracker for the Security
 	// section's + dialog. nil disables the security-create route.
 	SecurityCreator func(req SecurityCreateRequest) (SecurityCreateResponse, error)
@@ -528,6 +535,7 @@ func (s *Server) routeSimpleCommand(conn net.Conn, args []string, projectDir str
 		"ideation-status":    func() { s.handleIdeationStatus(conn) },
 		"idea-create":        func() { s.withBlockingOp(func() { s.handleIdeaCreate(conn, args[1:]) }) },
 		"bug-create":         func() { s.withBlockingOp(func() { s.handleBugCreate(conn, args[1:]) }) },
+		"fsm-where":          func() { s.handleFSMWhere(conn, args[1:]) },
 		"security-create":    func() { s.withBlockingOp(func() { s.handleSecurityCreate(conn, args[1:]) }) },
 		"features-generate":  func() { s.withBlockingOp(func() { s.handleFeaturesGenerate(conn) }) },
 		"findbugs-start":     func() { s.withBlockingOp(func() { s.handleFindbugsStart(conn) }) },

--- a/internal/marker/marker.go
+++ b/internal/marker/marker.go
@@ -147,6 +147,24 @@ func KnownTypes() []string {
 	return types
 }
 
+// RequiredFields lists the field lines a marker type must carry, sorted. Empty
+// for a type with no contract and for an unknown one, which is the same answer
+// Validate gives them.
+//
+// Exported so something telling a caller HOW to post a marker can read the
+// contract instead of restating it. A second list of required fields would be
+// wrong the first time a field is added here, and wrong silently: the caller
+// would build a command that post-time validation then rejects.
+func RequiredFields(markerType string) []string {
+	s, known := specs[markerType]
+	if !known || len(s.required) == 0 {
+		return nil
+	}
+	out := append([]string(nil), s.required...)
+	sort.Strings(out)
+	return out
+}
+
 // Validate checks m against its type's contract. Unknown types pass — only a
 // syntactically valid type name is required.
 func Validate(m Marker) error {

--- a/internal/pipelinefsm/doc.go
+++ b/internal/pipelinefsm/doc.go
@@ -57,6 +57,26 @@ type Document struct {
 	StageDefaults StageDefaults `json:"stage_defaults"`
 
 	Unclassified Unclassified `json:"unclassified_markers"`
+
+	// Invariants carries the budgets the states' prose refers to by name.
+	// Modelled so a caller can be told the number instead of the name: a plan or
+	// an agent that reads "past the budget it waits for a person" and has to
+	// guess what the budget is will guess, and a guessed budget is how the same
+	// timing bug gets rediscovered under a new number.
+	Invariants Invariants `json:"invariants"`
+}
+
+// Invariants is the document's block of cross-cutting facts: the named budgets
+// and the fields every state carries.
+type Invariants struct {
+	Doc string `json:"doc"`
+
+	// Constants maps a budget's name to its value and where it lives, e.g.
+	// "StuckRunningGrace" -> "15m — how long a running card is left alone …".
+	Constants map[string]string `json:"constants"`
+
+	// Fields documents what each per-state invariant means.
+	Fields map[string]string `json:"fields"`
 }
 
 // ResolvedStates returns every state with its inherited fields filled in.

--- a/internal/pipelinefsm/query.go
+++ b/internal/pipelinefsm/query.go
@@ -1,0 +1,160 @@
+package pipelinefsm
+
+import (
+	"sort"
+	"strings"
+)
+
+// The questions something INSIDE the pipeline asks: where am I, where can I go,
+// what does this marker do. They live here rather than in the command that
+// prints them because the answers are document logic and there will be more
+// than one asker — a command today, a per-ticket lookup later — and two readings
+// of the same document is the drift this package exists to prevent.
+
+// FindState returns the named state with its inherited liveness rule filled in.
+// Resolved rather than raw: a caller asking what happens if nothing happens must
+// get the rule that applies, not an empty field and a pointer to a stage default
+// it would then have to look up and apply itself.
+func (d Document) FindState(name string) (State, bool) {
+	for _, s := range d.States {
+		if s.Name == name {
+			return s.Resolve(d.StageDefaults), true
+		}
+	}
+	return State{}, false
+}
+
+// StateNames lists every declared state, sorted, for an error that has to say
+// what the caller could have asked for instead.
+func (d Document) StateNames() []string {
+	out := make([]string, 0, len(d.States))
+	for _, s := range d.States {
+		out = append(out, s.Name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// StatesAtPlacement returns every state the document says sits at a board
+// placement, in document order.
+//
+// Usually one. Two placements are genuinely many-to-one — implementation/running
+// covers seven states and done/running five — because the board shows a stage
+// running and the machine distinguishes the phases inside it. A caller resolving
+// a real item has to narrow those by other evidence, or say it could not.
+//
+// A state whose stage is "any" is not returned: it is reachable from every
+// column, so it identifies nothing about which column an item is in. Callers
+// match those on the within-stage state instead (queued, failed, outage).
+func (d Document) StatesAtPlacement(stage, state string) []State {
+	var out []State
+	for _, s := range d.States {
+		if s.Board.Stage == stage && s.Board.State == state {
+			out = append(out, s.Resolve(d.StageDefaults))
+		}
+	}
+	return out
+}
+
+// StatesAtAnyStage returns the states that sit at a within-stage state
+// regardless of column — stopped, queued, substrate-down, awaiting-decision.
+func (d Document) StatesAtAnyStage(state string) []State {
+	var out []State
+	for _, s := range d.States {
+		if s.Board.Stage == "any" && s.Board.State == state {
+			out = append(out, s.Resolve(d.StageDefaults))
+		}
+	}
+	return out
+}
+
+// StatesEnteredBy returns the states a marker leads INTO — the destinations of
+// every transition that records it. Used to narrow a blurred placement: the
+// board says which stage is running, and the newest marker in that stage says
+// which phase of it recorded that.
+//
+// A derived destination is skipped: it is a topological placeholder, so naming
+// it would answer with a state the item is not in.
+func (d Document) StatesEnteredBy(marker string) []State {
+	seen := map[string]bool{}
+	var out []State
+	for _, e := range d.MarkerUses(marker) {
+		if e.DstIsDerived || seen[e.Dst] {
+			continue
+		}
+		if s, ok := d.FindState(e.Dst); ok {
+			seen[e.Dst] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// Out returns the transitions that leave a state — the ways out, in document
+// order so the common path reads first.
+func (d Document) Out(state string) []Event {
+	var out []Event
+	for _, e := range d.Events {
+		for _, src := range e.Src {
+			if src == state {
+				out = append(out, e)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// MarkerType strips the [human:…] wrapper, and leaves a bare type alone.
+//
+// Three forms of the same name are in play: a caller says it the way it posts it
+// (`plan-ready`), the transition table writes it the way it appears on a ticket
+// (`[human:plan-ready]`), and the unclassified list uses the bare form. One of
+// them has to convert. Doing it here means no caller has to know which form a
+// given field happens to use, which is the kind of detail that otherwise gets
+// half-remembered at three call sites.
+func MarkerType(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "[human:")
+	return strings.TrimSuffix(s, "]")
+}
+
+// MarkerHeader is the inverse: the form a marker takes on a ticket.
+func MarkerHeader(markerType string) string {
+	return "[human:" + MarkerType(markerType) + "]"
+}
+
+// MarkerUses returns the transitions that record a marker, named in either
+// form. The document writes one transition's per-stage alternatives as
+// "[human:a] | [human:b]", so a lookup has to match a member rather than the
+// whole field.
+func (d Document) MarkerUses(marker string) []Event {
+	want := MarkerType(marker)
+	var out []Event
+	for _, e := range d.Events {
+		for _, m := range e.Markers() {
+			if MarkerType(m) == want {
+				out = append(out, e)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// RecordsContentOnly reports whether the document declares a marker as one that
+// deliberately does not move an item, and why if it says.
+//
+// The second return is the dual-role note, present only for a marker that is
+// BOTH — a transition from some states and a record from others. A caller that
+// treats "listed here" as "never a transition" would be wrong about those, which
+// is exactly the confusion the dual_role block was added to make visible.
+func (d Document) RecordsContentOnly(marker string) (listed bool, dualRole string) {
+	want := MarkerType(marker)
+	for _, m := range d.Unclassified.Markers {
+		if MarkerType(m) == want {
+			return true, d.Unclassified.DualRole[want]
+		}
+	}
+	return false, ""
+}

--- a/internal/pipelinefsm/waysout.go
+++ b/internal/pipelinefsm/waysout.go
@@ -1,0 +1,81 @@
+package pipelinefsm
+
+import "github.com/gethuman-sh/human/internal/marker"
+
+// WayOut is one transition leaving a state, as the thing standing in that state
+// needs to see it.
+//
+// Yours and Command are the load-bearing pair, and the reason this lives in the
+// package rather than in a command: an asker sees EVERY way out — that is how it
+// knows what waiting buys it and who it is waiting for — but only its own carry
+// something it can run. An edge with no command is not an edge to improvise.
+// Posting another actor's marker does not advance the item; it puts it in a
+// state nobody drove it to, and everything downstream then reasons about a run
+// that never happened.
+type WayOut struct {
+	Event   string `json:"event"`
+	To      string `json:"to"`
+	Actor   string `json:"actor"`
+	Marker  string `json:"marker,omitempty"`
+	Doc     string `json:"doc,omitempty"`
+	Yours   bool   `json:"yours"`
+	Command string `json:"command,omitempty"`
+
+	// ToIsDerived says To is a placeholder: the real destination is computed
+	// from the marker's body. Reported rather than hidden, so an asker does not
+	// plan around a destination that was never a promise.
+	ToIsDerived bool `json:"to_is_derived,omitempty"`
+
+	// MovesItem is false for an edge that records something without moving the
+	// item. An asker treating it as progress would wait for a change that is
+	// never coming.
+	MovesItem bool `json:"moves_item"`
+}
+
+// WaysOut lists the transitions leaving a state, in document order so the
+// common path reads first, with each marked for the asker.
+func (d Document) WaysOut(state, actor string) []WayOut {
+	events := d.Out(state)
+	out := make([]WayOut, 0, len(events))
+	for _, e := range events {
+		w := WayOut{
+			Event:       e.Name,
+			To:          e.Dst,
+			Actor:       e.Actor,
+			Marker:      e.Marker,
+			Doc:         e.Doc,
+			Yours:       e.Actor == actor,
+			ToIsDerived: e.DstIsDerived,
+			MovesItem:   e.Moves(),
+		}
+		if w.Yours {
+			w.Command = CommandFor(e, "<KEY>")
+		}
+		out = append(out, w)
+	}
+	return out
+}
+
+// CommandFor is what an asker runs to take an edge it owns, for a named item.
+//
+// Empty when the edge records no marker (a silent transition has nothing to
+// post) or names several (a per-stage alternation cannot be resolved without
+// knowing the stage, and inventing one would hand back a command for the wrong
+// stage).
+//
+// The required fields come from the marker package rather than being listed
+// here. A second list of them would be wrong the first time a field is added,
+// and wrong silently: the asker would build a command that post-time validation
+// then rejects, which is the failure moved later rather than prevented.
+func CommandFor(e Event, key string) string {
+	markers := e.Markers()
+	if len(markers) != 1 {
+		return ""
+	}
+	markerType := MarkerType(markers[0])
+	cmd := "human marker post " + key + " " + markerType
+	for _, f := range marker.RequiredFields(markerType) {
+		cmd += " --field " + f + "=<" + f + ">"
+	}
+	return cmd
+}

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gethuman-sh/human/cmd/cmddeploy"
 	"github.com/gethuman-sh/human/cmd/cmddoctor"
 	"github.com/gethuman-sh/human/cmd/cmdfigma"
+	"github.com/gethuman-sh/human/cmd/cmdfsm"
 	"github.com/gethuman-sh/human/cmd/cmdhandoff"
 	"github.com/gethuman-sh/human/cmd/cmdindex"
 	"github.com/gethuman-sh/human/cmd/cmdinit"
@@ -384,6 +385,10 @@ Configure trackers and tools in .humanconfig.yaml or pass credentials via flags/
 	codenavCmd.GroupID = "utility"
 	rootCmd.AddCommand(codenavCmd)
 
+	fsmCmd := cmdfsm.BuildFSMCmd()
+	fsmCmd.GroupID = "utility"
+	rootCmd.AddCommand(fsmCmd)
+
 	agentContextCmd := cmdagentcontext.BuildAgentContextCmd()
 	agentContextCmd.GroupID = "utility"
 	rootCmd.AddCommand(agentContextCmd)
@@ -596,6 +601,12 @@ var localSubcommands = map[string]bool{
 	// Describes the caller's own checkout and environment — the one thing the
 	// daemon cannot see on its behalf.
 	"capabilities": true,
+	// Answers from the machine compiled into THIS binary. Forwarding it would
+	// make the one caller it exists for — an agent in a container, on a project
+	// whose daemon it cannot reach — unable to ask, and would answer from the
+	// daemon's build rather than the asker's, so two binaries at different
+	// versions would silently disagree about which document they quoted.
+	"fsm": true,
 	// bug/security create call the daemon's bug-create/security-create route
 	// directly (like the desktop board buttons); they must not be forwarded, or
 	// the RunE would open a reentrant connection back into the daemon.


### PR DESCRIPTION
Replaces #441, which built the open half of this design instead of resolving it. The design record already said `where` is the command with the value; this is that command.

### `human fsm where <KEY>`

Answers with the one fact an agent reliably has — its ticket key. It does not know its state; that is what it is asking.

A daemon **route**, not a forwarded command: a forwarded cobra command gets env and vault on its context and no `Server` handle, while the answer needs the daemon's own liveness records and retry counters. Forwarding would also answer from the daemon's build rather than the asker's, so two binaries at different versions would silently disagree about which document they quoted.

**How the state is resolved, and why it sometimes isn't.** The board placement decides it outright for 16 of the 18 placements the machine declares. Two are genuinely many-to-one — `implementation/running` covers seven states, `done/running` five — because the board shows a stage running while the machine distinguishes the phases inside it. Those narrow by the newest marker in the winning stage. When that still doesn't identify one, the candidates come back **with the reason** rather than a guess: an agent acting on a state it is not in takes an edge it does not own.

A ticket whose placement no state describes — a closed one — says exactly that instead of naming a state. That keeps `where` independent of the still-open `hidden` decision rather than blocked on it.

**The yours/command rule** moves into the machine's own package so the answer is shaped once. Only the asker's own ways out carry something runnable; the rest are listed so an agent knows who it is waiting for. Required fields come from the marker package, not a second list.

**The budget is read through a new read-only counter.** `bumpStageRetries` increments as it reads — right for the retry path, catastrophic for a question, since `where` would spend a ticket's budget every time an agent asked where it was.

### The half that changes behaviour

All nine board-launched agents carry one shared fragment telling them to ask before they stop and ask a person; the session-start brief carries it too.

The fragment takes **no argument**. The draft in #441 bound each prompt to the state its agent normally occupies — wrong premise (an agent knows its key, not its state; a bound state is stale the moment a run moves on, and the fix run moves five times) and wrong in practice on the first attempt, binding the bug fixer to `preflight` when it is `fixing`, with a test that only checked the state existed and so couldn't catch it. A test now fails if the argument comes back.

### Two bugs my own tests caught

- Matching the column-independent states on the board state alone made every quiet card — including a **closed** one — resolve as `awaiting-decision`. An open decision is identified by the options block, which is what the document says itself.
- A route test that passed the route name through to the handler made two tests pass by comparing identical error responses.

`make check` green, rebased on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)