### PR TITLE
[SC-4063] Daemons only work on tickets their own user owns

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gethuman-sh/human/internal/stats"
 	"github.com/gethuman-sh/human/internal/tracker"
 	"github.com/gethuman-sh/human/internal/vault"
+	"github.com/gethuman-sh/human/internal/vieweridentity"
 )
 
 const daemonChildEnv = "_HUMAN_DAEMON_CHILD"
@@ -886,7 +887,7 @@ func runDaemonForeground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string,
 		// A nil participation predicate means "participate in every visible
 		// project" — the backward-compatible default. A machine that opts into a
 		// narrower set supplies a predicate here (SC-2047 opt-in participation).
-		branchReachable, boardParticipation(ds.srv.Projects), commitsPresent, prMerged, postDeployed,
+		branchReachable, boardParticipation(ds.srv.Projects), boardTicketIdentity(ds.srv.Projects), commitsPresent, prMerged, postDeployed,
 		liveBoardAgents, postFailedMarkerFunc(ds.srv.Projects, ds.vaultResolver, ds.daemonID),
 		closedTicketProbeFunc(ds.srv.Projects, ds.vaultResolver),
 		// The durable re-drive has no exiting agent to attribute — the run it is
@@ -2535,6 +2536,36 @@ func boardParticipation(projects *daemon.ProjectRegistry) daemon.ProjectParticip
 	}
 }
 
+// boardTicketIdentity returns the resolver the reconcile gate consults to decide
+// whether a ticket belongs to this machine's person (SC-4063). It routes the PM
+// key to its registered project and reads that project's "me" section, so a
+// daemon serving several projects applies each project's declared identity to its
+// own tickets rather than one project's identity to all of them.
+//
+// An unroutable key resolves to NO identity, which leaves the arm disabled for
+// that card rather than refusing it. That is deliberately the opposite
+// disposition from boardParticipation, which refuses an unroutable key: refusing
+// there withholds work from a project this machine may not have opted into, while
+// refusing here would withhold a person's own work on the strength of a routing
+// failure — and a routing failure says nothing about who owns the ticket. The
+// participation arm still refuses the same card, so nothing is loosened.
+func boardTicketIdentity(projects *daemon.ProjectRegistry) daemon.TicketIdentity {
+	if projects == nil {
+		return nil
+	}
+	return func(pmKey string) daemon.OwnerIdentity {
+		entry, err := projects.EntryForKey(pmKey)
+		if err != nil {
+			return nil
+		}
+		identity, err := vieweridentity.Load(entry.Dir)
+		if err != nil {
+			return nil
+		}
+		return identity
+	}
+}
+
 // boardBranchReachable reports whether a handoff branch resolves on this machine
 // (local ref or origin) — a board-context fix leaves its branch local on the
 // machine that produced it (SC-652). A 15s timeout bounds the git probe. The
@@ -4102,7 +4133,12 @@ func boardReconcileListerFunc(reg *daemon.ProjectRegistry, resolver *vault.Resol
 					continue
 				}
 				wg.Add(1)
-				go func(c tracker.Commenter, key string) {
+				// assignee/reporter ride along from the listing the fan-out has
+				// already fetched: they are what the work gate reads to refuse a
+				// ticket belonging to someone else (SC-4063), and re-reading the
+				// issue per card would double the tick's tracker traffic for facts
+				// this loop is already holding.
+				go func(c tracker.Commenter, key, assignee, reporter string) {
 					defer wg.Done()
 					fetchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 					defer cancel()
@@ -4116,9 +4152,11 @@ func boardReconcileListerFunc(reg *daemon.ProjectRegistry, resolver *vault.Resol
 						return
 					}
 					mu.Lock()
-					cards = append(cards, daemon.ReconcileCard{Key: key, Comments: comments})
+					cards = append(cards, daemon.ReconcileCard{
+						Key: key, Comments: comments, Assignee: assignee, Reporter: reporter,
+					})
 					mu.Unlock()
-				}(commenter, issue.Key)
+				}(commenter, issue.Key, issue.Assignee, issue.Reporter)
 			}
 		}
 		wg.Wait()

--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -2655,7 +2655,10 @@ func (p forgeDeployer) PushAndCreatePR(ctx context.Context, req daemon.PRRequest
 	if err != nil {
 		return daemon.PRResult{}, errors.WrapWithDetails(err, "opening pull request", "repo", repo, "head", req.Branch)
 	}
-	return daemon.PRResult{URL: pr.URL, Number: pr.Number}, nil
+	// pr.Draft is the ADOPTED PR's state, not the requested one: an existing open
+	// PR is returned as-is, so a draft opened by the review loop stays draft here
+	// and the deploy gate needs to know before it reaches the merge (SC-4027).
+	return daemon.PRResult{URL: pr.URL, Number: pr.Number, Draft: pr.Draft}, nil
 }
 
 // pushBranch pushes branch to origin, lease-pushing against the current remote

