### PR TITLE
[SC-4120] No tracker backend is privileged

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,17 +70,26 @@ ticket; stage says what is working on it; kind says where it lives.
 
 # Board rendering
 
-The desktop workflow board renders the issues of the **PM-role tracker only**. A tracker resolves to the pm role through an explicit `role: pm` in `.humanconfig` 
-It needs an explicit `role: pm` to appear on the board:
+The desktop workflow board renders the issues of the **PM-role tracker only**. Which tracker that is is a property of the **set** of configured trackers, not of any one backend — `tracker.ResolveTopology` answers it, and it names no kind:
+
+1. A tracker with an explicit `role: pm` is the PM tracker.
+2. Failing that, a lone non-engineering tracker is the PM tracker, **whatever backend it is**. Single-tracker is the default topology and there the one ticket is the PM ticket, so the common case needs no `role:` line at all.
+3. With several undeclared trackers none is chosen — the board says so instead of guessing.
+
+**No backend is privileged.** `role: pm` is only needed to disambiguate:
 
 ```yaml
 trackers:
   - kind: linear
     name: work
-    role: pm            # required for non-Shortcut PM trackers to render on the board
+    role: pm            # only needed when several trackers are configured
+  - kind: github
+    name: issues
 ```
 
-When a tracker resolves but none of them carries the pm role — or no tracker is configured at all — the board shows an explicit "No PM-role tracker configured" notice (naming the trackers it did find) instead of five silently empty columns, so the misconfiguration is visible rather than mistaken for "no work yet". A tracker that *failed to load* is a different fault and gets a different message: its failure is reported through the board's error banner (`board.ErrorBanner`), and the role notice stays silent, because telling a user whose secret store was unreachable to add `role: pm` sends them to edit a `.humanconfig` that needs no editing. 
+The engineering role is **never** inferred. Split topology turns on only where a tracker carries an explicit `role: engineering` (SC-254/SC-660).
+
+When several trackers resolve and none declares the role, the board shows a notice naming them instead of five silently empty columns, so the misconfiguration is visible rather than mistaken for "no work yet". A tracker that *failed to load* is a different fault: it is reported through the board's error banner (`board.ErrorBanner`) and the role notice stays silent, because telling a user whose secret store was unreachable to add `role: pm` sends them to edit a `.humanconfig` that needs no editing (SC-3554).
 
 # Review handoff
 

