### PR TITLE
[SC-4118] Give the commit-reference grammar one owner

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -11,6 +11,12 @@
 #
 # Exempt: merge commits, reverts, fixup/squash commits.
 # Bypass:  git commit --no-verify
+#
+# This is the SECOND spelling of a grammar internal/commitref owns in Go. It
+# stays shell on purpose — a hook that needs the binary built cannot be the
+# thing that gates building it — so the two are held in step by both being run
+# over internal/commitref.Corpus, which fails the build when they disagree.
+# Changing anything below means adding the case to that corpus first.
 
 msg=$(cat "$1")
 

--- a/internal/commitref/commitref.go
+++ b/internal/commitref/commitref.go
@@ -1,0 +1,156 @@
+// Package commitref owns the commit-message issue-reference grammar: which
+// forms are accepted, how a message is checked for one, how a reference to a
+// given key is searched for, and how the keys in a subject are read back out.
+//
+// It exists because that grammar was written four times — an extended-regexp in
+// .githooks/commit-msg, a grep-pattern builder in internal/gitrepo whose own
+// comment admitted it mirrored the hook, an extraction pair beside it, and the
+// canonical-form rule in internal/tracker. Four spellings of one rule is four
+// places to change and three chances to forget, and the failure is quiet in
+// both directions: a form the hook accepts but the search does not is a commit
+// nobody can find afterwards, and a form the search accepts but the hook does
+// not is a commit nobody could have made.
+//
+// The hook stays shell — a hook that needs the binary built cannot be the thing
+// that gates building it — so it is not a fifth caller but a second spelling
+// held in step by a shared corpus both sides are run over (corpus.go).
+package commitref
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Form is one accepted way to reference an issue in a commit message. The list
+// is the grammar: something that means to explain the rule to a person reads
+// these rather than restating them.
+type Form struct {
+	// Name is what a person calls this form.
+	Name string
+	// Example is a message fragment in this form, shown when a commit is
+	// rejected and used as a case in the corpus.
+	Example string
+	pattern *regexp.Regexp
+}
+
+// forms are the accepted reference styles, in the order the rejection message
+// lists them. Each mirrors one alternative of the hook's own pattern.
+var forms = []Form{
+	{
+		Name:    "numeric",
+		Example: "Issue #123",
+		pattern: regexp.MustCompile(`Issue\s+#[0-9]+`),
+	},
+	{
+		Name:    "prefixed",
+		Example: "Issue HUM-30",
+		pattern: regexp.MustCompile(`Issue\s+[A-Z]+-[0-9]+`),
+	},
+	{
+		Name:    "bracket",
+		Example: "[SC-57]",
+		pattern: regexp.MustCompile(`\[[A-Z]+-[0-9]+`),
+	},
+	{
+		Name:    "code host",
+		Example: "octocat/repo#42",
+		pattern: regexp.MustCompile(`[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[0-9]+`),
+	},
+	{
+		Name:    "project path",
+		Example: "MyProject/42",
+		pattern: regexp.MustCompile(`[A-Za-z][A-Za-z0-9._-]*/[0-9]+`),
+	},
+}
+
+// Forms lists the accepted reference styles.
+func Forms() []Form {
+	out := make([]Form, len(forms))
+	copy(out, forms)
+	return out
+}
+
+// HasAny reports whether message carries an issue reference in any accepted
+// form — the question the commit-msg hook asks.
+func HasAny(message string) bool {
+	for _, f := range forms {
+		if f.pattern.MatchString(message) {
+			return true
+		}
+	}
+	return false
+}
+
+// exemptSubject matches the commit kinds that need no reference: a merge, a
+// revert, and the two rebase-fixup prefixes, all of which take their subject
+// from a commit that already carried one.
+var exemptSubject = regexp.MustCompile(`^(Merge |Revert "|fixup! |squash! )`)
+
+// Exempt reports whether a message's own kind excuses it from carrying a
+// reference. It reads the FIRST line only: a body quoting a merge is still an
+// ordinary commit.
+func Exempt(message string) bool {
+	first, _, _ := strings.Cut(message, "\n")
+	return exemptSubject.MatchString(first)
+}
+
+var (
+	// prefixedKey and numericRef are the extraction grammar for reading keys
+	// back OUT of a subject: bracketed-or-bare PREFIX-N keys, and #N numeric
+	// references.
+	prefixedKey = regexp.MustCompile(`\[?([A-Z]{2,}-[0-9]+)\]?`)
+	numericRef  = regexp.MustCompile(`#([0-9]+)`)
+	numericKey  = regexp.MustCompile(`^[0-9]+$`)
+)
+
+// Keys extracts the ticket keys a subject references: every prefixed key
+// first, then every numeric one, each deduped in order of first appearance.
+//
+// The two groups are kept apart rather than interleaved because a caller
+// listing "the tickets this touched" wants the named ones first — a numeric
+// reference cannot be told from an issue number in another system by looking.
+func Keys(subjects []string) []string {
+	var prefixed, numeric []string
+	seen := map[string]bool{}
+	for _, subject := range subjects {
+		for _, m := range prefixedKey.FindAllStringSubmatch(subject, -1) {
+			if !seen[m[1]] {
+				seen[m[1]] = true
+				prefixed = append(prefixed, m[1])
+			}
+		}
+		for _, m := range numericRef.FindAllStringSubmatch(subject, -1) {
+			if !seen[m[1]] {
+				seen[m[1]] = true
+				numeric = append(numeric, m[1])
+			}
+		}
+	}
+	return append(prefixed, numeric...)
+}
+
+// IsNumericKey reports whether a key is purely numeric — the one key shape that
+// carries no prefix of its own and so has to be told what tracker it belongs to
+// before it can be written into a commit message.
+func IsNumericKey(key string) bool { return numericKey.MatchString(key) }
+
+// TrimBrackets strips surrounding whitespace and one layer of [ ] from a key,
+// the form the board and pipeline sometimes pass internally.
+func TrimBrackets(key string) string {
+	trimmed := strings.TrimSpace(key)
+	return strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "["), "]"))
+}
+
+// GrepPattern builds the extended-regexp `git log --grep` pattern matching
+// every accepted reference form for one key.
+//
+// The guards are the whole difficulty: a numeric key must not match inside a
+// longer number, and a prefixed key must not match inside a longer key — SC-5
+// finding every SC-57 commit is a wrong answer that looks like a right one.
+func GrepPattern(key string) string {
+	esc := regexp.QuoteMeta(key)
+	if IsNumericKey(key) {
+		return `\[#?` + esc + `\]|(^|[^0-9])#` + esc + `([^0-9]|$)|Issue #?` + esc + `([^0-9]|$)|/` + esc + `([^0-9]|$)`
+	}
+	return `\[` + esc + `\]|Issue ` + esc + `([^0-9]|$)|(^|[^A-Za-z0-9-])` + esc + `([^0-9]|$)`
+}

