### PR TITLE
[SC-4068] Stop calling a ticket's maturity a kind, or a stage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,11 +24,18 @@ everything else and say plainly what is blocked and why.
 
 # Tickets
 
-A ticket is **one artifact that evolves in place** through maturity stages (kinds):
+A ticket is **one artifact that evolves in place** — the same key from first thought
+to merge. It matures through three forms:
 
 1. **idea** — a raw thought, captured as a real ticket carrying the `human/idea` label (bare `idea` also classifies). Title-only is fine.
 2. **pm** — promotion: the ideation agent rewrites title/description into product language and removes the idea label. Same key forever; PM ticket descriptions stay product language, no implementation detail.
 3. **planned** — the engineering plan attaches to the ticket as a `[human:plan]` marker comment (full markdown; attach with `human marker post <KEY> plan --body-file -`, read it back with `human plan show <KEY>`). Re-planning posts a new plan comment; the latest wins.
+
+Those three are the ticket's **maturity**, and two neighbouring words are not it: a
+tracker's **kind** is its provider (`shortcut`, `linear`, `jira` — the `.humanconfig`
+section and `tracker.Instance.Kind`), and a **stage** is what the board is running
+(planning, implementation, review, deploy). Maturity says what is attached to the
+ticket; stage says what is working on it; kind says where it lives.
 
 **Topology rule:** whether planning ALSO creates a separate engineering ticket depends on the tracker config. Single-tracker is the default: unless a tracker carries an **explicit** `role: engineering` in `.humanconfig`, there is no second ticket — the plan comment on the ticket is the plan, and commits reference the one key. Split topology is opt-in: give a tracker an explicit `role: engineering` and planning then creates an engineering ticket on it whose description is the plan, with traceability running PM ticket → engineering ticket → git commits (reference the PM ticket in the engineering ticket, and both in commit messages). Role is never inferred from the tracker kind for the engineering side — a bare `linears:` entry with no `role:` stays single-tracker.
 

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -483,8 +483,9 @@ func IsSecurityType(s string) bool {
 	return isSecurityToken(s)
 }
 
-// IdeaLabel is the canonical label marking a ticket as a raw idea — the first
-// maturity stage of the evolving-ticket lifecycle. It is namespaced so it
+// IdeaLabel is the canonical label marking a ticket as a raw idea — the first of
+// the three forms an evolving ticket takes (idea, pm, planned). "Stage" is not
+// the word for it: that is what the board is running. It is namespaced so it
 // cannot collide with a team's existing labels; classification additionally
 // accepts the bare token (see IsIdea) so existing "idea" conventions count.
 const IdeaLabel = "human/idea"


### PR DESCRIPTION
The sentence that teaches this repo the ticket vocabulary spent two words the repo had already given away:

> A ticket is **one artifact that evolves in place** through maturity stages (kinds):

- **kind** is a tracker provider (`shortcut`, `linear`, `jira`) — the `.humanconfig` section and `tracker.Instance.Kind`. The same paragraph leans on that sense two lines later: *Role is never inferred from the tracker kind*.
- **stage** is what the board is running: planning, implementation, review, deploy.

So the three forms are named as maturity and nothing else, and the section now states the other two rather than leaving a reader to walk into them:

> Maturity says what is attached to the ticket; stage says what is working on it; kind says where it lives.

Saying it there is what keeps it from drifting back — it arrived by accident once already. `tracker.go` had inherited the same phrasing on `IdeaLabel` (the first maturity stage of the evolving-ticket lifecycle) and now agrees.

Text only: one paragraph in CLAUDE.md, one doc comment. Every factual claim in the section was re-checked against the code first and none of them had changed — `IdeaLabel`/`IsIdea`, the promotion path in `ideation.go`, `human plan show`, and `Instance.InferRole` all still say what the section says they do.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)