--- a/cmd/cmdconfig/config.go
+++ b/cmd/cmdconfig/config.go
@@ -170,7 +170,7 @@ func RunMigrate(out io.Writer, dir string, dryRun, unify bool) error {
 	// was in fact someone's issue tracker they need the line that says so.
 	if len(result.Moved) > 0 {
 		if _, err := fmt.Fprintln(out,
-			"If GitHub is where your issues live, add a githubs: entry with role: pm — a GitHub tracker has always needed it to reach the board."); err != nil {
+			"If GitHub is where your issues live, add a githubs: entry for it — a lone tracker reaches the board on any backend, and role: pm is needed only to pick between several."); err != nil {
 			return err
 		}
 	}

--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -1818,6 +1818,11 @@ type fetchJob struct {
 	inst    tracker.Instance
 	project string
 	dir     string
+	// role is the instance's role RESOLVED ACROSS ITS SET, not asked of the
+	// instance alone: which tracker is the PM one depends on what else is
+	// configured beside it, and asking each instance in isolation is how only
+	// Shortcut ever answered "pm" (SC-4120).
+	role string
 }
 
 func fetchTrackerIssuesFunc(reg *daemon.ProjectRegistry, resolver *vault.Resolver, logger zerolog.Logger) func() ([]daemon.TrackerIssuesResult, error) {
@@ -2109,13 +2114,25 @@ func logReportableLoadFailures(failures []error, dir, subsystem string) {
 // the whole listing for a single-project backend.
 func listingJobs(instances []tracker.Instance, dir string) []fetchJob {
 	var jobs []fetchJob
+	// Resolved once for the whole set, then stamped on every job cut from it.
+	top := tracker.ResolveTopology(instances)
+	roleOf := func(inst tracker.Instance) string {
+		switch {
+		case top.PM != nil && top.PM.Name == inst.Name && top.PM.Kind == inst.Kind:
+			return "pm"
+		case top.Engineering != nil && top.Engineering.Name == inst.Name && top.Engineering.Kind == inst.Kind:
+			return "engineering"
+		default:
+			return inst.InferRole()
+		}
+	}
 	for _, inst := range instances {
 		projects := inst.Projects
 		if len(projects) == 0 {
 			projects = []string{""}
 		}
 		for _, p := range projects {
-			jobs = append(jobs, fetchJob{inst: inst, project: p, dir: dir})
+			jobs = append(jobs, fetchJob{inst: inst, project: p, dir: dir, role: roleOf(inst)})
 		}
 	}
 	return jobs
@@ -2178,7 +2195,7 @@ func listTrackerIssues(reg *daemon.ProjectRegistry, resolver *vault.Resolver) ([
 			results[i] = daemon.TrackerIssuesResult{
 				TrackerName: job.inst.Name,
 				TrackerKind: job.inst.Kind,
-				TrackerRole: job.inst.InferRole(),
+				TrackerRole: job.role,
 				Project:     label,
 				Issues:      page.Issues,
 				Truncated:   page.Truncated,
@@ -3054,6 +3071,16 @@ func boardPRMerged(ctx context.Context, projects *daemon.ProjectRegistry, resolv
 	return reader.PullRequestMerged(ctx, repo, number)
 }
 
+// errNoPMTracker is the one answer every PM resolver gives when the set does not
+// name a PM tracker. It states the remedy in the terms the config uses, because
+// the two ways to get here — no tracker at all, and several undeclared ones —
+// have the same fix: say which one it is.
+func errNoPMTracker(dir string) error {
+	return errors.WithDetails(
+		"no PM-role tracker configured — add role: pm to the tracker whose issues belong on the board",
+		"dir", dir)
+}
+
 // resolvePMCommenter resolves the PM-role tracker.Commenter for a workspace.
 // It selects by ROLE (InferRole()=="pm"), never by key prefix: both trackers
 // can be configured with the same name, so key auto-detect mis-routes.
@@ -3062,13 +3089,16 @@ func resolvePMCommenter(dir string, lookup config.EnvLookup, resolver *vault.Res
 	if err != nil {
 		return nil, err
 	}
-	for _, inst := range instances {
-		if inst.InferRole() != "pm" {
-			continue
-		}
-		if c, ok := inst.Provider.(tracker.Commenter); ok {
-			return c, nil
-		}
+	// The PM tracker is a property of the SET, not of any one instance: an
+	// explicit role: pm wins, and failing that a lone non-engineering tracker
+	// is it, whatever backend it runs on. Asking each instance what it is was
+	// how only Shortcut ever answered "pm" (SC-4120).
+	pm := tracker.ResolveTopology(instances).PM
+	if pm == nil {
+		return nil, errNoPMTracker(dir)
+	}
+	if c, ok := pm.Provider.(tracker.Commenter); ok {
+		return c, nil
 	}
 	return nil, errors.WithDetails("no PM-role tracker with comment support configured", "dir", dir)
 }
@@ -3082,13 +3112,16 @@ func resolvePMGetter(dir string, lookup config.EnvLookup, resolver *vault.Resolv
 	if err != nil {
 		return nil, err
 	}
-	for _, inst := range instances {
-		if inst.InferRole() != "pm" {
-			continue
-		}
-		if g, ok := inst.Provider.(tracker.Getter); ok {
-			return g, nil
-		}
+	// The PM tracker is a property of the SET, not of any one instance: an
+	// explicit role: pm wins, and failing that a lone non-engineering tracker
+	// is it, whatever backend it runs on. Asking each instance what it is was
+	// how only Shortcut ever answered "pm" (SC-4120).
+	pm := tracker.ResolveTopology(instances).PM
+	if pm == nil {
+		return nil, errNoPMTracker(dir)
+	}
+	if g, ok := pm.Provider.(tracker.Getter); ok {
+		return g, nil
 	}
 	return nil, errors.WithDetails("no PM-role tracker with fetch support configured", "dir", dir)
 }
@@ -3102,13 +3135,16 @@ func resolvePMCurrentUser(dir string, lookup config.EnvLookup, resolver *vault.R
 	if err != nil {
 		return nil, err
 	}
-	for _, inst := range instances {
-		if inst.InferRole() != "pm" {
-			continue
-		}
-		if n, ok := inst.Provider.(tracker.CurrentUserNamer); ok {
-			return n, nil
-		}
+	// The PM tracker is a property of the SET, not of any one instance: an
+	// explicit role: pm wins, and failing that a lone non-engineering tracker
+	// is it, whatever backend it runs on. Asking each instance what it is was
+	// how only Shortcut ever answered "pm" (SC-4120).
+	pm := tracker.ResolveTopology(instances).PM
+	if pm == nil {
+		return nil, errNoPMTracker(dir)
+	}
+	if n, ok := pm.Provider.(tracker.CurrentUserNamer); ok {
+		return n, nil
 	}
 	return nil, nil
 }
@@ -3225,13 +3261,16 @@ func resolvePMTransitioner(dir string, lookup config.EnvLookup, resolver *vault.
 	if err != nil {
 		return nil, err
 	}
-	for _, inst := range instances {
-		if inst.InferRole() != "pm" {
-			continue
-		}
-		if t, ok := inst.Provider.(tracker.Transitioner); ok {
-			return t, nil
-		}
+	// The PM tracker is a property of the SET, not of any one instance: an
+	// explicit role: pm wins, and failing that a lone non-engineering tracker
+	// is it, whatever backend it runs on. Asking each instance what it is was
+	// how only Shortcut ever answered "pm" (SC-4120).
+	pm := tracker.ResolveTopology(instances).PM
+	if pm == nil {
+		return nil, errNoPMTracker(dir)
+	}
+	if t, ok := pm.Provider.(tracker.Transitioner); ok {
+		return t, nil
 	}
 	return nil, errors.WithDetails("no PM-role tracker with transition support configured", "dir", dir)
 }
@@ -3245,13 +3284,11 @@ func resolvePMOwner(dir string, lookup config.EnvLookup, resolver *vault.Resolve
 	if err != nil {
 		return nil, err
 	}
-	for _, inst := range instances {
-		if inst.InferRole() != "pm" {
-			continue
-		}
-		return inst.Provider, nil
+	pm := tracker.ResolveTopology(instances).PM
+	if pm == nil {
+		return nil, errors.WithDetails("no PM-role tracker configured to record ownership", "dir", dir)
 	}
-	return nil, errors.WithDetails("no PM-role tracker configured to record ownership", "dir", dir)
+	return pm.Provider, nil
 }
 
 // closeTicketerFunc builds the daemon's CloseTicketer closure: it stops any live
@@ -3995,16 +4032,15 @@ func resolvePMCreator(dir string, lookup config.EnvLookup, resolver *vault.Resol
 	if err != nil {
 		return nil, "", err
 	}
-	for _, inst := range instances {
-		if inst.InferRole() != "pm" {
-			continue
-		}
+	pm := tracker.ResolveTopology(instances).PM
+	if pm != nil {
+		inst := *pm
 		// tracker.Provider embeds Creator, so this assertion cannot fail
 		// today; kept for symmetry with resolvePMCommenter and as a guard
 		// should the Provider interface ever be split.
 		c, ok := inst.Provider.(tracker.Creator)
 		if !ok {
-			continue
+			return nil, "", errNoPMTracker(dir)
 		}
 		target := inst.FilingTarget()
 		if target == "" {
@@ -4027,13 +4063,16 @@ func resolvePMEditor(dir string, lookup config.EnvLookup, resolver *vault.Resolv
 	if err != nil {
 		return nil, err
 	}
-	for _, inst := range instances {
-		if inst.InferRole() != "pm" {
-			continue
-		}
-		if ed, ok := inst.Provider.(tracker.Editor); ok {
-			return ed, nil
-		}
+	// The PM tracker is a property of the SET, not of any one instance: an
+	// explicit role: pm wins, and failing that a lone non-engineering tracker
+	// is it, whatever backend it runs on. Asking each instance what it is was
+	// how only Shortcut ever answered "pm" (SC-4120).
+	pm := tracker.ResolveTopology(instances).PM
+	if pm == nil {
+		return nil, errNoPMTracker(dir)
+	}
+	if ed, ok := pm.Provider.(tracker.Editor); ok {
+		return ed, nil
 	}
 	return nil, errors.WithDetails("no PM-role tracker with edit support configured", "dir", dir)
 }

--- a/internal/board/gate.go
+++ b/internal/board/gate.go
@@ -38,13 +38,19 @@ func FirstPMResult(results []daemon.TrackerIssuesResult) (daemon.TrackerIssuesRe
 
 // PMRoleNotice explains an empty board that carries no PM-role tracker, so the
 // UI can show why nothing renders instead of five silently empty columns — the
-// SC-1655 defect, where a correctly configured non-Shortcut tracker returns
-// issues that the board discards for lacking the pm role. Only Shortcut infers
-// the pm role for free (see tracker.Instance.InferRole); every other kind needs
-// an explicit `role: pm` in .humanconfig. When trackers were fetched but none
-// carries the role, the message names them so the user knows which entry to
-// annotate; with no trackers at all it gives the generic setup hint. An empty
-// string means a PM-role result exists and the board renders normally.
+// SC-1655 defect, where a correctly configured tracker returns issues the board
+// discards for lacking the pm role.
+//
+// No backend earns the role by being itself. A single configured tracker is the
+// PM tracker whatever it is (tracker.ResolveTopology), so the common case needs
+// no role: line at all; this notice is what SEVERAL undeclared trackers get,
+// because there the machine genuinely cannot tell which board it is looking at
+// and guessing would scope the board silently and wrongly (SC-4120).
+//
+// When trackers were fetched but none carries the role the message names them,
+// so the user knows which entry to annotate; with no trackers at all it gives the
+// generic setup hint. An empty string means a PM-role result exists and the board
+// renders normally.
 func PMRoleNotice(results []daemon.TrackerIssuesResult) string {
 	if _, ok := FirstPMResult(results); ok {
 		return ""
@@ -67,9 +73,9 @@ func PMRoleNotice(results []daemon.TrackerIssuesResult) string {
 		if anyFailed(results) {
 			return ""
 		}
-		return "No PM-role tracker configured. Add role: pm to a tracker in .humanconfig so its issues appear on the board (see CLAUDE.md, \"Board rendering\")."
+		return "No tracker configured. Add one to .humanconfig so its issues appear on the board (see CLAUDE.md, \"Board rendering\")."
 	}
-	return fmt.Sprintf("No PM-role tracker configured. Found %s, but none has role: pm — add role: pm to one in .humanconfig so its issues appear on the board (see CLAUDE.md, \"Board rendering\").", strings.Join(found, ", "))
+	return fmt.Sprintf("More than one tracker is configured and none says which board this is. Found %s — add role: pm to the one whose issues belong here (see CLAUDE.md, \"Board rendering\").", strings.Join(found, ", "))
 }
 
 // ErrorBanner is every failure in a fetch, joined into the one line the board

--- a/internal/board/gate_test.go
+++ b/internal/board/gate_test.go
@@ -152,14 +152,19 @@ func TestPMRoleNotice(t *testing.T) {
 		{
 			name:    "no trackers at all gives generic hint",
 			results: nil,
-			want:    "No PM-role tracker configured. Add role: pm to a tracker in .humanconfig so its issues appear on the board (see CLAUDE.md, \"Board rendering\").",
+			want:    "No tracker configured. Add one to .humanconfig so its issues appear on the board (see CLAUDE.md, \"Board rendering\").",
 		},
 		{
-			name: "non-pm tracker is named so the user knows what to annotate",
+			// A LONE undeclared tracker no longer reaches this notice at all: it
+			// resolves to pm whatever backend it is, so the daemon stamps the role
+			// and the board renders. This is the several-candidates case, which is
+			// the only one the machine genuinely cannot decide.
+			name: "undeclared candidates are named so the user knows what to annotate",
 			results: []daemon.TrackerIssuesResult{
 				{TrackerName: "work", TrackerKind: "linear", Issues: []tracker.Issue{{Key: "ENG-1"}}},
+				{TrackerName: "board", TrackerKind: "shortcut", Issues: []tracker.Issue{{Key: "SC-1"}}},
 			},
-			want: "No PM-role tracker configured. Found work (linear), but none has role: pm — add role: pm to one in .humanconfig so its issues appear on the board (see CLAUDE.md, \"Board rendering\").",
+			want: "More than one tracker is configured and none says which board this is. Found work (linear), board (shortcut) — add role: pm to the one whose issues belong here (see CLAUDE.md, \"Board rendering\").",
 		},
 		{
 			name: "every result failed — the banner speaks, not role advice",
@@ -174,7 +179,7 @@ func TestPMRoleNotice(t *testing.T) {
 				{TrackerName: "broken", TrackerKind: "jira", Err: "boom"},
 				{TrackerName: "work", TrackerKind: "linear", Issues: []tracker.Issue{{Key: "ENG-1"}}},
 			},
-			want: "No PM-role tracker configured. Found work (linear), but none has role: pm — add role: pm to one in .humanconfig so its issues appear on the board (see CLAUDE.md, \"Board rendering\").",
+			want: "More than one tracker is configured and none says which board this is. Found work (linear) — add role: pm to the one whose issues belong here (see CLAUDE.md, \"Board rendering\").",
 		},
 	}
 	for _, tc := range tests {

--- a/internal/tracker/topology_test.go
+++ b/internal/tracker/topology_test.go
@@ -60,6 +60,9 @@ func TestResolveTopology_splitOnExplicitEngineering(t *testing.T) {
 	assert.Equal(t, "eng", top.Engineering.Name)
 }
 
+// Two undeclared trackers are ambiguous whatever they are. A Shortcut among them
+// used to win by kind, which is exactly the privilege this rule no longer grants:
+// the board says it cannot tell rather than picking one and being quietly wrong.
 func TestResolveTopology_singleWithoutEngineeringRole(t *testing.T) {
 	instances := []Instance{
 		{Name: "board", Kind: "shortcut"},
@@ -67,9 +70,23 @@ func TestResolveTopology_singleWithoutEngineeringRole(t *testing.T) {
 	}
 	top := ResolveTopology(instances)
 	assert.Equal(t, "single", top.Mode)
-	require.NotNil(t, top.PM)
-	assert.Equal(t, "board", top.PM.Name)
+	assert.Nil(t, top.PM, "neither declared pm, and neither kind earns it")
 	assert.Nil(t, top.Engineering)
+}
+
+// Declaring resolves it, on any backend — which is the whole remedy the board
+// notice points at.
+func TestResolveTopology_declaredPMWinsOnAnyKind(t *testing.T) {
+	for _, kind := range []string{"shortcut", "jira", "linear", "github", "gitlab", "azuredevops", "clickup"} {
+		t.Run(kind, func(t *testing.T) {
+			top := ResolveTopology([]Instance{
+				{Name: "board", Kind: kind, Role: "pm"},
+				{Name: "other", Kind: "linear"},
+			})
+			require.NotNil(t, top.PM)
+			assert.Equal(t, "board", top.PM.Name)
+		})
+	}
 }
 
 func TestResolveTopology_pmFallbackToSoleTracker(t *testing.T) {
@@ -92,8 +109,8 @@ func TestResolveTopology_pmAmbiguousStaysNil(t *testing.T) {
 
 func TestResolveTopology_firstRoleWins(t *testing.T) {
 	instances := []Instance{
-		{Name: "pm1", Kind: "shortcut"},
-		{Name: "pm2", Kind: "shortcut"},
+		{Name: "pm1", Kind: "shortcut", Role: "pm"},
+		{Name: "pm2", Kind: "shortcut", Role: "pm"},
 		{Name: "eng1", Kind: "linear", Role: "engineering"},
 		{Name: "eng2", Kind: "github", Role: "engineering"},
 	}

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -682,21 +682,28 @@ func (inst Instance) FilingTarget() string {
 	return ""
 }
 
-// InferRole returns the instance's role. An explicit role always wins. With no
-// explicit role, only the pm role is inferred (for Shortcut boards) so read-side
-// board scanning keeps working out of the box; the engineering role is never
-// inferred. Engineering (split) topology is opt-in: it turns on only when a
-// tracker carries an explicit role: engineering in .humanconfig. Inferring
-// engineering from the Linear kind silently flipped single-tracker setups back
-// into split topology and minted unwanted engineering tickets ([SC-254]).
+// InferRole returns the role this instance DECLARES. It infers nothing from the
+// backend: a kind carries no role, and an instance with no role: line has none.
+//
+// It used to name Shortcut — a Shortcut tracker got the pm role for free and
+// every other kind resolved to no role at all — so a correctly configured Jira,
+// Linear or GitHub board returned issues and rendered nothing, and the remedy was
+// a role: pm line the config had no reason to say. A rule that has to name one
+// backend is a rule that is wrong for the others.
+//
+// Which tracker is the PM tracker is not a property of an instance anyway; it is
+// a property of the SET, and ResolveTopology already answers it without naming a
+// kind: an explicit pm wins, and failing that a lone non-engineering tracker is
+// the PM one, whatever backend it is. Two undeclared candidates stay ambiguous
+// rather than being guessed at. Callers choosing a PM tracker must go through
+// ResolveTopology; this method answers only "what did this instance declare?".
+//
+// The engineering role was never inferred and still is not. Split topology stays
+// opt-in, because inferring engineering from the Linear kind is what silently
+// flipped single-tracker setups back into split topology and minted unwanted
+// engineering tickets ([SC-254]).
 func (inst Instance) InferRole() string {
-	if inst.Role != "" {
-		return inst.Role
-	}
-	if inst.Kind == "shortcut" {
-		return "pm"
-	}
-	return ""
+	return inst.Role
 }
 
 // ValidateTopology reports a divergence between the topology a config DECLARES

--- a/internal/tracker/tracker_test.go
+++ b/internal/tracker/tracker_test.go
@@ -846,12 +846,18 @@ func TestInferRole_SC254(t *testing.T) {
 		inst Instance
 		want string
 	}{
-		{"linear without role no longer infers engineering", Instance{Kind: "linear"}, ""},
+		// InferRole reports what an instance DECLARES and infers nothing from the
+		// backend. Which tracker is the PM one is a property of the set, answered
+		// by ResolveTopology — see the topology tests.
 		{"explicit engineering role honored", Instance{Kind: "linear", Role: "engineering"}, "engineering"},
 		{"explicit engineering role honored on any kind", Instance{Kind: "github", Role: "engineering"}, "engineering"},
-		{"shortcut still infers pm", Instance{Kind: "shortcut"}, "pm"},
-		{"explicit role overrides kind", Instance{Kind: "shortcut", Role: "engineering"}, "engineering"},
-		{"unknown kind without role is empty", Instance{Kind: "jira"}, ""},
+		{"explicit pm role honored", Instance{Kind: "jira", Role: "pm"}, "pm"},
+		// No backend is privileged: not the one that used to be, and not any other.
+		{"shortcut declares nothing", Instance{Kind: "shortcut"}, ""},
+		{"linear declares nothing", Instance{Kind: "linear"}, ""},
+		{"jira declares nothing", Instance{Kind: "jira"}, ""},
+		{"github declares nothing", Instance{Kind: "github"}, ""},
+		{"an unknown kind declares nothing", Instance{Kind: "somethingnew"}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## What happens

One backend was privileged. `tracker.Instance.InferRole` granted the pm role to a
Shortcut tracker for free; every other kind resolved to **no role at all** unless
the config carried an explicit `role: pm`.

The board renders the PM-role tracker only, so a correctly configured Linear,
Jira, GitHub, GitLab, Azure DevOps or ClickUp tracker fetched its issues and the
board discarded every one of them — five silently empty columns, or the
"No PM-role tracker configured" notice on a config with nothing wrong with it.
The remedy was a `role: pm` line the config had no reason to say, and which only
some users ever needed.

A rule that has to name one backend is a rule that is wrong for the others.

## Cause

Which tracker is the PM tracker is a property of the **set** of configured
trackers, not of any one instance — and `tracker.ResolveTopology` already knew
that, and already answered it without naming a kind:

1. an explicit `role: pm` wins;
2. failing that, a lone non-engineering tracker is the PM one, whatever it is;
3. several undeclared candidates stay ambiguous rather than being guessed at.

But the consumers that actually pick the PM tracker never asked it. They asked
each instance in isolation — `inst.InferRole() == "pm"` — which is a question an
instance cannot answer, and which therefore had to be answered by kind. That is
where the privilege lived: the seven `resolvePM*` helpers in the daemon, and the
role stamped on every board listing result.

## Wanted

- **No backend is privileged.** Nothing in the role rule names a kind.
- **A single configured tracker reaches the board with no `role:` line**, on any
  backend. Single-tracker is the default topology and the common case should need
  no configuration.
- **Several undeclared trackers stay ambiguous.** The machine says it cannot tell
  rather than scoping the board silently and wrongly, and the notice names the
  candidates so the fix is obvious.
- **The engineering role is still never inferred.** Split topology stays opt-in.

## The edge this must not create

Inferring engineering from a kind is what silently flipped single-tracker setups
into split topology and minted unwanted engineering tickets (SC-254/SC-660). That
guard must survive: only `role: engineering` makes an engineering tracker.

## Migration

An install with one tracker is unaffected and needs no edit — it now resolves on
any backend rather than only on Shortcut.

An install with **two or more trackers, none declaring a role**, previously had
its Shortcut chosen by kind and now gets the ambiguity notice naming both. Adding
`role: pm` to the intended one restores it. That is the case where the old
behaviour was guessing, and the guess is what this removes.

## Related

SC-1655 (the board discarding a correctly configured tracker's issues), SC-254,
SC-660, SC-3554.

## How

`InferRole` now reports only what an instance **declares**. The seven `resolvePM*` helpers and the board listing's role stamp go through `tracker.ResolveTopology`, which already had the kind-neutral rule and simply was not being asked.

Behaviour, both intended:

- A lone tracker reaches the board on any backend with no `role:` line.
- Several undeclared trackers get the ambiguity notice instead of the Shortcut among them winning by kind. Migration is one `role: pm` line, and the notice names the candidates.

The board notice was rewritten with it: it used to tell every roleless install to add `role: pm`, and now fires only for the genuinely ambiguous case. A tracker-less install gets a plain setup hint rather than role advice.

The SC-254/SC-660 guard is untouched — engineering is still never inferred.

`make check` green, `go test ./cmd/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)