### PR TITLE
[SC-4118] Drop the import both halves of the file stopped using

### DIFF
--- a/internal/init/step_lsp.go
+++ b/internal/init/step_lsp.go
@@ -1,7 +1,6 @@
 package init
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"


### PR DESCRIPTION
**main is red.** `internal/init/step_lsp.go` imports `encoding/json` and no longer uses it, so `go build ./...` fails.

Nobody's branch was wrong. `step_lsp.go` had two readers of JSON config and a branch each removed one:

- #463 (`settings.json`) took the decode out of `enableLspTool`
- #464 (`devcontainer.json`) took it out of `appendLspToDevcontainer`

Each branch still used `encoding/json` through the *other* function, so `make check` was green on both, and the merge of the two is the first tree where the import is unused. A gate that only ever sees one branch at a time cannot catch this.

`make check` green, `go test ./cmd/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)