### PR TITLE
[SC-3872] Stop telling a reader a closed ticket is a hole in the machine

### DIFF
--- a/internal/daemon/fsm_where.go
+++ b/internal/daemon/fsm_where.go
@@ -214,6 +214,18 @@ func statesFor(doc pipelinefsm.Document, card BoardCard, comments []tracker.Comm
 		}
 	}
 
+	// A closed ticket has left the pipeline. That is not a gap in the machine:
+	// the machine describes how an item moves THROUGH the pipeline, and closing
+	// takes it out rather than moving it within. The one real effect of closing —
+	// the ticket's agents are stopped — belongs to the reaper, which follows a
+	// container where this document follows a ticket, and docs/reaper.md already
+	// owns it. Saying "gap in the document" here sent a reader to fix the wrong
+	// file.
+	if card.Stage == BoardHidden {
+		return nil, "this ticket is closed, so it is no longer in the pipeline and no state describes it — " +
+			"closing takes an item out rather than moving it, and stopping its agents is the reaper's job (docs/reaper.md)"
+	}
+
 	candidates := doc.StatesAtPlacement(string(card.Stage), string(card.State))
 	switch len(candidates) {
 	case 0:
@@ -350,7 +362,11 @@ func intersectByName(candidates, allowed []pipelinefsm.State) []pipelinefsm.Stat
 // recomputes staleness: AgentProgress.Stalled already holds the rule, including
 // that a blocked agent is waiting for a person rather than hung.
 func whereAgent(key string, card BoardCard, deps WhereDeps) *WhereAgent {
-	if deps.Progress == nil || card.Stage == "" {
+	// Hidden is the board's way of saying "not on the board", not a stage work
+	// runs in, so there is no agent to be live or dead. Composing a name from it
+	// produced `board-SC-1234-hidden` — an agent that has never existed,
+	// reported as merely unknown, which reads as "we lost track of it".
+	if deps.Progress == nil || card.Stage == "" || card.Stage == BoardHidden {
 		return nil
 	}
 	name := agentNameFor(key, card.Stage)
@@ -374,7 +390,10 @@ func whereAgent(key string, card BoardCard, deps WhereDeps) *WhereAgent {
 // whereBudget reports what the stage has already spent. Read-only by contract:
 // the caller supplies a reader, never StageRetry.Attempts, which increments.
 func whereBudget(key string, card BoardCard, deps WhereDeps) *WhereBudget {
-	if deps.Attempts == nil || card.Stage == "" {
+	// Same as the agent: a closed ticket has no stage whose relaunches could be
+	// counted, and reading a counter for `hidden` would report a budget for work
+	// that will never run.
+	if deps.Attempts == nil || card.Stage == "" || card.Stage == BoardHidden {
 		return nil
 	}
 	spent, err := deps.Attempts(key, card.Stage)

--- a/internal/daemon/fsm_where_test.go
+++ b/internal/daemon/fsm_where_test.go
@@ -112,7 +112,26 @@ func TestWhere_SaysWhenNoStateDescribesThePlacement(t *testing.T) {
 	assert.Equal(t, string(BoardHidden), report.Board.Stage)
 	assert.Empty(t, report.State)
 	assert.Empty(t, report.Candidates)
-	assert.Contains(t, report.Why, "no state in the machine describes")
+	assert.Contains(t, report.Why, "closed", "and says WHY, in terms a reader can act on")
+	assert.NotContains(t, report.Why, "gap in the document",
+		"closing is not a gap: the machine describes movement THROUGH the pipeline, and reaper.md owns the agent stop")
+}
+
+// A closed ticket has no stage work runs in, so it must not be given an agent
+// name composed from `hidden` — `board-SC-1234-hidden` is an agent that has
+// never existed, and reporting it as merely unknown reads as "we lost track".
+func TestWhere_ClosedTicketHasNoAgentOrBudget(t *testing.T) {
+	deps := WhereDeps{
+		Now:      time.Unix(10_000, 0),
+		Progress: func(string) (AgentProgress, bool) { return AgentProgress{}, false },
+		Attempts: func(string, BoardStage) (int, error) { return 2, nil },
+	}
+	report := BuildWhere(whereDoc(t), "SC-1",
+		[]tracker.Comment{cmt(DeployedHeader, time.Unix(1000, 0))},
+		tracker.CategoryDone, false, "skill", deps)
+
+	assert.Nil(t, report.Agent, "nothing runs on a closed ticket")
+	assert.Nil(t, report.Budget, "and nothing will be relaunched")
 }
 
 // Liveness is read from the daemon's own record, never recomputed. A blocked


### PR DESCRIPTION
Found by running `where` against a real closed ticket — possible for the first time, since the daemon only started carrying the route minutes ago. Two things were wrong on that path, both confidently wrong rather than silent.

**It called closure a gap in the document.** The message read *"the item is somewhere the machine cannot name, which is a gap in the document rather than in the item"*, which sends a reader to fix the wrong file. The machine describes how an item moves **through** the pipeline; closing takes it out rather than moving it within, so there is no missing state and no missing edge to add. The one real effect of closing — the ticket's agents are stopped — belongs to the reaper, which follows a container where this document follows a ticket, and `docs/reaper.md` already owns it as "close is cancellation" with its code owner. The message now says the ticket is closed and points there.

**It invented an agent.** A closed ticket reported `board-SC-3865-hidden`, marked `known: false`. `hidden` is the board's way of saying "not on the board", not a stage work runs in, so that agent has never existed — and "unknown" reads as *we lost track of it* rather than *there is nothing here*. A closed ticket now carries no agent and no budget section: nothing runs on it, nothing will be relaunched.

Both were invisible to the unit tests because both are about what a real closed ticket looks like.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)