### PR TITLE
[SC-4118] Move a card's (stage, state) as one value with named transitions

### DIFF
--- a/internal/daemon/board_options.go
+++ b/internal/daemon/board_options.go
@@ -332,13 +332,13 @@ func attachOpenOptions(card *BoardCard, comments []tracker.Comment) {
 	// Posting is now rejected for this (marker.MinDecisionOptions), so this is
 	// the recovery path for blocks already on a ticket.
 	if len(opts) < marker.MinDecisionOptions {
-		card.State = BoardFailed
+		card.placeAt(card.placement().failedOn())
 		card.Error = "decision block offers only " + strconv.Itoa(len(opts)) + " answer; a decision needs at least " +
 			strconv.Itoa(marker.MinDecisionOptions) + " — the stage should have handled this itself"
 		return
 	}
 	if !optionStages[stage] {
-		card.State = BoardFailed
+		card.placeAt(card.placement().failedOn())
 		card.Error = "decision block names stage \"" + string(stage) + "\" the board cannot resume"
 		return
 	}

--- a/internal/daemon/board_placement.go
+++ b/internal/daemon/board_placement.go
@@ -1,0 +1,211 @@
+package daemon
+
+import (
+	"sort"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// Placement is a card's (stage, state) — the pair the board renders into a
+// column and a badge, and the pair every reconcile pass judges before it acts.
+//
+// It exists because the two halves were carried as loose strings that any code
+// could set independently. The derivation computed a pair by one set of rules
+// and later passes assigned over it (`card.State = BoardFailed`), so the result
+// was whatever the last writer said, and nothing anywhere asked whether the
+// combination was one the machine could actually produce. The legal pairs are
+// declared in pipeline-fsm.json and were checked only by a conformance test —
+// after the fact, on a document, not on the value.
+//
+// So the pair moves as one value with named transitions. Every way a card's
+// placement changes during derivation is a method here; a placement is only
+// reachable by the rule that names it, and legal() says whether the machine can
+// name the result at all.
+type Placement struct {
+	stage BoardStage
+	state BoardState
+}
+
+// Stage and State expose the halves for reading. Writing goes through the
+// transitions.
+func (p Placement) Stage() BoardStage { return p.stage }
+func (p Placement) State() BoardState { return p.state }
+
+// atStage places a card at the head of a stage with no state — the idle card
+// waiting for its turn. The backlog card and the ideas card are this.
+func atStage(stage BoardStage) Placement {
+	return Placement{stage: stage, state: BoardIdle}
+}
+
+// fromMarker is the ordinary placement: a marker classified into a (stage,
+// state) pair. ok is false for a body that is not a board marker, which is the
+// same answer ClassifyMarker gives.
+func fromMarker(body string) (Placement, bool) {
+	stage, state, ok := ClassifyMarker(body)
+	if !ok {
+		return Placement{}, false
+	}
+	return Placement{stage: stage, state: state}, true
+}
+
+// inStage moves a placement to the state the stage's own latest marker decides.
+// This is the second pass of derivation: the furthest stage is settled, and the
+// marker newest within it says whether that stage is running, done or failed.
+func (p Placement) inStage(state BoardState) Placement {
+	return Placement{stage: p.stage, state: state}
+}
+
+// supersededBy hands the card to a strictly-newer marker anywhere on the
+// ticket. A stale red the pipeline already moved past, or a done-stage loop a
+// chosen rebuild restarted from an earlier stage: the card follows the ticket's
+// current activity rather than a terminal the machine has left behind.
+func (p Placement) supersededBy(newer Placement) Placement { return newer }
+
+// queuedAt records that a decision ([human:option-chosen]) has re-queued a
+// stage whose relaunched agent has not posted its started marker yet. It is the
+// one placement no marker produces — synthesized here rather than classified —
+// so it exists only as the result of this transition.
+func queuedAt(stage BoardStage) Placement {
+	return Placement{stage: stage, state: BoardQueued}
+}
+
+// pausedOnDecision turns a running OR failed card into a waiting-on-human card
+// while an open decision block names its own stage or an earlier one the answer
+// would rework: the card is not working, and it is not dead either — it is
+// waiting for a human. Server-side twin of the client's decision-badge branch.
+// The caller applies the same at-or-before stage-rank predicate as the failure
+// watcher and reconcile pass (stagePausedOnOptions), so a block naming a stage
+// the card has not yet reached — a stale or target-relaunch block — never
+// clears an active run (SC-1669).
+//
+// Accepting BoardFailed alongside BoardRunning is the residual safety net
+// (SC-1957): a card can reach this point already reddened by a *-failed marker
+// posted before the recovery machinery's own relaunch consumed the question
+// (openOptionsBlock only treats a later BoardRunning marker or an option-chosen
+// as consumption — a *-failed marker does not). Surfacing that combination as
+// waiting-on-human rather than a plain failure is exactly what makes an
+// otherwise-erased question visible. This also subsumes the former SC-1857
+// done-stage PR-loop escalation special case: the escalation's block names the
+// implementation stage while the card's furthest stage is done, so the general
+// at-or-before rank rule (rank 3 <= rank 5) pauses it the same way the former
+// bespoke escalation check used to.
+//
+// Every other state is returned unchanged.
+func (p Placement) pausedOnDecision() Placement {
+	if p.state != BoardRunning && p.state != BoardFailed {
+		return p
+	}
+	return Placement{stage: p.stage, state: BoardIdle}
+}
+
+// determinedBy hands the card to a terminal determination — the last word about
+// the whole ticket (already merged, no fix warranted, a gate's stop, a launch
+// refused for want of a plan). Each files under a stage that ranks BELOW the
+// phantom runs it supersedes, so it must override furthest-stage-wins rather
+// than lose to it.
+func (p Placement) determinedBy(terminal Placement) Placement { return terminal }
+
+// failedOn reds a card in place, keeping its stage. It is how a malformed
+// decision block already on a ticket surfaces: the card says what is wrong
+// where the decision would have been, rather than the block vanishing.
+func (p Placement) failedOn() Placement {
+	return Placement{stage: p.stage, state: BoardFailed}
+}
+
+// legalPlacements is every (stage, state) pair the machine can produce: one per
+// classified marker, plus the placements derivation synthesizes without a
+// marker to classify.
+//
+// Built from orderedMarkerSpecs rather than restated, so a marker added there
+// is legal here the moment it exists — a second list would be wrong the first
+// time a marker is added, and wrong silently.
+func legalPlacements() map[Placement]bool {
+	legal := map[Placement]bool{
+		// No pipeline activity yet, and the two placements that come from the
+		// ticket itself rather than from any marker: a closed ticket is hidden,
+		// an idea-labelled one sits in Ideas until promotion removes the label.
+		atStage(BoardBacklog): true,
+		atStage(BoardHidden):  true,
+		atStage(BoardIdeas):   true,
+	}
+	for _, spec := range orderedMarkerSpecs {
+		legal[Placement{stage: spec.Stage, state: spec.State}] = true
+		// Any stage a marker can reach can also be paused on an open decision
+		// and re-queued by an answered one. Both are synthesized in derivation,
+		// not classified from a marker, so neither appears in the spec table.
+		legal[Placement{stage: spec.Stage, state: BoardIdle}] = true
+		legal[Placement{stage: spec.Stage, state: BoardQueued}] = true
+		// A malformed decision block reds the card in whatever stage it sits.
+		legal[Placement{stage: spec.Stage, state: BoardFailed}] = true
+	}
+	return legal
+}
+
+// legal reports whether the machine has a way to reach this placement. A card
+// placed where nothing can reach is a rendering the board cannot explain and no
+// reconcile pass will move — the shape of every stuck-card bug this type exists
+// to make unwritable.
+func (p Placement) legal() bool { return legalPlacements()[p] }
+
+// String renders a placement the way this project already writes one down —
+// "planning/running", and "backlog/" for an idle card. The trailing slash is
+// kept deliberately: it is the form the recorded placement baseline uses, and a
+// prettier rendering would be a second spelling of the same fact.
+func (p Placement) String() string {
+	return string(p.stage) + "/" + string(p.state)
+}
+
+// sortedLegalPlacements lists every legal placement in a stable order, so a
+// test reporting the set reads the same on every run.
+func sortedLegalPlacements() []Placement {
+	all := make([]Placement, 0, len(legalPlacements()))
+	for p := range legalPlacements() {
+		all = append(all, p)
+	}
+	sort.Slice(all, func(a, b int) bool {
+		if all[a].stage != all[b].stage {
+			return stageRank[all[a].stage] < stageRank[all[b].stage]
+		}
+		return all[a].state < all[b].state
+	})
+	return all
+}
+
+// placeAt is the ONLY writer of a card's stage and state. The two fields stay
+// exported because they are the board's wire format, but everything that
+// decides where a card goes goes through here — which is what keeps a later
+// pass from assigning over a placement the derivation reasoned its way to.
+func (c *BoardCard) placeAt(p Placement) {
+	c.Stage = p.stage
+	c.State = p.state
+}
+
+// cardAt is the only constructor of a placed card: every BoardCard the
+// derivation returns starts here, so no card is ever built with a stage and a
+// state written independently of each other.
+func cardAt(p Placement) BoardCard {
+	var card BoardCard
+	card.placeAt(p)
+	return card
+}
+
+// placementOf names a pair someone else already decided — a card that arrived
+// over the wire, a state the FSM document describes. It is deliberately NOT how
+// production code reaches a placement: everything that DECIDES where a card goes
+// uses the transitions above, so a pair only exists because a rule produced it.
+func placementOf(stage BoardStage, state BoardState) Placement {
+	return Placement{stage: stage, state: state}
+}
+
+// placement reads a card's current placement back as one value.
+func (c BoardCard) placement() Placement {
+	return placementOf(c.Stage, c.State)
+}
+
+// markerPlacement is the placement a comment's marker classifies to, together
+// with the comment itself — the pair the derivation carries while it decides
+// which marker owns the card.
+type markerPlacement struct {
+	placement Placement
+	comment   tracker.Comment
+}

--- a/internal/daemon/board_placement_test.go
+++ b/internal/daemon/board_placement_test.go
@@ -38,25 +38,17 @@ import (
 // the options block with one stage-and-count, so a placement that needs a
 // particular body cannot appear.
 
-// boardPlacement is one place a card can be.
-type boardPlacement struct {
-	Stage BoardStage `json:"stage"`
-	State BoardState `json:"state"`
-}
-
-func (p boardPlacement) String() string { return string(p.Stage) + "/" + string(p.State) }
-
 // producibleBoardPlacements returns every placement the derivation yields for
 // some thread built out of the marker vocabulary.
 //
 // The vocabulary comes from orderedMarkerSpecs rather than a list written here:
 // a list would be one more thing to keep in step with the markers, which is the
 // drift this whole exercise exists to catch, reproduced inside the check for it.
-func producibleBoardPlacements() map[boardPlacement][]string {
-	found := map[boardPlacement][]string{}
+func producibleBoardPlacements() map[Placement][]string {
+	found := map[Placement][]string{}
 	record := func(how string, comments []tracker.Comment, status tracker.Category, isIdea bool) {
 		card := DeriveBoardCard(comments, status, isIdea)
-		p := boardPlacement{card.Stage, card.State}
+		p := card.placement()
 		if _, seen := found[p]; !seen {
 			found[p] = []string{how}
 		}
@@ -119,12 +111,12 @@ func placementHow(body string) string {
 // claimedBoardPlacements maps each placement the machine describes to the
 // states claiming it. Several states may claim one placement — that is the blur
 // a marker thread cannot resolve, not a contradiction.
-func claimedBoardPlacements(t *testing.T) map[boardPlacement][]string {
+func claimedBoardPlacements(t *testing.T) map[Placement][]string {
 	t.Helper()
 	doc, err := pipelinefsm.Load()
 	require.NoError(t, err)
 
-	claimed := map[boardPlacement][]string{}
+	claimed := map[Placement][]string{}
 	for _, s := range doc.States {
 		if s.Board.Stage == "none" {
 			continue
@@ -134,11 +126,53 @@ func claimedBoardPlacements(t *testing.T) map[boardPlacement][]string {
 			stages = []BoardStage{BoardBacklog, BoardPlanning, BoardImplementation, BoardVerification, BoardDoneStage}
 		}
 		for _, stage := range stages {
-			p := boardPlacement{stage, BoardState(s.Board.State)}
+			p := placementOf(stage, BoardState(s.Board.State))
 			claimed[p] = append(claimed[p], s.Name)
 		}
 	}
 	return claimed
+}
+
+// TestBoardPlacement_EveryProducedPlacementIsLegal is the guard the Placement
+// type exists for: whatever the derivation's rules compose, the result must be
+// a placement the machine has a way to reach.
+//
+// It is the half the claimed-placement measurement below cannot cover. That one
+// compares against pipeline-fsm.json, a document written by hand and widened by
+// hand; this compares against the marker table the code itself dispatches on, so
+// it fails on a pair no marker and no transition can produce — a card rendered
+// somewhere the board cannot explain and no reconcile pass will move.
+func TestBoardPlacement_EveryProducedPlacementIsLegal(t *testing.T) {
+	for p, hows := range producibleBoardPlacements() {
+		assert.True(t, p.legal(),
+			"the derivation produces %s, which no marker or transition can reach — put %q through a named transition, or say why the pair is legal", p, hows[0])
+	}
+}
+
+// A guard that calls everything legal is not a guard. These are pairs the two
+// halves can spell but no rule produces: a closed card cannot be running, an
+// idea cannot fail, and a stage with no agent to lose has no outage.
+func TestBoardPlacement_APairNoRuleProducesIsIllegal(t *testing.T) {
+	for _, p := range []Placement{
+		placementOf(BoardHidden, BoardRunning),
+		placementOf(BoardIdeas, BoardFailed),
+		placementOf(BoardBacklog, BoardOutage),
+		placementOf(BoardIdeas, BoardQueued),
+	} {
+		assert.False(t, p.legal(), "%s is a pair no rule produces and must not be legal", p)
+	}
+}
+
+// The legal set is the derivation's own vocabulary, so every placement in it
+// must be one the board can render. A pair that is legal but unreachable is the
+// opposite drift: a rule that used to produce it and no longer does.
+func TestBoardPlacement_TheLegalSetIsNamedByRealStagesAndStates(t *testing.T) {
+	for _, p := range sortedLegalPlacements() {
+		assert.NotEmpty(t, string(p.Stage()), "a legal placement must name a stage: %s", p)
+		_, ranked := stageRank[p.Stage()]
+		assert.True(t, ranked || p.Stage() == BoardHidden,
+			"legal placement %s names a stage the board does not rank", p)
+	}
 }
 
 // A placement the document names must be a placement that exists. This is the

--- a/internal/daemon/board_state.go
+++ b/internal/daemon/board_state.go
@@ -130,11 +130,11 @@ func DeriveBoardCard(comments []tracker.Comment, statusType tracker.Category, is
 	// (the board's own Close action, or a teammate on the tracker) can still
 	// arrive here via an in-flight fetch — it must never render as open work.
 	if statusType == tracker.CategoryDone || statusType == tracker.CategoryClosed {
-		return BoardCard{Stage: BoardHidden}
+		return cardAt(atStage(BoardHidden))
 	}
 
 	if isIdea {
-		return BoardCard{Stage: BoardIdeas}
+		return cardAt(atStage(BoardIdeas))
 	}
 
 	furthest := BoardBacklog
@@ -143,46 +143,52 @@ func DeriveBoardCard(comments []tracker.Comment, statusType tracker.Category, is
 
 	// First pass: find the furthest stage that any marker reaches.
 	for _, c := range comments {
-		stage, _, ok := ClassifyMarker(c.Body)
+		p, ok := fromMarker(c.Body)
 		if !ok {
 			continue
 		}
 		anyMarker = true
-		if r := stageRank[stage]; r > furthestRank {
+		if r := stageRank[p.Stage()]; r > furthestRank {
 			furthestRank = r
-			furthest = stage
+			furthest = p.Stage()
 		}
 	}
 
 	_, hasPlan := latestPlanComment(comments)
 	hasRelated := hasCompletedRelatedRecord(comments)
 
-	var state BoardState
+	placed := atStage(furthest)
 	var latest tracker.Comment
 	if anyMarker {
 		// Second pass: within the furthest stage, the latest marker decides state.
+		var state BoardState
 		state, latest = latestStateInStage(comments, furthest)
+		placed = placed.inStage(state)
 
 		// A furthest-stage failure is authoritative only while it is the ticket's
 		// newest marker. A strictly-newer marker anywhere — a re-implementation
 		// restarting from an earlier stage (ticket 881) or a later deploy — retires
 		// the stale red; the card follows the ticket's current activity rather than a
 		// terminal failure the pipeline already moved past (SC-910).
-		if supersededByNewerMarker(state, furthest, comments) {
-			if newest, newestStage, newestState, ok := latestMarkerOverall(comments); ok && commentNewer(newest, latest) {
-				furthest, state, latest = newestStage, newestState, newest
+		if supersededByNewerMarker(placed, comments) {
+			if newest, ok := latestMarkerOverall(comments); ok && commentNewer(newest.comment, latest) {
+				placed, latest = placed.supersededBy(newest.placement), newest.comment
 			}
 		}
 	}
 
-	furthest, state, latest, anyMarker = applyStateOverrides(comments, furthest, state, latest, anyMarker)
+	placed, latest, anyMarker = applyStateOverrides(comments, placed, latest, anyMarker)
 
 	if !anyMarker {
 		// No pipeline activity yet: the open ticket waits in Backlog.
-		return BoardCard{Stage: BoardBacklog, HasPlan: hasPlan, HasRelatedRecord: hasRelated}
+		card := cardAt(atStage(BoardBacklog))
+		card.HasPlan, card.HasRelatedRecord = hasPlan, hasRelated
+		return card
 	}
 
-	card := BoardCard{Stage: furthest, State: state, HasPlan: hasPlan, HasRelatedRecord: hasRelated, StageEnteredAt: latest.Created, StageDaemonID: ParseDaemonID(latest.Body)}
+	card := cardAt(placed)
+	card.HasPlan, card.HasRelatedRecord = hasPlan, hasRelated
+	card.StageEnteredAt, card.StageDaemonID = latest.Created, ParseDaemonID(latest.Body)
 	card.EngineeringKey = firstEngineeringKey(comments)
 	card.Branch = latestPrefixedLine(comments, ReadyForReviewHeader, "branch:")
 	card.Commits = latestPrefixedLine(comments, ReadyForReviewHeader, "commits:")
@@ -192,7 +198,7 @@ func DeriveBoardCard(comments []tracker.Comment, statusType tracker.Category, is
 		card.ShippedPartial = true
 		card.ShippedPartialFollowOn = followOn
 	}
-	attachFailureAndResume(&card, state, latest)
+	attachFailureAndResume(&card, card.placement().State(), latest)
 	card.DeployPhase = deployPhaseFor(card, comments)
 	card.StopDecision, card.StopLinkedKey, card.StopReasoning = ticketReviewStop(latest)
 	attachOpenOptions(&card, comments)
@@ -238,7 +244,7 @@ func ticketReviewStop(deciding tracker.Comment) (decision, linked, reasoning str
 // parent's (SC-2596 pushed DeriveBoardCard over the gocyclo threshold;
 // extracting keeps the override chain readable in one place without
 // re-flattening it into the main derivation).
-func applyStateOverrides(comments []tracker.Comment, furthest BoardStage, state BoardState, latest tracker.Comment, anyMarker bool) (BoardStage, BoardState, tracker.Comment, bool) {
+func applyStateOverrides(comments []tracker.Comment, placed Placement, latest tracker.Comment, anyMarker bool) (Placement, tracker.Comment, bool) {
 	// A recorded decision ([human:option-chosen]) that no started/terminal marker
 	// has yet superseded: the chosen stage is (re)queued while the relaunch's
 	// started marker is pending or its launch was deferred to a healthy daemon.
@@ -246,10 +252,12 @@ func applyStateOverrides(comments []tracker.Comment, furthest BoardStage, state 
 	// stuck-running pass falsely reds it (SC-1320). Placed after the SC-910
 	// supersede so a decision strictly newer than a stale failure still wins.
 	if qStage, qChosen, ok := optionChosenQueued(comments); ok {
-		furthest, state, latest, anyMarker = qStage, BoardQueued, qChosen, true
+		placed, latest, anyMarker = queuedAt(qStage), qChosen, true
 	}
 
-	state = pauseOnOpenOptions(state, furthest, comments)
+	if stagePausedOnOptions(comments, placed.Stage()) {
+		placed = placed.pausedOnDecision()
+	}
 
 	// A terminal determination is the last word about the whole ticket: the work
 	// is already merged, no fix is warranted, a gate stopped the ticket, or the
@@ -263,38 +271,11 @@ func applyStateOverrides(comments []tracker.Comment, furthest BoardStage, state 
 	// carrying the stop decision for a gate's rejection. Placed after the
 	// decision-queue override so a determination strictly newer than a stale
 	// option-chosen still wins.
-	if t, tStage, tState, ok := newestTerminalDetermination(comments); ok {
-		furthest, state, latest, anyMarker = tStage, tState, t, true
+	if terminal, ok := newestTerminalDetermination(comments); ok {
+		placed, latest, anyMarker = placed.determinedBy(terminal.placement), terminal.comment, true
 	}
 
-	return furthest, state, latest, anyMarker
-}
-
-// pauseOnOpenOptions turns a running OR failed state into a waiting-on-human
-// state when an open [human:options] block names the card's own stage or an
-// earlier stage the answer would rework: the card is not working, and it is
-// not dead either — it is waiting for a human. Server-side twin of the
-// client's decision-badge branch. Uses the same at-or-before stage-rank
-// predicate as the failure watcher and reconcile pass (stagePausedOnOptions),
-// so a block naming a stage the card has not yet reached — a stale or
-// target-relaunch block — never clears an active run (SC-1669).
-//
-// Accepting BoardFailed alongside BoardRunning is the residual safety net
-// (SC-1957): a card can reach this point already reddened by a *-failed
-// marker posted before the recovery machinery's own relaunch consumed the
-// question (openOptionsBlock only treats a later BoardRunning marker or an
-// option-chosen as consumption — a *-failed marker does not). Surfacing that
-// combination as waiting-on-human rather than a plain failure is exactly what
-// makes an otherwise-erased question visible. This also subsumes the former
-// SC-1857 done-stage PR-loop escalation special case: the escalation's block
-// names the implementation stage while the card's furthest stage is done, so
-// the general at-or-before rank rule (rank 3 <= rank 5) pauses it the same way
-// the former bespoke escalation check used to.
-func pauseOnOpenOptions(state BoardState, furthest BoardStage, comments []tracker.Comment) BoardState {
-	if (state == BoardRunning || state == BoardFailed) && stagePausedOnOptions(comments, furthest) {
-		return BoardIdle
-	}
-	return state
+	return placed, latest, anyMarker
 }
 
 // supersededByNewerMarker reports whether the furthest-stage marker may be
@@ -303,13 +284,13 @@ func pauseOnOpenOptions(state BoardState, furthest BoardStage, comments []tracke
 // chosen rebuild has restarted from an earlier stage — its strictly-newer
 // implementation-started marker retires the loop marker so the card leaves the
 // done lane back to Building.
-func supersededByNewerMarker(state BoardState, furthest BoardStage, comments []tracker.Comment) bool {
+func supersededByNewerMarker(placed Placement, comments []tracker.Comment) bool {
 	// An outage marker is transient — a newer *-started marker from the reconcile
 	// relaunch retires it, exactly like a stale failure (SC-2307). Without this
 	// the card would sit on "machine down" even after the substrate returned and
 	// the relaunched agent posted its started marker.
-	return state == BoardFailed || state == BoardOutage ||
-		(furthest == BoardDoneStage && doneStageLoopActive(comments))
+	return placed.State() == BoardFailed || placed.State() == BoardOutage ||
+		(placed.Stage() == BoardDoneStage && doneStageLoopActive(comments))
 }
 
 // deployPhaseFor names the done-stage sub-phase of a running card: "pr-review"
@@ -411,39 +392,37 @@ func latestStateInStage(comments []tracker.Comment, stage BoardStage) (BoardStat
 	var haveLatest bool
 	var latest tracker.Comment
 	for _, c := range comments {
-		s, st, ok := ClassifyMarker(c.Body)
-		if !ok || s != stage {
+		p, ok := fromMarker(c.Body)
+		if !ok || p.Stage() != stage {
 			continue
 		}
 		if !haveLatest || commentNewer(c, latest) {
 			latest = c
 			haveLatest = true
-			state = st
+			state = p.State()
 		}
 	}
 	return state, latest
 }
 
-// latestMarkerOverall returns the newest board marker across ALL stages — its
-// comment, stage, and state — and whether any marker exists. Recency is global
-// (by Created), so a re-implementation restarted in an earlier stage or a later
-// deploy is seen even when the furthest stage's own newest marker is a stale
-// failure (SC-910).
-func latestMarkerOverall(comments []tracker.Comment) (tracker.Comment, BoardStage, BoardState, bool) {
-	var latest tracker.Comment
-	var stage BoardStage
-	var state BoardState
+// latestMarkerOverall returns the newest board marker across ALL stages — the
+// placement it classifies to and the comment carrying it — and whether any
+// marker exists. Recency is global (by Created), so a re-implementation
+// restarted in an earlier stage or a later deploy is seen even when the
+// furthest stage's own newest marker is a stale failure (SC-910).
+func latestMarkerOverall(comments []tracker.Comment) (markerPlacement, bool) {
+	var latest markerPlacement
 	var have bool
 	for _, c := range comments {
-		st, s, ok := ClassifyMarker(c.Body)
+		p, ok := fromMarker(c.Body)
 		if !ok {
 			continue
 		}
-		if !have || commentNewer(c, latest) {
-			latest, stage, state, have = c, st, s, true
+		if !have || commentNewer(c, latest.comment) {
+			latest, have = markerPlacement{placement: p, comment: c}, true
 		}
 	}
-	return latest, stage, state, have
+	return latest, have
 }
 
 // hasPlanEvidence reports whether the ticket has been planned. Two proofs, one
@@ -475,12 +454,12 @@ func hasPlanEvidence(comments []tracker.Comment) bool {
 // card's deciding `latest`, so the reason, the posting daemon, the stage-entered
 // time and a gate's StopDecision/StopReasoning all come off the determination
 // instead of the phantom.
-func newestTerminalDetermination(comments []tracker.Comment) (tracker.Comment, BoardStage, BoardState, bool) {
-	newest, stage, state, ok := latestMarkerOverall(comments)
-	if !ok || !isTerminalResolution(newest.Body) {
-		return tracker.Comment{}, "", "", false
+func newestTerminalDetermination(comments []tracker.Comment) (markerPlacement, bool) {
+	newest, ok := latestMarkerOverall(comments)
+	if !ok || !isTerminalResolution(newest.comment.Body) {
+		return markerPlacement{}, false
 	}
-	return newest, stage, state, true
+	return newest, true
 }
 
 // latestPlanComment returns the body of the newest [human:plan] comment with

--- a/internal/daemon/issue_detail_extras.go
+++ b/internal/daemon/issue_detail_extras.go
@@ -96,7 +96,7 @@ func latestFailureReason(comments []tracker.Comment) string {
 	// Agree with the card (DeriveBoardCard): a failure reason is shown only while
 	// the *-failed marker is the ticket's newest marker. A strictly-newer marker
 	// anywhere supersedes it (SC-910).
-	if newest, _, _, ok := latestMarkerOverall(comments); ok && commentNewer(newest, latest) {
+	if newest, ok := latestMarkerOverall(comments); ok && commentNewer(newest.comment, latest) {
 		return ""
 	}
 	return failureBody(latest.Body)


### PR DESCRIPTION
Phase 2 of SC-4118.

A board card's `(stage, state)` was two loose strings any code could set independently. The derivation reasons its way to a placement through four rules — furthest stage wins, the stage's latest marker decides, a strictly-newer marker supersedes a stale red, a terminal determination overrides — and then `attachOpenOptions` assigned `card.State = BoardFailed` straight over the result. Whatever wrote last won, and nothing asked whether the resulting pair was one the machine can produce.

`Placement` now carries both halves with unexported fields, and every way a card's placement changes during derivation is a named method: `inStage`, `supersededBy`, `queuedAt`, `pausedOnDecision`, `determinedBy`, `failedOn`. `placeAt` is the only writer of the card's fields — those stay exported because they are the board's wire format, so the desktop app's JSON is unchanged.

`legal()` is the guard: the legal set is built from `orderedMarkerSpecs` plus the placements derivation synthesizes without a marker, so a marker added there is legal the moment it exists. The check drives the real `DeriveBoardCard` over the real marker vocabulary and asserts every produced placement is reachable — against the table the code dispatches on, not against a document widened by hand.

The placement measurement had its own copy of the pair; it now uses the production type, so the placement the board renders and the placement the check enumerates are the same value.

No behaviour change: the existing suite passes untouched. `make check` green, `go test ./cmd/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)