--- a/internal/commitref/commitref_test.go
+++ b/internal/commitref/commitref_test.go
@@ -1,0 +1,135 @@
+package commitref_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/commitref"
+)
+
+// The package's own verdict on every case in the shared corpus.
+func TestGrammar_ReachesTheCorpusVerdict(t *testing.T) {
+	for _, tc := range commitref.Corpus {
+		t.Run(tc.Why, func(t *testing.T) {
+			accepted := commitref.Exempt(tc.Message) || commitref.HasAny(tc.Message)
+			assert.Equal(t, tc.Accepted, accepted, "message: %q", tc.Message)
+		})
+	}
+}
+
+// TestHook_ReachesTheSameVerdictAsTheGrammar is the point of the corpus.
+//
+// The commit-msg hook is a second spelling of this grammar and has to stay one:
+// a hook that needs the binary built cannot be the thing that gates building it.
+// Two spellings drift, and both directions are quiet — a form the hook accepts
+// and the search does not is a commit nobody can find afterwards; a form the
+// search accepts and the hook does not is a commit nobody could have made. So
+// the hook is actually RUN here, over the same cases.
+func TestHook_ReachesTheSameVerdictAsTheGrammar(t *testing.T) {
+	hook := hookPath(t)
+	if _, err := os.Stat(hook); err != nil {
+		t.Skipf("commit-msg hook not present at %s", hook)
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+	// The hook asks git what is staged, to exempt a docs-only commit. Run it in
+	// a repository of its own so the answer is "nothing" rather than whatever
+	// the developer happens to have staged.
+	repo := emptyRepo(t)
+
+	for _, tc := range commitref.Corpus {
+		t.Run(tc.Why, func(t *testing.T) {
+			msgFile := filepath.Join(t.TempDir(), "COMMIT_EDITMSG")
+			require.NoError(t, os.WriteFile(msgFile, []byte(tc.Message), 0o600))
+
+			cmd := exec.Command("bash", hook, msgFile)
+			cmd.Dir = repo
+			out, err := cmd.CombinedOutput()
+
+			assert.Equal(t, tc.Accepted, err == nil,
+				"the hook and the grammar disagree about %q\nhook said: %s", tc.Message, strings.TrimSpace(string(out)))
+		})
+	}
+}
+
+// Every form the rejection message advertises must be a form the hook accepts.
+// Advertising one it rejects is the cruellest shape this bug takes: the user
+// does exactly what they were told and is refused again.
+func TestHook_AcceptsEveryFormItAdvertises(t *testing.T) {
+	hook := hookPath(t)
+	if _, err := os.Stat(hook); err != nil {
+		t.Skipf("commit-msg hook not present at %s", hook)
+	}
+	source, err := os.ReadFile(hook) // #nosec G304 -- a fixed path inside the repo
+	require.NoError(t, err)
+
+	for _, form := range commitref.Forms() {
+		assert.Contains(t, string(source), form.Example,
+			"the hook's help must show the %s form the grammar accepts", form.Name)
+		assert.True(t, commitref.HasAny(form.Example),
+			"the grammar must accept the %s form it advertises", form.Name)
+	}
+}
+
+// hookPath resolves the hook absolutely: it is run from a repository of its
+// own, so a path relative to the package directory would not find it.
+func hookPath(t *testing.T) string {
+	t.Helper()
+	abs, err := filepath.Abs(filepath.Join("..", "..", ".githooks", "commit-msg"))
+	require.NoError(t, err)
+	return abs
+}
+
+func emptyRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init", "--quiet")
+	cmd.Dir = dir
+	require.NoError(t, cmd.Run(), "git init")
+	return dir
+}
+
+func TestKeys_PrefixedFirstThenNumericEachOnce(t *testing.T) {
+	keys := commitref.Keys([]string{
+		"[SC-79] [HUM-59] Add validation",
+		"Fix the parser (Issue #123)",
+		"[SC-79] Again",
+	})
+	assert.Equal(t, []string{"SC-79", "HUM-59", "123"}, keys)
+}
+
+// A short key must not find a longer one's commits. SC-5 matching every SC-57
+// is a wrong answer that reads like a right one.
+func TestGrepPattern_GuardsAgainstLongerKeys(t *testing.T) {
+	prefixed := commitref.GrepPattern("SC-57")
+	assert.Contains(t, prefixed, `\[SC-57\]`)
+	assert.NotContains(t, prefixed, `#?SC-57\]`,
+		"a prefixed key must not carry the numeric hash form")
+
+	assert.Contains(t, commitref.GrepPattern("42"), `\[#?42\]`,
+		"a numeric key is searched for in its own forms")
+
+	// The guard that matters: the pattern for a short key must not match a
+	// longer one built on it.
+	assert.Regexp(t, commitref.GrepPattern("SC-57"), "[SC-57] Add validation")
+	assert.NotRegexp(t, commitref.GrepPattern("SC-5"), "[SC-57] Add validation")
+	assert.NotRegexp(t, commitref.GrepPattern("42"), "Issue #421")
+}
+
+func TestTrimBrackets(t *testing.T) {
+	assert.Equal(t, "SC-57", commitref.TrimBrackets(" [SC-57] "))
+	assert.Equal(t, "SC-57", commitref.TrimBrackets("SC-57"))
+}
+
+func TestIsNumericKey(t *testing.T) {
+	assert.True(t, commitref.IsNumericKey("123"))
+	assert.False(t, commitref.IsNumericKey("SC-123"))
+	assert.False(t, commitref.IsNumericKey(""))
+}

