### PR TITLE
[SC-4118] Edit devcontainer.json in place instead of rewriting it

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/docker/cli v29.6.2+incompatible
 	github.com/fsnotify/fsnotify v1.10.1
+	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/google/go-containerregistry v0.21.7
 	github.com/hanwen/go-fuse/v2 v2.11.0
@@ -20,8 +21,9 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.2
-	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	github.com/tidwall/gjson v1.18.0
+	github.com/tidwall/sjson v1.2.5
 	github.com/wailsapp/wails/v2 v2.13.0
 	github.com/yuin/goldmark v1.8.5
 	gitlab.com/tozd/go/errors v0.11.1
@@ -274,7 +276,6 @@ require (
 	github.com/go-toolsmith/astp v1.1.0 // indirect
 	github.com/go-toolsmith/strparse v1.1.0 // indirect
 	github.com/go-toolsmith/typep v1.1.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/godoc-lint/godoc-lint v0.11.2 // indirect
@@ -488,6 +489,7 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/spf13/viper v1.21.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.3.1 // indirect
@@ -498,10 +500,8 @@ require (
 	github.com/therootcompany/xz v1.0.1 // indirect
 	github.com/theupdateframework/go-tuf v0.7.0 // indirect
 	github.com/theupdateframework/go-tuf/v2 v2.4.1 // indirect
-	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
-	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 // indirect
 	github.com/timonwong/loggercheck v0.11.0 // indirect
 	github.com/tkrajina/go-reflector v0.5.8 // indirect

--- a/internal/devcontainer/document.go
+++ b/internal/devcontainer/document.go
@@ -1,0 +1,180 @@
+package devcontainer
+
+import (
+	"os"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/gethuman-sh/human/errors"
+)
+
+// FileStore is the file access a Document needs. An interface so the wizard can
+// pass its own writer and a test can pass an in-memory one.
+type FileStore interface {
+	ReadFile(name string) ([]byte, error)
+	WriteFile(name string, data []byte, perm os.FileMode) error
+}
+
+// Document is one devcontainer.json being edited in place.
+//
+// Two places used to edit it — the wizard adding the human feature and the LSP
+// step appending a post-start command — and both decoded it into a
+// map[string]any and re-marshalled the whole file. Three things went wrong
+// every time, none of them announced:
+//
+//   - devcontainer.json is JSONC. encoding/json rejects it outright, so the
+//     feature writer FAILED on any file with a comment in it and the LSP writer
+//     silently skipped one.
+//   - MarshalIndent writes a map, so the file came back with its keys in
+//     alphabetical order and every comment gone.
+//   - postStartCommand is a string OR an array OR an object of named commands.
+//     `raw["postStartCommand"].(string)` reads the last two as absent, and the
+//     write then REPLACED the user's command with ours.
+//
+// Editing is surgical instead: the original bytes are kept and only the region
+// being changed is spliced, so comments, key order and the user's own
+// formatting all survive, and a shape this code cannot safely edit is reported
+// rather than overwritten.
+type Document struct {
+	store   FileStore
+	path    string
+	content string
+	changed bool
+}
+
+// LoadDocument reads path. A missing file is an error here — both callers only
+// edit a devcontainer that already exists; the wizard writes a fresh one by a
+// different path.
+func LoadDocument(store FileStore, path string) (*Document, error) {
+	data, err := store.ReadFile(path)
+	if err != nil {
+		return nil, errors.WrapWithDetails(err, "reading devcontainer.json", "path", path)
+	}
+	if !gjson.Valid(string(StripJSONC(data))) {
+		return nil, errors.WithDetails("devcontainer.json is not valid JSON", "path", path)
+	}
+	return &Document{store: store, path: path, content: string(data)}, nil
+}
+
+// Path is the file this document came from.
+func (d *Document) Path() string { return d.path }
+
+// Changed reports whether an edit altered the document.
+func (d *Document) Changed() bool { return d.changed }
+
+// HasFeature reports whether a feature is already declared.
+func (d *Document) HasFeature(key string) bool {
+	return gjson.Get(d.content, featurePath(key)).Exists()
+}
+
+// AddFeature declares a feature with no options, unless it is already declared.
+func (d *Document) AddFeature(key string) error {
+	if d.HasFeature(key) {
+		return nil
+	}
+	updated, err := sjson.SetRaw(d.content, featurePath(key), "{}")
+	if err != nil {
+		return errors.WrapWithDetails(err, "adding devcontainer feature", "path", d.path, "feature", key)
+	}
+	d.content = updated
+	d.changed = true
+	return nil
+}
+
+// featurePath escapes a feature key for gjson/sjson, whose path syntax reads a
+// dot as a level separator — and every feature key is a registry path full of
+// them.
+func featurePath(key string) string {
+	escaped := make([]rune, 0, len(key)+8)
+	for _, r := range key {
+		if r == '.' || r == '*' || r == '?' || r == '\\' {
+			escaped = append(escaped, '\\')
+		}
+		escaped = append(escaped, r)
+	}
+	return "features." + string(escaped)
+}
+
+// AppendPostStartCommand adds a shell command to postStartCommand under name,
+// and reports whether the document now carries it.
+//
+// The three shapes the spec allows are handled as themselves rather than as a
+// string with two wrong answers:
+//
+//   - absent: the command becomes postStartCommand.
+//   - a string: joined with " && ", the shell's own sequencing.
+//   - an object of named commands: added under its own name, which is exactly
+//     what the object form is for.
+//   - an array: refused. An array is ONE command's argv, not a list of them, so
+//     there is nothing to append to without changing what the user's command
+//     means. The caller is told, and the file is left alone — the old code read
+//     this as absent and deleted it.
+func (d *Document) AppendPostStartCommand(name, command string) error {
+	existing := gjson.Get(d.content, "postStartCommand")
+
+	switch {
+	case !existing.Exists():
+		return d.setPostStart(command)
+
+	case existing.Type == gjson.String:
+		if containsCommand(existing.String(), command) {
+			return nil
+		}
+		return d.setPostStart(existing.String() + " && " + command)
+
+	case existing.IsObject():
+		for key, value := range existing.Map() {
+			if key == name || containsCommand(value.String(), command) {
+				return nil
+			}
+		}
+		updated, err := sjson.Set(d.content, "postStartCommand."+name, command)
+		if err != nil {
+			return errors.WrapWithDetails(err, "adding named post-start command", "path", d.path, "name", name)
+		}
+		d.content = updated
+		d.changed = true
+		return nil
+
+	default:
+		return errors.WithDetails(
+			"postStartCommand is an array — a single command's arguments, with nothing to append to",
+			"path", d.path, "command", command,
+			"hint", "make postStartCommand an object of named commands, then re-run")
+	}
+}
+
+// containsCommand reports whether a command line already runs command, so
+// running the step twice adds nothing.
+func containsCommand(existing, command string) bool {
+	return existing != "" && command != "" && strings.Contains(existing, command)
+}
+
+// setPostStart writes postStartCommand as a plain string.
+func (d *Document) setPostStart(command string) error {
+	updated, err := sjson.Set(d.content, "postStartCommand", command)
+	if err != nil {
+		return errors.WrapWithDetails(err, "setting post-start command", "path", d.path)
+	}
+	d.content = updated
+	d.changed = true
+	return nil
+}
+
+// Save writes the document back. An unchanged document is not written at all,
+// so a devcontainer nobody edited keeps its own bytes exactly.
+func (d *Document) Save() error {
+	if !d.changed {
+		return nil
+	}
+	content := d.content
+	if content == "" || content[len(content)-1] != '\n' {
+		content += "\n"
+	}
+	if err := d.store.WriteFile(d.path, []byte(content), 0o644); err != nil {
+		return errors.WrapWithDetails(err, "writing devcontainer.json", "path", d.path)
+	}
+	return nil
+}

--- a/internal/devcontainer/document_test.go
+++ b/internal/devcontainer/document_test.go
@@ -1,0 +1,171 @@
+package devcontainer
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+type memStore struct {
+	files     map[string][]byte
+	writeSeen int
+}
+
+func (m *memStore) ReadFile(name string) ([]byte, error) {
+	data, ok := m.files[name]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return data, nil
+}
+
+func (m *memStore) WriteFile(name string, data []byte, _ os.FileMode) error {
+	m.writeSeen++
+	m.files[name] = data
+	return nil
+}
+
+const docPath = ".devcontainer/devcontainer.json"
+
+func loadDoc(t *testing.T, content string) (*Document, *memStore) {
+	t.Helper()
+	store := &memStore{files: map[string][]byte{docPath: []byte(content)}}
+	doc, err := LoadDocument(store, docPath)
+	require.NoError(t, err)
+	return doc, store
+}
+
+// devcontainer.json is JSONC and the file is the user's. Decoding it into a map
+// and re-marshalling returned it with the comments gone and the keys in
+// alphabetical order — so an edit of one key rewrote the whole file.
+func TestDocument_CommentsAndKeyOrderSurviveAnEdit(t *testing.T) {
+	original := `{
+  // the image everything else hangs off
+  "name": "human",
+  "image": "mcr.microsoft.com/devcontainers/go:1",
+  "features": {
+    // node is needed for the CLI
+    "ghcr.io/devcontainers/features/node:1": {}
+  },
+  "forwardPorts": [8080]
+}`
+	doc, store := loadDoc(t, original)
+
+	require.NoError(t, doc.AddFeature("ghcr.io/gethuman-sh/treehouse/human:1"))
+	require.NoError(t, doc.Save())
+
+	written := string(store.files[docPath])
+	assert.Contains(t, written, "// the image everything else hangs off", "comments survive")
+	assert.Contains(t, written, "// node is needed for the CLI")
+	assert.Less(t, strings.Index(written, `"name"`), strings.Index(written, `"image"`), "key order survives")
+	assert.Less(t, strings.Index(written, `"features"`), strings.Index(written, `"forwardPorts"`))
+	assert.True(t, gjson.Get(written, `features.ghcr\.io/gethuman-sh/treehouse/human:1`).Exists(),
+		"and the feature is actually added")
+	assert.True(t, gjson.Get(written, `features.ghcr\.io/devcontainers/features/node:1`).Exists(),
+		"next to the one already there")
+}
+
+// A commented file used to be unreadable: the feature writer failed on it and
+// the LSP writer skipped it, both because encoding/json rejects JSONC.
+func TestDocument_ACommentedFileIsReadable(t *testing.T) {
+	doc, _ := loadDoc(t, "{\n  // just a comment\n  \"name\": \"human\"\n}")
+	assert.False(t, doc.HasFeature("ghcr.io/gethuman-sh/treehouse/human:1"))
+	require.NoError(t, doc.AddFeature("ghcr.io/gethuman-sh/treehouse/human:1"))
+	assert.True(t, doc.HasFeature("ghcr.io/gethuman-sh/treehouse/human:1"))
+}
+
+// postStartCommand's array form is a single command's argv. The old code read
+// it as absent and wrote over it, silently deleting whatever the user ran on
+// every container start.
+func TestDocument_AnArgvPostStartCommandIsRefusedNotReplaced(t *testing.T) {
+	original := `{"name":"human","postStartCommand":["bash","-lc","./scripts/setup.sh"]}`
+	doc, store := loadDoc(t, original)
+
+	err := doc.AppendPostStartCommand("human-lsp", "npm i -g gopls")
+	require.Error(t, err, "there is nothing to append to an argv array without changing what it means")
+	assert.False(t, doc.Changed())
+	require.NoError(t, doc.Save())
+	assert.Zero(t, store.writeSeen, "the user's command is left exactly as it was")
+	assert.Equal(t, original, string(store.files[docPath]))
+}
+
+// The object form is the spec's own way to have more than one post-start
+// command, so ours joins it under its own name instead of replacing anything.
+func TestDocument_AnObjectPostStartCommandGainsANamedEntry(t *testing.T) {
+	doc, store := loadDoc(t, `{"postStartCommand":{"setup":"./scripts/setup.sh"}}`)
+
+	require.NoError(t, doc.AppendPostStartCommand("human-lsp", "npm i -g gopls"))
+	require.NoError(t, doc.Save())
+
+	written := string(store.files[docPath])
+	assert.Equal(t, "./scripts/setup.sh", gjson.Get(written, "postStartCommand.setup").String())
+	assert.Equal(t, "npm i -g gopls", gjson.Get(written, "postStartCommand.human-lsp").String())
+}
+
+func TestDocument_AStringPostStartCommandIsExtended(t *testing.T) {
+	doc, store := loadDoc(t, `{"postStartCommand":"./scripts/setup.sh"}`)
+
+	require.NoError(t, doc.AppendPostStartCommand("human-lsp", "npm i -g gopls"))
+	require.NoError(t, doc.Save())
+
+	assert.Equal(t, "./scripts/setup.sh && npm i -g gopls",
+		gjson.Get(string(store.files[docPath]), "postStartCommand").String())
+}
+
+func TestDocument_AnAbsentPostStartCommandIsSet(t *testing.T) {
+	doc, store := loadDoc(t, `{"name":"human"}`)
+
+	require.NoError(t, doc.AppendPostStartCommand("human-lsp", "npm i -g gopls"))
+	require.NoError(t, doc.Save())
+
+	assert.Equal(t, "npm i -g gopls", gjson.Get(string(store.files[docPath]), "postStartCommand").String())
+}
+
+// Running the wizard twice must change nothing the second time, in any of the
+// shapes — and a document nothing changed is not written at all.
+func TestDocument_EditsAreIdempotent(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+		edit    func(*Document) error
+	}{
+		{
+			name:    "feature already declared",
+			content: `{"features":{"ghcr.io/gethuman-sh/treehouse/human:1":{}}}`,
+			edit:    func(d *Document) error { return d.AddFeature("ghcr.io/gethuman-sh/treehouse/human:1") },
+		},
+		{
+			name:    "command already in the string",
+			content: `{"postStartCommand":"npm i -g gopls"}`,
+			edit:    func(d *Document) error { return d.AppendPostStartCommand("human-lsp", "npm i -g gopls") },
+		},
+		{
+			name:    "command already named",
+			content: `{"postStartCommand":{"human-lsp":"npm i -g gopls"}}`,
+			edit:    func(d *Document) error { return d.AppendPostStartCommand("human-lsp", "npm i -g gopls") },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			doc, store := loadDoc(t, tc.content)
+
+			require.NoError(t, tc.edit(doc))
+			assert.False(t, doc.Changed(), "the edit is already in the file")
+			require.NoError(t, doc.Save())
+			assert.Zero(t, store.writeSeen)
+			assert.Equal(t, tc.content, string(store.files[docPath]))
+		})
+	}
+}
+
+// A file that is not JSON at all is reported rather than replaced with one that
+// is — the same rule as every other document human edits but does not own.
+func TestDocument_ABrokenFileIsReportedNotReplaced(t *testing.T) {
+	store := &memStore{files: map[string][]byte{docPath: []byte(`{"name": `)}}
+	_, err := LoadDocument(store, docPath)
+	require.Error(t, err)
+	assert.Zero(t, store.writeSeen)
+}

