### PR TITLE
[SC-4118] Write every daemon marker through the protocol that owns them

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -875,8 +875,7 @@ func runDaemonForeground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string,
 		if err != nil {
 			return err
 		}
-		_, err = commenter.AddComment(postCtx, pmKey,
-			daemon.DeployedHeader+"\npr: "+prURL)
+		_, err = commenter.AddComment(postCtx, pmKey, daemon.DeployedBody(prURL))
 		return err
 	}
 	// A live container is not a working agent. The hook stream is the progress

--- a/cmd/cmdfsm/fsm.go
+++ b/cmd/cmdfsm/fsm.go
@@ -134,6 +134,7 @@ func buildMarkerCmd() *cobra.Command {
 				"marker":           pipelinefsm.MarkerHeader(name),
 				"type":             name,
 				"required_fields":  marker.RequiredFields(name),
+				"any_of_fields":    marker.AnyOfFields(name),
 				"moves_an_item":    len(uses) > 0,
 				"moves":            moves,
 				"records_content":  listed,

--- a/cmd/cmdfsm/fsm_test.go
+++ b/cmd/cmdfsm/fsm_test.go
@@ -39,7 +39,11 @@ func TestMarker_ReportsWhereItMovesAnItem(t *testing.T) {
 	assert.Equal(t, "[human:deployed]", got["marker"])
 	assert.Equal(t, true, got["moves_an_item"])
 	assert.NotEmpty(t, got["moves"])
-	assert.Contains(t, got["required_fields"], "pr", "the caller is told what the marker requires")
+	// deployed must say HOW the work shipped, and either field answers it, so
+	// the contract is a one-of rather than a required list. The caller is told
+	// both ways out — otherwise an already-merged branch has no postable marker.
+	assert.Contains(t, got["any_of_fields"], "pr", "the caller is told what the marker requires")
+	assert.Contains(t, got["any_of_fields"], "merged")
 }
 
 // Either form answers: a caller says a marker the way it posts it, and the

--- a/internal/daemon/board_claim.go
+++ b/internal/daemon/board_claim.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/marker"
 	"github.com/gethuman-sh/human/internal/tracker"
 )
 