--- a/internal/commitref/corpus.go
+++ b/internal/commitref/corpus.go
@@ -1,0 +1,49 @@
+package commitref
+
+// Case is one commit message and the verdict the grammar must reach on it.
+type Case struct {
+	// Message is the whole commit message, as git would hand it to the hook.
+	Message string
+	// Accepted is whether it may be committed: it carries a reference, or its
+	// kind excuses it from needing one.
+	Accepted bool
+	// Why names what the case is testing, so a failure says which rule moved.
+	Why string
+}
+
+// Corpus is the shared truth about the grammar.
+//
+// Two things implement it — this package and .githooks/commit-msg — and neither
+// can be derived from the other: the hook must stay shell, because a hook that
+// needs the binary built cannot be the thing that gates building it. So they are
+// held in step by both being run over these cases, which is what turns "two
+// spellings of one rule" from a silent drift into a failing test.
+//
+// It lives in the package rather than in a _test.go file because the hook's own
+// check needs it too, from a different package.
+var Corpus = []Case{
+	// Every accepted form, as the rejection message advertises it. A form
+	// advertised and not accepted is the cruellest version of this bug.
+	{Message: "Fix the parser\n\nIssue #123", Accepted: true, Why: "numeric, as advertised"},
+	{Message: "Fix the parser\n\nIssue HUM-30", Accepted: true, Why: "prefixed, as advertised"},
+	{Message: "[SC-57] Fix the parser", Accepted: true, Why: "bracket, as advertised"},
+	{Message: "Fix the parser\n\noctocat/repo#42", Accepted: true, Why: "code host, as advertised"},
+	{Message: "Fix the parser\n\nMyProject/42", Accepted: true, Why: "project path, as advertised"},
+
+	// The real shapes this project commits in.
+	{Message: "[SC-79] [HUM-59] Add validation", Accepted: true, Why: "split topology names both keys"},
+	{Message: "[SC-4118] Give settings.json one editor", Accepted: true, Why: "the ordinary single-tracker commit"},
+
+	// Kinds that carry no reference of their own because they inherit one.
+	{Message: "Merge pull request #460 from gethuman-sh/fix/x", Accepted: true, Why: "a merge is exempt"},
+	{Message: "Revert \"[SC-1] Add validation\"", Accepted: true, Why: "a revert is exempt"},
+	{Message: "fixup! [SC-1] Add validation", Accepted: true, Why: "a fixup is exempt"},
+	{Message: "squash! [SC-1] Add validation", Accepted: true, Why: "a squash is exempt"},
+
+	// Rejected: no reference anywhere.
+	{Message: "Fix the parser", Accepted: false, Why: "a subject alone is not a reference"},
+	{Message: "Fix the parser\n\nIt was wrong.", Accepted: false, Why: "prose is not a reference"},
+	{Message: "Update SC docs", Accepted: false, Why: "a prefix without a number is not a key"},
+	{Message: "Bump to 1.2.3", Accepted: false, Why: "a version is not a reference"},
+	{Message: "Merged the two paths", Accepted: false, Why: "only a real merge subject is exempt, not a word"},
+}

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -6,10 +6,10 @@ package gitrepo
 import (
 	"context"
 	"os/exec"
-	"regexp"
 	"strings"
 
 	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/commitref"
 )
 
 // runner executes a command and returns its combined stdout. It is a package