--- a/cmd/cmddaemon/prloopstate.go
+++ b/cmd/cmddaemon/prloopstate.go
@@ -18,9 +18,19 @@ import (
 // (SC-1484/SC-2133); the state-store read that decides this loop never got
 // the same treatment, which is exactly how SC-2307 read a superseded verdict.
 // Package vars so tests can shrink them to keep the suite fast.
+// The bound is set by how long a step's write can trail the event that looks like
+// its exit, not by how long a write takes. On SC-3613 the reviewer's `Stop`
+// arrived at 08:42:32 and its verdict landed at 08:43:39 — 67 seconds later — and
+// a 6-second settle concluded "recorded nothing" and reddened a review that went
+// on to approve (SC-4026). 100 seconds covers that with margin.
+//
+// It costs nothing in the ordinary case: a step writes its report as the last
+// thing it does, so a real exit is fresh on the first read and never waits. Only
+// the pathological read backs off, and there the alternative is a red card a
+// person has to clear.
 var (
-	prLoopReadRecheckStep  = 2 * time.Second
-	prLoopReadRecheckTries = 3
+	prLoopReadRecheckStep  = 10 * time.Second
+	prLoopReadRecheckTries = 10
 )
 
 // readPRReviewVerdict returns the machine reviewer's verdict recorded in

--- a/cmd/cmddeploy/deploy.go
+++ b/cmd/cmddeploy/deploy.go
@@ -29,6 +29,7 @@ import (
 // BuildDeployCmd creates the top-level "deploy" command.
 func BuildDeployCmd(deps cmdutil.Deps) *cobra.Command {
 	var branch, title string
+	var ready bool
 	cmd := &cobra.Command{
 		Use:   "deploy KEY",
 		Short: "Ship a ticket's branch: PR, CI gate, rebase if stale, merge, markers, ticket close",
@@ -45,11 +46,12 @@ gate blocks until checks conclude, so this command can run for many minutes.`,
 				return err
 			}
 			defer resolved.Cleanup()
-			return RunDeploy(cmd.Context(), resolved.Provider, cmd.OutOrStdout(), resolved.Key, branch, title)
+			return RunDeploy(cmd.Context(), resolved.Provider, cmd.OutOrStdout(), resolved.Key, branch, title, ready)
 		},
 	}
 	cmd.Flags().StringVar(&branch, "branch", "", "Branch to ship (default: the ticket's review-handoff branch)")
 	cmd.Flags().StringVar(&title, "title", "", "PR title (default: the ticket title)")
+	cmd.Flags().BoolVar(&ready, "ready", false, "Ship a pull request the machine review loop is still holding in draft: un-draft it and merge")
 	return cmd
 }
 
@@ -84,7 +86,7 @@ var newTransitionDeps = func(p tracker.Provider) daemon.BoardTransitionDeps {
 }
 
 // RunDeploy derives branch and title, then runs the deploy gate.
-func RunDeploy(ctx context.Context, p tracker.Provider, out io.Writer, key, branch, title string) error {
+func RunDeploy(ctx context.Context, p tracker.Provider, out io.Writer, key, branch, title string, ready bool) error {
 	engineering := ""
 	if branch == "" {
 		comments, err := p.ListComments(ctx, key)
@@ -109,7 +111,11 @@ func RunDeploy(ctx context.Context, p tracker.Provider, out io.Writer, key, bran
 		title = issue.Title
 	}
 
-	if err := deployEngine(ctx, newTransitionDeps(p), key, title, prBody(key, engineering, branch), branch); err != nil {
+	deps := newTransitionDeps(p)
+	// Only an explicit gesture may clear the review loop's draft interlock; the
+	// engine refuses a draft otherwise and says what is holding it (SC-4027).
+	deps.MergeDraftPR = ready
+	if err := deployEngine(ctx, deps, key, title, prBody(key, engineering, branch), branch); err != nil {
 		return err
 	}
 	_, err := fmt.Fprintf(out, "Deployed %s (%s)\n", key, branch)

--- a/cmd/cmddeploy/deploy_test.go
+++ b/cmd/cmddeploy/deploy_test.go
@@ -79,7 +79,7 @@ func TestRunDeploy_derivesBranchAndTitleFromHandoffAndTicket(t *testing.T) {
 	}
 	var buf bytes.Buffer
 
-	err := RunDeploy(context.Background(), p, &buf, "SC-1", "", "")
+	err := RunDeploy(context.Background(), p, &buf, "SC-1", "", "", false)
 	require.NoError(t, err)
 	require.Len(t, *calls, 1)
 	call := (*calls)[0]
@@ -96,7 +96,7 @@ func TestRunDeploy_explicitFlagsSkipDerivation(t *testing.T) {
 	p := &stubProvider{}
 	var buf bytes.Buffer
 
-	err := RunDeploy(context.Background(), p, &buf, "SC-1", "release/x", "Custom title")
+	err := RunDeploy(context.Background(), p, &buf, "SC-1", "release/x", "Custom title", false)
 	require.NoError(t, err)
 	require.Len(t, *calls, 1)
 	assert.Equal(t, "release/x", (*calls)[0].branch)
@@ -108,7 +108,7 @@ func TestRunDeploy_noHandoffNoBranchFails(t *testing.T) {
 	p := &stubProvider{}
 	var buf bytes.Buffer
 
-	err := RunDeploy(context.Background(), p, &buf, "SC-1", "", "")
+	err := RunDeploy(context.Background(), p, &buf, "SC-1", "", "", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no review handoff")
 	assert.Empty(t, *calls)
@@ -122,7 +122,7 @@ func TestRunDeploy_handoffWithoutBranchFails(t *testing.T) {
 	}}}
 	var buf bytes.Buffer
 
-	err := RunDeploy(context.Background(), p, &buf, "SC-1", "", "")
+	err := RunDeploy(context.Background(), p, &buf, "SC-1", "", "", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no branch")
 	assert.Empty(t, *calls)
@@ -133,7 +133,7 @@ func TestRunDeploy_engineErrorPropagates(t *testing.T) {
 	p := &stubProvider{}
 	var buf bytes.Buffer
 
-	err := RunDeploy(context.Background(), p, &buf, "SC-1", "release/x", "T")
+	err := RunDeploy(context.Background(), p, &buf, "SC-1", "release/x", "T", false)
 	require.Error(t, err)
 	assert.NotContains(t, buf.String(), "Deployed")
 }

--- a/internal/board/ownership.go
+++ b/internal/board/ownership.go
@@ -1,8 +1,6 @@
 package board
 
 import (
-	"strings"
-
 	"github.com/gethuman-sh/human/internal/daemon"
 	"github.com/gethuman-sh/human/internal/vieweridentity"
 )
@@ -37,10 +35,10 @@ func MarkOwnership(cards []daemon.BoardViewCard, viewer vieweridentity.Identity)
 	}
 }
 
-// ownerOf is the assignee, or the reporter when there is no assignee.
+// ownerOf reads the shared rule off the card. The rule itself lives in
+// daemon.OwnerOf because the daemon's work gate decides what to WORK by the same
+// answer this decides what to DIM; if they disagreed the board would dim cards
+// the machine is driving, or show as yours cards it will never touch.
 func ownerOf(c daemon.BoardViewCard) string {
-	if a := strings.TrimSpace(c.Assignee); a != "" {
-		return a
-	}
-	return strings.TrimSpace(c.Reporter)
+	return daemon.OwnerOf(c.Assignee, c.Reporter)
 }

--- a/internal/daemon/board_failure.go
+++ b/internal/daemon/board_failure.go
@@ -393,17 +393,46 @@ func handoffSearchNote(stage BoardStage, header string) string {
 }
 
 // drivePRLoopExit routes a PR review/fix loop agent's exit to the loop driver
-// instead of the generic stage-failure path, reclaiming its worktree first (the
-// reviewer is read-only, the fixer already pushed its work). It reports whether
-// the exit was a loop step and thus fully handled here. A non-loop stage returns
-// false so the caller falls through to the stage-failure handling.
+// instead of the generic stage-failure path. It reports whether the exit was a
+// loop step and thus fully handled here. A non-loop stage returns false so the
+// caller falls through to the stage-failure handling.
 //
 // The exiting run's identity travels with the call: a step that dies before
 // recording its outcome can only be explained from its artifacts, and dropping
 // the name here is what left the loop's escalation with nothing to say (SC-1892).
+//
+// A SUBSTRATE FAILURE IS NOT AN EXIT (SC-4026). The hook fires StopFailure on a
+// model API error, and Claude Code retries through it — the run carries on. The
+// loop used to drive on that event regardless, read a verdict the reviewer had
+// not written yet, and red the card while the review was still working: measured
+// on SC-3613, a server_error at 08:42:16 escalated at 08:42:25, and the reviewer
+// went on to record `approved` at 08:43:39 and exit 0 at 08:44:06.
+//
+// Liveness cannot decide this. The hook runs inside the claude process, so asking
+// the container whether claude is alive races the process's own exit and answers
+// "yes" for a clean finish as readily as for a retry. The error type is the fact
+// that is actually available, and classifyUnavailability already knows how to
+// read it — the loop simply never consulted it, because this function returns
+// long before the generic path's classification (board_failure.go, below).
+//
+// A run that genuinely dies on a substrate failure is not stranded: the durable
+// reconcile pass re-drives a loop card whose half-agent is gone, on the machine
+// that owns it. Waiting for that is strictly better than escalating a review that
+// is still running, because the reconcile answer is right in both cases.
+//
+// The worktree handoff moved inside the exit branch for the same reason. It flips
+// the flag that authorizes removing the run's worktree, and the FIXER's
+// deliverable is an unpushed local commit by design — waiving that protection on
+// an error the run then recovers from is how the commit would be lost.
 func drivePRLoopExit(pmKey string, stage BoardStage, agentName, errorType string, advancePRLoop func(pmKey, agentName, errorType string) error, onHandoff func(agentName string), logger zerolog.Logger) bool {
 	if stage != prReviewAgentStage && stage != prFixAgentStage {
 		return false
+	}
+	if kind, reason := classifyErrorType(errorType); kind == endingPaused {
+		logger.Info().Str("pm", pmKey).Str("stage", string(stage)).Str("agent", agentName).
+			Str("reason", reason).
+			Msg("board PR loop: substrate failure mid-run, not treating it as the step's exit")
+		return true
 	}
 	if onHandoff != nil {
 		onHandoff(agentName)

--- a/internal/daemon/board_ownership.go
+++ b/internal/daemon/board_ownership.go
@@ -1,0 +1,21 @@
+package daemon
+
+import "strings"
+
+// OwnerOf answers "whose ticket is this?" from the two fields every tracker
+// records: the assignee, falling back to the reporter when there is no assignee
+// (SC-3339). Empty when neither is recorded — which is "owner unknown", NOT
+// "owned by nobody in particular", and callers must decide which of those they
+// are asking about.
+//
+// It lives here, in the package the daemon's work gate and the board's viewer
+// overlay both import, because the two of them must agree: the board dims a card
+// the daemon refuses to work, and a card the board shows as yours must be one the
+// daemon will pick up. Two copies of this rule would drift into a board that lies
+// about which cards the machine is actually driving.
+func OwnerOf(assignee, reporter string) string {
+	if a := strings.TrimSpace(assignee); a != "" {
+		return a
+	}
+	return strings.TrimSpace(reporter)
+}

--- a/internal/daemon/board_ownership_test.go
+++ b/internal/daemon/board_ownership_test.go
@@ -83,3 +83,23 @@ func TestSetTicketOwnerIgnoresAnEmptyKey(t *testing.T) {
 
 	assert.Empty(t, owned)
 }
+
+// OwnerOf is the one definition of "whose ticket is this?" — the daemon's work
+// gate and the board's dimming overlay both read it, so the cases are pinned
+// here rather than in either caller.
+func TestOwnerOf(t *testing.T) {
+	t.Run("assignee wins", func(t *testing.T) {
+		assert.Equal(t, "Alice", OwnerOf("Alice", "Bob"))
+	})
+	t.Run("reporter when unassigned", func(t *testing.T) {
+		assert.Equal(t, "Bob", OwnerOf("", "Bob"))
+	})
+	t.Run("whitespace is not an assignee", func(t *testing.T) {
+		assert.Equal(t, "Bob", OwnerOf("   ", "Bob"))
+	})
+	// Neither field recorded is "owner unknown", not "owned by nobody": the empty
+	// string is what every caller keys its unknown-owner branch off.
+	t.Run("neither recorded is empty", func(t *testing.T) {
+		assert.Empty(t, OwnerOf("", ""))
+	})
+}

--- a/internal/daemon/board_reconcile.go
+++ b/internal/daemon/board_reconcile.go
@@ -187,7 +187,7 @@ func reconcileOnce(ctx context.Context, listCards ReconcileLister, gate WorkGate
 	// The PR-loop re-drive runs BEFORE the stuck-running pass so a loop card
 	// stranded by a restart is re-driven rather than reddened — the stuck pass
 	// also skips it (doneStageLoopActive), but ordering makes the ownership clear.
-	if n := reconcilePRLoops(ctx, gate.forReview(cards), liveAgents, driveLoop, logger); n > 0 {
+	if n := reconcilePRLoops(ctx, gate.forTakeover(cards), liveAgents, driveLoop, logger); n > 0 {
 		logger.Info().Int("redriven", n).Msg("board reconcile: re-drove stalled PR review→fix loops")
 	}
 	// An outage card is re-driven BEFORE the stuck-running pass: it is not a hang
@@ -252,12 +252,26 @@ func doneStageLoopActive(comments []tracker.Comment) bool {
 // idempotently (AdvancePRLoop's escalate no-ops on an already-open options
 // block, and the alive-guard prevents racing a second launch). nil deps disable it.
 //
-// It receives DrivableCards from the forReview gate, so it only ever sees loop
-// cards whose branch this machine can obtain: a loop re-drive walks the producing
-// machine's branch toward the credentialed Deploy that publishes it, and a daemon
-// that cannot reach that branch is not handed the card at all (SC-2047). This is
-// the by-construction replacement for the per-path reachability check the loop
-// re-drive was missing — the gate is now the only way a card reaches this pass.
+// It receives DrivableCards from the forTAKEOVER gate, not forReview. A
+// mid-flight review→fix loop is a RUNNING stage, and the gate's two intents split
+// exactly there: forTakeover governs a still-running stage, forReview governs work
+// its owner has finished and handed off. Being on the wrong side of that line is
+// what let a peer daemon red a review it was not running (SC-4025).
+//
+// The peer cannot help itself. The outcome this pass reads — the reviewer's
+// verdict in stage.pr-review — lives in the agent state store, which is local to
+// the daemon host and never posted to the tracker. A machine that did not launch
+// the reviewer reads its own empty store, concludes the step recorded nothing, and
+// escalates: on SC-3613 and SC-3569 that happened 21 to 117 seconds into rounds
+// that went on to finish and approve. Reachability could not have stopped it,
+// because the loop pushes its branch before opening the draft PR, so origin
+// resolves the branch on every peer.
+//
+// forTakeover carries the reachability arm too, so the SC-2047 property this pass
+// had before is unchanged; what it adds is the ownership arm, and the loop's
+// started marker carries the machine: stamp that arm reads. The daemon id is
+// persisted across restarts (LoadOrCreateDaemonID), so the restart-orphan case
+// this pass exists for still matches its own stamp and is still re-driven.
 func reconcilePRLoops(ctx context.Context, drivable DrivableCards, liveAgents LiveAgentLister, driveLoop func(pmKey string) error, logger zerolog.Logger) int {
 	if driveLoop == nil || liveAgents == nil {
 		return 0

--- a/internal/daemon/board_reconcile.go
+++ b/internal/daemon/board_reconcile.go
@@ -32,6 +32,12 @@ var BoardReconcileJitter = 0.5
 type ReconcileCard struct {
 	Key      string
 	Comments []tracker.Comment
+	// Assignee and Reporter answer whose ticket this is, the fact the work gate
+	// needs to refuse another person's work (SC-4063). Empty on both means the
+	// owner could not be resolved, which the gate reads as unknown rather than as
+	// someone else's — see WorkGate.mineToWork.
+	Assignee string
+	Reporter string
 }
 
 // ReconcileLister enumerates the open PM cards to reconcile. Injected so the
@@ -112,14 +118,14 @@ type FailedMarkerPoster func(ctx context.Context, pmKey, body string) error
 // It runs one pass immediately at start (recovers a restart-orphaned handoff
 // without waiting a full interval) then on a ticker, mirroring
 // RunAgentZombieSweep. nil deps disable it.
-func RunBoardReconcile(ctx context.Context, listCards ReconcileLister, reachable BranchReachable, participates ProjectParticipation, commitsPresent CommitsPresent, mergedProbe PRMergedProbe, postDeployed DeployedPoster, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, closedProbe ClosedTicketProbe, chainReview func(pmKey string) error, driveLoop func(pmKey string) error, retry StageRetry, progress AgentProgressProbe, stopAgent func(agentName string) error, daemonID string, interval time.Duration, logger zerolog.Logger) {
+func RunBoardReconcile(ctx context.Context, listCards ReconcileLister, reachable BranchReachable, participates ProjectParticipation, identityFor TicketIdentity, commitsPresent CommitsPresent, mergedProbe PRMergedProbe, postDeployed DeployedPoster, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, closedProbe ClosedTicketProbe, chainReview func(pmKey string) error, driveLoop func(pmKey string) error, retry StageRetry, progress AgentProgressProbe, stopAgent func(agentName string) error, daemonID string, interval time.Duration, logger zerolog.Logger) {
 	if listCards == nil || chainReview == nil {
 		return
 	}
 
 	logger.Info().Msg("board reconcile started")
 
-	gate := WorkGate{reachable: reachable, participates: participates, daemonID: daemonID}
+	gate := WorkGate{reachable: reachable, participates: participates, daemonID: daemonID, identityFor: identityFor}
 
 	// Recover a restart-orphaned handoff immediately, before the first wait. The
 	// jitter applies only to subsequent cycles, so a restart-orphan is never made
@@ -160,18 +166,22 @@ func reconcileOnce(ctx context.Context, listCards ReconcileLister, gate WorkGate
 		logger.Warn().Err(err).Msg("board reconcile: cannot list PM cards")
 		return
 	}
-	// The by-construction choke point (SC-2047): every work-driving pass below is
-	// handed cards ONLY through the gate — forReview for the ones that continue a
-	// finished-and-handed-off stage, forTakeover for the one that reds and
-	// relaunches a still-running stage. Neither can see the raw board, so a path
-	// added here cannot act on work this machine cannot reach or does not own; the
-	// two machine-local passes (a read-only forge probe and this machine's own
-	// orphaned containers) keep the raw list because they act on nothing that
-	// lives on another disk.
+	// The choke point (SC-2047, widened by SC-4063): every pass below that WRITES
+	// to a ticket is handed cards only through the gate — forReview for the ones
+	// that continue a finished-and-handed-off stage, forTakeover for those that red
+	// and relaunch a still-running stage, forOwnWork for the one whose subject is
+	// the forge rather than a branch. So no pass can act on a ticket belonging to
+	// another person, or on work this machine cannot reach or does not own.
+	//
+	// reconcileOrphanedAgents is the ONE pass left on the raw list, and only
+	// because it writes to no ticket: it stops containers running on THIS machine,
+	// which is this machine's business whoever owns the ticket — leaving a
+	// container alive because its ticket is someone else's would strand a process
+	// nobody else can reach.
 	if n := reconcileOrphanedHandoffs(gate.forReview(cards), commitsPresent, chainReview, logger); n > 0 {
 		logger.Info().Int("launched", n).Msg("board reconcile: chained review for orphaned handoffs")
 	}
-	if n := reconcileShippedFailures(ctx, cards, mergedProbe, postDeployed, logger); n > 0 {
+	if n := reconcileShippedFailures(ctx, gate.forOwnWork(cards), mergedProbe, postDeployed, logger); n > 0 {
 		logger.Info().Int("cleared", n).Msg("board reconcile: confirmed shipped, cleared stale deploy-failed red")
 	}
 	// The PR-loop re-drive runs BEFORE the stuck-running pass so a loop card
@@ -640,12 +650,18 @@ func stuckRunningReason(stage BoardStage) string {
 // retires the failure on the next derivation. Reuses DeriveBoardCard verbatim so
 // detection can never disagree with the board's rendered state. nil deps disable
 // the pass. Returns the number of cards cleared.
-func reconcileShippedFailures(ctx context.Context, cards []ReconcileCard, mergedProbe PRMergedProbe, postDeployed DeployedPoster, logger zerolog.Logger) int {
+//
+// It takes the forOwnWork gate rather than the raw board: posting [human:deployed]
+// is a write on someone's ticket and must obey the ownership rule like every other
+// write (SC-4063). It must NOT take forReview — that arm demands a reachable
+// branch, and the branch of a merged PR is deleted at merge, so reachability would
+// filter out exactly the cards this pass exists to clear.
+func reconcileShippedFailures(ctx context.Context, drivable DrivableCards, mergedProbe PRMergedProbe, postDeployed DeployedPoster, logger zerolog.Logger) int {
 	if mergedProbe == nil || postDeployed == nil {
 		return 0
 	}
 	cleared := 0
-	for _, card := range cards {
+	for _, card := range drivable.cards {
 		derived := DeriveBoardCard(card.Comments, tracker.CategoryUnstarted, false)
 		// Only a done-stage failure that names a PR can be confirmed shipped: the
 		// out-of-band merge posts no marker, so the forge's merged flag is the only

--- a/internal/daemon/board_reconcile_gate.go
+++ b/internal/daemon/board_reconcile_gate.go
@@ -12,6 +12,27 @@ import (
 // that keeps a single-daemon board unchanged; a configured machine narrows it.
 type ProjectParticipation func(pmKey string) bool
 
+// OwnerIdentity is the set of names that mean "this machine's person". Declared
+// as an interface here so the gate does not depend on how identity is
+// configured; internal/vieweridentity.Identity satisfies it, which is the same
+// value the board's dimming overlay compares against — the machine refusing to
+// work a card and the board dimming it are then one decision, not two.
+type OwnerIdentity interface {
+	// Known reports whether any identity is declared at all.
+	Known() bool
+	// Matches reports whether name is one of this machine's identities. An empty
+	// name never matches.
+	Matches(name string) bool
+}
+
+// TicketIdentity resolves the identity that governs a PM key's project. It is a
+// function of the key rather than one value because a daemon can serve several
+// registered projects and each declares its own `me:` — resolving once globally
+// would apply one project's identity to another's tickets. A nil function, or a
+// nil return, disables the ownership arm for that card ("nil disables", the
+// package convention that keeps an unconfigured install working exactly as before).
+type TicketIdentity func(pmKey string) OwnerIdentity
+
 // WorkGate is the single decision every work-driving reconcile pass consults to
 // answer one question: may THIS machine drive this card forward? It is the
 // by-construction choke point SC-2047 requires. Work-driving passes never receive
@@ -20,7 +41,13 @@ type ProjectParticipation func(pmKey string) bool
 // check is a property of the only collection a pass is given, not a call each path
 // must remember and a future path might forget.
 //
-// The gate has two intents because ownership of a stage ends by FINISHING it:
+// Whose TICKET it is comes first and applies to every intent: a machine does
+// autonomous work only on tickets its own person owns (SC-4063). That is a
+// property of the ticket, not of what the pass wants to do with it, so it is not
+// an arm of one intent — it is checked before the intent is consulted at all.
+// A human gesture never reaches here and is deliberately not restricted by it.
+//
+// The gate then has three intents because ownership of a STAGE ends by FINISHING it:
 //   - forTakeover governs reddening/relaunching a still-running stage. A running
 //     stage is unfinished work bound to the machine that owns it; it is never
 //     wrested away by another machine deciding from a distance that it stalled
@@ -28,6 +55,11 @@ type ProjectParticipation func(pmKey string) bool
 //   - forReview governs chaining a review or continuing a post-handoff loop. A
 //     handoff is the owner's explicit signal that implementation finished, so any
 //     participating machine that can genuinely obtain the branch may take it up.
+//   - forOwnWork governs a pass that needs no branch at all. It applies ownership
+//     and participation and stops there. reconcileShippedFailures is the case:
+//     it asks the forge whether the PR merged, and the branch it would probe is
+//     DELETED at merge — gating it on reachability would filter out precisely the
+//     cards it exists to clear.
 type WorkGate struct {
 	// reachable reports whether a card's branch resolves on THIS machine (local
 	// ref or origin). nil disables the reachability arm — the "nil disables"
@@ -39,6 +71,10 @@ type WorkGate struct {
 	// daemonID is this machine's identity, used to tell its OWN running stage from
 	// a peer's when a card has no branch fact yet (the pre-branch ownership arm).
 	daemonID string
+	// identityFor resolves the person whose tickets this machine may work, per
+	// project. nil disables the arm — an install that declares no `me:` keeps
+	// today's behaviour rather than stopping work on upgrade.
+	identityFor TicketIdentity
 }
 
 // DrivableCards is the subset of the board a work-driving reconcile pass is
@@ -71,15 +107,26 @@ func (g WorkGate) forTakeover(cards []ReconcileCard) DrivableCards {
 	return DrivableCards{cards: filterCards(cards, g.drivableForTakeover)}
 }
 
+// forOwnWork returns the cards this machine may act on with no branch involved:
+// the ticket is its person's and the project is one it participates in. Used by
+// the pass whose subject is the forge's merge state rather than a branch.
+func (g WorkGate) forOwnWork(cards []ReconcileCard) DrivableCards {
+	return DrivableCards{cards: filterCards(cards, g.drivableForOwnWork)}
+}
+
+func (g WorkGate) drivableForOwnWork(card ReconcileCard) bool {
+	return g.mineToWork(card) && g.participatesIn(card.Key)
+}
+
 func (g WorkGate) drivableForReview(card ReconcileCard) bool {
-	if !g.participatesIn(card.Key) {
+	if !g.drivableForOwnWork(card) {
 		return false
 	}
 	return g.reachableHere(g.derive(card))
 }
 
 func (g WorkGate) drivableForTakeover(card ReconcileCard) bool {
-	if !g.participatesIn(card.Key) {
+	if !g.drivableForOwnWork(card) {
 		return false
 	}
 	derived := g.derive(card)
@@ -87,6 +134,36 @@ func (g WorkGate) drivableForTakeover(card ReconcileCard) bool {
 		return false
 	}
 	return g.reachableHere(derived)
+}
+
+// mineToWork reports whether the TICKET belongs to this machine's person — the
+// assignee, or the reporter when unassigned (daemon.OwnerOf, the same rule the
+// board dims by).
+//
+// Two distinct absences are both treated as "carry on", and deliberately:
+//
+//   - No identity declared. An install with no `me:` section has never expressed
+//     whose work this machine does, and refusing everything would stop a working
+//     single-daemon board dead on upgrade.
+//   - No owner resolvable on the card. An empty owner is "unknown", not "someone
+//     else's": a tracker that fails to resolve a member name hands back an empty
+//     string with the error swallowed, so reading absence as refusal would let one
+//     flaky members call stand the whole pipeline down for a tick.
+//
+// Only a RESOLVED owner that is demonstrably not this machine's person refuses.
+func (g WorkGate) mineToWork(card ReconcileCard) bool {
+	if g.identityFor == nil {
+		return true
+	}
+	identity := g.identityFor(card.Key)
+	if identity == nil || !identity.Known() {
+		return true
+	}
+	owner := OwnerOf(card.Assignee, card.Reporter)
+	if owner == "" {
+		return true
+	}
+	return identity.Matches(owner)
 }
 
 func (g WorkGate) derive(card ReconcileCard) BoardCard {

--- a/internal/daemon/board_reconcile_test.go
+++ b/internal/daemon/board_reconcile_test.go
@@ -37,6 +37,37 @@ func takeoverSetAs(cards []ReconcileCard, reachable BranchReachable, daemonID st
 	return WorkGate{reachable: reachable, daemonID: daemonID}.forTakeover(cards)
 }
 
+// ownWork is the branch-free gate: the pass whose subject is the forge's merge
+// state, not a branch this machine must resolve.
+func ownWork(cards []ReconcileCard) DrivableCards {
+	return WorkGate{}.forOwnWork(cards)
+}
+
+// asPerson is the identity resolver a test uses to pin the ticket-ownership arm:
+// every key resolves to the same declared person.
+func asPerson(names ...string) TicketIdentity {
+	return func(string) OwnerIdentity { return testIdentity(names) }
+}
+
+// testIdentity mirrors vieweridentity.Identity's contract (a set of names, matched
+// case-insensitively, an empty name never matching) without importing it, so the
+// gate's tests exercise the interface the gate actually declares.
+type testIdentity []string
+
+func (t testIdentity) Known() bool { return len(t) > 0 }
+
+func (t testIdentity) Matches(name string) bool {
+	if strings.TrimSpace(name) == "" {
+		return false
+	}
+	for _, n := range t {
+		if strings.EqualFold(n, strings.TrimSpace(name)) {
+			return true
+		}
+	}
+	return false
+}
+
 // An orphaned handoff — a [human:ready-for-review] with no subsequent review
 // marker — is exactly the card the live fix→review chain missed on restart, so
 // the reconcile pass must launch its review.
@@ -211,7 +242,7 @@ func TestRunBoardReconcile_RecoversOrphanWithNoLiveEvent(t *testing.T) {
 	ctx := t.Context()
 	// A long interval proves the recovery comes from the immediate startup pass,
 	// not a ticker tick.
-	go RunBoardReconcile(ctx, lister, alwaysReachable, nil, nil, nil, nil, nil, nil, nil, chain, nil, StageRetry{}, nil, nil, "", time.Hour, zerolog.Nop())
+	go RunBoardReconcile(ctx, lister, alwaysReachable, nil, nil, nil, nil, nil, nil, nil, nil, chain, nil, StageRetry{}, nil, nil, "", time.Hour, zerolog.Nop())
 
 	select {
 	case pmKey := <-chained:
@@ -238,7 +269,7 @@ func TestReconcileShippedFailures_MergedPRClearsRed(t *testing.T) {
 		postedKey, postedURL = pmKey, prURL
 		return nil
 	}
-	n := reconcileShippedFailures(context.Background(), cards, merged, post, zerolog.Nop())
+	n := reconcileShippedFailures(context.Background(), ownWork(cards), merged, post, zerolog.Nop())
 
 	assert.Equal(t, 1, n)
 	assert.Equal(t, "SC-1", postedKey)
@@ -257,7 +288,7 @@ func TestReconcileShippedFailures_UnmergedPRLeftRed(t *testing.T) {
 	posted := false
 	merged := func(_ context.Context, _ string) (bool, error) { return false, nil }
 	post := func(_ context.Context, _, _ string) error { posted = true; return nil }
-	n := reconcileShippedFailures(context.Background(), cards, merged, post, zerolog.Nop())
+	n := reconcileShippedFailures(context.Background(), ownWork(cards), merged, post, zerolog.Nop())
 
 	assert.Equal(t, 0, n)
 	assert.False(t, posted)
@@ -273,7 +304,7 @@ func TestReconcileShippedFailures_NoPRURLSkipped(t *testing.T) {
 	probed := false
 	merged := func(_ context.Context, _ string) (bool, error) { probed = true; return true, nil }
 	post := func(_ context.Context, _, _ string) error { return nil }
-	n := reconcileShippedFailures(context.Background(), cards, merged, post, zerolog.Nop())
+	n := reconcileShippedFailures(context.Background(), ownWork(cards), merged, post, zerolog.Nop())
 
 	assert.Equal(t, 0, n)
 	assert.False(t, probed)
@@ -283,7 +314,7 @@ func TestReconcileShippedFailures_NoPRURLSkipped(t *testing.T) {
 func TestReconcileShippedFailures_NilDepsDisabled(t *testing.T) {
 	cards := []ReconcileCard{{Key: "SC-1", Comments: []tracker.Comment{
 		cmt("[human:deploy-failed]\nx\npr: https://github.com/o/r/pull/7", time.Unix(1, 0))}}}
-	assert.Equal(t, 0, reconcileShippedFailures(context.Background(), cards, nil, nil, zerolog.Nop()))
+	assert.Equal(t, 0, reconcileShippedFailures(context.Background(), ownWork(cards), nil, nil, zerolog.Nop()))
 }
 
 // liveAgents is the test lister: the set of board agent names currently running

--- a/internal/daemon/board_reconcile_ticketowner_test.go
+++ b/internal/daemon/board_reconcile_ticketowner_test.go
@@ -1,0 +1,136 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// The ticket-ownership arm (SC-4063): a machine does autonomous work only on
+// tickets its own person owns. These pin the arm itself; the end-to-end proof
+// that every pass inherits it is below.
+func TestWorkGate_TicketOwnership(t *testing.T) {
+	gate := WorkGate{reachable: alwaysReachable, identityFor: asPerson("Alice")}
+	card := func(assignee, reporter string) ReconcileCard {
+		return ReconcileCard{Key: "SC-1", Assignee: assignee, Reporter: reporter}
+	}
+
+	t.Run("my ticket is drivable by every intent", func(t *testing.T) {
+		c := card("Alice", "Alice")
+		assert.Len(t, gate.forReview([]ReconcileCard{c}).cards, 1)
+		assert.Len(t, gate.forTakeover([]ReconcileCard{c}).cards, 1)
+		assert.Len(t, gate.forOwnWork([]ReconcileCard{c}).cards, 1)
+	})
+
+	// The bug this exists for: a peer daemon reddening a review it is not running
+	// and cannot observe, on a ticket belonging to someone else.
+	t.Run("another person's ticket reaches no intent", func(t *testing.T) {
+		c := card("Bob", "Bob")
+		assert.Empty(t, gate.forReview([]ReconcileCard{c}).cards)
+		assert.Empty(t, gate.forTakeover([]ReconcileCard{c}).cards)
+		assert.Empty(t, gate.forOwnWork([]ReconcileCard{c}).cards)
+	})
+
+	t.Run("assignee decides when both are recorded", func(t *testing.T) {
+		assert.Empty(t, gate.forReview([]ReconcileCard{card("Bob", "Alice")}).cards)
+		assert.Len(t, gate.forReview([]ReconcileCard{card("Alice", "Bob")}).cards, 1)
+	})
+
+	t.Run("reporter decides when unassigned", func(t *testing.T) {
+		assert.Len(t, gate.forReview([]ReconcileCard{card("", "Alice")}).cards, 1)
+		assert.Empty(t, gate.forReview([]ReconcileCard{card("", "Bob")}).cards)
+	})
+
+	// An unresolved owner is "unknown", never "someone else's". Shortcut hands back
+	// an empty name with the error swallowed when its member lookup fails, so
+	// reading absence as refusal would let one flaky call stand the pipeline down.
+	t.Run("an unresolved owner is worked, not refused", func(t *testing.T) {
+		assert.Len(t, gate.forReview([]ReconcileCard{card("", "")}).cards, 1)
+	})
+
+	// Upgrade safety: an install that has never declared who it is keeps working
+	// exactly as it did before this arm existed.
+	t.Run("no declared identity disables the arm", func(t *testing.T) {
+		open := WorkGate{reachable: alwaysReachable}
+		assert.Len(t, open.forReview([]ReconcileCard{card("Bob", "Bob")}).cards, 1)
+
+		declaredEmpty := WorkGate{reachable: alwaysReachable, identityFor: asPerson()}
+		assert.Len(t, declaredEmpty.forReview([]ReconcileCard{card("Bob", "Bob")}).cards, 1)
+
+		unroutable := WorkGate{reachable: alwaysReachable,
+			identityFor: func(string) OwnerIdentity { return nil }}
+		assert.Len(t, unroutable.forReview([]ReconcileCard{card("Bob", "Bob")}).cards, 1)
+	})
+
+	// One person is a display name on one tracker and a login on another, so the
+	// identity is a set and the comparison ignores case.
+	t.Run("any declared name matches, case-insensitively", func(t *testing.T) {
+		both := WorkGate{reachable: alwaysReachable, identityFor: asPerson("Alice", "alice-gh")}
+		assert.Len(t, both.forReview([]ReconcileCard{card("ALICE-GH", "")}).cards, 1)
+	})
+}
+
+// The end-to-end proof of the choke point on the ownership axis: reconcileOnce
+// hands every writing pass only its gated set, so another person's card is
+// neither reviewed, nor re-driven, nor reddened, nor cleared — by construction,
+// through the one gate, with no per-pass check.
+func TestReconcileOnce_AnotherPersonsWorkIsUntouchedAcrossEveryPass(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	lister := func(context.Context) ([]ReconcileCard, error) {
+		return []ReconcileCard{{
+			Key:      "SC-1",
+			Assignee: "Bob",
+			Reporter: "Bob",
+			Comments: []tracker.Comment{
+				cmt("[human:ready-for-review]\nbranch: feat/x", now.Add(-StuckRunningGrace-time.Minute)),
+				cmt("[human:implementation-started]", now.Add(-StuckRunningGrace-2*time.Minute)),
+			},
+		}}, nil
+	}
+	var chained, driven []string
+	var posted []struct{ Key, Body string }
+	cleared := 0
+	gate := WorkGate{reachable: alwaysReachable, daemonID: "d1", identityFor: asPerson("Alice")}
+
+	reconcileOnce(context.Background(), lister, gate,
+		nil,
+		func(context.Context, string) (bool, error) { return true, nil },
+		func(context.Context, string, string) error { cleared++; return nil },
+		liveAgents(), capturingPoster(&posted), nil,
+		func(k string) error { chained = append(chained, k); return nil },
+		func(k string) error { driven = append(driven, k); return nil },
+		StageRetry{}, nil, nil, "d1", zerolog.Nop())
+
+	assert.Empty(t, chained, "another person's handoff is not reviewed")
+	assert.Empty(t, driven, "another person's loop is not re-driven")
+	assert.Empty(t, posted, "another person's stuck card is not reddened")
+	assert.Zero(t, cleared, "another person's shipped failure is not cleared")
+}
+
+// The shipped-failure pass must NOT ride the review gate: a merged PR's branch is
+// deleted at merge, so a reachability arm would filter out exactly the cards this
+// pass exists to clear. Gating it on ownership alone is what keeps it working.
+func TestReconcileShippedFailures_ClearsEvenWhenTheBranchIsGone(t *testing.T) {
+	cards := []ReconcileCard{{
+		Key:      "SC-1",
+		Assignee: "Alice",
+		Comments: []tracker.Comment{
+			cmt("[human:ready-for-review]\nbranch: autofix/sc-1", time.Unix(1, 0)),
+			cmt("[human:deploy-failed]\nmerge conflict on main\npr: https://github.com/o/r/pull/7", time.Unix(2, 0)),
+		},
+	}}
+	gate := WorkGate{reachable: neverReachable, identityFor: asPerson("Alice")}
+	posted := false
+	merged := func(context.Context, string) (bool, error) { return true, nil }
+	post := func(context.Context, string, string) error { posted = true; return nil }
+
+	n := reconcileShippedFailures(context.Background(), gate.forOwnWork(cards), merged, post, zerolog.Nop())
+
+	assert.Equal(t, 1, n)
+	assert.True(t, posted, "an unreachable branch must not hide a shipped PR")
+}

--- a/internal/daemon/board_reconcile_ticketowner_test.go
+++ b/internal/daemon/board_reconcile_ticketowner_test.go
@@ -134,3 +134,40 @@ func TestReconcileShippedFailures_ClearsEvenWhenTheBranchIsGone(t *testing.T) {
 	assert.Equal(t, 1, n)
 	assert.True(t, posted, "an unreachable branch must not hide a shipped PR")
 }
+
+// SC-4025. A mid-flight PR review loop is a RUNNING stage, so the re-drive pass
+// takes the takeover gate: a loop whose started marker was stamped by another
+// daemon is that machine's to finish. The peer cannot judge it — the verdict it
+// would read lives in the owning host's state store, so an empty read there says
+// nothing about the review, and acting on it reddens a review still in flight.
+//
+// Driven through reconcileOnce rather than the pass directly, because the defect
+// was the pass being handed the wrong gate, not the pass's own logic.
+func TestReconcileOnce_PRLoopStartedElsewhereIsNotRedriven(t *testing.T) {
+	loopCard := func(machine string) []ReconcileCard {
+		return []ReconcileCard{{
+			Key:      "SC-1",
+			Assignee: "Alice",
+			Comments: []tracker.Comment{
+				cmt("[human:ready-for-review]\nbranch: feat/x", time.Unix(1, 0)),
+				cmt(prReviewStartedBody("https://example/pr/7", 7, "feat/x")+"\nmachine: "+machine, time.Unix(2, 0)),
+			},
+		}}
+	}
+	drive := func(cards []ReconcileCard) []string {
+		var driven []string
+		lister := func(context.Context) ([]ReconcileCard, error) { return cards, nil }
+		reconcileOnce(context.Background(), lister,
+			WorkGate{reachable: alwaysReachable, daemonID: "d1", identityFor: asPerson("Alice")},
+			nil, nil, nil, liveAgents(), nil, nil,
+			func(string) error { return nil },
+			func(k string) error { driven = append(driven, k); return nil },
+			StageRetry{}, nil, nil, "d1", zerolog.Nop())
+		return driven
+	}
+
+	assert.Empty(t, drive(loopCard("d2")), "a peer's running loop is not this machine's to judge")
+	// The restart-orphan this pass exists for is unaffected: the daemon id is
+	// persisted, so a restarted daemon still matches its own stamp.
+	assert.Equal(t, []string{"SC-1"}, drive(loopCard("d1")), "this machine still re-drives its own stalled loop")
+}

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -1263,6 +1263,72 @@ func (d BoardTransitionDeps) deploy(ctx context.Context, req BoardTransitionRequ
 	_ = d.DeployBranch(ctx, req.PMKey, req.PMTitle, doneBody(req.PMKey, card), card.Branch)
 }
 
+// settleDraft decides a pull request the machine review loop is still holding,
+// BEFORE the CI gate rather than at the merge.
+//
+// The loop opens its PR draft so a half-reviewed change cannot be merged even if
+// the daemon's own gate failed, and only the loop's approval un-drafts it. A
+// deploy arriving by any other route — the CLI, the board's Deploy, a deploy-fix
+// re-run — used to spend the whole CI wait and then take a forge 405 that named
+// nothing about drafts (SC-4027). Deciding it here means the card says what is
+// actually holding the change, and costs nothing when there is no draft.
+//
+// MergeDraftPR is a person overriding the interlock, so the log says the un-draft
+// was deliberate rather than leaving a silent release in the trail.
+//
+// Extracted from DeployBranch rather than inlined: the gate is already at the
+// complexity ceiling, and "what to do about a draft" is one subject with its own
+// two outcomes.
+func (d BoardTransitionDeps) settleDraft(ctx context.Context, pmKey string, res PRResult, logger zerolog.Logger) error {
+	if !res.Draft {
+		return nil
+	}
+	if !d.MergeDraftPR {
+		return d.deployFailed(pmKey, res.URL, deployReason(
+			"this pull request is held in draft by the machine review loop, so the forge will not merge it — it un-drafts itself when the review approves; to ship it without that, re-run the deploy with --ready",
+			nil))
+	}
+	logger.Info().Int("pr", res.Number).Msg("deploy: un-drafting the reviewed PR on explicit instruction")
+	if err := d.Deployer.MarkReadyForReview(ctx, d.WorkspaceDir, res.Number); err != nil {
+		return d.deployFailed(pmKey, res.URL, deployReason(
+			"the pull request could not be marked ready for merge — open the PR and mark it ready, then re-run Deploy", err))
+	}
+	return nil
+}
+
+// regateAfterRebase re-establishes the two facts a freshness rebase invalidated,
+// and is a no-op when no rebase happened.
+//
+// The force-push rewrote the head, which re-triggers CI on it and clears the
+// forge's cached mergeability. Merging into either of those is the SC-1184 race:
+// GitHub reports the state unstable and 405s a merge on a branch that is
+// perfectly clean. So the CI gate runs again on the rebased head — the
+// mergeability recompute alone does not cover in-flight checks — and then the
+// recompute is waited out.
+//
+// Extracted from DeployBranch to keep that function inside the complexity gate;
+// it is one subject, "the branch moved, so re-check what moving invalidated".
+func (d BoardTransitionDeps) regateAfterRebase(ctx context.Context, pmKey string, res PRResult, branch string, rebased bool, logger zerolog.Logger) error {
+	if !rebased {
+		return nil
+	}
+	logger.Info().Int("pr", res.Number).Msg("deploy: branch was stale; rebased onto the base, re-gating CI")
+	if err := d.waitForChecks(ctx, res); err != nil {
+		if ciFailureFixable(err) {
+			return d.deployFailedOrDispatchFixer(ctx, pmKey, res, ciFailureHeadline(err), err, branch)
+		}
+		return d.deployFailed(pmKey, res.URL, deployReason(ciFailureHeadline(err), err))
+	}
+	if err := d.awaitMergeable(ctx, res.Number); err != nil {
+		headline := "the forge still reports the pull request unmergeable after the freshness rebase — open the PR to see why, then re-run Deploy"
+		if stateUnreadable(err) {
+			headline = "could not read the pull request's mergeability — " + credentialRemedy
+		}
+		return d.deployFailed(pmKey, res.URL, deployReason(headline, err))
+	}
+	return nil
+}
+
 // DeployBranch runs the deterministic deploy gate for pmKey's branch: the
 // already-merged short-circuit, push + PR, the CI gate, the freshness rebase,
 // the merge, branch cleanup, markers, and the ticket close. Failures are both
@@ -1309,24 +1375,8 @@ func (d BoardTransitionDeps) DeployBranch(ctx context.Context, pmKey, title, prB
 			err))
 	}
 	logger.Info().Int("pr", res.Number).Str("url", res.URL).Msg("deploy: pull request open")
-	// A draft is decided before the CI gate, not at the merge. The review loop
-	// opens its PR draft so a half-reviewed change cannot be merged even if the
-	// daemon's own gate failed, and only the loop's approval un-drafts it — so a
-	// deploy arriving by any other route (the CLI, the board's Deploy, a deploy-fix
-	// re-run) would spend the whole CI gate and then be refused by the forge with a
-	// 405 that named nothing about drafts (SC-4027). Say what is holding the
-	// change, and where the interlock is deliberately overridden, say that instead.
-	if res.Draft {
-		if !d.MergeDraftPR {
-			return d.deployFailed(pmKey, res.URL, deployReason(
-				"this pull request is held in draft by the machine review loop, so the forge will not merge it — it un-drafts itself when the review approves; to ship it without that, re-run the deploy with --ready",
-				nil))
-		}
-		logger.Info().Int("pr", res.Number).Msg("deploy: un-drafting the reviewed PR on explicit instruction")
-		if err := d.Deployer.MarkReadyForReview(ctx, d.WorkspaceDir, res.Number); err != nil {
-			return d.deployFailed(pmKey, res.URL, deployReason(
-				"the pull request could not be marked ready for merge — open the PR and mark it ready, then re-run Deploy", err))
-		}
+	if err := d.settleDraft(ctx, pmKey, res, logger); err != nil {
+		return err
 	}
 	if err := d.waitForChecks(ctx, res); err != nil {
 		if ciFailureFixable(err) {
@@ -1362,29 +1412,8 @@ func (d BoardTransitionDeps) DeployBranch(ctx context.Context, pmKey, title, prB
 				ensureErr, branch)
 		}
 	}
-	if rebased {
-		logger.Info().Int("pr", res.Number).Msg("deploy: branch was stale; rebased onto the base, re-gating CI")
-		// The freshness force-push rewrote the head and re-triggered CI on it.
-		// Merging while that fresh run is still in_progress is exactly the
-		// SC-1184 race: GitHub reports mergeable_state unstable and 405s the
-		// merge. Re-gate CI on the rebased head — the mergeability recompute
-		// alone does not cover the in-flight checks — before waiting out the
-		// recompute window.
-		if err := d.waitForChecks(ctx, res); err != nil {
-			if ciFailureFixable(err) {
-				return d.deployFailedOrDispatchFixer(ctx, pmKey, res, ciFailureHeadline(err), err, branch)
-			}
-			return d.deployFailed(pmKey, res.URL, deployReason(ciFailureHeadline(err), err))
-		}
-		// The re-push invalidated the forge's cached mergeability; merging
-		// before the recompute settles draws a spurious 405 on a clean branch.
-		if err := d.awaitMergeable(ctx, res.Number); err != nil {
-			headline := "the forge still reports the pull request unmergeable after the freshness rebase — open the PR to see why, then re-run Deploy"
-			if stateUnreadable(err) {
-				headline = "could not read the pull request's mergeability — " + credentialRemedy
-			}
-			return d.deployFailed(pmKey, res.URL, deployReason(headline, err))
-		}
+	if err := d.regateAfterRebase(ctx, pmKey, res, branch, rebased, logger); err != nil {
+		return err
 	}
 	if err := d.mergeWithRetry(ctx, res.Number); err != nil {
 		return d.deployFailed(pmKey, res.URL, deployReason(

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -97,6 +97,13 @@ type PRRequest struct {
 type PRResult struct {
 	URL    string
 	Number int
+	// Draft reports that the pull request the gate is about to ship is in the
+	// forge's draft state. It is carried out of PR creation/adoption because the
+	// deploy gate cannot otherwise know: the review loop opens its PR draft on
+	// purpose, and an adopted PR is returned as-is, so a deploy driven by anything
+	// other than the loop's own approval reaches the merge with no idea the change
+	// is still held for review (SC-4027).
+	Draft bool
 }
 
 // deployWaitHeartbeat is how many CI polls pass between "still running" log
@@ -173,6 +180,13 @@ type BoardTransitionDeps struct {
 	// Empty leaves markers un-signed (the signer's empty-machine no-op), so an
 	// un-provisioned daemon still functions.
 	DaemonID string
+	// MergeDraftPR authorizes the deploy gate to un-draft a pull request the
+	// machine review loop is still holding, and ship it. It is a person saying "I
+	// have judged this reviewed enough", so it is set only from an explicit
+	// gesture (`human deploy --ready`) and never by an automatic path: the draft is
+	// the interlock that stops a half-reviewed change merging when the daemon's own
+	// gate fails, and a machine that could clear its own interlock has none.
+	MergeDraftPR bool
 	// Logger records best-effort post-merge failures (e.g. a failed automated
 	// close) and the deploy gate's progress. The zero value is a safe no-op
 	// writer, so an un-wired path stays valid without a logger — but wire one
@@ -1295,6 +1309,25 @@ func (d BoardTransitionDeps) DeployBranch(ctx context.Context, pmKey, title, prB
 			err))
 	}
 	logger.Info().Int("pr", res.Number).Str("url", res.URL).Msg("deploy: pull request open")
+	// A draft is decided before the CI gate, not at the merge. The review loop
+	// opens its PR draft so a half-reviewed change cannot be merged even if the
+	// daemon's own gate failed, and only the loop's approval un-drafts it — so a
+	// deploy arriving by any other route (the CLI, the board's Deploy, a deploy-fix
+	// re-run) would spend the whole CI gate and then be refused by the forge with a
+	// 405 that named nothing about drafts (SC-4027). Say what is holding the
+	// change, and where the interlock is deliberately overridden, say that instead.
+	if res.Draft {
+		if !d.MergeDraftPR {
+			return d.deployFailed(pmKey, res.URL, deployReason(
+				"this pull request is held in draft by the machine review loop, so the forge will not merge it — it un-drafts itself when the review approves; to ship it without that, re-run the deploy with --ready",
+				nil))
+		}
+		logger.Info().Int("pr", res.Number).Msg("deploy: un-drafting the reviewed PR on explicit instruction")
+		if err := d.Deployer.MarkReadyForReview(ctx, d.WorkspaceDir, res.Number); err != nil {
+			return d.deployFailed(pmKey, res.URL, deployReason(
+				"the pull request could not be marked ready for merge — open the PR and mark it ready, then re-run Deploy", err))
+		}
+	}
 	if err := d.waitForChecks(ctx, res); err != nil {
 		if ciFailureFixable(err) {
 			return d.deployFailedOrDispatchFixer(ctx, pmKey, res, ciFailureHeadline(err), err, branch)
@@ -1558,6 +1591,12 @@ func isTransientMergeRefusal(err error) bool {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
+	// A draft refusal is also a 405, and it is the opposite of transient: nothing
+	// about the branch changes while it is retried, so matching it here spent the
+	// full retry window on a refusal that was never going to lift (SC-4027).
+	if strings.Contains(msg, "still a draft") {
+		return false
+	}
 	return strings.Contains(msg, "not mergeable") || strings.Contains(msg, "405")
 }
 

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -1046,6 +1046,14 @@ func (d BoardTransitionDeps) escalatePRLoop(ctx context.Context, pmKey string, c
 	if _, open := openOptionsBlock(comments); open {
 		return nil
 	}
+	// Already escalated and nothing has moved since: say it once. A single run can
+	// produce two events that both look like its exit — the hook fires StopFailure
+	// on an API error and Stop when the turn ends, and the parser's own contract
+	// is that a Stop may follow a StopFailure — which drove this twice sixteen
+	// seconds apart on SC-3613 and posted the identical marker both times.
+	if _, latest := latestStateInStage(comments, BoardDoneStage); strings.HasPrefix(strings.TrimSpace(latest.Body), PRReviewFailedHeader) {
+		return nil
+	}
 	stage := latestPRLoopStage(comments)
 	if stage == PRStageFix && outcome.FixExit != PRFixDone {
 		var b strings.Builder

--- a/internal/daemon/board_unavailable.go
+++ b/internal/daemon/board_unavailable.go
@@ -56,6 +56,12 @@ func classifyErrorType(errorType string) (endingKind, string) {
 		return endingPaused, "model usage limit"
 	case t == "overloaded" || t == "overloaded_error":
 		return endingPaused, "model API overloaded"
+	// The model API's own 5xx. It is the substrate failing, not the work, and
+	// Claude Code retries through it — so a run that carries on past one must not
+	// have been charged for it, and one that does not is still an outage rather
+	// than a stage that decided something wrong (SC-4026).
+	case t == "server_error" || t == "api_error":
+		return endingPaused, "model API returned an error"
 	case t == "authentication_error" || t == "auth":
 		return endingNeedsPerson, "model API authentication was refused"
 	case strings.Contains(t, "billing") || strings.Contains(t, "credit"):

--- a/internal/daemon/deploy_draft_test.go
+++ b/internal/daemon/deploy_draft_test.go
@@ -1,0 +1,113 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/forge"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// draftDeployDeps wires a deploy whose PR is adopted in the forge's draft state —
+// what every deploy that did not come through the review loop's own approval
+// finds, because the loop opens its PR draft and only approval un-drafts it.
+func draftDeployDeps(t *testing.T, mergeDraft bool) (*fakeCommenter, *fakeDeployer, BoardTransitionDeps) {
+	t.Helper()
+	c := &fakeCommenter{}
+	d := &fakeDeployer{
+		res:    PRResult{URL: "https://example/pr/7", Number: 7, Draft: true},
+		checks: []forge.ChecksState{forge.ChecksPassing},
+	}
+	deps := newDeps(c, &fakeLauncher{}, d)
+	deps.MergeDraftPR = mergeDraft
+	return c, d, deps
+}
+
+// SC-4027. The forge reports a conflict-free draft as mergeable, so nothing
+// upstream catches it and the gate used to spend the whole CI wait and then take
+// a 405 that named nothing about drafts. Decide it before the CI gate, and say
+// what is actually holding the change.
+func TestDeployBranch_DraftPRIsRefusedWithItsRealReason(t *testing.T) {
+	c, d, deps := draftDeployDeps(t, false)
+
+	err := deps.DeployBranch(context.Background(), "SC-1", "SC-1", "body", "autofix/sc-1")
+
+	require.Error(t, err)
+	assert.Zero(t, d.merged, "a draft must not reach the merge")
+	assert.Zero(t, d.checkCall, "nor spend the CI gate first")
+	assert.Zero(t, d.markReadyCall, "and must not be un-drafted without being asked")
+
+	body, ok := posted(c, DeployFailedHeader)
+	require.True(t, ok, "the card must say why")
+	assert.Contains(t, body, "held in draft by the machine review loop")
+	assert.Contains(t, body, "--ready")
+}
+
+// The person's gesture: --ready means "I have judged this reviewed enough". It
+// un-drafts and ships, which is the whole point of having a gesture at all.
+func TestDeployBranch_ReadyOverrideUnDraftsAndMerges(t *testing.T) {
+	_, d, deps := draftDeployDeps(t, true)
+
+	require.NoError(t, deps.DeployBranch(context.Background(), "SC-1", "SC-1", "body", "autofix/sc-1"))
+
+	assert.Equal(t, 7, d.markedReady, "the held PR is released deliberately")
+	assert.Equal(t, 1, d.merged)
+}
+
+// A non-draft PR is untouched: the change adds a stop, not a step.
+func TestDeployBranch_NonDraftPRIsUnaffected(t *testing.T) {
+	c := &fakeCommenter{}
+	d := &fakeDeployer{
+		res:    PRResult{URL: "https://example/pr/7", Number: 7},
+		checks: []forge.ChecksState{forge.ChecksPassing},
+	}
+	deps := newDeps(c, &fakeLauncher{}, d)
+
+	require.NoError(t, deps.DeployBranch(context.Background(), "SC-1", "SC-1", "body", "autofix/sc-1"))
+
+	assert.Zero(t, d.markReadyCall, "nothing to un-draft")
+	assert.Equal(t, 1, d.merged)
+}
+
+// The loop's own approval path is the one caller that legitimately ships a PR
+// that WAS draft: it un-drafts first, so by the time the engine re-adopts it the
+// PR is ready and the new refusal never fires.
+func TestAdvancePRLoop_ApprovedStillMergesThroughTheDraftCheck(t *testing.T) {
+	c := &fakeCommenter{comments: reviewStartedComments(1, "https://example/pr/7", 7, "feat/x")}
+	c.comments = append(c.comments,
+		cmt("[human:ready-for-review]\nbranch: feat/x", time.Unix(1, 0)))
+	d := &fakeDeployer{
+		res:    PRResult{URL: "https://example/pr/7", Number: 7},
+		checks: []forge.ChecksState{forge.ChecksPassing},
+	}
+	deps := newDeps(c, &fakeLauncher{}, d)
+
+	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", PRLoopOutcome{
+		ReviewVerdict: PRVerdictApproved, ReviewRecorded: true, FixRecorded: true,
+	}))
+
+	assert.Equal(t, 7, d.markedReady, "the loop un-drafts on approval, as before")
+	assert.Equal(t, 1, d.merged)
+}
+
+// isTransientMergeRefusal matched any 405, and a draft refusal is a 405 — so the
+// merge was retried for the full window on a refusal that could never lift.
+func TestIsTransientMergeRefusal_DraftIsTerminal(t *testing.T) {
+	draft := errForTest("github PUT /repos/o/r/pulls/450/merge returned 405: " +
+		`{"message":"Pull Request is still a draft"}`)
+	stale := errForTest("github PUT /repos/o/r/pulls/450/merge returned 405: " +
+		`{"message":"Pull Request is not mergeable"}`)
+
+	assert.False(t, isTransientMergeRefusal(draft), "nothing about the branch changes while a draft is retried")
+	assert.True(t, isTransientMergeRefusal(stale), "the racy post-rebase refusal still rides out")
+}
+
+type errForTest string
+
+func (e errForTest) Error() string { return string(e) }
+
+var _ tracker.Commenter = (*fakeCommenter)(nil)

--- a/internal/daemon/pr_loop_midrun_test.go
+++ b/internal/daemon/pr_loop_midrun_test.go
@@ -1,0 +1,80 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// SC-4026. The hook fires StopFailure on a model API error and Claude Code
+// retries through it, so the run carries on. Driving the loop on that event reads
+// a verdict the step has not written yet and reds a review that is still working
+// — measured on SC-3613, where a server_error escalated the card nine seconds
+// after it arrived and the reviewer went on to approve 83 seconds later.
+func TestDrivePRLoopExit_SubstrateFailureIsNotAnExit(t *testing.T) {
+	transient := []string{"server_error", "api_error", "overloaded", "rate_limit"}
+	for _, errorType := range transient {
+		t.Run(errorType, func(t *testing.T) {
+			var advanced []string
+			var reclaimed []string
+
+			handled := drivePRLoopExit("SC-1", prReviewAgentStage, "board-SC-1-prreview", errorType,
+				func(pmKey, _, _ string) error { advanced = append(advanced, pmKey); return nil },
+				func(name string) { reclaimed = append(reclaimed, name) },
+				zerolog.Nop())
+
+			assert.True(t, handled, "the event belongs to the loop and is consumed here")
+			assert.Empty(t, advanced, "a run that is still retrying has not produced an outcome to act on")
+			// The fixer's deliverable is an unpushed local commit; the handoff flag
+			// authorizes removing its worktree, so it must not be flipped on an error
+			// the run then recovers from.
+			assert.Empty(t, reclaimed, "the worktree stays protected while the run continues")
+		})
+	}
+}
+
+// The other half: a genuine exit still drives the loop. Without this the fix
+// would be indistinguishable from switching the loop off.
+func TestDrivePRLoopExit_RealExitStillDrivesTheLoop(t *testing.T) {
+	for _, errorType := range []string{"", "unrecognised_thing"} {
+		t.Run("errorType="+errorType, func(t *testing.T) {
+			var advanced []string
+			var reclaimed []string
+
+			handled := drivePRLoopExit("SC-1", prFixAgentStage, "board-SC-1-prfix", errorType,
+				func(pmKey, _, _ string) error { advanced = append(advanced, pmKey); return nil },
+				func(name string) { reclaimed = append(reclaimed, name) },
+				zerolog.Nop())
+
+			assert.True(t, handled)
+			assert.Equal(t, []string{"SC-1"}, advanced)
+			assert.Equal(t, []string{"board-SC-1-prfix"}, reclaimed)
+		})
+	}
+}
+
+// A single run can produce two events that both look like its exit: the hook
+// fires StopFailure on an API error and Stop when the turn ends, and a Stop may
+// follow a StopFailure by contract. On SC-3613 that posted the identical
+// escalation twice, sixteen seconds apart. Nothing moved in between, so the card
+// must say it once.
+func TestEscalatePRLoop_DoesNotRepeatItself(t *testing.T) {
+	c := &fakeCommenter{comments: reviewStartedComments(1, "https://example/pr/7", 7, "feat/x")}
+	deps := newDeps(c, &fakeLauncher{}, &fakeDeployer{})
+	outcome := PRLoopOutcome{ReviewRecorded: false}
+
+	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", outcome))
+	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", outcome))
+
+	failures := 0
+	for _, cm := range c.comments {
+		if strings.HasPrefix(strings.TrimSpace(cm.Body), PRReviewFailedHeader) {
+			failures++
+		}
+	}
+	assert.Equal(t, 1, failures, "the second drive of the same dead round adds nothing to say")
+}

--- a/internal/forge/github/client.go
+++ b/internal/forge/github/client.go
@@ -178,6 +178,7 @@ func (c *Client) FindOpenPullRequest(ctx context.Context, repoName, head string)
 				Repo:   repoName,
 				Head:   head,
 				Title:  item.Title,
+				Draft:  item.Draft,
 				Number: item.Number,
 				URL:    item.HTMLURL,
 			}, nil

--- a/internal/forge/github/types.go
+++ b/internal/forge/github/types.go
@@ -96,7 +96,12 @@ type pullListItem struct {
 	Title   string `json:"title"`
 	HTMLURL string `json:"html_url"`
 	State   string `json:"state"`
-	Head    struct {
+	// Draft is why a deploy that adopts this PR may not be able to merge it. The
+	// review loop opens its PR draft on purpose, and a draft that is otherwise
+	// clean is still reported mergeable by the REST API, so this field is the only
+	// thing that distinguishes the two (SC-4027).
+	Draft bool `json:"draft"`
+	Head  struct {
 		Ref string `json:"ref"`
 	} `json:"head"`
 }

--- a/internal/pipelinefsm/pipeline-fsm.json
+++ b/internal/pipelinefsm/pipeline-fsm.json
@@ -822,7 +822,7 @@
       "dst": "stopped",
       "actor": "daemon",
       "marker": "[human:pr-review-failed]",
-      "doc": "Budget spent, unreviewable, or an outcome it cannot parse. It never merges on a state it cannot read.",
+      "doc": "Budget spent, unreviewable, or an outcome it cannot parse. It never merges on a state it cannot read. What does NOT fire it: a substrate failure mid-run. The hook reports a model API error as StopFailure and Claude Code retries through it, so the run carries on — driving the loop there read a verdict the reviewer had not written yet and reddened a review that went on to approve (SC-4026). Such an event is consumed and ignored; a run that genuinely dies on one is recovered by the durable re-drive, on the machine that owns the stage. It also fires at most once per dead round: one run can raise both a StopFailure and a Stop, and an escalation with nothing changed since the last one is not restated.",
       "where": "internal/daemon/board_transition.go AdvancePRLoop — prEscalationReason names which of the three it was"
     },
     {

--- a/internal/pipelinefsm/pipeline-fsm.json
+++ b/internal/pipelinefsm/pipeline-fsm.json
@@ -1064,8 +1064,9 @@
     }
   ],
   "ownership": {
-    "doc": "Which machine may fire a transition. A stage is stamped with the daemon that posted its deciding marker (BoardCard.StageDaemonID, from the marker's machine: field).",
+    "doc": "Who may fire a transition, on two axes. Whose TICKET it is: the assignee, or the reporter when unassigned (daemon.OwnerOf), compared against the machine's declared identity (the .humanconfig `me:` section). Which MACHINE holds a running stage: the daemon that posted the stage's deciding marker (BoardCard.StageDaemonID, from the marker's machine: field). The ticket axis decides whether this machine touches the item at all; the machine axis decides who may take over a stage already running.",
     "rules": [
+      "A machine does autonomous work only on tickets its own person owns: WorkGate.mineToWork in internal/daemon/board_reconcile_gate.go, checked before any intent, so every reconcile pass that writes to a ticket inherits it. Two absences both mean carry on rather than refuse — no identity declared (an install that never said whose work this machine does keeps working as before) and no owner resolvable on the card (an empty owner is unknown, not someone else's, and a tracker that fails to resolve a member name returns exactly that). Only a resolved owner who is demonstrably not this machine's person refuses.",
       "The machine acting on its own initiative — the reconcile takeover pass — refuses a stage another daemon stamped: WorkGate.ownedHereOrUnowned in internal/daemon/board_reconcile_gate.go. An unstamped stage (single-daemon, or a thread written before stamping) is takeable by anyone.",
       "A human gesture is NOT restricted by ownership. Racing a live foreign run is prevented instead by idempotency: a running card refuses every drop (isDuplicateDrop), whichever machine started it.",
       "Ownership is carried to the board as stageDaemonId so a reader can tell a stage owned elsewhere from an unowned one. It is the missing input for liveness across machines: no agent running HERE means dead only if this machine owns the stage."

--- a/internal/pipelinefsm/pipeline-fsm.json
+++ b/internal/pipelinefsm/pipeline-fsm.json
@@ -1117,7 +1117,7 @@
         "if_nothing_happens": "The durable reconcile pass (every ~2 minutes) posts [human:deploy-failed] and relaunches in place. TWO budgets bound that, and which one is spent depends on how the stage died. A vanished agent is an unexplained death and is charged: DefaultStageRetries (2). An agent this pass judged hung and stopped itself is NOT charged — the work did not fail, a judgement about it did — but repetition is bounded separately by MaxSilenceReaps (3), past which the machine stops relaunching and says a person is needed."
       },
       "pr-loop": {
-        "stale_when": "No loop half-agent alive on this machine. The generic stuck-running pass deliberately SKIPS a loop card (doneStageLoopActive), so a loop is recovered by re-driving rather than by redding.",
+        "stale_when": "No loop half-agent alive on the machine that owns the stage — the same ownership qualifier the other stage rules carry, and the one this rule was missing. A loop's outcome lives in the owning host's agent state store and is never posted to the tracker, so 'no agent alive HERE' is evidence only on the machine that started it; read as a fleet-wide fact it made a peer red a review that was still running and went on to approve (SC-4025). The generic stuck-running pass deliberately SKIPS a loop card (doneStageLoopActive), so a loop is recovered by re-driving rather than by redding.",
         "if_nothing_happens": "reconcilePRLoops re-reads the recorded state and advances or escalates, idempotently. Bounded by DefaultPRReviewRounds (3); past it the loop escalates rather than merging on a state it cannot read."
       }
     }

--- a/internal/pipelinefsm/pipeline-fsm.json
+++ b/internal/pipelinefsm/pipeline-fsm.json
@@ -810,7 +810,7 @@
       "dst": "ci-gate",
       "actor": "daemon",
       "where": "board_transition.go AdvancePRLoop",
-      "doc": "The reviewer approved. The draft is un-drafted and the item goes to the CI gate. Recorded as a marker like every other outcome of the loop — success used to be the only transition here that left no trace, so a reader could not tell an approved review whose merge is running from a review still in flight. It also retires the loop sub-phase, so the badge stops reading 'PR review…' through the CI gate, rebase and merge.",
+      "doc": "The reviewer approved. The draft is un-drafted and the item goes to the CI gate. This is the approval route, and it is not the only way in: the deploy gate itself now refuses a pull request it finds still in draft, before the CI wait rather than at the merge, and says the review loop is holding it — a person who has judged it reviewed enough overrides that with `human deploy --ready`, which un-drafts and ships (SC-4027). No automatic path clears the interlock, because a machine that can clear its own interlock has none. Recorded as a marker like every other outcome of the loop — success used to be the only transition here that left no trace, so a reader could not tell an approved review whose merge is running from a review still in flight. It also retires the loop sub-phase, so the badge stops reading 'PR review…' through the CI gate, rebase and merge.",
       "marker": "[human:pr-review-passed]"
     },
     {


### PR DESCRIPTION
A peer daemon was reddening, claiming and escalating work it was not running and
could not observe. Measured on this board, all from one machine on tickets owned
by someone else: `pr-review-failed` on SC-3569 at 21, 12 and 117 seconds into the
owner's review rounds, on SC-3581 twice, on SC-3613 twice, plus a `[human:options]`
decision block posted onto SC-3569.

The damage was not the red badge. SC-3569 has three `pr-review-started` markers in
its whole history; two were killed within seconds and no review ran in either.
`DefaultPRReviewRounds` is 3. The third round ran, recorded `changes-requested`
with a real blocking finding — and the loop escalated with "the machine review did
not converge within the round budget". It converged on its first real round. The
fixer never ran.

## Whose ticket is this?

Nothing anywhere asked. The daemon had two ownership notions and neither answers
it: `ownedHereOrUnowned` compares the MACHINE stamped on a stage's deciding
marker, binds only the takeover passes, and passes any unstamped stage — which is
most of them, because only daemon-posted markers carry a `machine:` line and the
ones agents post through `human marker post` do not. `ProjectParticipation` asks
whether this machine opted into the project.

The facts were already there and already parsed: the issue's assignee and
reporter, and the `me:` identity `internal/board` already dims by. `WorkGate`
now asks before any intent, so every pass that writes to a ticket inherits the
answer instead of remembering to ask.

Two absences mean carry on, not refuse — an install that declares no identity
keeps today's behaviour rather than stopping dead on upgrade, and an owner that
did not resolve is unknown rather than someone else's, because Shortcut returns an
empty name with the error swallowed and one flaky members call must not stand the
pipeline down.

## SC-4025 — a running loop belongs to the machine running it

The PR-loop re-drive took `forReview`, which by design has no ownership arm: a
handoff is finished work. A mid-flight review is not finished work, and that is
exactly where the gate's two intents split. A peer cannot judge it even in
principle — the verdict lives in `stage.pr-review` in the owning host's state
store and is never posted to the tracker, so a peer reads its own empty store and
concludes the reviewer recorded nothing. Reachability was never going to catch it:
the loop pushes its branch before opening the draft PR.

The FSM document's `pr-loop` liveness rule said "on this machine" where the other
four stage rules say "on the machine that owns the stage". It described the defect
as the rule. Corrected in the same commit.

## SC-4026 — a model API error mid-review is not the reviewer's exit

The hook reports a model API error as `StopFailure` and Claude Code retries
through it. The loop drove on that event regardless, read a verdict the step had
not written, and reddened a review still working: on SC-3613 a `server_error` at
08:42:16 escalated at 08:42:25, and the reviewer recorded `approved` at 08:43:39
and exited 0 at 08:44:06. Four of SC-3581's six false markers were this path with
no peer involved.

Liveness cannot decide it — the hook runs inside the claude process, so asking
whether claude is alive races the process's own exit. The error type can, and
`classifyErrorType` already knew how to read it; the loop returned long before
reaching it.

Two further consequences of the same event: the worktree handoff was flipped on a
mid-run error, waiving removal protection on a FIXER whose deliverable is an
unpushed local commit; and the escalation repeated itself, because one run can
raise both a `StopFailure` and a `Stop`. The state-read settle bound goes from 6
seconds to 100 — set by the 67-second gap in the real incident, and free in the
ordinary case where a real exit is fresh on the first read.

## SC-4027 — a deploy that finds a draft says so

Every PR the loop opens is a draft, on purpose. Only approval un-drafts it, and
the un-draft lived in that one caller — so `human deploy` waited out the whole CI
gate and was refused with "the forge refused the merge — open the PR to see why".
It could not have known: an adopted PR is returned as-is, `pullListItem` did not
decode `draft`, and `PRResult` had nowhere to put it. Nothing upstream covered for
it either, because the forge reports a conflict-free draft as mergeable.

And it was slow: `isTransientMergeRefusal` matches any 405, which is also what a
draft refusal is, so the merge was retried every three seconds for a full minute
on a refusal that could never lift.

`human deploy --ready` is the person's override. No automatic path sets it — a
machine that can clear its own interlock has none.

## Verification

Every fix was reverted in place to confirm its tests go red, then restored. The
substrate-failure, draft-refusal, ownership and loop-gate tests all fail before
and pass after.

`make check` green (4962 tests, lint 0 issues, gocyclo clean), `go test ./cmd/...`
green, `make fsm` well-formed. `DeployBranch` went over the complexity ceiling and
two stages were extracted — `settleDraft` and `regateAfterRebase` — each already
one subject.

## Not fixed here

**SC-4082.** The hook path drives the pipeline on a ticket key taken from
`HUMAN_AGENT_NAME` over a token-authenticated route, with no check that this
machine launched the agent. The obvious fix races agent cleanup and would drop
legitimate exits, stranding cards — worse than the hole. It needs a fact that
outlives cleanup, or the ownership question asked from the ticket.

**SC-3195** (read-side disregard of a foreign verdict) stays closed by decision:
it exists because a write-side rule is only as strong as the fleet's oldest
daemon, and the standing assumption is that every daemon upgrades.

Two daemons belonging to the same user still race each other on the ticket axis;
that is the machine axis, which SC-4025 covers for the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)