### PR TITLE
[SC-4118] Give settings.json one editor that refuses to lose the user's data

### DIFF
--- a/internal/claude/gitidentity.go
+++ b/internal/claude/gitidentity.go
@@ -1,13 +1,10 @@
 package claude
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 
-	"github.com/gethuman-sh/human/errors"
 	"github.com/gethuman-sh/human/internal/botidentity"
 )
 
@@ -41,20 +38,9 @@ func InstallGitIdentity(w io.Writer, fw FileWriter) error {
 }
 
 func mergeGitIdentityIntoSettings(w io.Writer, fw FileWriter, path string, id botidentity.Identity) error {
-	settings := make(map[string]any)
-
-	data, err := fw.ReadFile(path)
-	if err == nil {
-		if jsonErr := json.Unmarshal(data, &settings); jsonErr != nil {
-			return errors.WrapWithDetails(jsonErr, "parsing settings.json", "path", path)
-		}
-	} else if !os.IsNotExist(err) {
-		return errors.WrapWithDetails(err, "reading settings.json", "path", path)
-	}
-
-	envMap, _ := settings["env"].(map[string]any)
-	if envMap == nil {
-		envMap = make(map[string]any)
+	settings, err := LoadSettings(fw, path)
+	if err != nil {
+		return err
 	}
 
 	desired := map[string]string{
@@ -63,30 +49,18 @@ func mergeGitIdentityIntoSettings(w io.Writer, fw FileWriter, path string, id bo
 		"GIT_COMMITTER_NAME":  id.Name,
 		"GIT_COMMITTER_EMAIL": id.Email,
 	}
-
-	changed := false
 	for _, k := range gitIdentityEnvKeys {
-		if cur, _ := envMap[k].(string); cur != desired[k] {
-			envMap[k] = desired[k]
-			changed = true
+		if err := settings.SetEnv(k, desired[k]); err != nil {
+			return err
 		}
 	}
 
-	if !changed {
+	if !settings.Changed() {
 		_, _ = fmt.Fprintf(w, "  unchanged %s (bot git identity already set)\n", path)
 		return nil
 	}
-
-	settings["env"] = envMap
-
-	out, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return errors.WrapWithDetails(err, "marshaling settings.json")
-	}
-	out = append(out, '\n')
-
-	if err := fw.WriteFile(path, out, 0o644); err != nil {
-		return errors.WrapWithDetails(err, "writing settings.json", "path", path)
+	if err := settings.Save(); err != nil {
+		return err
 	}
 
 	_, _ = fmt.Fprintf(w, "  updated %s (bot git identity set)\n", path)

--- a/internal/claude/hooks.go
+++ b/internal/claude/hooks.go
@@ -1,10 +1,8 @@
 package claude
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 
 	"github.com/gethuman-sh/human/errors"
@@ -54,93 +52,30 @@ func InstallHooks(w io.Writer, fw FileWriter) error {
 }
 
 func mergeHooksIntoSettings(w io.Writer, fw FileWriter, path string) error {
-	settings := make(map[string]any)
-
-	data, err := fw.ReadFile(path)
-	if err == nil {
-		if jsonErr := json.Unmarshal(data, &settings); jsonErr != nil {
-			return errors.WrapWithDetails(jsonErr, "parsing settings.json", "path", path)
-		}
-	} else if !os.IsNotExist(err) {
-		// Anything other than "not found" — permission denied, NFS stall,
-		// I/O error — must propagate so we never overwrite a settings file
-		// the user can't currently read with a fresh empty one.
-		return errors.WrapWithDetails(err, "reading settings.json", "path", path)
+	settings, err := LoadSettings(fw, path)
+	if err != nil {
+		return err
 	}
 
-	hooks, _ := settings["hooks"].(map[string]any)
-	if hooks == nil {
-		hooks = make(map[string]any)
-	}
-
-	changed := false
 	for _, evt := range hookEvents {
-		if addHookCommand(hooks, evt.name, hookCommand, evt.async, evt.matcher) {
-			changed = true
+		if err := settings.AddHook(evt.name, hookCommand, evt.async, evt.matcher); err != nil {
+			return err
 		}
 	}
 	// SessionStart also injects the agent-context guidance. It runs synchronously
 	// (not async) so Claude Code reads its additionalContext output as context.
-	if addHookCommand(hooks, "SessionStart", agentContextHookCommand, false, "") {
-		changed = true
+	if err := settings.AddHook("SessionStart", agentContextHookCommand, false, ""); err != nil {
+		return err
 	}
 
-	if !changed {
+	if !settings.Changed() {
 		_, _ = fmt.Fprintf(w, "  unchanged %s (hooks already registered)\n", path)
 		return nil
 	}
-
-	settings["hooks"] = hooks
-
-	out, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return errors.WrapWithDetails(err, "marshaling settings.json")
-	}
-	out = append(out, '\n')
-
-	if err := fw.WriteFile(path, out, 0o644); err != nil {
-		return errors.WrapWithDetails(err, "writing settings.json", "path", path)
+	if err := settings.Save(); err != nil {
+		return err
 	}
 
 	_, _ = fmt.Fprintf(w, "  updated %s (hooks registered)\n", path)
 	return nil
-}
-
-// addHookCommand registers a command for an event if that exact command is not
-// already present. Returns true if a new matcher was added.
-func addHookCommand(hooks map[string]any, eventName, command string, async bool, matcher string) bool {
-	matchers, _ := hooks[eventName].([]any)
-
-	// Check if this command is already registered for the event.
-	for _, m := range matchers {
-		matcherObj, ok := m.(map[string]any)
-		if !ok {
-			continue
-		}
-		hookList, _ := matcherObj["hooks"].([]any)
-		for _, h := range hookList {
-			hookDef, ok := h.(map[string]any)
-			if !ok {
-				continue
-			}
-			if cmd, _ := hookDef["command"].(string); cmd == command {
-				return false // already registered
-			}
-		}
-	}
-
-	hookDef := map[string]any{
-		"type":    "command",
-		"command": command,
-	}
-	if async {
-		hookDef["async"] = true
-	}
-
-	newMatcher := map[string]any{
-		"matcher": matcher,
-		"hooks":   []any{hookDef},
-	}
-	hooks[eventName] = append(matchers, newMatcher)
-	return true
 }

--- a/internal/claude/settings.go
+++ b/internal/claude/settings.go
@@ -1,0 +1,195 @@
+package claude
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/gethuman-sh/human/errors"
+)
+
+// Settings is one Claude Code settings.json — the user's file, which `human`
+// edits but does not own.
+//
+// Three places used to edit it, each with its own copy of load, merge and
+// write: the hook installer, the bot git identity, and the LSP enablement. Each
+// reached into the decoded JSON with a type assertion whose failure is silent —
+// `settings["env"].(map[string]any)` yields nil for a key holding anything
+// else, the code then built a fresh map, and the write REPLACED what was there.
+// A user whose env or hooks block was any other shape lost it, with nothing
+// said. That is the failure this type exists to make unwritable: a key holding
+// the wrong shape is an error the caller must see, never a key to overwrite.
+//
+// Everything else about the file is preserved byte-for-byte-ish: unknown keys
+// round-trip untouched, and a file that needs no change is not rewritten at all.
+type Settings struct {
+	fw     FileWriter
+	path   string
+	values map[string]any
+	// changed records whether a mutator actually altered anything, so a caller
+	// can report "unchanged" and skip the write — the settings file of a user
+	// who runs `human install` twice must not be rewritten the second time.
+	changed bool
+}
+
+// LoadSettings reads path, or starts an empty document when it does not exist.
+//
+// Any read error other than "not found" is returned rather than swallowed: a
+// settings file that is momentarily unreadable — permission denied, an NFS
+// stall — must never be replaced with a fresh empty one.
+func LoadSettings(fw FileWriter, path string) (*Settings, error) {
+	s := &Settings{fw: fw, path: path, values: map[string]any{}}
+
+	data, err := fw.ReadFile(path)
+	switch {
+	case err == nil:
+		if jsonErr := json.Unmarshal(data, &s.values); jsonErr != nil {
+			return nil, errors.WrapWithDetails(jsonErr, "parsing settings.json", "path", path)
+		}
+		if s.values == nil {
+			s.values = map[string]any{}
+		}
+	case os.IsNotExist(err):
+	default:
+		return nil, errors.WrapWithDetails(err, "reading settings.json", "path", path)
+	}
+	return s, nil
+}
+
+// Path is the file this document came from, for the messages a caller prints.
+func (s *Settings) Path() string { return s.path }
+
+// Changed reports whether a mutator altered the document.
+func (s *Settings) Changed() bool { return s.changed }
+
+// object returns the object under key, creating it when the key is absent.
+//
+// A key holding a non-object is refused. Silently treating it as absent is what
+// turned "your hooks are shaped oddly" into "your hooks are gone".
+func (s *Settings) object(key string) (map[string]any, error) {
+	raw, present := s.values[key]
+	if !present || raw == nil {
+		created := map[string]any{}
+		s.values[key] = created
+		return created, nil
+	}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return nil, errors.WithDetails("settings key does not hold an object",
+			"path", s.path, "key", key,
+			"hint", "fix or remove the key by hand — refusing to overwrite it")
+	}
+	return obj, nil
+}
+
+// SetEnv sets an environment variable Claude Code injects into the session.
+func (s *Settings) SetEnv(key, value string) error {
+	env, err := s.object("env")
+	if err != nil {
+		return err
+	}
+	if current, _ := env[key].(string); current == value {
+		return nil
+	}
+	env[key] = value
+	s.changed = true
+	return nil
+}
+
+// EnvValue reads an environment variable back, and whether it is set to a
+// string at all.
+func (s *Settings) EnvValue(key string) (string, bool) {
+	env, ok := s.values["env"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	value, ok := env[key].(string)
+	return value, ok
+}
+
+// AddHook registers command for a hook event unless that exact command is
+// already registered for it, so installing twice adds nothing.
+//
+// matcher is the event's matcher pattern ("" for the default). async marks a
+// hook Claude Code may run without waiting; a blocking hook must not set it.
+func (s *Settings) AddHook(event, command string, async bool, matcher string) error {
+	hooks, err := s.object("hooks")
+	if err != nil {
+		return err
+	}
+	matchers, err := hookMatchers(s.path, hooks, event)
+	if err != nil {
+		return err
+	}
+	if hookCommandRegistered(matchers, command) {
+		return nil
+	}
+
+	hookDef := map[string]any{"type": "command", "command": command}
+	if async {
+		hookDef["async"] = true
+	}
+	hooks[event] = append(matchers, map[string]any{
+		"matcher": matcher,
+		"hooks":   []any{hookDef},
+	})
+	s.changed = true
+	return nil
+}
+
+// hookMatchers reads an event's matcher list. Like object(), a value of the
+// wrong shape is refused rather than replaced — appending to a fresh list here
+// would drop whatever the user had registered for that event.
+func hookMatchers(path string, hooks map[string]any, event string) ([]any, error) {
+	raw, present := hooks[event]
+	if !present || raw == nil {
+		return nil, nil
+	}
+	matchers, ok := raw.([]any)
+	if !ok {
+		return nil, errors.WithDetails("hook event does not hold a list of matchers",
+			"path", path, "event", event,
+			"hint", "fix or remove the event by hand — refusing to overwrite it")
+	}
+	return matchers, nil
+}
+
+// hookCommandRegistered reports whether command already appears under any of an
+// event's matchers. Entries of an unexpected shape are skipped rather than
+// refused: this only asks a question, and a matcher it cannot read is one that
+// cannot be the command being looked for.
+func hookCommandRegistered(matchers []any, command string) bool {
+	for _, m := range matchers {
+		matcherObj, ok := m.(map[string]any)
+		if !ok {
+			continue
+		}
+		hookList, _ := matcherObj["hooks"].([]any)
+		for _, h := range hookList {
+			hookDef, ok := h.(map[string]any)
+			if !ok {
+				continue
+			}
+			if cmd, _ := hookDef["command"].(string); cmd == command {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Save writes the document back. An unchanged document is not written at all,
+// so a settings file nobody edited keeps its own formatting.
+func (s *Settings) Save() error {
+	if !s.changed {
+		return nil
+	}
+	out, err := json.MarshalIndent(s.values, "", "  ")
+	if err != nil {
+		return errors.WrapWithDetails(err, "marshaling settings.json", "path", s.path)
+	}
+	out = append(out, '\n')
+	if err := s.fw.WriteFile(s.path, out, 0o644); err != nil {
+		return errors.WrapWithDetails(err, "writing settings.json", "path", s.path)
+	}
+	return nil
+}

--- a/internal/claude/settings_test.go
+++ b/internal/claude/settings_test.go
@@ -1,0 +1,181 @@
+package claude
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// settingsFS is a FileWriter over an in-memory file set, with an optional read
+// error for the "the file exists but cannot be read right now" case.
+type settingsFS struct {
+	files     map[string][]byte
+	readErr   error
+	writeErr  error
+	writeSeen int
+}
+
+func newSettingsFS(files map[string][]byte) *settingsFS {
+	if files == nil {
+		files = map[string][]byte{}
+	}
+	return &settingsFS{files: files}
+}
+
+func (f *settingsFS) MkdirAll(string, os.FileMode) error { return nil }
+
+func (f *settingsFS) ReadFile(name string) ([]byte, error) {
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+	data, ok := f.files[name]
+	if !ok {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	}
+	return data, nil
+}
+
+func (f *settingsFS) WriteFile(name string, data []byte, _ os.FileMode) error {
+	if f.writeErr != nil {
+		return f.writeErr
+	}
+	f.writeSeen++
+	f.files[name] = data
+	return nil
+}
+
+const settingsPath = "/home/dev/.claude/settings.json"
+
+// A settings key holding something other than the expected shape is the user's
+// data. Reading it with a type assertion whose failure is silent, building a
+// fresh map and writing it back is how `human install` deleted an env block it
+// could not parse — with nothing said, on a file `human` edits but does not own.
+func TestSettings_RefusesToOverwriteAKeyOfTheWrongShape(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		file string
+		edit func(*Settings) error
+	}{
+		{
+			name: "env is not an object",
+			file: `{"env": ["GIT_AUTHOR_NAME=someone"]}`,
+			edit: func(s *Settings) error { return s.SetEnv("GIT_AUTHOR_NAME", "humanbot") },
+		},
+		{
+			name: "hooks is not an object",
+			file: `{"hooks": "see the other file"}`,
+			edit: func(s *Settings) error { return s.AddHook("Stop", "human hook", true, "") },
+		},
+		{
+			name: "a hook event is not a list of matchers",
+			file: `{"hooks": {"Stop": {"command": "something-else"}}}`,
+			edit: func(s *Settings) error { return s.AddHook("Stop", "human hook", true, "") },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := newSettingsFS(map[string][]byte{settingsPath: []byte(tc.file)})
+			settings, err := LoadSettings(fs, settingsPath)
+			require.NoError(t, err)
+
+			require.Error(t, tc.edit(settings), "a key of the wrong shape must be reported, not replaced")
+			require.NoError(t, settings.Save())
+			assert.Zero(t, fs.writeSeen, "nothing may be written after a refusal")
+			assert.Equal(t, tc.file, string(fs.files[settingsPath]), "the user's file is untouched")
+		})
+	}
+}
+
+// A read that fails for any reason other than "not found" must not become an
+// empty document — a settings file behind a permission error or a stalled
+// mount would be replaced by the write that follows.
+func TestSettings_AnUnreadableFileIsNotAnEmptyOne(t *testing.T) {
+	fs := newSettingsFS(nil)
+	fs.readErr = errors.New("permission denied")
+
+	_, err := LoadSettings(fs, settingsPath)
+	require.Error(t, err)
+}
+
+// A missing file IS an empty document: the first install writes one.
+func TestSettings_AMissingFileStartsEmpty(t *testing.T) {
+	fs := newSettingsFS(nil)
+	settings, err := LoadSettings(fs, settingsPath)
+	require.NoError(t, err)
+
+	require.NoError(t, settings.SetEnv("ENABLE_LSP_TOOL", "1"))
+	require.NoError(t, settings.Save())
+
+	value, ok := settings.EnvValue("ENABLE_LSP_TOOL")
+	assert.True(t, ok)
+	assert.Equal(t, "1", value)
+	assert.Equal(t, 1, fs.writeSeen)
+}
+
+// Everything `human` does not know about round-trips untouched. The file is the
+// user's, and an editor that drops the parts it has no opinion on is worse than
+// one that refuses to run.
+func TestSettings_KeysHumanDoesNotKnowAboutSurvive(t *testing.T) {
+	original := `{"model":"opus","permissions":{"allow":["Bash(ls:*)"]},"env":{"EDITOR":"vim"}}`
+	fs := newSettingsFS(map[string][]byte{settingsPath: []byte(original)})
+
+	settings, err := LoadSettings(fs, settingsPath)
+	require.NoError(t, err)
+	require.NoError(t, settings.SetEnv("ENABLE_LSP_TOOL", "1"))
+	require.NoError(t, settings.Save())
+
+	var written map[string]any
+	require.NoError(t, json.Unmarshal(fs.files[settingsPath], &written))
+	assert.Equal(t, "opus", written["model"])
+	assert.NotNil(t, written["permissions"])
+	assert.Equal(t, map[string]any{"EDITOR": "vim", "ENABLE_LSP_TOOL": "1"}, written["env"],
+		"a new variable joins the env block rather than replacing it")
+}
+
+// A document nothing changed is not written at all, so running `human install`
+// twice leaves the second run's file byte-for-byte as the user last had it.
+func TestSettings_AnUnchangedDocumentIsNotRewritten(t *testing.T) {
+	fs := newSettingsFS(map[string][]byte{settingsPath: []byte(`{"env":{"ENABLE_LSP_TOOL":"1"}}`)})
+
+	settings, err := LoadSettings(fs, settingsPath)
+	require.NoError(t, err)
+	require.NoError(t, settings.SetEnv("ENABLE_LSP_TOOL", "1"))
+
+	assert.False(t, settings.Changed(), "setting a value to what it already is changes nothing")
+	require.NoError(t, settings.Save())
+	assert.Zero(t, fs.writeSeen)
+}
+
+// Installing the same hook twice adds one registration, and a second command on
+// the same event joins it rather than replacing it.
+func TestSettings_AddHookIsIdempotentAndAdditive(t *testing.T) {
+	fs := newSettingsFS(nil)
+	settings, err := LoadSettings(fs, settingsPath)
+	require.NoError(t, err)
+
+	require.NoError(t, settings.AddHook("SessionStart", "human hook", true, ""))
+	require.NoError(t, settings.AddHook("SessionStart", "human hook", true, ""))
+	require.NoError(t, settings.AddHook("SessionStart", "human agent-context --hook", false, ""))
+	require.NoError(t, settings.Save())
+
+	var written struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+			Hooks   []struct {
+				Command string `json:"command"`
+				Async   bool   `json:"async"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	require.NoError(t, json.Unmarshal(fs.files[settingsPath], &written))
+	require.Len(t, written.Hooks["SessionStart"], 2, "the same command must not register twice")
+	assert.Equal(t, "human hook", written.Hooks["SessionStart"][0].Hooks[0].Command)
+	assert.True(t, written.Hooks["SessionStart"][0].Hooks[0].Async)
+	assert.Equal(t, "human agent-context --hook", written.Hooks["SessionStart"][1].Hooks[0].Command)
+	assert.False(t, written.Hooks["SessionStart"][1].Hooks[0].Async,
+		"the context hook is blocking — Claude Code reads its output as context")
+}

--- a/internal/init/step_lsp.go
+++ b/internal/init/step_lsp.go
@@ -257,39 +257,19 @@ func enableLspTool(w io.Writer, fw claude.FileWriter) error {
 	}
 
 	settingsPath := filepath.Join(home, ".claude", "settings.json")
-	settings := make(map[string]any)
-
-	data, err := fw.ReadFile(settingsPath)
-	if err == nil {
-		if jsonErr := json.Unmarshal(data, &settings); jsonErr != nil {
-			return errors.WrapWithDetails(jsonErr, "parsing settings.json", "path", settingsPath)
-		}
-	} else if !os.IsNotExist(err) {
-		return errors.WrapWithDetails(err, "reading settings.json", "path", settingsPath)
+	settings, err := claude.LoadSettings(fw, settingsPath)
+	if err != nil {
+		return err
 	}
-
-	// Merge into the existing env map.
-	envMap, _ := settings["env"].(map[string]any)
-	if envMap == nil {
-		envMap = make(map[string]any)
+	if err := settings.SetEnv("ENABLE_LSP_TOOL", "1"); err != nil {
+		return err
 	}
-
-	if envMap["ENABLE_LSP_TOOL"] == "1" {
+	if !settings.Changed() {
 		_, _ = fmt.Fprintf(w, "  ENABLE_LSP_TOOL already set in %s\n", settingsPath)
 		return nil
 	}
-
-	envMap["ENABLE_LSP_TOOL"] = "1"
-	settings["env"] = envMap
-
-	out, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return errors.WrapWithDetails(err, "marshaling settings.json")
-	}
-	out = append(out, '\n')
-
-	if err := fw.WriteFile(settingsPath, out, 0o644); err != nil {
-		return errors.WrapWithDetails(err, "writing settings.json", "path", settingsPath)
+	if err := settings.Save(); err != nil {
+		return err
 	}
 
 	_, _ = fmt.Fprintf(w, "  Enabled ENABLE_LSP_TOOL in %s\n", settingsPath)


### PR DESCRIPTION
Phase 3 of SC-4118.

Three places edited `settings.json`, each with its own copy of load/merge/write: `internal/claude/hooks.go`, `internal/claude/gitidentity.go`, and `internal/init/step_lsp.go` — the third one the original survey had missed, which is what having three copies does.

Each reached into the decoded JSON with a silent type assertion. `settings["env"].(map[string]any)` yields nil for a key holding anything else; the code then built a fresh map and wrote it back. A user whose `env` or `hooks` block was any other shape lost it, with nothing said, in a file `human` edits but does not own.

`Settings` is now the one editor:

- a key of the wrong shape is an **error the caller sees**, never a key to overwrite — including a hook event that is not a list of matchers
- a read that fails for any reason other than "not found" is not an empty document
- keys `human` has no opinion on (`model`, `permissions`, other env vars) round-trip untouched
- an unchanged document is not written at all, so a second `human install` leaves the file alone

Tests state the refusals rather than the happy path: after a refusal nothing is written and the file is byte-for-byte what the user wrote.

`make check` green, `go test ./cmd/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)