@@ -364,20 +364,6 @@ type Commit struct {
 	Subject  string `json:"subject"`
 }
 
-// keyRefPattern builds the extended-regexp grep pattern matching every accepted
-// commit-message reference form for key (the .githooks/commit-msg grammar):
-// bracket style ([SC-57]), "Issue SC-57" / "Issue #123", and guarded bare or
-// path-style occurrences (owner/repo#42, MyProject/42). Guards keep a numeric
-// key from matching inside longer numbers and a prefixed key from matching
-// inside longer keys (SC-5 must not match SC-57).
-func keyRefPattern(key string) string {
-	esc := regexp.QuoteMeta(key)
-	if regexp.MustCompile(`^[0-9]+$`).MatchString(key) {
-		return `\[#?` + esc + `\]|(^|[^0-9])#` + esc + `([^0-9]|$)|Issue #?` + esc + `([^0-9]|$)|/` + esc + `([^0-9]|$)`
-	}
-	return `\[` + esc + `\]|Issue ` + esc + `([^0-9]|$)|(^|[^A-Za-z0-9-])` + esc + `([^0-9]|$)`
-}
-
 // CommitsFor lists the commits on HEAD whose message references key in any
 // accepted reference format, newest first, excluding merge-PR commits — the
 // exact discovery agents otherwise hand-roll with git log --grep incantations.
