### PR TITLE
[SC-3884] Move the credentials instead of cloning them

### DIFF
--- a/cmd/cmdconfig/config.go
+++ b/cmd/cmdconfig/config.go
@@ -24,13 +24,16 @@ func BuildConfigCmd() *cobra.Command {
 		Long: `Write the forges: section a config needs now that a githubs: entry is an
 issue tracker and nothing more.
 
-A githubs: entry with no role used to be both a tracker and the code host that
-opened pull requests. It stays as the tracker and gains a forge entry beside it
-carrying the same token. An entry that declared role: forge was never a tracker
-and is moved into forges: outright.
+A githubs: entry that declared no role — or the retired role: forge — held
+credentials for the code host, so it moves into forges:. If GitHub is genuinely
+where your issues live, declare that with role: pm on a githubs: entry, which is
+what the board has always required of a GitHub tracker anyway.
 
-Vault references are copied as references, never resolved — a token written
-into a config file is a credential leak. Running it twice changes nothing.`,
+Only name, kind, url and token travel; projects, role and the rest are tracker
+concepts. Comments come with the entry, vault references stay references — a
+token written into a config file is a credential leak — and an entry whose
+credentials cannot be carried is left alone rather than deleted. Running it
+twice changes nothing.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return RunMigrate(cmd.OutOrStdout(), ".", dryRun)
 		},
@@ -52,21 +55,24 @@ func RunMigrate(out io.Writer, dir string, dryRun bool) error {
 		return err
 	}
 
-	verb := "Wrote"
+	verb, target := "Moved", "Updated"
 	if dryRun {
-		verb = "Would write"
-	}
-	for _, name := range result.Added {
-		if _, err := fmt.Fprintf(out, "%s forges: entry %q\n", verb, name); err != nil {
-			return err
-		}
+		verb, target = "Would move", "Target"
 	}
 	for _, name := range result.Moved {
-		if _, err := fmt.Fprintf(out, "%s githubs: entry %q (role: forge) into forges:\n",
-			map[bool]string{true: "Would move", false: "Moved"}[dryRun], name); err != nil {
+		if _, err := fmt.Fprintf(out, "%s githubs: entry %q into forges:\n", verb, name); err != nil {
 			return err
 		}
 	}
-	_, err = fmt.Fprintf(out, "%s: %s\n", map[bool]string{true: "Target", false: "Updated"}[dryRun], result.File)
+	// Named explicitly, because this is the one thing the migration cannot know:
+	// an entry that declared nothing looked exactly like credentials, and if it
+	// was in fact someone's issue tracker they need the line that says so.
+	if len(result.Moved) > 0 {
+		if _, err := fmt.Fprintln(out,
+			"If GitHub is where your issues live, add a githubs: entry with role: pm — a GitHub tracker has always needed it to reach the board."); err != nil {
+			return err
+		}
+	}
+	_, err = fmt.Fprintf(out, "%s: %s\n", target, result.File)
 	return err
 }

--- a/cmd/cmdconfig/config_test.go
+++ b/cmd/cmdconfig/config_test.go
@@ -15,7 +15,7 @@ func writeCfg(t *testing.T, dir, content string) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".humanconfig.yaml"), []byte(content), 0o600))
 }
 
