### PR TITLE
[SC-3916] A deploy that is interrupted should be hard to do and impossible to miss

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -1235,10 +1235,53 @@ func staleBuildNotice(runningCommit, onDiskCommit string) string {
 		runningCommit, onDiskCommit)
 }
 
+// Stop timing. The grace period is what an idle daemon needs to put itself
+// down. The drain default deliberately does NOT cover a whole deploy: every
+// caller of `daemon stop` wants a prompt answer (the desktop's close flow shells
+// out to this command), so a daemon that is genuinely mid-deploy is reported
+// rather than waited on for the better part of an hour. Someone who does want to
+// sit through it says so with --wait.
+const stopPollInterval = 100 * time.Millisecond
+
+// Vars, not consts, so tests can shrink the waits they are exercising.
+var (
+	stopGrace        = 5 * time.Second
+	stopDrainDefault = 30 * time.Second
+)
+
+// inFlightOps reports how many restart-blocking operations the daemon is
+// running, best-effort. It is asked BEFORE the stop signal, because a daemon
+// that has begun shutting down closes its listener first and could no longer
+// answer — so the number is read while the answer still exists. A package var
+// for tests.
+var inFlightOps = func() (int, bool) {
+	info, err := daemon.ReadInfo()
+	if err != nil {
+		return 0, false
+	}
+	status, err := daemon.GetDaemonBusy(info.Addr, info.Token)
+	if err != nil {
+		return 0, false
+	}
+	return status.InFlight, true
+}
+
 func buildDaemonStopCmd() *cobra.Command {
-	return &cobra.Command{
+	var force bool
+	var wait time.Duration
+	cmd := &cobra.Command{
 		Use:   "stop",
 		Short: "Stop a running daemon",
+		Long: `Stop the running daemon.
+
+A daemon runs its forwarded commands in its own process and exits once they
+finish, and the long one is a ` + "`human deploy`" + ` sitting on its CI gate for minutes.
+So a daemon that does not stop promptly is reported as what it is — still
+finishing N operations — instead of as a bare timeout, and --wait sits through it.
+
+--force ends the daemon now and abandons that work. It signals this daemon's
+process alone — unlike killing by name, which also ends every other ` + "`human`" + `
+command running on the machine, including a deploy someone is waiting on.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out := cmd.OutOrStdout()
 
@@ -1250,26 +1293,24 @@ func buildDaemonStopCmd() *cobra.Command {
 				return nil
 			}
 
+			// Read the in-flight count before signalling: this is the only moment
+			// the daemon can still be asked.
+			inFlight, known := 0, false
+			if !force {
+				inFlight, known = inFlightOps()
+			}
+
 			_, _ = fmt.Fprintf(out, "Stopping daemon (PID %d)...\n", pid)
-			if err := stopProcess(pid); err != nil {
-				return errors.WrapWithDetails(err, "failed to stop daemon", "pid", pid)
+			signal, verb := stopProcess, "stop"
+			if force {
+				signal, verb = killProcess, "force-stop"
+			}
+			if err := signal(pid); err != nil {
+				return errors.WrapWithDetails(err, "failed to "+verb+" daemon", "pid", pid)
 			}
 
-			// Poll for exit (up to 5s).
-			const (
-				pollInterval = 100 * time.Millisecond
-				pollTimeout  = 5 * time.Second
-			)
-			deadline := time.Now().Add(pollTimeout)
-			for time.Now().Before(deadline) {
-				if !isProcessAlive(pid) {
-					break
-				}
-				time.Sleep(pollInterval)
-			}
-
-			if isProcessAlive(pid) {
-				return errors.WithDetails("daemon did not exit within timeout", "pid", pid)
+			if err := awaitDaemonExit(out, pid, inFlight, wait, known, force); err != nil {
+				return err
 			}
 
 			RemovePidFile()
@@ -1278,6 +1319,52 @@ func buildDaemonStopCmd() *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&force, "force", false, "End the daemon immediately, abandoning in-flight work (signals this daemon only)")
+	cmd.Flags().DurationVar(&wait, "wait", stopDrainDefault, "How long to wait for in-flight work to finish (e.g. 45m to sit through a deploy)")
+	return cmd
+}
+
+// awaitDaemonExit waits for the signalled daemon to go. Past the grace period it
+// splits the two cases a single timeout used to report as one: a daemon draining
+// work it was told to finish, which is named and waited on for wait, and a
+// daemon that is stuck with nothing in flight, which is reported with the
+// remedy. The split is the point — "did not exit within timeout" reads as broken
+// and sends an operator to a signal aimed by name, which also ends the CLI half
+// of the very deploy the daemon was finishing.
+func awaitDaemonExit(out io.Writer, pid, inFlight int, wait time.Duration, known, force bool) error {
+	if waitForProcessExit(pid, stopGrace) {
+		return nil
+	}
+	if force {
+		return errors.WithDetails("daemon did not exit after a forced stop", "pid", pid)
+	}
+	if !known || inFlight == 0 {
+		return errors.WithDetails(
+			"daemon did not exit within the grace period and reported no work in flight — re-run with --force to end it (that signals this daemon only, unlike killing by name)",
+			"pid", pid, "grace", stopGrace.String())
+	}
+	_, _ = fmt.Fprintf(out,
+		"The daemon is finishing %d in-flight operation(s) and exits when they are done — a deploy on its CI gate can take many minutes.\nWaiting %s; --wait sits through it, --force ends it now and abandons the work.\n",
+		inFlight, wait)
+	if waitForProcessExit(pid, wait) {
+		return nil
+	}
+	return errors.WithDetails(
+		"daemon is still finishing in-flight work — it exits on its own when that work is done, so re-run stop later, re-run with --wait to sit through it, or --force to end it now (that signals this daemon only, unlike killing by name)",
+		"pid", pid, "in_flight", inFlight, "waited", wait.String())
+}
+
+// waitForProcessExit polls until the process is gone or the bound elapses,
+// reporting whether it exited.
+func waitForProcessExit(pid int, bound time.Duration) bool {
+	deadline := time.Now().Add(bound)
+	for time.Now().Before(deadline) {
+		if !isProcessAlive(pid) {
+			return true
+		}
+		time.Sleep(stopPollInterval)
+	}
+	return !isProcessAlive(pid)
 }
 
 // --- PID file helpers (delegated to internal/daemon) ---

--- a/cmd/cmddaemon/daemon_stop_test.go
+++ b/cmd/cmddaemon/daemon_stop_test.go
@@ -1,0 +1,159 @@
+package cmddaemon
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// shrinkStopGrace makes the pre-drain grace test-sized. The production value is
+// five seconds; a test proving which branch runs does not need to spend them.
+func shrinkStopGrace(t *testing.T, grace time.Duration) {
+	t.Helper()
+	orig := stopGrace
+	stopGrace = grace
+	t.Cleanup(func() { stopGrace = orig })
+}
+
+// livePID returns the pid of a process that stays alive until it is signalled,
+// and is reaped the moment it dies — a zombie child still answers signal 0, so
+// without the reaper a stopped process would keep looking alive to the very
+// liveness check under test.
+func livePID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("sleep", "300")
+	require.NoError(t, cmd.Start())
+	reaped := make(chan struct{})
+	go func() { _ = cmd.Wait(); close(reaped) }()
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		<-reaped
+	})
+	return cmd.Process.Pid
+}
+
+// A daemon that exits inside the grace period is the ordinary case: no waiting
+// message, no error.
+func TestAwaitDaemonExit_ExitsInGrace(t *testing.T) {
+	shrinkStopGrace(t, 2*time.Second)
+	pid := livePID(t)
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		_ = stopProcess(pid)
+	}()
+
+	var out bytes.Buffer
+	require.NoError(t, awaitDaemonExit(&out, pid, 0, time.Minute, true, false))
+	assert.Empty(t, out.String(), "an ordinary stop says nothing about waiting")
+}
+
+// The regression this exists for: a daemon draining in-flight work was reported
+// as "did not exit within timeout" after five seconds, which reads as broken and
+// is what sends an operator to a signal aimed by name — which also ends every
+// other `human` process on the machine, the CLI half of the running deploy
+// included. It must instead name what is being finished, and wait for it.
+func TestAwaitDaemonExit_DrainingIsNamedAndWaitedOut(t *testing.T) {
+	shrinkStopGrace(t, 200*time.Millisecond)
+	pid := livePID(t)
+	go func() {
+		time.Sleep(600 * time.Millisecond) // outlives the grace, inside the wait
+		_ = stopProcess(pid)
+	}()
+
+	var out bytes.Buffer
+	require.NoError(t, awaitDaemonExit(&out, pid, 2, 5*time.Second, true, false))
+	assert.Contains(t, out.String(), "2 in-flight operation(s)")
+	assert.Contains(t, out.String(), "--force")
+}
+
+// Work that outlasts the wait is not a failure of the daemon: it exits on its
+// own when the work is done, and the error has to say so rather than leave
+// "kill it" as the only reading.
+func TestAwaitDaemonExit_StillDrainingWhenTheWaitRunsOut(t *testing.T) {
+	shrinkStopGrace(t, 200*time.Millisecond)
+	var out bytes.Buffer
+	err := awaitDaemonExit(&out, livePID(t), 1, 300*time.Millisecond, true, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exits on its own")
+	assert.Contains(t, err.Error(), "--wait")
+	assert.Contains(t, err.Error(), "--force")
+}
+
+// Nothing in flight and still alive past the grace is a genuinely stuck daemon:
+// report it, and name the remedy that ends this daemon alone.
+func TestAwaitDaemonExit_StuckWithNothingInFlight(t *testing.T) {
+	shrinkStopGrace(t, 200*time.Millisecond)
+	var out bytes.Buffer
+	err := awaitDaemonExit(&out, livePID(t), 0, time.Hour, true, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no work in flight")
+	assert.Empty(t, out.String(), "a stuck daemon is not reported as draining")
+}
+
+// An unreadable in-flight count must not be read as "it is busy, wait": unknown
+// falls back to the stuck branch, which returns promptly.
+func TestAwaitDaemonExit_UnknownCountDoesNotWait(t *testing.T) {
+	shrinkStopGrace(t, 200*time.Millisecond)
+	var out bytes.Buffer
+	start := time.Now()
+	err := awaitDaemonExit(&out, livePID(t), 0, time.Hour, false, false)
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 5*time.Second)
+}
+
+// --force skips the drain entirely: it is the operator saying the work may be
+// abandoned, so a surviving process is an error, not something to wait on.
+func TestAwaitDaemonExit_ForceDoesNotDrain(t *testing.T) {
+	shrinkStopGrace(t, 200*time.Millisecond)
+	var out bytes.Buffer
+	start := time.Now()
+	err := awaitDaemonExit(&out, livePID(t), 3, time.Hour, true, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forced stop")
+	assert.Less(t, time.Since(start), 5*time.Second)
+}
+
+// The stop command asks the daemon what it is finishing BEFORE signalling it,
+// because a daemon that has begun shutting down has already closed the listener
+// the question travels over — ask afterwards and the answer is always "cannot
+// tell", which is the stuck branch.
+func TestDaemonStop_ReadsInFlightBeforeSignalling(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	pid := livePID(t)
+	require.NoError(t, WritePidFile(pid))
+
+	aliveWhenAsked := false
+	orig := inFlightOps
+	inFlightOps = func() (int, bool) {
+		aliveWhenAsked = isProcessAlive(pid)
+		return 0, true
+	}
+	t.Cleanup(func() { inFlightOps = orig })
+
+	var out bytes.Buffer
+	cmd := buildDaemonStopCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	require.NoError(t, cmd.Execute())
+	assert.True(t, aliveWhenAsked, "the daemon must still be running when it is asked what it is finishing")
+	assert.Contains(t, out.String(), "Daemon stopped")
+}
+
+// --force is a real flag, and its help draws the distinction that matters: it
+// ends this daemon, not every process that happens to be called "human". --wait
+// is the other half — the default is short so every scripted caller (the desktop
+// close flow shells out to this command) still gets a prompt answer.
+func TestDaemonStop_Flags(t *testing.T) {
+	cmd := buildDaemonStopCmd()
+	require.NotNil(t, cmd.Flags().Lookup("force"))
+	wait := cmd.Flags().Lookup("wait")
+	require.NotNil(t, wait)
+	assert.Equal(t, stopDrainDefault.String(), wait.DefValue)
+	assert.Less(t, stopDrainDefault, time.Minute, "the default wait must stay short enough for a scripted caller")
+	assert.Contains(t, strings.ToLower(cmd.Long), "every other")
+}

--- a/cmd/cmddaemon/handover_unix.go
+++ b/cmd/cmddaemon/handover_unix.go
@@ -328,7 +328,10 @@ func reexecChild(ctx context.Context, c *handoverCoordinator) error {
 // left, or the drain deadline elapses. Daemon command handlers are drained
 // separately by the server's own graceful shutdown (s.wg), and long-running
 // board/deploy work never reaches here because a handover is postponed while it
-// is in flight — so this only waits on proxied agent egress.
+// is in flight — which is true of a forwarded `human deploy` only because
+// executeCommand counts itself as a blocking op (server.go handleConn); before
+// that, a rebuild could commit the handover while the outgoing process was
+// still holding a deploy on its CI gate.
 func (c *handoverCoordinator) drainInflight(ctx context.Context) {
 	if c.activeConns == nil {
 		return

--- a/cmd/cmddaemon/sysattr_unix.go
+++ b/cmd/cmddaemon/sysattr_unix.go
@@ -26,3 +26,11 @@ func isProcessAlive(pid int) bool {
 func stopProcess(pid int) error {
 	return syscall.Kill(pid, syscall.SIGTERM)
 }
+
+// killProcess ends the process with the given PID outright. It exists so
+// `human daemon stop --force` has an answer for a wedged daemon that names ONE
+// pid — the reach for `killall human` matches every process of that name, which
+// on this machine includes the `human deploy` a user is waiting on.
+func killProcess(pid int) error {
+	return syscall.Kill(pid, syscall.SIGKILL)
+}

--- a/cmd/cmddaemon/sysattr_windows.go
+++ b/cmd/cmddaemon/sysattr_windows.go
@@ -42,3 +42,10 @@ func stopProcess(pid int) error {
 	}
 	return p.Kill()
 }
+
+// killProcess ends the process outright. Windows has no gentler stop to
+// distinguish it from, so it is the same call — the flag still matters because
+// it names one pid instead of every process called "human".
+func killProcess(pid int) error {
+	return stopProcess(pid)
+}

--- a/cmd/cmddeploy/deploy.go
+++ b/cmd/cmddeploy/deploy.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 
 	"github.com/gethuman-sh/human/cmd/cmdauto"
@@ -69,6 +70,11 @@ var newTransitionDeps = func(p tracker.Provider) daemon.BoardTransitionDeps {
 	return daemon.BoardTransitionDeps{
 		Commenter: p,
 		Deployer:  cmddaemon.NewForgeDeployer(vault.NewResolverFromConfig(vcfg), os.LookupEnv),
+		// The gate's own progress, on stderr: forwarded to the daemon this is the
+		// daemon log (the only place a deploy that was interrupted mid-CI leaves a
+		// trace), and run locally it is the terminal — which is what a command
+		// that can legitimately sit fifteen minutes on a CI gate owes its caller.
+		Logger: zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger(),
 		CloseTicket: func(pmKey string) error {
 			return cmdauto.RunSemanticTransition(context.Background(), p, io.Discard, pmKey, tracker.CategoryDone, false)
 		},

--- a/docs/reaper.md
+++ b/docs/reaper.md
@@ -275,6 +275,41 @@ which does not, so a stage stopped by § 5 records `reason: "completed"` even
 though the machine killed it. The card's marker still says silence reap; the
 run's `outcome.json` does not.
 
+## The daemon's own exit is not a reap, and ends work anyway
+
+Everything above is the machine ending an agent on purpose. The other way work
+ends is the daemon process going away underneath it — and the work that dies
+there is not in a container at all. A forwarded command executes **inside** the
+daemon (`Server.executeCommand`), and the long one is `human deploy`, which can
+sit up to `deployTimeout` = **45 minutes** on its CI gate. It leaves no
+container, no execution log and no marker, so an interrupted deploy is
+afterwards indistinguishable from one that never started.
+
+Three things keep that from happening silently:
+
+- **A rebuild postpones.** The self-restart watcher hands over only when
+  `BlockingOps()` is zero, and a forwarded command counts itself, so a handover
+  never commits while a deploy is on its gate. (`handoverCoordinator.watch`,
+  `cmd/cmddaemon/handover_unix.go`.)
+- **A stop names what it is waiting for.** `human daemon stop` reads the
+  in-flight count *before* signalling — a shutting-down daemon has closed the
+  listener the question travels over — and past a **5s** grace it either reports
+  a daemon stuck with nothing in flight, or says how many operations it is
+  finishing and waits `--wait` (default `stopDrainDefault` = **30s**; the desktop
+  close flow shells out to this command, so the default stays short). Outlasting
+  the wait is not a failure: the daemon exits on its own when the work is done.
+  `--force` ends it now, abandoning the work.
+- **The gate says what it is doing.** `DeployBranch` logs queued → started → PR
+  open → CI verdict → merged → done, with a "CI still running" heartbeat every
+  `deployWaitHeartbeat` = **10 polls** (~5 minutes). A deploy that stops
+  mid-trail is what an interruption looks like in the log.
+
+What none of this can cover is `SIGKILL`: it cannot be caught, the deploy dies
+with the process, and nothing is recorded. This is why `--force` signals one pid
+and why killing by name is the wrong reach — every `human` process on the
+machine answers to that name, including the CLI half of the deploy someone is
+waiting on.
+
 ## Timings and constants, in one place
 
 | Constant | Value | Where |
@@ -297,6 +332,10 @@ run's `outcome.json` does not.
 | `DefaultStageRetries` | 2 | `internal/daemon/board_retry.go` |
 | `OutageWaitBound` | 6h | `internal/daemon/board_outage.go` |
 | `execRetentionDays` | 90 | `internal/agent/agentlog.go` |
+| `deployTimeout` | 45m | `internal/daemon/board_transition.go` |
+| `deployWaitHeartbeat` | 10 polls (~5m) | same |
+| `stopGrace` | 5s | `cmd/cmddaemon/daemon.go` |
+| `stopDrainDefault` | 30s (`--wait`) | same |
 
 ## Why a single reap can never stall the sweep
 

--- a/internal/daemon/blockingops_test.go
+++ b/internal/daemon/blockingops_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
 )
 
 func TestBlockingOpsCounting(t *testing.T) {
@@ -65,6 +66,65 @@ func TestBlockingOpsNested(t *testing.T) {
 	wg.Wait()
 	if got := s.BlockingOps(); got != 0 {
 		t.Fatalf("after all ops BlockingOps = %d, want 0", got)
+	}
+}
+
+// TestForwardedCommandIsBlockingOp proves a plain forwarded command — the shape
+// `human deploy` takes, which sits for minutes on a CI gate — counts as
+// restart-blocking work. Without it the binary watcher hands over while the
+// outgoing process is still running the deploy, and the deploy belongs to a
+// daemon that has already given its identity away.
+func TestForwardedCommandIsBlockingOp(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	s := &Server{
+		Token:  "tok",
+		Logger: zerolog.Nop(),
+		CmdFactory: func() *cobra.Command {
+			root := &cobra.Command{Use: "test", SilenceUsage: true}
+			root.AddCommand(&cobra.Command{
+				Use: "slow",
+				RunE: func(_ *cobra.Command, _ []string) error {
+					close(entered)
+					<-release
+					return nil
+				},
+			})
+			return root
+		},
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	s.Listener = ln
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.ListenAndServe(ctx) }()
+
+	conn, err := net.DialTimeout("tcp", ln.Addr().String(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	req := Request{Token: "tok", Protocol: Protocol, Args: []string{"slow"}}
+	line, _ := json.Marshal(req)
+	if _, err := conn.Write(append(line, '\n')); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	<-entered
+	if got := s.BlockingOps(); got != 1 {
+		t.Fatalf("BlockingOps during a forwarded command = %d, want 1", got)
+	}
+	close(release)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for s.BlockingOps() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("BlockingOps stayed at %d after the command returned", s.BlockingOps())
+		}
+		time.Sleep(time.Millisecond)
 	}
 }
 

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -99,6 +99,11 @@ type PRResult struct {
 	Number int
 }
 
+// deployWaitHeartbeat is how many CI polls pass between "still running" log
+// lines — five minutes at the default interval. Often enough that a live deploy
+// is visibly live, rare enough that a 45-minute wait does not bury the log.
+const deployWaitHeartbeat = 10
+
 // Deploy pacing. Package vars so tests can run the CI gate without real time.
 var (
 	deployCheckInterval = 30 * time.Second
@@ -169,8 +174,11 @@ type BoardTransitionDeps struct {
 	// un-provisioned daemon still functions.
 	DaemonID string
 	// Logger records best-effort post-merge failures (e.g. a failed automated
-	// close). The zero value is a safe no-op writer, so an un-wired path stays
-	// valid without a logger.
+	// close) and the deploy gate's progress. The zero value is a safe no-op
+	// writer, so an un-wired path stays valid without a logger — but wire one
+	// for any path that can deploy: a gate that sits ten minutes on CI and is
+	// then interrupted leaves no other evidence it ever ran, which is exactly
+	// the state that has to be reconstructed from merge timestamps afterwards.
 	Logger zerolog.Logger
 	// Diagnose distills why a dead run died, so a loop step that escalated
 	// without recording an outcome reports the real cause instead of a generic
@@ -1239,10 +1247,16 @@ func (d BoardTransitionDeps) deploy(ctx context.Context, req BoardTransitionRequ
 // posted as deploy-failed markers (the board's channel) and returned (the CLI's
 // channel).
 func (d BoardTransitionDeps) DeployBranch(ctx context.Context, pmKey, title, prBody, branch string) error {
+	// The queue is part of the story: a deploy that waited behind another one
+	// has not started yet, and only the log can say which of the two a stalled
+	// operator is looking at.
+	logger := d.Logger.With().Str("pm", pmKey).Str("branch", branch).Logger()
+	logger.Info().Msg("deploy: queued")
 	deployGate.Lock()
 	defer deployGate.Unlock()
 	ctx, cancel := context.WithTimeout(ctx, deployTimeout)
 	defer cancel()
+	logger.Info().Dur("timeout", deployTimeout).Msg("deploy: started")
 
 	// Already-merged carve-out: a re-run Deploy on a card whose branch is already
 	// on the base has nothing to ship. Opening a PR would draw the forge's 422
@@ -1251,6 +1265,7 @@ func (d BoardTransitionDeps) DeployBranch(ctx context.Context, pmKey, title, prB
 	// This mirrors the "already done, stop cleanly" carve-outs Planning and
 	// Implementation already carry (SC-911).
 	if d.Deployer.BranchMerged(ctx, d.WorkspaceDir, branch) {
+		logger.Info().Msg("deploy: branch is already on the base; nothing to ship")
 		_, _ = d.Commenter.AddComment(ctx, pmKey,
 			DeployedHeader+"\nalready merged into the base branch; no new PR opened")
 		d.closeTicketBestEffort(pmKey)
@@ -1271,6 +1286,7 @@ func (d BoardTransitionDeps) DeployBranch(ctx context.Context, pmKey, title, prB
 			"could not push "+branch+" and open its pull request — check the branch and forge access, then re-run Deploy",
 			err))
 	}
+	logger.Info().Int("pr", res.Number).Str("url", res.URL).Msg("deploy: pull request open")
 	if err := d.waitForChecks(ctx, res); err != nil {
 		if ciFailureFixable(err) {
 			return d.deployFailedOrDispatchFixer(ctx, pmKey, res, ciFailureHeadline(err), err, branch)
@@ -1306,6 +1322,7 @@ func (d BoardTransitionDeps) DeployBranch(ctx context.Context, pmKey, title, prB
 		}
 	}
 	if rebased {
+		logger.Info().Int("pr", res.Number).Msg("deploy: branch was stale; rebased onto the base, re-gating CI")
 		// The freshness force-push rewrote the head and re-triggered CI on it.
 		// Merging while that fresh run is still in_progress is exactly the
 		// SC-1184 race: GitHub reports mergeable_state unstable and 405s the
@@ -1338,10 +1355,22 @@ func (d BoardTransitionDeps) DeployBranch(ctx context.Context, pmKey, title, prB
 	// recorded-and-surfaced, not silent: a failed close leaves the card in the
 	// board's Fix column (the frontend only drops a card once the ticket leaves
 	// the tracker's open list), so the operator must see it and close by hand.
+	logger.Info().Int("pr", res.Number).Str("url", res.URL).Msg("deploy: merged")
 	_ = d.Deployer.DeleteRemoteBranch(ctx, d.WorkspaceDir, branch)
 	_, _ = d.Commenter.AddComment(ctx, pmKey, DeployedHeader+"\npr: "+res.URL)
 	d.closeTicketBestEffort(pmKey)
+	logger.Info().Msg("deploy: done")
 	return nil
+}
+
+// headlineOf takes the actionable first line of a marker body — the same line
+// the card's badge shows — so a log line carries the verdict without the cause
+// chain's newlines running through it.
+func headlineOf(reason string) string {
+	if i := strings.IndexByte(reason, '\n'); i >= 0 {
+		return reason[:i]
+	}
+	return reason
 }
 
 // failureReason renders a deploy-failed marker body per the marker-body
@@ -1577,6 +1606,12 @@ func (d BoardTransitionDeps) closeTicketBestEffort(pmKey string) {
 func (d BoardTransitionDeps) waitForChecks(ctx context.Context, res PRResult) error {
 	ticker := time.NewTicker(deployCheckInterval)
 	defer ticker.Stop()
+	// This wait is the deploy's long silence — minutes with nothing written
+	// down, which is what makes an interrupted deploy indistinguishable
+	// afterwards from one that never started. A heartbeat every few minutes is
+	// enough to tell the two apart without a line per poll.
+	d.Logger.Info().Int("pr", res.Number).Msg("deploy: waiting for CI checks")
+	polls := 0
 	for {
 		state, err := d.Deployer.PullRequestChecks(ctx, d.WorkspaceDir, res.Number)
 		if err != nil {
@@ -1587,10 +1622,18 @@ func (d BoardTransitionDeps) waitForChecks(ctx context.Context, res PRResult) er
 		}
 		switch state {
 		case forge.ChecksPassing:
+			d.Logger.Info().Int("pr", res.Number).Int("polls", polls).Msg("deploy: CI checks passed")
 			return nil
 		case forge.ChecksFailing:
+			d.Logger.Info().Int("pr", res.Number).Int("polls", polls).Msg("deploy: CI checks failed")
 			return errors.WithDetails("CI checks failed", "pr", res.URL,
 				deployFailingChecksDetail, d.checkNames(res.Number, forge.ChecksFailing))
+		}
+		polls++
+		if polls%deployWaitHeartbeat == 0 {
+			d.Logger.Info().Int("pr", res.Number).
+				Dur("waited", time.Duration(polls)*deployCheckInterval).
+				Msg("deploy: CI still running")
 		}
 		select {
 		case <-ctx.Done():
@@ -1629,6 +1672,8 @@ func (d BoardTransitionDeps) checkNames(number int, want forge.ChecksState) stri
 // deployFailed posts the failure marker on its own context: the pipeline's
 // context may already be cancelled (timeout), and the marker must still land.
 func (d BoardTransitionDeps) deployFailed(pmKey, prURL, reason string) error {
+	d.Logger.Warn().Str("pm", pmKey).Str("pr", prURL).
+		Str("reason", headlineOf(reason)).Msg("deploy: failed")
 	postCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	body := DeployFailedHeader + "\n" + reason

--- a/internal/daemon/daemon_busy.go
+++ b/internal/daemon/daemon_busy.go
@@ -14,6 +14,14 @@ import (
 // view already does (SC-3015).
 type DaemonBusyStatus struct {
 	Busy bool `json:"busy"`
+	// InFlight is how many restart-blocking operations the daemon is running
+	// right now — forwarded commands (a `human deploy` on its CI gate is the
+	// long one) and the heavy board routes. It is what turns "the daemon did
+	// not exit within the timeout" from a dead end into a sentence that names
+	// what the daemon is finishing, so an operator waits instead of reaching
+	// for a signal that also kills every other `human` process on the machine.
+	// Zero on an older daemon that does not send the field.
+	InFlight int `json:"in_flight"`
 }
 
 // handleDaemonBusy answers the daemon-busy route. A nil LeaseChecker (an
@@ -30,7 +38,9 @@ func (s *Server) handleDaemonBusy(conn net.Conn) {
 			return
 		}
 	}
-	data, err := json.Marshal(DaemonBusyStatus{Busy: busy})
+	// The route itself is not counted (routeSimpleCommand runs it uncounted), so
+	// asking the question never becomes part of its own answer.
+	data, err := json.Marshal(DaemonBusyStatus{Busy: busy, InFlight: s.BlockingOps()})
 	if err != nil {
 		s.writeError(conn, err.Error(), 1)
 		return

--- a/internal/daemon/deploy_log_test.go
+++ b/internal/daemon/deploy_log_test.go
@@ -1,0 +1,103 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/forge"
+)
+
+// deployLogDeps wires the deploy engine to a buffer it writes its progress into.
+func deployLogDeps(t *testing.T, p *fakeDeployer, c *fakeCommenter) (BoardTransitionDeps, *bytes.Buffer) {
+	t.Helper()
+	orig := deployCheckInterval
+	deployCheckInterval = time.Millisecond
+	t.Cleanup(func() { deployCheckInterval = orig })
+
+	var buf bytes.Buffer
+	deps := newDeps(c, nil, p)
+	deps.Launcher = nil
+	deps.Logger = zerolog.New(&buf)
+	return deps, &buf
+}
+
+// A deploy that runs to a merge writes down every step it took. Without this
+// the gate is silent for as long as CI takes, so a deploy interrupted mid-wait
+// — by a restart, or by a signal aimed at the daemon — is indistinguishable
+// afterwards from one that never ran, and has to be reconstructed from merge
+// timestamps.
+func TestDeployBranchLogsItsProgress(t *testing.T) {
+	p := &fakeDeployer{
+		res:    PRResult{Number: 42, URL: "https://example/pr/42"},
+		checks: []forge.ChecksState{forge.ChecksPending, forge.ChecksPending, forge.ChecksPassing},
+	}
+	deps, buf := deployLogDeps(t, p, &fakeCommenter{})
+
+	require.NoError(t, deps.DeployBranch(context.Background(), "SC-1", "t", "body", "feat/x"))
+
+	log := buf.String()
+	for _, want := range []string{
+		"deploy: queued",
+		"deploy: started",
+		"deploy: pull request open",
+		"deploy: waiting for CI checks",
+		"deploy: CI checks passed",
+		"deploy: merged",
+		"deploy: done",
+	} {
+		assert.Contains(t, log, want)
+	}
+	assert.Contains(t, log, `"pm":"SC-1"`)
+	assert.Contains(t, log, `"branch":"feat/x"`)
+	assert.Contains(t, log, `"pr":42`)
+}
+
+// The wait itself reports that it is still alive, so a long CI gate is visible
+// as a running deploy rather than as nothing at all.
+func TestWaitForChecksHeartbeats(t *testing.T) {
+	pending := make([]forge.ChecksState, deployWaitHeartbeat+1)
+	for i := range pending {
+		pending[i] = forge.ChecksPending
+	}
+	p := &fakeDeployer{
+		res:    PRResult{Number: 7, URL: "https://example/pr/7"},
+		checks: append(pending, forge.ChecksPassing),
+	}
+	deps, buf := deployLogDeps(t, p, &fakeCommenter{})
+
+	require.NoError(t, deps.DeployBranch(context.Background(), "SC-2", "t", "body", "feat/y"))
+	assert.Contains(t, buf.String(), "deploy: CI still running")
+}
+
+// A failure says so in the log as well as on the ticket, with the actionable
+// headline and none of the cause chain's newlines.
+func TestDeployFailedLogsHeadlineOnly(t *testing.T) {
+	p := &fakeDeployer{
+		res:    PRResult{Number: 9, URL: "https://example/pr/9"},
+		checks: []forge.ChecksState{forge.ChecksFailing},
+	}
+	deps, buf := deployLogDeps(t, p, &fakeCommenter{})
+
+	require.Error(t, deps.DeployBranch(context.Background(), "SC-3", "t", "body", "feat/z"))
+
+	log := buf.String()
+	assert.Contains(t, log, "deploy: failed")
+	// One JSON object per line: a reason carrying the cause chain would have
+	// split the record across lines.
+	for _, line := range strings.Split(strings.TrimSpace(log), "\n") {
+		assert.True(t, strings.HasPrefix(line, "{") && strings.HasSuffix(line, "}"), "log line not a single record: %q", line)
+	}
+}
+
+func TestHeadlineOf(t *testing.T) {
+	assert.Equal(t, "the headline", headlineOf("the headline\n\ncause: deeper cause"))
+	assert.Equal(t, "no newline", headlineOf("no newline"))
+	assert.Empty(t, headlineOf(""))
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -182,9 +182,11 @@ type Server struct {
 	Listener net.Listener
 
 	// blockingOps counts in-flight requests a self-restart must not interrupt
-	// (a deploy waiting on CI, an autonomous launch). The binary watcher
-	// postpones its handover while this is non-zero rather than killing the
-	// work mid-flight. Streaming/read routes are deliberately excluded.
+	// (a deploy waiting on CI, an autonomous launch, any forwarded command).
+	// The binary watcher postpones its handover while this is non-zero rather
+	// than handing over with the work still running in the outgoing process,
+	// and `human daemon stop` reads it to say what it is waiting for instead of
+	// timing out with no reason. Streaming/polling routes are excluded.
 	blockingOps atomic.Int64
 
 	wg sync.WaitGroup // tracks in-flight handler goroutines for graceful shutdown
@@ -262,8 +264,9 @@ func (s *Server) BlockingOps() int {
 
 // withBlockingOp runs fn while counting it as a restart-blocking operation, so
 // a concurrent binary-change handover postpones itself instead of interrupting
-// fn. Wrap only the heavy, must-not-interrupt route handlers with it; leave
-// read and streaming routes uncounted.
+// fn. Every forwarded command is counted, plus the heavy route handlers; only
+// the board's own polling routes and the streaming ones are left out, because a
+// handover that waits for those would never find a quiet moment to commit in.
 func (s *Server) withBlockingOp(fn func()) {
 	s.blockingOps.Add(1)
 	defer s.blockingOps.Add(-1)
@@ -342,8 +345,14 @@ func (s *Server) handleConn(conn net.Conn) {
 		return
 	}
 
-	// Apply client environment variables and execute the command.
-	s.executeCommand(conn, req, projectDir)
+	// A forwarded command executes IN this process, so a restart takes it with
+	// it — and the longest of them is `human deploy`, which sits for minutes on
+	// a CI gate with nothing written down. Counting it keeps a rebuild's
+	// handover from committing while a deploy is mid-flight, so the work is
+	// never owned by a process that has already handed its identity away.
+	s.withBlockingOp(func() {
+		s.executeCommand(conn, req, projectDir)
+	})
 }
 
 // executeCommand applies env vars (including safe mode) and runs the CLI command.


### PR DESCRIPTION
Two deploys yesterday morning returned **no output at all** and merged nothing while CI was pending; the next run merged. The CI gate was innocent — `waitForChecks` loops until the checks conclude. Both runs died with the daemon when it was restarted, and the CLI process is also called `human`, so the signal aimed at the daemon by name took the deploy with it. A killed process prints nothing.

Working that out took merge-commit timestamps against the daemon pidfile mtime, because **the deploy gate writes nothing down**. Three commits, three consequences.

## 1. A forwarded command is work a restart must not interrupt

A forwarded command executes *inside* the daemon; only the board routes were counted as restart-blocking. So a rebuild handover could commit while a `human deploy` sat on its CI gate, leaving the deploy owned by a process that had already handed its pidfile, daemon.json and sockets away. The drain comment asserted this could not happen; now it is true, and the comment names the line that makes it true.

Every forwarded command counts, not a classified subset — a rule that decides which commands are heavy is a rule that will be wrong about the next one. Polling and streaming routes stay out, or a handover would never find a quiet moment.

## 2. `daemon stop` says what it is finishing

"daemon did not exit within timeout" after five seconds covered two opposite states: a wedged daemon, and one deliberately finishing a deploy. Read as the first, the remedy is to kill by name — which is exactly what cost the two deploys.

The in-flight count now comes from the `daemon-busy` route (additive field; an older daemon reports zero) and is read **before** the signal, since a shutting-down daemon has closed the listener the question travels over. Past the grace, stop either reports a daemon stuck with nothing in flight, or names how many operations it is finishing and waits.

- `--wait` (default **30s**) sits through it. Short on purpose: the desktop close flow shells out to this command, and outlasting the wait is not a failure — the daemon exits on its own when the work is done, and the error says so.
- `--force` ends it now, signalling **this pid alone**. That is the point: the precise version of the reach that caused this.

## 3. The gate has a voice

`DeployBranch` logs queued → started → PR open → CI verdict → rebase → merged → done, with a "CI still running" heartbeat every 10 polls (~5 min). A failure logs its headline beside the marker it already posts. And the CLI deploy deps, whose zero-value logger discarded everything, now carry a real one on stderr — the daemon log when forwarded, the terminal when not.

`docs/reaper.md` gains the axis it was missing: it covers every way the machine ends an *agent* and had nothing on work that is not in a container. The daemon own exit is not a reap and ends work anyway.

## What this does not fix

`SIGKILL` cannot be caught. A `killall -9` still ends the deploy with no record — which is why `--force` exists and why killing by name is the wrong reach.

`make check` green; `go test ./cmd/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)