@@ -392,7 +378,7 @@ var CommitsFor = func(ctx context.Context, dir, key string) ([]Commit, error) {
 // can stub git access in tests.
 var CommitsForRev = func(ctx context.Context, dir, key, rev string) ([]Commit, error) {
 	out, err := runner(ctx, "git", "-C", dir, "log", "--extended-regexp",
-		"--grep="+keyRefPattern(key), "--format=%H%x1f%h%x1f%s", rev)
+		"--grep="+commitref.GrepPattern(key), "--format=%H%x1f%h%x1f%s", rev)
 	if err != nil {
 		return nil, errors.WrapWithDetails(err, "listing commits for key", "dir", dir, "key", key)
 	}
@@ -444,14 +430,6 @@ var CurrentBranch = func(ctx context.Context, dir string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// prefixedKeyPattern and numericRefPattern are the fixed extraction grammar
-// for ticket keys in commit subjects: bracketed-or-bare PREFIX-N keys and #N
-// numeric references.
-var (
-	prefixedKeyPattern = regexp.MustCompile(`\[?([A-Z]{2,}-[0-9]+)\]?`)
-	numericRefPattern  = regexp.MustCompile(`#([0-9]+)`)
-)
-
 // TicketKeys extracts the ticket keys referenced by commits touching paths
 // (all history when paths is empty): prefixed keys first, then numeric ones,
 // each deduped in order of first appearance (newest commit first). Package var
@@ -465,23 +443,7 @@ var TicketKeys = func(ctx context.Context, dir string, paths []string) ([]string
 	if err != nil {
 		return nil, errors.WrapWithDetails(err, "listing commit subjects", "dir", dir)
 	}
-	var prefixed, numeric []string
-	seen := map[string]bool{}
-	for _, subject := range strings.Split(string(out), "\n") {
-		for _, m := range prefixedKeyPattern.FindAllStringSubmatch(subject, -1) {
-			if !seen[m[1]] {
-				seen[m[1]] = true
-				prefixed = append(prefixed, m[1])
-			}
-		}
-		for _, m := range numericRefPattern.FindAllStringSubmatch(subject, -1) {
-			if !seen[m[1]] {
-				seen[m[1]] = true
-				numeric = append(numeric, m[1])
-			}
-		}
-	}
-	return append(prefixed, numeric...), nil
+	return commitref.Keys(strings.Split(string(out), "\n")), nil
 }
 
 // LatestTag resolves the recency boundary tag: the nearest reachable tag,

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -696,20 +696,6 @@ func TestCommitsFor_gitError(t *testing.T) {
 	}
 }
 
-func TestKeyRefPattern_numericVsPrefixed(t *testing.T) {
-	num := keyRefPattern("42")
-	if want := `\[#?42\]`; !strings.Contains(num, want) {
-		t.Errorf("numeric pattern %q missing %q", num, want)
-	}
-	pre := keyRefPattern("SC-57")
-	if want := `\[SC-57\]`; !strings.Contains(pre, want) {
-		t.Errorf("prefixed pattern %q missing %q", pre, want)
-	}
-	if strings.Contains(pre, `#?SC-57\]`) {
-		t.Errorf("prefixed pattern %q must not carry the numeric hash form", pre)
-	}
-}
-
 func TestCurrentBranch(t *testing.T) {
 	withRunner(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
 		return []byte("feature/x\n"), nil

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/commitref"
 )
 
 // githubIssueRe matches GitHub issue keys like "owner/repo#123".
@@ -138,11 +139,10 @@ func ExtractProject(key string) string {
 const shortcutCommitPrefix = "SC-"
 
 // trimKeyBrackets strips surrounding whitespace and one layer of [ ] from a
-// key, the form the board/pipeline sometimes passes internally.
-func trimKeyBrackets(key string) string {
-	trimmed := strings.TrimSpace(key)
-	return strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "["), "]"))
-}
+// key, the form the board/pipeline sometimes passes internally. The shape of a
+// key inside a commit reference belongs to the commit-reference grammar, so it
+// is asked rather than spelled again here.
+func trimKeyBrackets(key string) string { return commitref.TrimBrackets(key) }
 
 // CanonicalCommitKey normalizes a ticket key to the canonical form used in
 // commit references. kind is the owning tracker's kind. A bare numeric key is