--- a/internal/init/step_devcontainer.go
+++ b/internal/init/step_devcontainer.go
@@ -143,38 +143,19 @@ const nodeFeatureKey = "ghcr.io/devcontainers/features/node:1"
 // ensureHumanFeature reads an existing devcontainer.json and adds the human
 // feature if it is missing. Returns hints if the file was updated.
 func ensureHumanFeature(w io.Writer, fw claude.FileWriter) ([]string, error) {
-	data, err := fw.ReadFile(devcontainerPath)
+	doc, err := devcontainer.LoadDocument(fw, devcontainerPath)
 	if err != nil {
-		return nil, errors.WrapWithDetails(err, "reading existing devcontainer config")
+		return nil, err
 	}
-
-	raw := map[string]any{}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return nil, errors.WrapWithDetails(err, "parsing existing devcontainer config")
+	if err := doc.AddFeature(humanFeatureKey); err != nil {
+		return nil, err
 	}
-
-	features, _ := raw["features"].(map[string]any)
-	if features != nil {
-		if _, ok := features[humanFeatureKey]; ok {
-			_, _ = fmt.Fprintln(w, "Keeping existing devcontainer config (human feature already present).")
-			return nil, nil
-		}
+	if !doc.Changed() {
+		_, _ = fmt.Fprintln(w, "Keeping existing devcontainer config (human feature already present).")
+		return nil, nil
 	}
-
-	if features == nil {
-		features = map[string]any{}
-		raw["features"] = features
-	}
-	features[humanFeatureKey] = map[string]any{}
-
-	out, err := json.MarshalIndent(raw, "", "  ")
-	if err != nil {
-		return nil, errors.WrapWithDetails(err, "marshalling updated devcontainer config")
-	}
-	out = append(out, '\n')
-
-	if err := fw.WriteFile(devcontainerPath, out, 0o644); err != nil {
-		return nil, errors.WrapWithDetails(err, "writing updated devcontainer config")
+	if err := doc.Save(); err != nil {
+		return nil, err
 	}
 
 	_, _ = fmt.Fprintln(w, "Added human feature to existing devcontainer config.")

--- a/internal/init/step_lsp.go
+++ b/internal/init/step_lsp.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gethuman-sh/human/errors"
 	"github.com/gethuman-sh/human/internal/claude"
+	"github.com/gethuman-sh/human/internal/devcontainer"
 )
 
 // LspPlugin describes an LSP server and its Claude Code plugin.
@@ -279,37 +280,27 @@ func enableLspTool(w io.Writer, fw claude.FileWriter) error {
 // appendLspToDevcontainer reads .devcontainer/devcontainer.json and appends
 // LSP install commands to postStartCommand. Silently skips if no config exists.
 func appendLspToDevcontainer(w io.Writer, fw claude.FileWriter, cmds []string) {
-	data, err := fw.ReadFile(devcontainerPath)
+	doc, err := devcontainer.LoadDocument(fw, devcontainerPath)
 	if err != nil {
 		return
 	}
-	raw := map[string]any{}
-	if err := json.Unmarshal(data, &raw); err != nil {
+	// A shape the document will not edit blind (an argv array) is reported here
+	// rather than swallowed with everything else: skipping silently is what let
+	// the previous version delete the user's command without saying so.
+	if err := doc.AppendPostStartCommand(lspPostStartName, strings.Join(cmds, " && ")); err != nil {
+		_, _ = fmt.Fprintf(w, "  Left %s alone: %v\n", devcontainerPath, err)
 		return
 	}
-
-	lspCmd := strings.Join(cmds, " && ")
-
-	// Check if commands are already present.
-	existing, _ := raw["postStartCommand"].(string)
-	if strings.Contains(existing, lspCmd) {
+	if !doc.Changed() {
 		return
 	}
-
-	if existing != "" {
-		raw["postStartCommand"] = existing + " && " + lspCmd
-	} else {
-		raw["postStartCommand"] = lspCmd
-	}
-
-	out, err := json.MarshalIndent(raw, "", "  ")
-	if err != nil {
-		return
-	}
-	out = append(out, '\n')
-
-	if err := fw.WriteFile(devcontainerPath, out, 0o644); err != nil {
+	if err := doc.Save(); err != nil {
 		return
 	}
 	_, _ = fmt.Fprintf(w, "  Updated %s with LSP install commands\n", devcontainerPath)
 }
+
+// lspPostStartName is the key the LSP installs take when postStartCommand is an
+// object of named commands — so re-running the step updates its own entry
+// instead of adding another.
+const lspPostStartName = "human-lsp"


### PR DESCRIPTION
Phase 4 of SC-4118.

Two places edited `devcontainer.json` — the wizard adding the human feature, the LSP step appending a post-start command — and both decoded it into a map and re-marshalled the whole file. Three things went wrong every time, none announced:

- **It is JSONC.** `encoding/json` rejects it, so the feature writer *failed* on any file carrying a comment and the LSP writer silently skipped one.
- **`MarshalIndent` writes a map**, so the file came back alphabetised with every comment gone.
- **`postStartCommand` is a string OR an array OR an object of named commands.** `raw["postStartCommand"].(string)` reads the last two as absent, and the write then replaced the user's own command with ours.

Editing is surgical now (`sjson` over the original bytes, both deps already in the module), so comments, key order and the user's formatting all survive. The object form gains a named entry — that is what the form is for. The argv array is refused with a hint rather than overwritten: there is nothing to append to a single command's arguments without changing what it means.

`make check` green, `go test ./cmd/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)