-func TestRunMigrate_reportsWhatItWrote(t *testing.T) {
+func TestRunMigrate_reportsWhatItMoved(t *testing.T) {
 	dir := t.TempDir()
 	writeCfg(t, dir, "githubs:\n  - name: human\n    token: gh://token\n")
 
@@ -23,8 +23,19 @@ func TestRunMigrate_reportsWhatItWrote(t *testing.T) {
 	require.NoError(t, RunMigrate(&buf, dir, false))
 
 	out := buf.String()
-	assert.Contains(t, out, `Wrote forges: entry "human"`)
+	assert.Contains(t, out, `Moved githubs: entry "human" into forges:`)
 	assert.Contains(t, out, "Updated:")
+}
+
+// The one thing the migration cannot know is whether that entry was in fact
+// someone's issue tracker, so it must say so rather than decide in silence.
+func TestRunMigrate_saysHowToKeepAGitHubTracker(t *testing.T) {
+	dir := t.TempDir()
+	writeCfg(t, dir, "githubs:\n  - name: human\n    token: gh://token\n")
+
+	var buf bytes.Buffer
+	require.NoError(t, RunMigrate(&buf, dir, false))
+	assert.Contains(t, buf.String(), "role: pm")
 }
 
 // A dry run says "would", not "did". Reporting a write that did not happen is
@@ -37,7 +48,7 @@ func TestRunMigrate_dryRunSaysWould(t *testing.T) {
 	require.NoError(t, RunMigrate(&buf, dir, true))
 
 	out := buf.String()
-	assert.Contains(t, out, "Would write")
+	assert.Contains(t, out, "Would move")
 	assert.NotContains(t, out, "Updated:")
 }
 

--- a/internal/settings/migrate.go
+++ b/internal/settings/migrate.go
@@ -25,17 +25,27 @@ func (m ForgeMigration) Empty() bool { return len(m.Added) == 0 && len(m.Moved) 
 // MigrateForges writes the forges: section a config needs now that a githubs:
 // entry is an issue tracker and nothing more.
 //
-// Two shapes predate the separation and both are handled, because both stop
-// opening pull requests without it:
+// Two shapes predate the separation, and both MOVE — the githubs: entry becomes
+// a forges: entry and is removed:
 //
-//   - A githubs: entry with no role used to be tracker AND forge. It stays as
-//     the tracker and gains a forge entry beside it carrying the same token —
-//     the one identity becomes the two it was always doing the work of.
-//   - A githubs: entry with role: forge was never a tracker at all. It moves:
-//     the forge entry is written and the githubs: entry is removed, because
-//     leaving it behind would leave a tracker declaring a role that no longer
-//     exists — and loading it now fails loudly, which would make a completed
-//     migration look like a broken one.
+//   - role: forge was never a tracker at all. Leaving it behind would leave a
+//     tracker declaring a role that no longer exists, and loading it now fails,
+//     which would make a completed migration look like a broken one.
+//   - No role at all is the same case wearing no label. It is what a GitHub
+//     entry looked like when one entry meant both things, and what it held was
+//     credentials — the evidence is three bugs deep ([SC-1671], [SC-2132],
+//     [SC-3868]), every one of them an unattended pass asking such an entry for
+//     tickets and getting a rate-limited search across every issue the token
+//     could see. Copying it instead of moving it would leave that entry standing
+//     as a tracker and hand the board the same 403 banner the separation was
+//     meant to end.
+//
+// So a migration reports what it moved, and says how to declare a GitHub issue
+// tracker if that is genuinely what the entry was: role: pm, which the board has
+// required from a GitHub tracker all along. Guessing the other way is the
+// costlier mistake — a config that quietly resumes burning a search quota looks
+// like a tool bug, where a tracker that has to be re-declared is a line of YAML
+// and a message that names it.
 //
 // An entry whose token is a vault reference migrates as the reference, never as
 // a resolved secret: this writes a config file, and a resolved token in one is
@@ -122,15 +132,24 @@ func planEntry(entry *yaml.Node, existing map[string]bool) entryPlan {
 	role := scalarAt(entry, "role")
 	token := scalarAt(entry, "token")
 
-	// A tracker role (pm, engineering, tracker) never opened pull requests, so
-	// the entry has nothing to migrate and stays exactly as it is.
+	// A declared tracker role (pm, engineering, tracker) says the entry is an
+	// issue tracker, so it never opened pull requests and stays exactly as it is.
 	if role != "" && role != "forge" {
 		return entryPlan{name: name, keep: true}
 	}
-	plan := entryPlan{name: name, keep: role != "forge", moved: role == "forge"}
+	// An undeclared entry, or one declaring the retired forge role, is credentials
+	// for the code host: it moves.
+	plan := entryPlan{name: name}
 	if token != "" && !existing[name] {
-		plan.forge = forgeEntryNode(name, scalarAt(entry, "url"), token)
+		plan.forge = forgeEntryFrom(entry, name)
 	}
+	// Removal is only earned by a forge entry actually written — except for the
+	// retired role, where leaving the entry in place would fail the load and a
+	// successful-looking migration would hand back a broken config. Anything else
+	// stays: deleting configuration without replacing it is the one outcome a
+	// migration must never produce.
+	plan.moved = plan.forge != nil || role == "forge"
+	plan.keep = !plan.moved
 	return plan
 }
 
@@ -150,22 +169,29 @@ func existingForgeNames(mapping *yaml.Node) map[string]bool {
 	return names
 }
 
-// forgeEntryNode builds one forges: entry. The URL is carried only when the
-// source entry set one, so a migrated config does not acquire a hardcoded
-// api.github.com that the loader would have defaulted anyway.
-func forgeEntryNode(name, url, token string) *yaml.Node {
-	entry := &yaml.Node{Kind: yaml.MappingNode}
-	add := func(k, v string) {
-		entry.Content = append(entry.Content,
-			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: k},
-			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: v})
+// forgeEntryFrom turns a githubs: entry into a forges: entry by moving the node
+// itself and dropping the keys a forge has no use for.
+//
+// Moving rather than rebuilding is what keeps the comments: someone wrote
+// "# the token lives in 1Password" next to that line, and a migration that
+// silently eats their notes has damaged the file it was asked to repair. Only
+// name, kind, url and token survive — projects, role, create_in, safe and
+// description are issue-tracker concepts, and carrying them across would rebuild
+// the union in the config file.
+func forgeEntryFrom(entry *yaml.Node, name string) *yaml.Node {
+	keep := map[string]bool{"name": true, "kind": true, "url": true, "token": true}
+	var content []*yaml.Node
+	for i := 0; i+1 < len(entry.Content); i += 2 {
+		if keep[entry.Content[i].Value] {
+			content = append(content, entry.Content[i], entry.Content[i+1])
+		}
 	}
-	add("name", name)
-	if url != "" {
-		add("url", url)
+	entry.Content = content
+	head := fmt.Sprintf("Moved here from githubs: by `human config migrate` — %q opens pull requests.", name)
+	if entry.HeadComment != "" {
+		head += "\n" + entry.HeadComment
 	}
-	add("token", token)
-	entry.HeadComment = fmt.Sprintf("Written by `human config migrate` from the githubs: entry %q.", name)
+	entry.HeadComment = head
 	return entry
 }
 

--- a/internal/settings/migrate_test.go
+++ b/internal/settings/migrate_test.go
@@ -39,21 +39,54 @@ func readCfg(t *testing.T, path string) string {
 	return string(data)
 }
 
-// The common case: an entry that was tracker and forge at once becomes the two
-// things it was doing the work of. The tracker entry stays exactly where it was.
-func TestMigrateForges_addsAForgeBesideTheTracker(t *testing.T) {
+// The common case, and the one the whole separation is about: an undeclared
+// githubs: entry was credentials for the code host, so it MOVES. Copying it
+// would leave it standing as a tracker, and the board would go straight back to
+// asking GitHub for a rate-limited search across every issue the token can see —
+// the SC-3868 banner, restored by the migration meant to end it.
+func TestMigrateForges_movesAnUndeclaredEntry(t *testing.T) {
 	dir := t.TempDir()
 	path := writeCfg(t, dir, "githubs:\n  - name: human\n    token: gh://token\n")
 
 	result, err := MigrateForges(dir, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"human"}, result.Added)
-	assert.Empty(t, result.Moved)
+	assert.Equal(t, []string{"human"}, result.Moved)
 
 	out := readCfg(t, path)
 	assert.Contains(t, out, "forges:")
-	assert.Contains(t, out, "githubs:", "the tracker entry stays — it is a tracker")
+	assert.NotContains(t, sectionKeys(out), "githubs",
+		"an undeclared entry was never declared to hold tickets")
 	assert.Contains(t, out, "gh://token")
+}
+
+// Tracker-only fields do not travel: carrying projects or a role onto a forge
+// would rebuild the union in the config file itself.
+func TestMigrateForges_dropsTrackerFieldsOnTheWay(t *testing.T) {
+	dir := t.TempDir()
+	path := writeCfg(t, dir,
+		"githubs:\n  - name: human\n    token: ghp_x\n    projects:\n      - acme/web\n    create_in: acme/web\n    safe: true\n")
+
+	_, err := MigrateForges(dir, false)
+	require.NoError(t, err)
+
+	out := readCfg(t, path)
+	assert.Contains(t, out, "token: ghp_x")
+	assert.NotContains(t, out, "projects")
+	assert.NotContains(t, out, "create_in")
+	assert.NotContains(t, out, "safe")
+}
+
+// An entry with no token has nothing to move: a migration must never delete
+// configuration it cannot replace.
+func TestMigrateForges_keepsAnEntryItCannotReplace(t *testing.T) {
+	dir := t.TempDir()
+	path := writeCfg(t, dir, "githubs:\n  - name: human\n")
+
+	result, err := MigrateForges(dir, false)
+	require.NoError(t, err)
+	assert.True(t, result.Empty())
+	assert.Contains(t, sectionKeys(readCfg(t, path)), "githubs")
 }
 
 // A vault reference migrates as a reference. Resolving it would write a live
@@ -146,17 +179,6 @@ shortcuts:
 	assert.Contains(t, out, "# the token lives in 1Password")
 	assert.Contains(t, out, "role: pm")
 	assert.Contains(t, out, "forges:")
-}
-
-// A token-less entry has nothing to carry over, so no forge entry is written
-// for it — a forge with no credential could not open a pull request anyway.
-func TestMigrateForges_skipsATokenlessEntry(t *testing.T) {
-	dir := t.TempDir()
-	writeCfg(t, dir, "githubs:\n  - name: human\n")
-
-	result, err := MigrateForges(dir, false)
-	require.NoError(t, err)
-	assert.True(t, result.Empty())
 }
 
 func TestMigrateForges_noConfigFile(t *testing.T) {


### PR DESCRIPTION
Closes SC-3884. A defect in SC-3876's migration, found by re-reading its own demo output.

## What was wrong

`human config migrate` copied. For the shape that actually exists — a `githubs:` entry with no role, holding the token that opened pull requests — it wrote the `forges:` entry and left the `githubs:` entry in place:

```
$ human tracker list --table          # after migrating
NAME   TYPE      ROLE  URL
human  github          https://api.github.com     ← still a tracker
board  shortcut  pm    https://api.app.shortcut.com
```

That entry is a full issue tracker now, and `listingJobs` filters nothing (deliberately — that was the point of SC-3876). So every board refresh asks GitHub for issues again: a search across everything the token can see, on the search endpoint's own quota, answered into a column that renders none of it. **SC-3868 exactly, restored by the command written to carry people past it** — and only for the configs that had the problem, since one declaring `role: pm` was always left alone.

## The fix

An entry that declared no role was never declared to hold tickets, and three bugs say what it holds instead (SC-1671, SC-2132, SC-3868 — every one an unattended pass asking such an entry for tickets). So it moves.

Where that guess is wrong, the cost is a line of YAML and a message that names it, which the run now prints:

```
Moved githubs: entry "human" into forges:
If GitHub is where your issues live, add a githubs: entry with role: pm — a GitHub
tracker has always needed it to reach the board.
Updated: .humanconfig.yaml
```

The other direction has no such recovery: a config quietly burning a search quota reads as a tool bug, not a config one.

## Two smaller faults fixed with it

- **Comments were being eaten.** The entry was rebuilt from scratch, so `# the token lives in 1Password` next to someone's token was dropped — the exact damage a test in the same file asserts against. It now moves the YAML node, so comments come with it.
- **Tracker fields would have travelled.** `projects`, `create_in`, `safe` and `role` would have landed on a forge, rebuilding the union inside the config file. Only `name`, `kind`, `url` and `token` cross.
- An entry whose credentials cannot be carried (no token) is left alone rather than deleted — a migration must never remove what it cannot replace.

## Verification

`make check` green, `go test ./cmd/...` green. Driven end to end: the demo config that exposed the bug now migrates to a `forges:`-only shape, `tracker list` shows Shortcut alone (so the board issues no GitHub search), `forge list` shows the code host, and the hand-written comment survives the move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)