### PR TITLE
[SC-3872] Tell an agent where the ticket has been, not only where it is

### DIFF
--- a/cmd/cmdfsm/fsm.go
+++ b/cmd/cmdfsm/fsm.go
@@ -68,7 +68,10 @@ func load() (pipelinefsm.Document, error) {
 }
 
 func buildWhereCmd() *cobra.Command {
-	var actor string
+	var (
+		actor   string
+		history int
+	)
 	cmd := &cobra.Command{
 		Use:   "where KEY",
 		Short: "Where an item is, what holds there, and which ways out are yours",
@@ -84,7 +87,7 @@ func buildWhereCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			report, err := daemon.FSMWhere(addr, token, daemon.WhereRequest{Key: args[0], Actor: actor})
+			report, err := daemon.FSMWhere(addr, token, daemon.WhereRequest{Key: args[0], Actor: actor, History: history})
 			if err != nil {
 				return err
 			}
@@ -92,6 +95,7 @@ func buildWhereCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&actor, "actor", defaultActor, "Who is asking (user, daemon, skill) — only this actor's ways out carry a command")
+	cmd.Flags().IntVar(&history, "history", 0, "How many past positions to include (0 = default, -1 = none)")
 	return cmd
 }
 

--- a/internal/claude/embed/shared/fsm.md
+++ b/internal/claude/embed/shared/fsm.md
@@ -15,6 +15,13 @@ know which state you are in, because that is what it tells you — along with wh
 must be true while an item sits there, who may move it, and what happens if
 nobody does.
 
+It also tells you where the item has **been**. `history` lists the states it
+passed through with times, oldest first, and stops before now; `entered` says
+when it reached where it is. Read them before repeating work: they are how you
+tell a first attempt from a third, which the retry budget does not show because
+it counts stage relaunches and not review rounds. History is the trail only —
+where you are **now** is `state` (or `candidates`), never the last history entry.
+
 **Only a way out marked `"yours": true` carries a `command`.** That is the point
 of asking. The rest are listed so you can see what waiting buys you and who you
 are waiting for — the daemon, or a person — but they are not yours to take.

--- a/internal/daemon/fsm_where.go
+++ b/internal/daemon/fsm_where.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"sort"
 	"strings"
 	"time"
 
