### PR TITLE
[SC-3887] Let a rerun finish what the first run started

### DIFF
--- a/internal/settings/migrate.go
+++ b/internal/settings/migrate.go
@@ -143,12 +143,20 @@ func planEntry(entry *yaml.Node, existing map[string]bool) entryPlan {
 	if token != "" && !existing[name] {
 		plan.forge = forgeEntryFrom(entry, name)
 	}
-	// Removal is only earned by a forge entry actually written — except for the
-	// retired role, where leaving the entry in place would fail the load and a
-	// successful-looking migration would hand back a broken config. Anything else
-	// stays: deleting configuration without replacing it is the one outcome a
-	// migration must never produce.
-	plan.moved = plan.forge != nil || role == "forge"
+	// Removal is earned three ways, and the third is the one this missed at
+	// first. A forge entry written here obviously replaces it. The retired
+	// role: forge must go whether or not anything replaced it, since leaving it
+	// fails the load. And an undeclared entry whose name is ALREADY in forges:
+	// was carried across by an earlier run — the replacement is right there in
+	// the file, so keeping the tracker only leaves the board searching GitHub
+	// for issues again ([SC-3868]). That state is not hypothetical: the first
+	// version of this migration copied instead of moving, so every config
+	// migrated before [SC-3884] looks exactly like it.
+	//
+	// Everything else stays. Deleting configuration with no replacement in sight
+	// is the one outcome a migration must never produce.
+	alreadyCarried := role == "" && token != "" && existing[name]
+	plan.moved = plan.forge != nil || role == "forge" || alreadyCarried
 	plan.keep = !plan.moved
 	return plan
 }

--- a/internal/settings/migrate_test.go
+++ b/internal/settings/migrate_test.go
@@ -129,6 +129,39 @@ func TestMigrateForges_leavesADeclaredTrackerAlone(t *testing.T) {
 	assert.True(t, result.Empty())
 }
 
+// The state every early migration left behind: the first version of this
+// command copied, so the forges: entry exists AND the githubs: entry is still
+// standing as a tracker — which is the board searching GitHub for issues again.
+// A rerun has to finish the job rather than see a name it recognises and stop.
+func TestMigrateForges_finishesAHalfDoneMigration(t *testing.T) {
+	dir := t.TempDir()
+	path := writeCfg(t, dir,
+		"githubs:\n  - name: human\n    token: gh://token\nforges:\n  - name: human\n    token: gh://token\n")
+
+	result, err := MigrateForges(dir, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"human"}, result.Moved)
+	assert.Empty(t, result.Added, "the forge is already there — only the tracker had to go")
+
+	out := readCfg(t, path)
+	assert.NotContains(t, sectionKeys(out), "githubs")
+	assert.Contains(t, out, "forges:")
+	assert.Contains(t, out, "gh://token")
+}
+
+// The same shape with a DECLARED tracker is not a half-done migration: someone
+// runs GitHub issues and GitHub pull requests under one name, deliberately.
+func TestMigrateForges_leavesADeclaredTrackerThatSharesAForgeName(t *testing.T) {
+	dir := t.TempDir()
+	path := writeCfg(t, dir,
+		"githubs:\n  - name: human\n    token: ghp_x\n    role: pm\nforges:\n  - name: human\n    token: ghp_x\n")
+
+	result, err := MigrateForges(dir, false)
+	require.NoError(t, err)
+	assert.True(t, result.Empty())
+	assert.Contains(t, sectionKeys(readCfg(t, path)), "githubs")
+}
+
 func TestMigrateForges_isIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	path := writeCfg(t, dir, "githubs:\n  - name: human\n    token: gh://token\n")


### PR DESCRIPTION
Closes SC-3887. Found live, on a daemon rebuilt onto the separated code with a config in exactly this shape — not in review.

## The trap

SC-3876's migration copied. SC-3884 made it move. But every config migrated in that window is left holding **both** entries:

```yaml
githubs:
  - name: human
    token: gh://token        # still a tracker — the board asks it for issues
forges:
  # Written by `human config migrate` from the githubs: entry "human".
  - name: human
    token: gh://token
```

So the board goes back to searching GitHub for every issue the token can see, once per refresh — the rate-limited endpoint SC-3868 removed.

And re-running the fixed command **could not clear it**. It saw a `forges:` entry already carrying that name, took the "never delete what I cannot replace" branch, and kept the tracker. The one command written to get people out of this state was the one command that could not.

## The rule's missing third case

Removal is earned three ways, not two:

1. A forge entry written by this run replaces it.
2. The retired `role: forge` goes regardless — leaving it fails the load, and a successful-looking migration that hands back a broken config is worse than none.
3. **An undeclared entry whose name is already in `forges:`** was carried across by an earlier run. The replacement is right there in the same file, so removing the tracker deletes nothing.

A `role: pm` entry sharing a forge name is the opposite case and stays put — running GitHub issues and GitHub pull requests under one name is something someone did deliberately. Both are pinned by tests.

## Verification

`make check` green. Driven end to end against a config in the half-migrated shape: before, `tracker list` shows the GitHub tracker; after, it shows only Shortcut and `forge list` shows the code host, with the `forges:` entry untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)