@@ -155,7 +155,7 @@ func trimKeyBrackets(key string) string {
 // returned unchanged.
 func CanonicalCommitKey(key, kind string) string {
 	trimmed := trimKeyBrackets(key)
-	if kind == "shortcut" && numericRe.MatchString(trimmed) {
+	if kind == "shortcut" && commitref.IsNumericKey(trimmed) {
 		return shortcutCommitPrefix + trimmed
 	}
 	return trimmed
@@ -170,7 +170,7 @@ func CanonicalCommitKey(key, kind string) string {
 // Shortcut's "SC-" prefix (SC-2855). Any key that already carries its own
 // format prefix is irrelevant to canonicalization, so "" is returned.
 func CommitKind(key string, instances []Instance) string {
-	if !numericRe.MatchString(trimKeyBrackets(key)) {
+	if !commitref.IsNumericKey(trimKeyBrackets(key)) {
 		return ""
 	}
 	for _, inst := range instances {


### PR DESCRIPTION
Phase 5 of SC-4118, the last one.

The commit-message issue-reference grammar was written four times:

1. an extended-regexp in `.githooks/commit-msg`
2. `keyRefPattern` in `internal/gitrepo`, whose own comment admitted it mirrored the hook
3. `prefixedKeyPattern`/`numericRefPattern` beside it, for reading keys back out
4. the canonical-key rule in `internal/tracker`

Four spellings of one rule is four places to change and three chances to forget, and the failure is quiet in both directions: a form the hook accepts and the search does not is a commit nobody can find afterwards; a form the search accepts and the hook does not is a commit nobody could have made.

`internal/commitref` owns it now — accepted forms, `HasAny`, `Exempt`, `GrepPattern`, `Keys`, `IsNumericKey`, `TrimBrackets` — and gitrepo and tracker delegate.

**The hook stays shell on purpose**: a hook that needs the binary built cannot be the thing that gates building it. So it is not a fifth caller but a second spelling, and the two are held in step by both being run over `commitref.Corpus` — the test actually executes `.githooks/commit-msg` (in a repository of its own, so the staged-file exemption answers "nothing" rather than whatever the developer has staged) and compares its exit status with the package's verdict. A second test checks that every form the rejection message advertises is a form that is actually accepted.

`make check` green, `go test ./cmd/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)