@@ -28,6 +29,25 @@ type WhereReport struct {
 	State      string       `json:"state,omitempty"`
 	Candidates []WhereState `json:"candidates,omitempty"`
 	Why        string       `json:"why,omitempty"`
+
+	// Entered is when the item arrived where it is, and what recorded that.
+	//
+	// Without it stale_when cannot be evaluated by the thing reading it: the rule
+	// says "past StuckRunningGrace with no live agent", and an asker that knows
+	// only its agent's idle time cannot tell a card parked for a minute from one
+	// parked for three days. The agent's liveness and the item's age are
+	// different clocks and only one of them was being reported.
+	Entered *WhereEntered `json:"entered,omitempty"`
+
+	// History is where the item has BEEN, oldest first, ending before where it is
+	// now. In states rather than markers, because the asker already thinks in
+	// states — that is the vocabulary the rest of this answer uses, and making it
+	// translate marker names into positions is how it gets one wrong.
+	//
+	// It deliberately stops short of the current position, which lives in State
+	// and Entered. A trail whose last entry might or might not be "now" is the
+	// confusing shape.
+	History []WhereEvent `json:"history,omitempty"`
 
 	// Agent is the liveness of the stage's agent, read from the daemon's own
 	// records rather than recomputed. A second implementation of "is it alive"
@@ -71,6 +91,36 @@ type WhereAgent struct {
 	Blocked         bool   `json:"blocked,omitempty"`
 }
 
+// WhereEntered is when the item arrived where it is.
+type WhereEntered struct {
+	At      string `json:"at"`
+	Seconds int    `json:"seconds"`
+	Via     string `json:"via"`
+}
+
+// WhereEvent is one position the item held, and when it got there.
+type WhereEvent struct {
+	// State is where the marker took it, when the machine names exactly one
+	// destination for that marker. Empty when it names several or none — an
+	// honest blank beats a plausible guess in a trail an agent reasons from.
+	State string `json:"state,omitempty"`
+	// Marker is always present, so an entry whose state could not be named is
+	// still legible.
+	Marker     string `json:"marker"`
+	At         string `json:"at"`
+	SecondsAgo int    `json:"seconds_ago"`
+}
+
+// DefaultWhereHistory is how many past markers ride along by default.
+//
+// Ten covers a full PR review→fix loop (DefaultPRReviewRounds is 3, two markers
+// a round) plus what preceded it, which is the question history actually
+// answers: not "what happened" — the ticket has that — but "is this my first
+// pass or my third", because a card round the loop twice needs a different move
+// from one on its first attempt, and the retry budget counts stage relaunches
+// rather than loop rounds.
+const DefaultWhereHistory = 10
+
 // WhereBudget is the automatic-relaunch budget for the item's current stage.
 type WhereBudget struct {
 	Kind  string `json:"kind"`
@@ -91,6 +141,9 @@ type WhereDeps struct {
 	Attempts func(pmKey string, stage BoardStage) (int, error)
 	// MaxAttempts is the cap those attempts are counted against.
 	MaxAttempts int
+	// HistoryLimit bounds the trail. Zero means DefaultWhereHistory; negative
+	// means no history at all, for a caller that only wants the position.
+	HistoryLimit int
 	// Now is injected so the staleness answer is testable.
 	Now time.Time
 }
@@ -121,6 +174,8 @@ func BuildWhere(doc pipelinefsm.Document, key string, comments []tracker.Comment
 		report.State = states[0].Name
 	}
 
+	report.Entered = whereEntered(doc, comments, deps.Now)
+	report.History = whereHistory(doc, comments, deps.HistoryLimit, deps.Now)
 	report.Agent = whereAgent(key, card, deps)
 	report.Budget = whereBudget(key, card, deps)
 	return report
@@ -187,6 +242,79 @@ func statesFor(doc pipelinefsm.Document, card BoardCard, comments []tracker.Comm
 	}
 	return narrowed, "the newest " + string(card.Stage) + " marker (" + header +
 		") is posted by more than one phase, so the ones it could be are listed"
+}
+
+// classifiedMarkers returns the pipeline markers in the thread, oldest first,
+// paired with the times their comments were posted.
+//
+// The times come from the comments themselves — a marker IS a comment, so when
+// it was posted is when the item moved. Nothing else in the tool records that:
+// `human marker list` reports type and fields only, so before this an asker
+// could see what had happened and never when.
+func classifiedMarkers(comments []tracker.Comment) []tracker.Comment {
+	var out []tracker.Comment
+	for _, c := range comments {
+		if _, _, ok := ClassifyMarker(c.Body); ok {
+			out = append(out, c)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Created.Before(out[j].Created) })
+	return out
+}
+
+// whereEntered reports when the item reached where it is, from the newest
+// classified marker: the one that put it there.
+func whereEntered(doc pipelinefsm.Document, comments []tracker.Comment, now time.Time) *WhereEntered {
+	trail := classifiedMarkers(comments)
+	if len(trail) == 0 {
+		return nil
+	}
+	latest := trail[len(trail)-1]
+	return &WhereEntered{
+		At:      latest.Created.UTC().Format(time.RFC3339),
+		Seconds: int(now.Sub(latest.Created).Seconds()),
+		Via:     markerHeaderOf(latest.Body),
+	}
+}
+
+// whereHistory is where the item has BEEN, oldest first, stopping before where
+// it is now — the newest marker is the current position and is reported by
+// State and Entered instead.
+//
+// Bounded, and carrying no comment bodies. The bound is token cost; the missing
+// bodies are the real rule. A full thread invites an asker to re-derive its own
+// view of where the item is, which is a second implementation of the derivation
+// — the defect class this machine's document exists to prevent. `human marker
+// show` has the bodies for the rare case that genuinely needs one.
+func whereHistory(doc pipelinefsm.Document, comments []tracker.Comment, limit int, now time.Time) []WhereEvent {
+	if limit < 0 {
+		return nil
+	}
+	if limit == 0 {
+		limit = DefaultWhereHistory
+	}
+	trail := classifiedMarkers(comments)
+	if len(trail) <= 1 {
+		return nil
+	}
+	past := trail[:len(trail)-1]
+	if limit > 0 && len(past) > limit {
+		past = past[len(past)-limit:]
+	}
+	out := make([]WhereEvent, 0, len(past))
+	for _, c := range past {
+		header := markerHeaderOf(c.Body)
+		event := WhereEvent{
+			Marker:     header,
+			At:         c.Created.UTC().Format(time.RFC3339),
+			SecondsAgo: int(now.Sub(c.Created).Seconds()),
+		}
+		if entered := doc.StatesEnteredBy(header); len(entered) == 1 {
+			event.State = entered[0].Name
+		}
+		out = append(out, event)
+	}
+	return out
 }
 
 // markerHeaderOf extracts the [human:…] header from a comment body.

--- a/internal/daemon/fsm_where_route.go
+++ b/internal/daemon/fsm_where_route.go
@@ -18,6 +18,9 @@ type WhereRequest struct {
 	// guessing it withholds a command rather than offering one the caller may not
 	// use.
 	Actor string `json:"actor,omitempty"`
+	// History bounds the trail of past positions. Zero means the default;
+	// negative means none, for a caller that only wants the position.
+	History int `json:"history,omitempty"`
 }
 
 // WhereCommentReader loads one ticket's comment thread and status. Injected so
@@ -67,9 +70,10 @@ func (s *Server) handleFSMWhere(conn net.Conn, args []string) {
 	}
 
 	report := BuildWhere(doc, req.Key, comments, status, isIdea, actor, WhereDeps{
-		Progress: s.whereProgress(),
-		Attempts: s.WhereAttempts,
-		Now:      time.Now(),
+		Progress:     s.whereProgress(),
+		Attempts:     s.WhereAttempts,
+		HistoryLimit: req.History,
+		Now:          time.Now(),
 	})
 	data, err := json.Marshal(report)
 	if err != nil {

--- a/internal/daemon/fsm_where_test.go
+++ b/internal/daemon/fsm_where_test.go
@@ -181,3 +181,97 @@ func TestWhere_AnswersWithoutTheOptionalSections(t *testing.T) {
 	assert.Nil(t, report.Agent)
 	assert.Nil(t, report.Budget)
 }
+
+// A marker IS a comment, so when it was posted is when the item moved. That is
+// the only record of pipeline timing anywhere in the tool — `human marker list`
+// reports type and fields and no times at all.
+func TestWhere_EnteredComesFromTheMarkerComment(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	arrived := now.Add(-90 * time.Minute)
+	report := BuildWhere(whereDoc(t), "SC-1", []tracker.Comment{
+		cmt(PlanningStartedHeader, arrived.Add(-time.Hour)),
+		cmt(PlanReadyHeader, arrived),
+	}, tracker.CategoryUnstarted, false, "user", WhereDeps{Now: now})
+
+	require.NotNil(t, report.Entered)
+	assert.Equal(t, arrived.UTC().Format(time.RFC3339), report.Entered.At)
+	assert.Equal(t, 5400, report.Entered.Seconds, "how long the ITEM has sat here, not how idle an agent is")
+	assert.Equal(t, PlanReadyHeader, report.Entered.Via)
+}
+
+// History is where the item has BEEN, in states, and stops before where it is
+// now — a trail whose last entry might or might not be "now" is the confusing
+// shape this avoids.
+func TestWhere_HistoryIsStatesAndStopsBeforeNow(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	report := BuildWhere(whereDoc(t), "SC-1", []tracker.Comment{
+		cmt(PlanningStartedHeader, now.Add(-3*time.Hour)),
+		cmt(PlanReadyHeader, now.Add(-2*time.Hour)),
+		cmt(ImplementationStartedHeader, now.Add(-time.Hour)),
+	}, tracker.CategoryUnstarted, false, "skill", WhereDeps{Now: now})
+
+	require.Len(t, report.History, 2, "the newest marker is the current position, not history")
+	assert.Equal(t, "planning", report.History[0].State, "oldest first")
+	assert.Equal(t, "planned", report.History[1].State)
+	assert.Equal(t, 10800, report.History[0].SecondsAgo)
+	assert.Equal(t, ImplementationStartedHeader, report.Entered.Via,
+		"and the newest one is reported as where it is now")
+}
+
+// A marker several transitions record cannot be turned into one state. The entry
+// stays legible via its marker rather than carrying a plausible guess an agent
+// would then reason from.
+func TestWhere_HistoryLeavesAnAmbiguousStateBlank(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	report := BuildWhere(whereDoc(t), "SC-1", []tracker.Comment{
+		cmt(ImplementationStartedHeader, now.Add(-2*time.Hour)),
+		cmt(ReadyForReviewHeader, now.Add(-time.Hour)),
+	}, tracker.CategoryUnstarted, false, "skill", WhereDeps{Now: now})
+
+	require.Len(t, report.History, 1)
+	assert.Equal(t, ImplementationStartedHeader, report.History[0].Marker,
+		"the marker is always there even when the state cannot be named")
+	assert.Empty(t, report.History[0].State,
+		"implementation-started leads to both preflight and implementing, so neither is claimed")
+}
+
+// Bounded, so a long-running ticket does not hand an agent its whole life story.
+func TestWhere_HistoryIsBounded(t *testing.T) {
+	now := time.Unix(100_000, 0)
+	var comments []tracker.Comment
+	for i := range 30 {
+		comments = append(comments, cmt(PlanningStartedHeader, now.Add(-time.Duration(30-i)*time.Hour)))
+	}
+	report := BuildWhere(whereDoc(t), "SC-1", comments, tracker.CategoryUnstarted, false, "skill",
+		WhereDeps{Now: now, HistoryLimit: 4})
+
+	assert.Len(t, report.History, 4, "the most recent, not the first")
+	assert.Equal(t, DefaultWhereHistory, 10, "and the default covers a full PR review→fix loop")
+}
+
+// A caller that only wants the position can say so.
+func TestWhere_HistoryCanBeSuppressed(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	report := BuildWhere(whereDoc(t), "SC-1", []tracker.Comment{
+		cmt(PlanningStartedHeader, now.Add(-2*time.Hour)),
+		cmt(PlanReadyHeader, now.Add(-time.Hour)),
+	}, tracker.CategoryUnstarted, false, "user", WhereDeps{Now: now, HistoryLimit: -1})
+
+	assert.Empty(t, report.History)
+	assert.NotNil(t, report.Entered, "but where it is now still answers")
+}
+
+// No comment bodies ride along. A full thread invites an agent to re-derive its
+// own view of where the item is and disagree with the machine.
+func TestWhere_HistoryCarriesNoCommentBodies(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	secret := PlanReadyHeader + "\nbody: something an agent might re-derive from"
+	report := BuildWhere(whereDoc(t), "SC-1", []tracker.Comment{
+		cmt(secret, now.Add(-2*time.Hour)),
+		cmt(ImplementationStartedHeader, now.Add(-time.Hour)),
+	}, tracker.CategoryUnstarted, false, "skill", WhereDeps{Now: now})
+
+	require.Len(t, report.History, 1)
+	assert.Equal(t, PlanReadyHeader, report.History[0].Marker)
+	assert.NotContains(t, report.History[0].Marker, "re-derive")
+}


### PR DESCRIPTION
Follow-up to #442, from a question that found a real gap: `where` reported a position with no time on it.

### `entered` — a correctness gap, not a nicety

`stale_when` says things like *"past StuckRunningGrace with no live agent"*, and the report carried only the **agent's** idle time. Those are different clocks. A card parked in `planned` for three days looked identical to one parked for a minute, so the rule could not be evaluated by the thing reading it.

### `history` — which pass is this

What it buys beyond `entered`: a card round the review→fix loop twice needs a different move from one on its first attempt, and the retry budget does not show that — it counts stage relaunches, not loop rounds.

**The times come from the comments.** A marker *is* a comment, so when it was posted is when the item moved — and that is the only record of pipeline timing anywhere in the tool, since `human marker list` returns type and fields and no times at all.

### Two shape decisions, both about not confusing the reader

- **History is in states, not marker names.** The rest of the answer speaks states; making an agent translate marker names into positions is how it gets one wrong. A marker that several transitions record leaves the state blank and keeps the marker — a plausible guess in a trail an agent reasons from is worse than an honest gap.
- **History stops before the current position.** A trail whose last entry might or might not be "now" is the confusing shape. Where it is now stays in `state` / `candidates` and `entered`.

Bounded at ten (`--history N`, `-1` for none), and carrying no comment bodies. The bound is token cost; the missing bodies are the real rule — a full thread invites an agent to re-derive its own view of where the item is, which is a second implementation of the derivation, the defect class this document exists to prevent. `human marker show` has the bodies for the rare case.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)