@@ -52,7 +53,7 @@ func (d BoardTransitionDeps) winClaim(ctx context.Context, pmKey string, stage B
 	if strings.TrimSpace(d.DaemonID) == "" {
 		return true, nil
 	}
-	body := ClaimHeader + "\n" + ClaimStagePrefix + " " + string(stage)
+	body := markerBody(marker.Marker{Type: MarkerClaim, Fields: fields("stage", string(stage))})
 	posted, err := d.Commenter.AddComment(ctx, pmKey, body)
 	if err != nil {
 		return false, errors.WrapWithDetails(err, "posting stage claim", "pm", pmKey, "stage", string(stage))

--- a/internal/daemon/board_failure.go
+++ b/internal/daemon/board_failure.go
@@ -221,8 +221,8 @@ func handleBoardAgentExit(ctx context.Context, runs *RunRegistry, runID, agentNa
 	if handleSilenceReapExit(ctx, pmKey, stage, agentName, errorType, comments, commenter, retry, logger) {
 		return
 	}
-	body := failedHeaderFor(stage) + "\n" + appendModelOutcomeNote(failureMarkerBody(diagnose, agentName, errorType), latestClass, pmKey, string(stage))
-	if _, err := commenter.AddComment(ctx, pmKey, body); err != nil {
+	diagnosis := appendModelOutcomeNote(failureMarkerBody(diagnose, agentName, errorType), latestClass, pmKey, string(stage))
+	if err := postMarker(ctx, commenter, pmKey, failureMarker(failedTypeFor(stage), diagnosis)); err != nil {
 		logger.Warn().Err(err).Str("agent", agentName).Msg("board failure: cannot post failed marker")
 		// Without the failed marker the card does not derive to a failed state,
 		// which is precisely what every in-place retry transition requires — so
@@ -333,8 +333,9 @@ func chainReviewAfterCleanBuild(ctx context.Context, pmKey, agentName, errorType
 			if verificationAgentAlive(pmKey, liveAgents, logger) {
 				return
 			}
-			body := ReviewFailedHeader + "\n" + failureMarkerBody(diagnose, agentName, errorType) +
-				"\n\n" + handoffSearchNote(BoardVerification, ReviewCompleteHeader)
+			failed := failureMarker(MarkerReviewFailed, failureMarkerBody(diagnose, agentName, errorType))
+			failed.Body = strings.TrimSpace(failed.Body + "\n\n" + handoffSearchNote(BoardVerification, ReviewCompleteHeader))
+			body := markerBody(failed)
 			if _, err := commenter.AddComment(ctx, pmKey, body); err != nil {
 				logger.Warn().Err(err).Str("pm", pmKey).Msg("board merged-stage: cannot post review-failed after mid-review exit")
 			}
@@ -354,12 +355,11 @@ func handleNeedsPersonExit(ctx context.Context, pmKey string, stage BoardStage, 
 	if kind != endingNeedsPerson {
 		return false
 	}
-	header := failedHeaderFor(stage)
-	if header == "" {
+	failedType := failedTypeFor(stage)
+	if failedType == "" {
 		return false
 	}
-	body := header + "\n" + needsPersonReason(reason)
-	if _, err := commenter.AddComment(ctx, pmKey, body); err != nil {
+	if err := postMarker(ctx, commenter, pmKey, failureMarker(failedType, needsPersonReason(reason))); err != nil {
 		logger.Warn().Err(err).Str("agent", agentName).Msg("board failure: cannot post needs-person marker")
 	}
 	return true
@@ -379,8 +379,8 @@ func handleSilenceReapExit(ctx context.Context, pmKey string, stage BoardStage, 
 	if !ok || !retry.enabled() {
 		return false
 	}
-	header := failedHeaderFor(stage)
-	if header == "" {
+	failedType := failedTypeFor(stage)
+	if failedType == "" {
 		return false
 	}
 	if silenceReapGaveUp(comments, stage) {
@@ -388,14 +388,13 @@ func handleSilenceReapExit(ctx context.Context, pmKey string, stage BoardStage, 
 	}
 	stops := silenceReapCount(comments, stage) + 1
 	if stops > MaxSilenceReaps {
-		body := header + "\n" + silenceReapGiveUpReason(stage, stops)
-		if _, err := commenter.AddComment(ctx, pmKey, body); err != nil {
+		giveUp := failureMarker(failedType, silenceReapGiveUpReason(stage, stops))
+		if err := postMarker(ctx, commenter, pmKey, giveUp); err != nil {
 			logger.Warn().Err(err).Str("agent", agentName).Msg("board failure: cannot post silence-reap give-up marker")
 		}
 		return true
 	}
-	body := header + "\n" + silenceReapReason(idle)
-	if _, err := commenter.AddComment(ctx, pmKey, body); err != nil {
+	if err := postMarker(ctx, commenter, pmKey, failureMarker(failedType, silenceReapReason(idle))); err != nil {
 		logger.Warn().Err(err).Str("agent", agentName).Msg("board failure: cannot post silence-reap marker")
 		return true
 	}
@@ -579,9 +578,9 @@ func chainReviewAfterBuild(ctx context.Context, pmKey string, comments []tracker
 	case ProbeAbsent:
 		// A definite phantom-commit handoff (a retry that never pushed its work) —
 		// the loud failure the ticket wants: red the card, do not review nothing.
-		body := ImplementationFailedHeader +
-			"\nhandoff names commits absent from branch " + branch + " on this machine — re-run the fix"
-		if _, err := commenter.AddComment(ctx, pmKey, body); err != nil {
+		phantom := failureMarker(MarkerImplementationFailed,
+			"handoff names commits absent from branch "+branch+" on this machine — re-run the fix")
+		if err := postMarker(ctx, commenter, pmKey, phantom); err != nil {
 			logger.Warn().Err(err).Str("pm", pmKey).Msg("board chain: cannot post phantom-commit failure")
 		}
 		return
@@ -602,10 +601,12 @@ func chainReviewAfterBuild(ctx context.Context, pmKey string, comments []tracker
 // state, so the durable reconcile pass retries the check — an unreadable probe
 // is left/retried, never treated as evidence of missing work (SC-2403).
 func postHandoffCheckUnreadable(ctx context.Context, pmKey, branch, detail string, commenter tracker.Commenter, daemonID string, logger zerolog.Logger) {
-	body := HandoffCheckUnreadableHeader +
-		"\ncould not verify the handoff for branch " + branch + " on this machine — " + detail +
-		"\nleaving the card for a daemon that can complete the check; it will be retried."
-	if _, err := commenter.AddComment(ctx, pmKey, body); err != nil {
+	unreadable := marker.Marker{
+		Type: MarkerHandoffCheckUnreadable,
+		Body: "could not verify the handoff for branch " + branch + " on this machine — " + detail +
+			"\nleaving the card for a daemon that can complete the check; it will be retried.",
+	}
+	if err := postMarker(ctx, commenter, pmKey, unreadable); err != nil {
 		logger.Warn().Err(err).Str("pm", pmKey).Msg("board chain: cannot post handoff-check-unreadable diagnostic")
 	}
 }

--- a/internal/daemon/board_failure_test.go
+++ b/internal/daemon/board_failure_test.go
@@ -958,7 +958,7 @@ func TestHandleBoardAgentExit_UsesDiagnoserHeadlineAndDetail(t *testing.T) {
 	defer c.mu.Unlock()
 	require.Len(t, c.added, 1)
 	body := c.added[0]
-	want := ImplementationFailedHeader + "\nclaude exited with code 1: API Error\n\nagent: board-SC-1-implementation\n\nlast output:\n~~~\nboom\n~~~"
+	want := ImplementationFailedHeader + "\nreason: claude exited with code 1: API Error\n\nagent: board-SC-1-implementation\n\nlast output:\n~~~\nboom\n~~~"
 	assert.Equal(t, want, body)
 	// Contract pin: the card's one-line error is exactly the headline.
 	assert.Equal(t, "claude exited with code 1: API Error", failureReason(body))
@@ -976,7 +976,7 @@ func TestHandleBoardAgentExit_NilDiagnoserFallsBackToGeneric(t *testing.T) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	require.Len(t, c.added, 1)
-	assert.Equal(t, PlanningFailedHeader+"\n"+genericStageFailure, c.added[0])
+	assert.Equal(t, PlanningFailedHeader+"\nreason: "+genericStageFailure, c.added[0])
 }
 
 // SC-2555 step 5b: a recorded failing model-call class is appended to the failed
@@ -1036,7 +1036,7 @@ func TestHandleBoardAgentExit_ModelOutcomeAdditiveWhenOKOrAbsent(t *testing.T) {
 			c.mu.Lock()
 			defer c.mu.Unlock()
 			require.Len(t, c.added, 1)
-			assert.Equal(t, PlanningFailedHeader+"\n"+genericStageFailure, c.added[0],
+			assert.Equal(t, PlanningFailedHeader+"\nreason: "+genericStageFailure, c.added[0],
 				"the marker must be byte-for-byte unchanged when no failing outcome is recorded")
 		})
 	}
@@ -1055,7 +1055,7 @@ func TestHandleBoardAgentExit_EmptyHeadlineFallsBackToGeneric(t *testing.T) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	require.Len(t, c.added, 1)
-	assert.Equal(t, PlanningFailedHeader+"\n"+genericStageFailure, c.added[0])
+	assert.Equal(t, PlanningFailedHeader+"\nreason: "+genericStageFailure, c.added[0])
 }
 
 // The watch loop must hand the hook event's error type to the diagnoser —

--- a/internal/daemon/board_marker_post.go
+++ b/internal/daemon/board_marker_post.go
@@ -1,0 +1,110 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/gethuman-sh/human/internal/marker"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// postMarker renders a marker through the protocol's own writer and posts it.
+//
+// The daemon writes most of the markers in the system and used to build them by
+// concatenating a header constant with a line of prose. That put the biggest
+// writer outside the one place that knows the format: `human marker post`
+// validates required fields, head-token enums and the decision-block contract,
+// and the daemon validated nothing. The results were not hypothetical — it
+// posted deploy-failed markers with no reason, deployed markers that said
+// nothing about how the work shipped, and single-answer decision blocks the
+// protocol explicitly forbids ([SC-3889]).
+//
+// A validation failure here is a programming error, not a runtime condition, so
+// it is logged loudly and the marker is posted anyway. Dropping it would be the
+// worse failure: the reader sees no marker at all and the card stalls with
+// nothing to explain it, which is exactly the silent stall this protocol exists
+// to prevent. The test suite is where an invalid marker is meant to be caught
+// (TestDaemonPostedMarkersSatisfyTheirContract).
+func postMarker(ctx context.Context, c tracker.Commenter, key string, m marker.Marker, fieldOrder ...string) error {
+	if err := marker.Validate(m); err != nil {
+		log.Error().Err(err).Str("type", m.Type).Str("key", key).
+			Msg("posting a marker that does not satisfy its own contract")
+	}
+	_, err := c.AddComment(ctx, key, marker.Render(m, fieldOrder))
+	return err
+}
+
+// markerBody renders without posting, for the callers that hand a body to
+// something else (a signing wrapper, a test double, a queued write).
+func markerBody(m marker.Marker, fieldOrder ...string) string {
+	if err := marker.Validate(m); err != nil {
+		log.Error().Err(err).Str("type", m.Type).
+			Msg("composing a marker that does not satisfy its own contract")
+	}
+	return marker.Render(m, fieldOrder)
+}
+
+// DeployedBody renders the [human:deployed] marker for work that shipped
+// through a pull request.
+//
+// Exported because the daemon command wires a confirm-shipped probe that posts
+// this marker from outside the package; it used to build the body there by
+// concatenation, which put a second author of the format one edit away from the
+// one that owns it.
+func DeployedBody(prURL string) string {
+	return markerBody(marker.Marker{Type: MarkerDeployed, Fields: fields("pr", prURL)})
+}
+
+// optionsMarker composes a decision block — the stage that resumes once it is
+// answered, the context that raised it, and one field per answer — and returns
+// the field order alongside it.
+//
+// The order is part of the wire format, not presentation: a numbered answer id
+// is not a field name the marker grammar accepts, so the reader takes the first
+// one as the start of the body and everything after it as prose. stage and
+// context therefore have to be written before the answers or they are not
+// fields at all — which is how a decision block ended up validating as one with
+// no stage. validateOptions counts answers in both halves, so the answers
+// themselves are read correctly either way.
+func optionsMarker(stage BoardStage, context string, opts []BoardOption) (marker.Marker, []string) {
+	m := marker.Marker{
+		Type:   MarkerOptions,
+		Fields: fields("stage", string(stage), "context", context),
+	}
+	order := []string{"stage", "context"}
+	for _, o := range opts {
+		m.Fields[o.ID] = o.Label
+		order = append(order, o.ID)
+	}
+	return m, order
+}
+
+// failureMarker builds a *-failed marker from a composed diagnosis.
+//
+// The split is not cosmetic: the card badge shows one line and the detail pane
+// shows the rest, so the headline goes in `reason` (the field every *-failed
+// spec requires) and the detail stays prose in the body. Keeping the whole
+// diagnosis in `reason` would fold its blank line into a field continuation and
+// silently truncate the field block at the first empty line; keeping it all in
+// the body would post a marker with no reason at all, which is what the daemon
+// did before. failureBody recomposes the two halves for the reader.
+func failureMarker(markerType, diagnosis string) marker.Marker {
+	headline, detail, _ := strings.Cut(strings.TrimSpace(diagnosis), "\n")
+	return marker.Marker{
+		Type:   markerType,
+		Fields: fields("reason", strings.TrimSpace(headline)),
+		Body:   strings.TrimSpace(detail),
+	}
+}
+
+// fields is shorthand for the one-or-two field markers that make up most of
+// what the daemon posts.
+func fields(pairs ...string) map[string]string {
+	out := make(map[string]string, len(pairs)/2)
+	for i := 0; i+1 < len(pairs); i += 2 {
+		out[pairs[i]] = pairs[i+1]
+	}
+	return out
+}

--- a/internal/daemon/board_marker_post_test.go
+++ b/internal/daemon/board_marker_post_test.go
@@ -1,0 +1,126 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/marker"
+)
+
+// composedOptionsBody renders a decision block through the real composer, which
+// returns the marker and its field order as one answer.
+func composedOptionsBody(stage BoardStage, context string, opts []BoardOption) string {
+	m, order := optionsMarker(stage, context, opts)
+	return markerBody(m, order...)
+}
+
+// TestDaemonPostedMarkersSatisfyTheirContract walks every marker type the
+// daemon writes, composes it the way the daemon composes it, and puts the
+// rendered body back through the protocol's own reader and validator.
+//
+// This is the test the funnel exists for. postMarker logs and posts anyway when
+// a marker fails validation — dropping it would stall the card silently — so
+// nothing at runtime refuses a malformed marker, and without this the daemon
+// could go on posting deploy-failed markers with no reason and deployed markers
+// that never said how the work shipped, exactly as it did.
+//
+// Composing through the real builders is the point: a test that hand-wrote the
+// bodies would validate its own strings and pass while the daemon posted
+// something else.
+func TestDaemonPostedMarkersSatisfyTheirContract(t *testing.T) {
+	eligible := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		markerType string
+		body       string
+	}{
+		{MarkerDeployed, DeployedBody("https://example/pr/7")},
+		{MarkerDeployed, markerBody(marker.Marker{
+			Type:   MarkerDeployed,
+			Fields: fields("merged", "already in the base branch; no new PR opened"),
+		})},
+		{MarkerDeployFailed, markerBody(failureMarker(MarkerDeployFailed,
+			"CI checks failed on the pull request — fix the failing checks, then re-run Deploy\n\nfailing: frontend-test"))},
+		{MarkerNeedsPlanning, markerBody(failureMarker(MarkerNeedsPlanning, needsPlanningReason))},
+		{MarkerPRReviewFailed, markerBody(failureMarker(MarkerPRReviewFailed,
+			"could not launch the PR review agent — no container runtime"))},
+		{MarkerReviewFailed, markerBody(failureMarker(MarkerReviewFailed, genericStageFailure))},
+		{MarkerPipeline, markerBody(marker.Marker{Type: MarkerPipeline, Fields: fields("kind", "fix")})},
+		{MarkerOptions, composedOptionsBody(BoardImplementation, "the fixer needs a decision", []BoardOption{
+			{ID: "1", Label: "Rebuild the branch"},
+			{ID: "2", Label: "Take it over by hand"},
+		})},
+		{MarkerOptionChosen, markerBody(marker.Marker{Type: MarkerOptionChosen, Head: "1: Rebuild the branch"})},
+		{MarkerStageWait, composeStageWait(BoardPlanning, eligible, eligible.Add(31*time.Minute), WaitCausePollBoundary)},
+		{MarkerClaim, markerBody(marker.Marker{Type: MarkerClaim, Fields: fields("stage", string(BoardPlanning))})},
+		{MarkerCloseFailed, markerBody(failureMarker(MarkerCloseFailed, "the automated close of SC-1 failed: tracker unreachable"))},
+		{MarkerPlanningFailed, markerBody(failureMarker(failedTypeFor(BoardPlanning), genericStageFailure))},
+		{MarkerImplementationFailed, markerBody(failureMarker(failedTypeFor(BoardImplementation), genericStageFailure))},
+		{MarkerPlanningOutage, markerBody(pausedOutageMarker(outageTypeFor(BoardPlanning), nil, "", "", "the secret store"))},
+		{MarkerImplementationOutage, markerBody(pausedOutageMarker(outageTypeFor(BoardImplementation), nil, "", "", ""))},
+		{MarkerReviewOutage, markerBody(pausedOutageMarker(outageTypeFor(BoardVerification), nil, "", "", ""))},
+		{MarkerDeployOutage, markerBody(pausedOutageMarker(outageTypeFor(BoardDoneStage), nil, "", "", ""))},
+		{MarkerPRReviewStarted, prReviewStartedBody("https://example/pr/7", 7, "feat/x")},
+		{MarkerDeployFixStarted, markerBody(marker.Marker{
+			Type:   MarkerDeployFixStarted,
+			Fields: fields("pr", "https://example/pr/7", "number", "7", "branch", "feat/x"),
+			Body:   "CI checks failed on the pull request",
+		}, "pr", "number", "branch")},
+		{MarkerHandoffCheckUnreadable, markerBody(marker.Marker{
+			Type: MarkerHandoffCheckUnreadable,
+			Body: "could not verify the handoff for branch feat/x on this machine — git timed out",
+		})},
+	}
+
+	// A decision block only validates when its field order is the one the real
+	// composer returns, so the two are taken together rather than re-stated.
+	covered := map[string]bool{}
+	for _, tc := range cases {
+		t.Run(tc.markerType, func(t *testing.T) {
+			parsed, ok := marker.ParseBody(tc.body)
+			require.True(t, ok, "a daemon-posted body must read back as a marker: %q", tc.body)
+			assert.Equal(t, tc.markerType, parsed.Type, "the posted body must carry the type it was composed as")
+			assert.NoError(t, marker.Validate(parsed),
+				"the daemon must not post a marker its own protocol rejects: %q", tc.body)
+		})
+		covered[tc.markerType] = true
+	}
+
+	for _, markerType := range daemonMarkerTypes {
+		assert.True(t, covered[markerType],
+			"marker type %q is posted by the daemon but no case here checks it against the protocol", markerType)
+	}
+}
+
+// TestFailureMarkerSplitsHeadlineFromDetail pins the split the card depends on:
+// the badge shows one line and the detail pane shows the rest, so the headline
+// must survive as the reason field and the detail as prose — and failureBody
+// must put them back together in that order. Both halves in one field folds the
+// blank line into a continuation and truncates the field block; both in the body
+// posts a *-failed marker with no reason at all, which is what the daemon did
+// before it went through this builder.
+func TestFailureMarkerSplitsHeadlineFromDetail(t *testing.T) {
+	body := markerBody(failureMarker(MarkerImplementationFailed,
+		"claude exited with code 1: API Error\n\nagent: board-SC-1-implementation\n\nlast output:\n~~~\nboom\n~~~"))
+
+	assert.Equal(t, "claude exited with code 1: API Error", failureReason(body),
+		"the card's one-line error is the headline, never the field name or the detail")
+	assert.Contains(t, failureBody(body), "last output:", "the detail pane keeps the whole diagnosis")
+
+	parsed, ok := marker.ParseBody(body)
+	require.True(t, ok)
+	assert.NoError(t, marker.Validate(parsed))
+}
+
+// TestFailureBodyReadsMarkersPostedBeforeTheReasonField is the back-compat half:
+// markers already on live tickets carry their diagnosis as prose with no reason
+// field, and they must keep rendering the same card they always did.
+func TestFailureBodyReadsMarkersPostedBeforeTheReasonField(t *testing.T) {
+	legacy := ImplementationFailedHeader + "\nclaude exited with code 1: API Error\n\nagent: board-SC-1-implementation"
+
+	assert.Equal(t, "claude exited with code 1: API Error", failureReason(legacy))
+	assert.Contains(t, failureBody(legacy), "agent: board-SC-1-implementation")
+}

--- a/internal/daemon/board_markers.go
+++ b/internal/daemon/board_markers.go
@@ -88,11 +88,38 @@ const (
 	// downstream readers key off this const rather than a bare literal.
 	TicketReviewMarkerType = "ticket-review"
 
+	// The marker TYPE names the daemon posts, and the headers derived from them.
+	//
+	// Derived rather than written twice: a header and its type name are the same
+	// fact spelled two ways, and the protocol's writer takes the type while the
+	// board's readers match the header. Two literals would be one edit away from
+	// disagreeing.
+	MarkerDeployed               = "deployed"
+	MarkerDeployFailed           = "deploy-failed"
+	MarkerNeedsPlanning          = "needs-planning"
+	MarkerPRReviewFailed         = "pr-review-failed"
+	MarkerReviewFailed           = "review-failed"
+	MarkerPipeline               = "pipeline"
+	MarkerOptions                = "options"
+	MarkerOptionChosen           = "option-chosen"
+	MarkerStageWait              = "stage-wait"
+	MarkerClaim                  = "claim"
+	MarkerCloseFailed            = "close-failed"
+	MarkerPlanningFailed         = "planning-failed"
+	MarkerImplementationFailed   = "implementation-failed"
+	MarkerPlanningOutage         = "planning-outage"
+	MarkerImplementationOutage   = "implementation-outage"
+	MarkerReviewOutage           = "review-outage"
+	MarkerDeployOutage           = "deploy-outage"
+	MarkerPRReviewStarted        = "pr-review-started"
+	MarkerDeployFixStarted       = "deploy-fix-started"
+	MarkerHandoffCheckUnreadable = "handoff-check-unreadable"
+
 	PlanningStartedHeader       = "[human:planning-started]"
 	PlanReadyHeader             = "[human:plan-ready]"
-	PlanningFailedHeader        = "[human:planning-failed]"
+	PlanningFailedHeader        = "[human:" + MarkerPlanningFailed + "]"
 	ImplementationStartedHeader = "[human:implementation-started]"
-	ImplementationFailedHeader  = "[human:implementation-failed]"
+	ImplementationFailedHeader  = "[human:" + MarkerImplementationFailed + "]"
 	// NeedsPlanningHeader is the implementation launch's refuse-and-surface
 	// marker: the stage that exists only to carry out a plan was launched on a
 	// ticket that has none, so the launch is refused before any agent claims the
@@ -102,7 +129,7 @@ const (
 	// as a crash. DeriveBoardCard promotes it over the phantom implementation
 	// markers it refused (newestTerminalDetermination — it is one of the
 	// registered terminalResolutions).
-	NeedsPlanningHeader = "[human:needs-planning]"
+	NeedsPlanningHeader = "[human:" + MarkerNeedsPlanning + "]"
 	// NoFixNeededHeader is the autofix pipeline's second clean terminal marker:
 	// triage concluded the reported bug warrants no code change (not-a-bug or
 	// undetermined). It carries no [human:ready-for-review] handoff, so the
@@ -119,7 +146,7 @@ const (
 	// terminal with the implementation stage's [human:no-fix-needed].
 	NothingToDoHeader   = "[human:nothing-to-do]"
 	ReviewStartedHeader = "[human:review-started]"
-	ReviewFailedHeader  = "[human:review-failed]"
+	ReviewFailedHeader  = "[human:" + MarkerReviewFailed + "]"
 	PRStartedHeader     = "[human:pr-started]"
 	PRPushedHeader      = "[human:pr-pushed]"
 	PRFailedHeader      = "[human:pr-failed]"
@@ -129,8 +156,8 @@ const (
 	// lifecycle is "deploying", not "opening a PR". The PR markers stay
 	// recognized so threads written before the deploy pipeline still derive.
 	DeployStartedHeader = "[human:deploy-started]"
-	DeployedHeader      = "[human:deployed]"
-	DeployFailedHeader  = "[human:deploy-failed]"
+	DeployedHeader      = "[human:" + MarkerDeployed + "]"
+	DeployFailedHeader  = "[human:" + MarkerDeployFailed + "]"
 
 	// PR review→fix loop markers (SC-1387): the pre-merge sub-phase of the
 	// deploy (done) stage where the machine reviewer and fixer alternate on the
@@ -139,9 +166,9 @@ const (
 	// review) reds it like any other deploy-phase failure. They deliberately
 	// live in the done stage rather than a new pipeline stage, so the
 	// verification→done transition adjacency (board_transition.go) is unchanged.
-	PRReviewStartedHeader = "[human:pr-review-started]"
+	PRReviewStartedHeader = "[human:" + MarkerPRReviewStarted + "]"
 	PRFixStartedHeader    = "[human:pr-fix-started]"
-	PRReviewFailedHeader  = "[human:pr-review-failed]"
+	PRReviewFailedHeader  = "[human:" + MarkerPRReviewFailed + "]"
 	// PRReviewPassedHeader records the loop CONVERGING: the reviewer approved and
 	// the card proceeds to the CI gate and merge. Every other outcome of the loop
 	// already left a marker — both launches and the escalation — so success was
@@ -157,7 +184,7 @@ const (
 	// (SC-1557): a CI failure or rebase conflict at the deploy gate dispatches the
 	// human-deploy-fixer instead of redding, so this reads as the done stage running.
 	// Each occurrence is one deploy-fix round — the budget counts them (deployFixRounds).
-	DeployFixStartedHeader = "[human:deploy-fix-started]"
+	DeployFixStartedHeader = "[human:" + MarkerDeployFixStarted + "]"
 
 	// Outage markers are the NON-failing transient twin of the *-failed headers,
 	// one per relaunchable stage. A stage that reported the substrate it needs was
@@ -166,10 +193,10 @@ const (
 	// durable reconcile pass relaunches it each interval without charging the
 	// retry budget (SC-2307). `-outage` never prefixes another header, so
 	// ClassifyMarker's prefix match stays unambiguous.
-	PlanningOutageHeader       = "[human:planning-outage]"
-	ImplementationOutageHeader = "[human:implementation-outage]"
-	ReviewOutageHeader         = "[human:review-outage]"
-	DeployOutageHeader         = "[human:deploy-outage]"
+	PlanningOutageHeader       = "[human:" + MarkerPlanningOutage + "]"
+	ImplementationOutageHeader = "[human:" + MarkerImplementationOutage + "]"
+	ReviewOutageHeader         = "[human:" + MarkerReviewOutage + "]"
+	DeployOutageHeader         = "[human:" + MarkerDeployOutage + "]"
 )
 
 // PlanCommentHeader marks a comment whose body IS the engineering plan for
@@ -186,7 +213,7 @@ const PlanCommentHeader = "[human:plan]"
 // orderedMarkerSpecs, so ClassifyMarker never classifies it and the card
 // stays green (deployed) while still carrying a visible "close this manually"
 // flag. Best-effort close means recorded-and-surfaced, never red, never silent.
-const CloseFailedHeader = "[human:close-failed]"
+const CloseFailedHeader = "[human:" + MarkerCloseFailed + "]"
 
 // RelatedStartedHeader / RelatedHeader bracket the filing-time related-work
 // triage (SC-2405). Both are deliberately kept OUT of orderedMarkerSpecs, like
@@ -281,7 +308,7 @@ func hasBugVerdict(comments []tracker.Comment) bool {
 // restarted after a crash is restarted as a fix and never refused for having no
 // plan (SC-2989). A plan executor writes none: its identity is the absence of
 // this marker plus the ticket kind.
-const PipelineStartedHeader = "[human:pipeline]"
+const PipelineStartedHeader = "[human:" + MarkerPipeline + "]"
 
 // recordedPipeline reports the pipeline identity a run wrote at start, or fixNone
 // when the ticket carries no [human:pipeline] marker (a plan executor, or a run
@@ -319,7 +346,35 @@ func recordedPipeline(comments []tracker.Comment) fixPipeline {
 // classifies it and the card keeps its current (implementation-done) state,
 // leaving the durable reconcile pass to retry the check rather than reddening
 // good work on an answer that was never given (SC-2403).
-const HandoffCheckUnreadableHeader = "[human:handoff-check-unreadable]"
+const HandoffCheckUnreadableHeader = "[human:" + MarkerHandoffCheckUnreadable + "]"
+
+// daemonMarkerTypes is every marker type the daemon itself writes. It is the
+// completeness list TestDaemonPostedMarkersSatisfyTheirContract walks: a type
+// added here with no case in that test fails the build, which is what keeps a
+// new daemon marker from shipping without anyone checking it against the
+// protocol's own validator.
+var daemonMarkerTypes = []string{
+	MarkerDeployed,
+	MarkerDeployFailed,
+	MarkerNeedsPlanning,
+	MarkerPRReviewFailed,
+	MarkerReviewFailed,
+	MarkerPipeline,
+	MarkerOptions,
+	MarkerOptionChosen,
+	MarkerStageWait,
+	MarkerClaim,
+	MarkerCloseFailed,
+	MarkerPlanningFailed,
+	MarkerImplementationFailed,
+	MarkerPlanningOutage,
+	MarkerImplementationOutage,
+	MarkerReviewOutage,
+	MarkerDeployOutage,
+	MarkerPRReviewStarted,
+	MarkerDeployFixStarted,
+	MarkerHandoffCheckUnreadable,
+}
 
 // markerSpec maps a marker header to the (stage, state) it represents.
 type markerSpec struct {

--- a/internal/daemon/board_options.go
+++ b/internal/daemon/board_options.go
@@ -249,8 +249,10 @@ func (d BoardTransitionDeps) ApplyOption(ctx context.Context, req BoardOptionReq
 		return errors.WithDetails("unknown option id", "pm", req.PMKey, "option", req.OptionID)
 	}
 
-	if _, err := d.Commenter.AddComment(ctx, req.PMKey,
-		OptionChosenHeader+" "+chosen.ID+": "+chosen.Label); err != nil {
+	// The pick rides in the head token, where the readers already look for it
+	// (parseOptionChosen splits id from label on the header line).
+	chosenMarker := marker.Marker{Type: MarkerOptionChosen, Head: chosen.ID + ": " + chosen.Label}
+	if err := postMarker(ctx, d.Commenter, req.PMKey, chosenMarker); err != nil {
 		return errors.WrapWithDetails(err, "recording option choice", "pm", req.PMKey)
 	}
 

--- a/internal/daemon/board_outage.go
+++ b/internal/daemon/board_outage.go
@@ -75,17 +75,17 @@ func newerThan(comments []tracker.Comment, cutoff tracker.Comment) []tracker.Com
 // ever coming back. The first body line is the headline the card badge reads
 // (failureReason), so the card itself says why it needs attention.
 func outageHandoverBody(stage BoardStage, reason string, waited time.Duration, since time.Time) string {
-	header := failedHeaderFor(stage)
-	if header == "" {
+	failedType := failedTypeFor(stage)
+	if failedType == "" {
 		return ""
 	}
 	what := strings.TrimSpace(reason)
 	if what == "" {
 		what = "the substrate it depends on"
 	}
-	return header + "\n" +
-		"waited " + waited.Round(time.Minute).String() + " for the substrate to come back and it never did — this needs a person: " + what + "\n" +
-		"unreachable since " + since.UTC().Format(time.RFC3339) + ". No retry budget was spent on the wait, so a Retry has every attempt available once the substrate is back."
+	return markerBody(failureMarker(failedType,
+		"waited "+waited.Round(time.Minute).String()+" for the substrate to come back and it never did — this needs a person: "+what+"\n"+
+			"unreachable since "+since.UTC().Format(time.RFC3339)+". No retry budget was spent on the wait, so a Retry has every attempt available once the substrate is back."))
 }
 
 // handOverOutage reds a card whose outage outlived OutageWaitBound so a person
@@ -124,11 +124,11 @@ func handOverOutage(ctx context.Context, pmKey string, derived BoardCard, postFa
 // Split out of handleBoardAgentExit so the say-once guard costs this function's
 // complexity budget rather than that one's.
 func handleOutageExit(ctx context.Context, pmKey string, stage BoardStage, agentName, errorType string, comments []tracker.Comment, commenter tracker.Commenter, diagnose BoardFailureDiagnoser, retry StageRetry, kind endingKind, reason string, daemonID string, logger zerolog.Logger) bool {
-	header := outageHeaderFor(stage)
-	if header == "" || (!retry.recordedOutage(pmKey, stage) && kind != endingPaused) {
+	outageType := outageTypeFor(stage)
+	if outageType == "" || (!retry.recordedOutage(pmKey, stage) && kind != endingPaused) {
 		return false
 	}
-	body := header + "\n" + pausedOutageBody(diagnose, agentName, errorType, reason)
+	body := markerBody(pausedOutageMarker(outageType, diagnose, agentName, errorType, reason))
 	// Say it once and leave it standing: every relaunch that re-hits the same
 	// outage lands here, so re-posting an identical marker would spam the ticket
 	// for as long as the substrate stays down (SC-2851). The standing marker also
@@ -145,24 +145,28 @@ func handleOutageExit(ctx context.Context, pmKey string, stage BoardStage, agent
 	return true
 }
 
-// pausedOutageBody composes the house-style paused statement: the substrate
-// reason, an optional machine-readable resume: line (when the diagnosis names
+// pausedOutageMarker composes the house-style paused statement: the substrate
+// reason, an optional machine-readable resume field (when the diagnosis names
 // a stated recovery time), and the do-nothing reassurance. reason defaults to
 // "the substrate it depends on" when empty — the recorded-outage case with no
 // classified signal reason.
-func pausedOutageBody(diagnose BoardFailureDiagnoser, agentName, errorType, reason string) string {
+func pausedOutageMarker(outageType string, diagnose BoardFailureDiagnoser, agentName, errorType, reason string) marker.Marker {
 	what := strings.TrimSpace(reason)
 	if what == "" {
 		what = "the substrate it depends on"
 	}
-	var b strings.Builder
-	b.WriteString("paused — " + what)
-	if resume, ok := resumeTimeFromDiagnosis(diagnose, agentName, errorType); ok {
-		b.WriteString("\nresume: " + resume.Format(time.RFC3339))
+	m := marker.Marker{
+		Type: outageType,
+		Body: "paused — " + what + "\nThe work is written and safe on the ticket. It continues automatically when " +
+			what + " clears. Nothing to do.",
 	}
-	b.WriteString("\nThe work is written and safe on the ticket. It continues automatically when " +
-		what + " clears. Nothing to do.")
-	return b.String()
+	// A stated recovery time is the one machine-readable fact in this marker
+	// (parseResumeLine reads it back to bound the wait), so it is a field rather
+	// than a line of the prose it used to sit in the middle of.
+	if resume, ok := resumeTimeFromDiagnosis(diagnose, agentName, errorType); ok {
+		m.Fields = fields("resume", resume.Format(time.RFC3339))
+	}
+	return m
 }
 
 // resumeTimeFromDiagnosis runs the diagnoser (when wired) and scans its

--- a/internal/daemon/board_reconcile.go
+++ b/internal/daemon/board_reconcile.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/gethuman-sh/human/internal/marker"
 	"github.com/gethuman-sh/human/internal/tracker"
 )
 
@@ -497,8 +498,8 @@ func reconcileOneStuckCard(ctx context.Context, card ReconcileCard, alive map[st
 	if !stuckCardIsOursToRed(derived, card) {
 		return false
 	}
-	header := failedHeaderFor(derived.Stage)
-	if header == "" {
+	failedType := failedTypeFor(derived.Stage)
+	if failedType == "" {
 		return false
 	}
 	if now.Sub(derived.StageEnteredAt) < StuckRunningGrace {
@@ -525,17 +526,18 @@ func reconcileOneStuckCard(ctx context.Context, card ReconcileCard, alive map[st
 	// relaunching and says a person is needed, naming the count once; skip
 	// is set when the give-up marker is already on the thread, so a second
 	// daemon reaching the same cap posts nothing more.
-	body, givingUp, skip := stuckRunningSilenceBody(header, derived.Stage, card.Comments, silenced, idleReason)
+	failed, givingUp, skip := stuckRunningSilenceBody(failedType, derived.Stage, card.Comments, silenced, idleReason)
 	if skip {
 		return false
 	}
 	// If this stage was preceded by a recorded inter-stage wait, name that
 	// cause in the red so a stall that followed a long wait is attributable
-	// rather than judged from silence (SC-2462).
+	// rather than judged from silence (SC-2462). It joins the detail prose, not
+	// the field block: it qualifies the diagnosis rather than being read back.
 	if cause := latestStageWaitCause(card.Comments); cause != "" {
-		body += "\nafter wait cause: " + cause
+		failed.Body = strings.TrimSpace(failed.Body + "\nafter wait cause: " + cause)
 	}
-	if err := postFailed(ctx, card.Key, body); err != nil {
+	if err := postFailed(ctx, card.Key, markerBody(failed)); err != nil {
 		logger.Warn().Err(err).Str("pm", card.Key).
 			Msg("board reconcile: cannot red stuck-running card")
 		return false
@@ -570,18 +572,18 @@ func reconcileOneStuckCard(ctx context.Context, card ReconcileCard, alive map[st
 // (skip — the dedup that keeps two daemons from both posting it). Split out
 // of reconcileStuckRunning so that function's branching stays inside the
 // complexity gate.
-func stuckRunningSilenceBody(header string, stage BoardStage, comments []tracker.Comment, silenced bool, idleReason string) (body string, givingUp, skip bool) {
+func stuckRunningSilenceBody(failedType string, stage BoardStage, comments []tracker.Comment, silenced bool, idleReason string) (m marker.Marker, givingUp, skip bool) {
 	if !silenced {
-		return header + "\n" + stuckRunningReason(stage), false, false
+		return failureMarker(failedType, stuckRunningReason(stage)), false, false
 	}
 	if silenceReapGaveUp(comments, stage) {
-		return "", false, true
+		return marker.Marker{}, false, true
 	}
 	stops := silenceReapCount(comments, stage) + 1
 	if stops > MaxSilenceReaps {
-		return header + "\n" + silenceReapGiveUpReason(stage, stops), true, false
+		return failureMarker(failedType, silenceReapGiveUpReason(stage, stops)), true, false
 	}
-	return header + "\n" + silenceReapReason(idleReason), false, false
+	return failureMarker(failedType, silenceReapReason(idleReason)), false, false
 }
 
 // cardPausedOnOpenOptions reports whether a card carries an open

--- a/internal/daemon/board_state.go
+++ b/internal/daemon/board_state.go
@@ -381,10 +381,22 @@ func failureBody(body string) string {
 	// separates the field block from the prose, so ask it.
 	trimmed := strings.TrimSpace(body)
 	if m, ok := marker.ParseBody(trimmed); ok {
-		if rest := strings.TrimSpace(m.Body); rest != "" {
+		// The headline lives in `reason` (the field the *-failed specs require)
+		// and the detail in the prose body — failureMarker splits them there, so
+		// this is where they are put back together. Either half alone is still a
+		// diagnosis: a marker posted before the field existed carries prose only,
+		// and a one-line failure carries a reason only.
+		reason := strings.TrimSpace(m.Fields["reason"])
+		rest := strings.TrimSpace(m.Body)
+		switch {
+		case reason != "" && rest != "":
+			return reason + "\n\n" + rest
+		case reason != "":
+			return reason
+		case rest != "":
 			return rest
 		}
-		// A marker carrying only fields has no diagnosis to give: show the header.
+		// A marker carrying neither has no diagnosis to give: show the header.
 		return firstLine(trimmed)
 	}
 	// Not a marker at all: there is no field block to skip and no prose to find,

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -559,7 +559,9 @@ func (d BoardTransitionDeps) ApplyFix(ctx context.Context, req BoardFixRequest) 
 		// Record which pipeline this run is, durably on the ticket, so a later
 		// recovery relaunch restarts the FIX pipeline even if the ticket-kind
 		// fetch blips and no verdict has been posted yet (SC-2989).
-		_, _ = d.Commenter.AddComment(ctx, req.PMKey, PipelineStartedHeader+"\nkind: fix")
+		_ = postMarker(ctx, d.Commenter, req.PMKey, marker.Marker{
+			Type: MarkerPipeline, Fields: fields("kind", "fix"),
+		})
 	}
 	return err
 }
@@ -599,7 +601,9 @@ func (d BoardTransitionDeps) ApplySecurityFix(ctx context.Context, req SecurityF
 		// Durable pipeline identity, mirroring ApplyFix: a recovery relaunch reads
 		// this first and restarts the security-fix pipeline rather than refusing the
 		// run for having no plan (SC-2989).
-		_, _ = d.Commenter.AddComment(ctx, req.PMKey, PipelineStartedHeader+"\nkind: security")
+		_ = postMarker(ctx, d.Commenter, req.PMKey, marker.Marker{
+			Type: MarkerPipeline, Fields: fields("kind", "security"),
+		})
 	}
 	return err
 }
@@ -719,8 +723,7 @@ func (d BoardTransitionDeps) startAgentStage(ctx context.Context, pmKey string, 
 	}
 	name := agentNameFor(pmKey, stage)
 	if err := d.launchAgent(ctx, pmKey, name, prompt); err != nil {
-		failBody := failedHeaderFor(stage) + "\n" + errors.CauseChain(err)
-		_, _ = d.Commenter.AddComment(ctx, pmKey, failBody)
+		_ = postMarker(ctx, d.Commenter, pmKey, failureMarker(failedTypeFor(stage), errors.CauseChain(err)))
 		return false, errors.WrapWithDetails(err, "launching agent", "pm", pmKey, "stage", string(stage))
 	}
 	return true, nil
@@ -860,7 +863,7 @@ func (d BoardTransitionDeps) refuseIfUnplanned(ctx context.Context, pmKey string
 	// when, rather than looping forever between planning and implementation.
 	if drives := countPlanRefusals(comments); drives >= PlanRedriveBound {
 		since, _ := oldestNeedsPlanning(comments)
-		body := NeedsPlanningHeader + "\n" + planStuckReason(drives, since)
+		body := markerBody(failureMarker(MarkerNeedsPlanning, planStuckReason(drives, since)))
 		if _, err := d.Commenter.AddComment(ctx, pmKey, body); err != nil {
 			return true, errors.WrapWithDetails(err, "posting plan-stuck escalation marker", "pm", pmKey)
 		}
@@ -873,7 +876,7 @@ func (d BoardTransitionDeps) refuseIfUnplanned(ctx context.Context, pmKey string
 	// spam the thread — then drive the card into planning so a person never
 	// has to notice the refusal by hand.
 	if !newestIsRefusal {
-		body := NeedsPlanningHeader + "\n" + needsPlanningReason
+		body := markerBody(failureMarker(MarkerNeedsPlanning, needsPlanningReason))
 		if _, err := d.Commenter.AddComment(ctx, pmKey, body); err != nil {
 			return true, errors.WrapWithDetails(err, "posting needs-planning marker", "pm", pmKey)
 		}
@@ -901,8 +904,10 @@ var startDeploy = func(d BoardTransitionDeps, req BoardTransitionRequest, card B
 // unchanged — a handoff with no branch has nothing to open.
 func (d BoardTransitionDeps) runDoneStage(_ context.Context, req BoardTransitionRequest, card BoardCard) error {
 	if card.Branch == "" {
-		body := DeployFailedHeader + "\nno branch recorded on ready-for-review handoff"
-		_, _ = d.Commenter.AddComment(context.Background(), req.PMKey, body)
+		_ = postMarker(context.Background(), d.Commenter, req.PMKey, marker.Marker{
+			Type:   MarkerDeployFailed,
+			Fields: fields("reason", "no branch recorded on ready-for-review handoff"),
+		})
 		return errors.WithDetails("no branch recorded for deploy", "pm", req.PMKey)
 	}
 	startPRReview(d, req, card)
@@ -923,8 +928,10 @@ var startPRReview = func(d BoardTransitionDeps, req BoardTransitionRequest, card
 // work) it short-circuits to the terminal success path exactly like DeployBranch.
 func (d BoardTransitionDeps) openDraftPRAndReview(ctx context.Context, pmKey string, card BoardCard) error {
 	if d.Deployer.BranchMerged(ctx, d.WorkspaceDir, card.Branch) {
-		_, _ = d.Commenter.AddComment(ctx, pmKey,
-			DeployedHeader+"\nalready merged into the base branch; no new PR opened")
+		_ = postMarker(ctx, d.Commenter, pmKey, marker.Marker{
+			Type:   MarkerDeployed,
+			Fields: fields("merged", "already in the base branch; no new PR opened"),
+		})
 		d.closeTicketBestEffort(pmKey)
 		return nil
 	}
@@ -952,10 +959,10 @@ func (d BoardTransitionDeps) openDraftPRAndReview(ctx context.Context, pmKey str
 // prReviewStartedBody carries the loop's PR binding on the started marker so the
 // Stop-hook driver can recover (url, number, branch) without a forge lookup.
 func prReviewStartedBody(url string, number int, branch string) string {
-	return PRReviewStartedHeader +
-		"\npr: " + url +
-		"\nnumber: " + strconv.Itoa(number) +
-		"\nbranch: " + branch
+	return markerBody(marker.Marker{
+		Type:   MarkerPRReviewStarted,
+		Fields: fields("pr", url, "number", strconv.Itoa(number), "branch", branch),
+	}, "pr", "number", "branch")
 }
 
 func prReviewDispatch(pmKey string, number int, branch string) string {
@@ -996,7 +1003,7 @@ func deployFixRounds(comments []tracker.Comment) int {
 func (d BoardTransitionDeps) launchPRLoopAgent(ctx context.Context, pmKey string, stage BoardStage, prompt string) error {
 	name := agentNameFor(pmKey, stage)
 	if err := d.launchAgent(ctx, pmKey, name, prompt); err != nil {
-		body := PRReviewFailedHeader + "\ncould not launch the PR " + string(stage) + " agent — " + errors.CauseChain(err)
+		body := markerBody(failureMarker(MarkerPRReviewFailed, "could not launch the PR "+string(stage)+" agent — "+errors.CauseChain(err)))
 		_, _ = d.Commenter.AddComment(ctx, pmKey, body)
 		return errors.WrapWithDetails(err, "launching PR loop agent", "pm", pmKey, "stage", string(stage))
 	}
@@ -1086,27 +1093,29 @@ func (d BoardTransitionDeps) escalatePRLoop(ctx context.Context, pmKey string, c
 	}
 	stage := latestPRLoopStage(comments)
 	if stage == PRStageFix && outcome.FixExit != PRFixDone {
-		var b strings.Builder
-		b.WriteString(OptionsHeader + "\nstage: " + string(BoardImplementation) + "\n")
 		ctxLine := outcome.FixSummary
 		if ctxLine == "" {
 			ctxLine = "the PR review→fix loop needs a decision the fixer could not make"
 		}
-		b.WriteString("context: " + ctxLine + "\n")
 		opts := outcome.FixOptions
 		if len(opts) == 0 {
-			// A generic single option keeps the block valid (parseOptionsBlock needs
-			// ≥1) so the human can always move the card off the loop.
-			opts = []BoardOption{{ID: "1", Label: "Rebuild the branch to resolve the decision the fixer raised"}}
+			// The fallback offers the two answers a human actually has here.
+			// It used to offer one, with a comment explaining that one was
+			// enough to keep the block parseable — but the protocol forbids a
+			// single-answer block on purpose: it parks the card until someone
+			// clicks the only thing on offer, which is a dead end dressed as a
+			// choice (marker.MinDecisionOptions). Posting it anyway meant the
+			// daemon wrote the exact shape `human marker post` rejects.
+			opts = []BoardOption{
+				{ID: "1", Label: "Rebuild the branch to resolve the decision the fixer raised"},
+				{ID: "2", Label: "Take it over by hand — stop the loop and leave the branch as it is"},
+			}
 		}
-		for _, o := range opts {
-			b.WriteString(o.ID + ": " + o.Label + "\n")
-		}
-		_, err := d.Commenter.AddComment(ctx, pmKey, b.String())
-		return err
+		m, order := optionsMarker(BoardImplementation, ctxLine, opts)
+		return postMarker(ctx, d.Commenter, pmKey, m, order...)
 	}
 	_, _ = d.Commenter.AddComment(ctx, pmKey,
-		PRReviewFailedHeader+"\n"+prEscalationReason(stage, outcome, d.Diagnose))
+		markerBody(failureMarker(MarkerPRReviewFailed, prEscalationReason(stage, outcome, d.Diagnose))))
 	return nil
 }
 
@@ -1203,7 +1212,7 @@ func (d BoardTransitionDeps) AdvanceDeployFix(ctx context.Context, pmKey string,
 		return d.DeployBranch(ctx, pmKey, pmKey, doneBody(pmKey, card), card.Branch)
 	}
 	_, _ = d.Commenter.AddComment(ctx, pmKey,
-		DeployFailedHeader+"\n"+deployFixEscalationReason(fixExit, dispatchedFailure(comments)))
+		markerBody(failureMarker(MarkerDeployFailed, deployFixEscalationReason(fixExit, dispatchedFailure(comments)))))
 	return nil
 }
 
@@ -1371,7 +1380,10 @@ func (d BoardTransitionDeps) DeployBranch(ctx context.Context, pmKey, title, prB
 	if d.Deployer.BranchMerged(ctx, d.WorkspaceDir, branch) {
 		logger.Info().Msg("deploy: branch is already on the base; nothing to ship")
 		_, _ = d.Commenter.AddComment(ctx, pmKey,
-			DeployedHeader+"\nalready merged into the base branch; no new PR opened")
+			markerBody(marker.Marker{
+				Type:   MarkerDeployed,
+				Fields: fields("merged", "already in the base branch; no new PR opened"),
+			}))
 		d.closeTicketBestEffort(pmKey)
 		return nil
 	}
@@ -1443,7 +1455,9 @@ func (d BoardTransitionDeps) DeployBranch(ctx context.Context, pmKey, title, prB
 	// the tracker's open list), so the operator must see it and close by hand.
 	logger.Info().Int("pr", res.Number).Str("url", res.URL).Msg("deploy: merged")
 	_ = d.Deployer.DeleteRemoteBranch(ctx, d.WorkspaceDir, branch)
-	_, _ = d.Commenter.AddComment(ctx, pmKey, DeployedHeader+"\npr: "+res.URL)
+	_ = postMarker(ctx, d.Commenter, pmKey, marker.Marker{
+		Type: MarkerDeployed, Fields: fields("pr", res.URL),
+	})
 	d.closeTicketBestEffort(pmKey)
 	logger.Info().Msg("deploy: done")
 	return nil
@@ -1688,9 +1702,9 @@ func (d BoardTransitionDeps) closeTicketBestEffort(pmKey string) {
 
 	postCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	body := CloseFailedHeader + "\ndeployed, but the automated close of " + pmKey +
-		" failed: " + errors.CauseChain(err) + "\nclose this ticket manually to clear the card."
-	_, _ = d.Commenter.AddComment(postCtx, pmKey, body)
+	closeFailed := failureMarker(MarkerCloseFailed, "the automated close of "+pmKey+" failed: "+errors.CauseChain(err))
+	closeFailed.Body = strings.TrimSpace("Close this ticket manually to clear the card.\n\n" + closeFailed.Body)
+	_ = postMarker(postCtx, d.Commenter, pmKey, closeFailed)
 }
 
 // waitForChecks blocks until the PR's CI verdict is conclusive. Passing
@@ -1768,11 +1782,11 @@ func (d BoardTransitionDeps) deployFailed(pmKey, prURL, reason string) error {
 		Str("reason", headlineOf(reason)).Msg("deploy: failed")
 	postCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	body := DeployFailedHeader + "\n" + reason
+	m := failureMarker(MarkerDeployFailed, reason)
 	if prURL != "" {
-		body += "\npr: " + prURL
+		m.Fields["pr"] = prURL
 	}
-	_, _ = d.Commenter.AddComment(postCtx, pmKey, body)
+	_ = postMarker(postCtx, d.Commenter, pmKey, m, "reason", "pr")
 	return errors.WithDetails("deploy failed: "+reason, "pm", pmKey, "pr", prURL)
 }
 
@@ -1795,12 +1809,12 @@ func (d BoardTransitionDeps) deployFailedOrDispatchFixer(ctx context.Context, pm
 // failure headline and the PR binding for the trail) and launches the fixer. The
 // marker keeps the card spinning rather than red while the fixer works.
 func (d BoardTransitionDeps) dispatchDeployFixer(ctx context.Context, pmKey string, res PRResult, branch, headline string) error {
-	body := DeployFixStartedHeader +
-		"\n" + headline +
-		"\npr: " + res.URL +
-		"\nnumber: " + strconv.Itoa(res.Number) +
-		"\nbranch: " + branch
-	if _, err := d.Commenter.AddComment(ctx, pmKey, body); err != nil {
+	m := marker.Marker{
+		Type:   MarkerDeployFixStarted,
+		Fields: fields("pr", res.URL, "number", strconv.Itoa(res.Number), "branch", branch),
+		Body:   headline,
+	}
+	if err := postMarker(ctx, d.Commenter, pmKey, m, "pr", "number", "branch"); err != nil {
 		return errors.WrapWithDetails(err, "posting deploy-fix-started marker", "pm", pmKey)
 	}
 	return d.launchDeployFixAgent(ctx, pmKey, deployFixDispatch(pmKey, res.Number, branch))
@@ -1812,7 +1826,7 @@ func (d BoardTransitionDeps) dispatchDeployFixer(ctx context.Context, pmKey stri
 func (d BoardTransitionDeps) launchDeployFixAgent(ctx context.Context, pmKey, prompt string) error {
 	name := agentNameFor(pmKey, deployFixAgentStage)
 	if err := d.launchAgent(ctx, pmKey, name, prompt); err != nil {
-		body := DeployFailedHeader + "\ncould not launch the deploy fixer — " + errors.CauseChain(err)
+		body := markerBody(failureMarker(MarkerDeployFailed, "could not launch the deploy fixer — "+errors.CauseChain(err)))
 		_, _ = d.Commenter.AddComment(ctx, pmKey, body)
 		return errors.WrapWithDetails(err, "launching deploy fixer", "pm", pmKey)
 	}
@@ -2035,37 +2049,59 @@ func doneBody(pmKey string, card BoardCard) string {
 	return b.String()
 }
 
-// failedHeaderFor returns the *-failed marker header for a stage.
-func failedHeaderFor(stage BoardStage) string {
+// failedTypeFor returns the *-failed marker TYPE for a stage — what a writer
+// needs. Empty for a stage that has no failed marker.
+func failedTypeFor(stage BoardStage) string {
 	switch stage {
 	case BoardPlanning:
-		return PlanningFailedHeader
+		return MarkerPlanningFailed
 	case BoardImplementation:
-		return ImplementationFailedHeader
+		return MarkerImplementationFailed
 	case BoardVerification:
-		return ReviewFailedHeader
+		return MarkerReviewFailed
 	case BoardDoneStage:
-		return DeployFailedHeader
+		return MarkerDeployFailed
 	default:
 		return ""
 	}
 }
 
-// outageHeaderFor returns the *-outage marker header for a stage, mirroring
-// failedHeaderFor. Empty for a stage that has no relaunch path (SC-2307).
-func outageHeaderFor(stage BoardStage) string {
+// failedHeaderFor returns the *-failed marker header for a stage — what a
+// reader matches on. Derived from failedTypeFor so the two cannot disagree.
+func failedHeaderFor(stage BoardStage) string {
+	return headerForType(failedTypeFor(stage))
+}
+
+// outageTypeFor returns the *-outage marker TYPE for a stage, mirroring
+// failedTypeFor. Empty for a stage that has no relaunch path (SC-2307).
+func outageTypeFor(stage BoardStage) string {
 	switch stage {
 	case BoardPlanning:
-		return PlanningOutageHeader
+		return MarkerPlanningOutage
 	case BoardImplementation:
-		return ImplementationOutageHeader
+		return MarkerImplementationOutage
 	case BoardVerification:
-		return ReviewOutageHeader
+		return MarkerReviewOutage
 	case BoardDoneStage:
-		return DeployOutageHeader
+		return MarkerDeployOutage
 	default:
 		return ""
 	}
+}
+
+// outageHeaderFor returns the *-outage marker header for a stage.
+func outageHeaderFor(stage BoardStage) string {
+	return headerForType(outageTypeFor(stage))
+}
+
+// headerForType renders a marker type as the header its readers match, and
+// keeps "no marker for this stage" spelled the same on both sides: an empty
+// type is an empty header, never "[human:]".
+func headerForType(markerType string) string {
+	if markerType == "" {
+		return ""
+	}
+	return "[human:" + markerType + "]"
 }
 
 // latestStageState returns the latest marker's state within a given stage,

--- a/internal/daemon/board_transition_test.go
+++ b/internal/daemon/board_transition_test.go
@@ -14,7 +14,6 @@ import (
 
 	humanerrors "github.com/gethuman-sh/human/errors"
 	"github.com/gethuman-sh/human/internal/forge"
-	"github.com/gethuman-sh/human/internal/marker"
 	"github.com/gethuman-sh/human/internal/tracker"
 	"github.com/gethuman-sh/human/internal/vault"
 )
@@ -887,7 +886,7 @@ func TestApplyTransitionDeployEnsureMergeableConflict(t *testing.T) {
 	require.NotEmpty(t, failed)
 	// The marker's first line is the card badge: it must tell the user the next
 	// step, with the raw cause following in the detail block.
-	headline := firstLine(marker.Prose(failed))
+	headline := failureReason(failed)
 	assert.Contains(t, headline, "resolve the conflict on feat/x")
 	assert.Contains(t, headline, "re-run Deploy")
 	assert.Contains(t, failed, "rebase hit a conflict")
@@ -1597,7 +1596,7 @@ func TestApplyTransitionDeployRecomputeStaysUnmergeable(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, failed)
-	headline := firstLine(marker.Prose(failed))
+	headline := failureReason(failed)
 	assert.Contains(t, headline, "open the PR to see why")
 	assert.Contains(t, headline, "re-run Deploy")
 }
@@ -1700,7 +1699,7 @@ func TestApplyTransitionDeployTransientMergeRefusalTimesOut(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, failed)
-	headline := firstLine(marker.Prose(failed))
+	headline := failureReason(failed)
 	assert.Contains(t, headline, "the forge refused the merge")
 	assert.Contains(t, headline, "re-run Deploy")
 }
@@ -1728,7 +1727,7 @@ func TestApplyTransitionDeployCIFailureHeadline(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, failed)
-	headline := firstLine(marker.Prose(failed))
+	headline := failureReason(failed)
 	assert.Contains(t, headline, "fix the failing checks")
 	assert.Contains(t, headline, "re-run Deploy")
 }
@@ -1839,7 +1838,7 @@ func TestDeployBranch_SecretStoreAuthFailure_NotFixable(t *testing.T) {
 	}
 	require.NotEmpty(t, failed, "the failure must red the card with a deploy-failed marker")
 	assert.Empty(t, started, "no deploy-fix must be started")
-	headline := firstLine(marker.Prose(failed))
+	headline := failureReason(failed)
 	assert.Contains(t, strings.ToLower(headline), "authenticat",
 		"the headline must state authentication is the problem")
 	assert.NotContains(t, headline, "CI checks failed",
@@ -1865,7 +1864,7 @@ func TestDeployBranch_SecretStoreAuthFailure_PushPath(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, failed)
-	headline := firstLine(marker.Prose(failed))
+	headline := failureReason(failed)
 	assert.Contains(t, strings.ToLower(headline), "authenticat")
 	assert.NotContains(t, headline, "check the branch and forge access")
 }

--- a/internal/daemon/board_wait.go
+++ b/internal/daemon/board_wait.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/gethuman-sh/human/internal/marker"
 	"github.com/gethuman-sh/human/internal/tracker"
 )
 
@@ -16,7 +17,7 @@ import (
 // orderedMarkerSpecs, so ClassifyMarker never sees it and it never moves a card.
 // Its body carries the eligibility anchor, the measured wait, and the cause, so a
 // wait is attributable and distinguishable from a stall by reading the ticket.
-const StageWaitHeader = "[human:stage-wait]"
+const StageWaitHeader = "[human:" + MarkerStageWait + "]"
 
 // Body-line prefixes for a stage-wait marker, following the `key: value`
 // convention of ClaimStagePrefix / the pr:/branch: handoff lines.
@@ -82,15 +83,19 @@ func eligibleAnchor(comments []tracker.Comment) (time.Time, bool) {
 	return newest.Created, true
 }
 
-// composeStageWait builds the marker body (without the daemon stamp).
+// composeStageWait builds the marker body (without the daemon stamp). The field
+// order is the wire format its readers already parse by prefix, so it is stated
+// explicitly rather than left to the map's iteration order.
 func composeStageWait(stage BoardStage, eligibleAt, startedAt time.Time, cause WaitCause) string {
-	var b strings.Builder
-	b.WriteString(StageWaitHeader + "\n")
-	b.WriteString(StageWaitStagePrefix + " " + string(stage) + "\n")
-	b.WriteString(StageWaitEligiblePrefix + " " + eligibleAt.UTC().Format(time.RFC3339) + "\n")
-	b.WriteString(StageWaitWaitedPrefix + " " + startedAt.Sub(eligibleAt).Round(time.Second).String() + "\n")
-	b.WriteString(StageWaitCausePrefix + " " + string(cause))
-	return b.String()
+	return markerBody(marker.Marker{
+		Type: MarkerStageWait,
+		Fields: fields(
+			"stage", string(stage),
+			"eligible", eligibleAt.UTC().Format(time.RFC3339),
+			"waited", startedAt.Sub(eligibleAt).Round(time.Second).String(),
+			"cause", string(cause),
+		),
+	}, "stage", "eligible", "waited", "cause")
 }
 
 // recordStageWait posts a [human:stage-wait] marker when the gap between the

--- a/internal/daemon/pr_loop_exec_test.go
+++ b/internal/daemon/pr_loop_exec_test.go
@@ -272,7 +272,9 @@ func TestOpenDraftPRAndReview_alreadyMerged_shortCircuits(t *testing.T) {
 
 	deployed, ok := posted(c, DeployedHeader)
 	require.True(t, ok, "an already-merged branch ends deployed, not reviewed")
-	assert.Contains(t, deployed, "already merged")
+	// The marker must name HOW the work shipped: no PR was opened, so `merged:`
+	// carries it. A bare header is a deployed marker the protocol rejects.
+	assert.Contains(t, deployed, "merged: already in the base branch")
 	assert.Equal(t, "SC-1", closed)
 	assert.Zero(t, p.call, "no PR must be opened for already-merged work")
 	assert.Zero(t, l.calls, "no reviewer must be launched for already-merged work")

--- a/internal/marker/marker.go
+++ b/internal/marker/marker.go
@@ -35,10 +35,17 @@ type Marker struct {
 // known types enforce their required fields and head enums so a malformed
 // handoff fails at post time, not at the reader.
 type spec struct {
-	required  []string
+	required []string
+	// anyOf names fields of which AT LEAST ONE must be present — a contract
+	// `required` cannot express. It is data rather than a closure so that
+	// everything telling a caller how to post the marker can read it: a
+	// hand-written validator satisfies Validate and leaves RequiredFields
+	// answering "nothing required", which hands an agent a command that posts a
+	// marker this package then rejects.
+	anyOf     []string
 	headEnum  []string
 	needsHead bool
-	// validate carries a contract the required/head fields cannot express.
+	// validate carries a contract the field lists cannot express.
 	validate func(Marker) error
 }
 
@@ -102,10 +109,17 @@ var specs = map[string]spec{
 	"nothing-to-do":         {required: []string{"evidence"}},
 	"deploy-started":        {},
 	"deploy-failed":         {required: []string{"reason"}},
-	"deployed":              {required: []string{"pr"}},
-	"bug-verdict":           {needsHead: true, headEnum: []string{"confirmed", "not-a-bug", "undetermined"}},
-	"bug-verify":            {needsHead: true, headEnum: []string{"DONE", "NOT DONE"}},
-	"options":               {required: []string{"stage"}, validate: validateOptions},
+	// A deployed marker must say HOW the work shipped, and there are two honest
+	// answers: through a pull request, or by a branch that was already in the
+	// base when the deploy ran. Requiring pr outright made the second case
+	// unpostable, so the daemon posted a bare header instead — a marker its own
+	// protocol rejects, which is what routing every writer through this
+	// validator surfaced. pr comes first because it is the ordinary shipping
+	// path, and something that must name one field names that one.
+	"deployed":    {anyOf: []string{"pr", "merged"}},
+	"bug-verdict": {needsHead: true, headEnum: []string{"confirmed", "not-a-bug", "undetermined"}},
+	"bug-verify":  {needsHead: true, headEnum: []string{"DONE", "NOT DONE"}},
+	"options":     {required: []string{"stage"}, validate: validateOptions},
 	// The ticket-review gate's verdict. The head carries the outcome so a reader
 	// can classify it without parsing the body, exactly as bug-verdict does; the
 	// gate ACTS on every outcome, so these name what it did, not what it asks for.
@@ -165,6 +179,21 @@ func RequiredFields(markerType string) []string {
 	return out
 }
 
+// AnyOfFields lists the fields a marker type must carry AT LEAST ONE of, in the
+// order the contract prefers them — so a caller that has to name exactly one
+// names the first. Empty when the type has no such contract.
+//
+// Exported for the same reason as RequiredFields: `human fsm next` builds the
+// runnable `human marker post` command from these lists, and a contract it
+// cannot read is a command that posts a marker Validate then rejects.
+func AnyOfFields(markerType string) []string {
+	s, known := specs[markerType]
+	if !known || len(s.anyOf) == 0 {
+		return nil
+	}
+	return append([]string(nil), s.anyOf...)
+}
+
 // Validate checks m against its type's contract. Unknown types pass — only a
 // syntactically valid type name is required.
 func Validate(m Marker) error {
@@ -179,6 +208,12 @@ func Validate(m Marker) error {
 		if strings.TrimSpace(m.Fields[req]) == "" {
 			return errors.WithDetails("marker is missing a required field", "type", m.Type, "field", req)
 		}
+	}
+	if len(s.anyOf) > 0 && !slices.ContainsFunc(s.anyOf, func(f string) bool {
+		return strings.TrimSpace(m.Fields[f]) != ""
+	}) {
+		return errors.WithDetails("marker must carry one of these fields", "type", m.Type,
+			"one of", strings.Join(s.anyOf, "|"))
 	}
 	if s.needsHead && strings.TrimSpace(m.Head) == "" {
 		return errors.WithDetails("marker requires a head token", "type", m.Type, "allowed", strings.Join(s.headEnum, "|"))

--- a/internal/pipelinefsm/pipeline-fsm.json
+++ b/internal/pipelinefsm/pipeline-fsm.json
@@ -59,7 +59,7 @@
         "daemon"
       ],
       "stale_when": "Past StuckRunningGrace with no live agent, like any running stage.",
-      "if_nothing_happens": "The agent's death is recorded as a PLANNING failure, because planning is the stage it runs under. Note the gap: the backlog stage has no *-failed marker of its own (failedHeaderFor returns none for it), so neither the live watcher nor the durable pass can red a card derived at backlog/running directly — recovery here depends entirely on the enclosing planning dispatch."
+      "if_nothing_happens": "The agent's death is recorded as a PLANNING failure, because planning is the stage it runs under. Note the gap: the backlog stage has no *-failed marker of its own (failedTypeFor returns none for it), so neither the live watcher nor the durable pass can red a card derived at backlog/running directly — recovery here depends entirely on the enclosing planning dispatch."
     },
     {
       "name": "ticket-reviewed",
@@ -701,7 +701,7 @@
       "actor": "daemon",
       "marker": "[human:implementation-failed]",
       "where": "board_failure.go",
-      "doc": "The daemon's failure watcher classifies an agent that exited without posting its handoff. It fires for the implementation stage as a whole — failedHeaderFor(BoardImplementation) knows the stage, never which phase the run had reached — so every state of the stage leads here."
+      "doc": "The daemon's failure watcher classifies an agent that exited without posting its handoff. It fires for the implementation stage as a whole — failedTypeFor(BoardImplementation) knows the stage, never which phase the run had reached — so every state of the stage leads here."
     },
     {
       "name": "start-review",
@@ -749,7 +749,7 @@
         "reason"
       ],
       "doc": "The review stage itself failed — a binding gate such as a missing branch or unreachable commits — not a failing verdict.",
-      "where": "internal/daemon/board_failure.go — the failure watcher, via failedHeaderFor(BoardVerification)"
+      "where": "internal/daemon/board_failure.go — the failure watcher, via failedTypeFor(BoardVerification)"
     },
     {
       "name": "start-deploy",

--- a/internal/pipelinefsm/waysout.go
+++ b/internal/pipelinefsm/waysout.go
@@ -77,5 +77,12 @@ func CommandFor(e Event, key string) string {
 	for _, f := range marker.RequiredFields(markerType) {
 		cmd += " --field " + f + "=<" + f + ">"
 	}
+	// A one-of contract still has to produce ONE runnable command, so it names
+	// the contract's preferred field. The alternatives are reported by
+	// `human fsm marker`, which is where a caller looks when the default is not
+	// the case they are in.
+	if anyOf := marker.AnyOfFields(markerType); len(anyOf) > 0 {
+		cmd += " --field " + anyOf[0] + "=<" + anyOf[0] + ">"
+	}
 	return cmd
 }


### PR DESCRIPTION
Phase 1 of SC-4118 (replace raw file/map/string manipulation with domain objects).

The daemon writes most of the `[human:*]` markers in the system and built their bodies by concatenating a header constant with a line of prose at ~20 sites. `internal/marker` — which validates required fields, head enums and the decision-block contract — was reached only by the three CLI commands, so the protocol's biggest writer checked nothing against it.

What that produced, all now fixed:

- `deploy-failed` / `review-failed` / `pr-review-failed` / `needs-planning` / `close-failed` markers posted with no `reason`, which their specs require.
- `deployed` posted as a bare header when the branch was already in the base — a marker its own protocol rejects. The spec now says `pr` **or** `merged` (`anyOf`), expressed as data so `human fsm next` still builds a runnable `human marker post` command.
- A decision block whose `stage` and `context` were written after the numbered answers. A numbered id is not a field name the grammar accepts, so everything after the first answer reads back as body prose — the block validated as one with no stage.

`postMarker`/`markerBody` are the single funnel. `failureMarker` splits a diagnosis into the headline the card badge shows (the `reason` field) and the detail prose; `failureBody` recomposes them, including for markers already on live tickets that carry prose and no `reason` field. Marker headers are now derived from their type names.

`TestDaemonPostedMarkersSatisfyTheirContract` walks every daemon marker type, composing each through the real builder, and `daemonMarkerTypes` is the completeness list so a new marker cannot ship unchecked.

`make check` green, `go test ./cmd/...` green, `make fsm` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)