### PR TITLE
[SC-4152] Point the agent-context fragment at commands that exist

### DIFF
--- a/cmd/cmdagentcontext/agent-context.md
+++ b/cmd/cmdagentcontext/agent-context.md
@@ -6,11 +6,11 @@ The `human` CLI is available here. Prefer its tools over ad-hoc approaches.
 When a `human` daemon is running it serves a shared, always-fresh code index — no `index` step, works the same on the host, in any worktree, and inside any agent container. Just query:
 - `human codenav def <name>` — go-to-definition (`--outline` for signature + location only)
 - `human codenav refs <name>` — find references (with enclosing symbol + line)
-- `human codenav callers <qname>` / `callees <qname>` — call graph
+- `human codenav callers <qname>` / `human codenav callees <qname>` — call graph
 - `human codenav callpath --from A --to B` — concrete call paths
 - `human codenav impact <qname>` (or `--diff`) — blast radius of a change
 - `human codenav search <query>` — full-text search (`--symbols` for names)
-- `human codenav overview` / `outline <file>` — cold-start a codebase
+- `human codenav overview` / `human codenav outline <file>` — cold-start a codebase
 
 If a codenav query says the repo is not indexed, the daemon is still building the shared index — retry shortly (or, with no daemon, run `human codenav index .`); do not fall back to grep.
 
@@ -25,15 +25,16 @@ If a codenav query says the repo is not indexed, the daemon is still building th
 
 ## Pipeline protocol — use these instead of hand-building comments or git incantations
 - `human marker post|show|list <KEY> [TYPE]` — post/read the structured `[human:*]` handoff comments (plan, review verdicts, deploy results); validated, latest-wins
-- `human handoff post <KEY>` / `handoff show <KEY>` — the ready-for-review handoff; post derives branch/commits/daemon and verifies the commits are pushed
+- `human handoff post <KEY>` / `human handoff show <KEY>` — the ready-for-review handoff; post derives branch/commits/daemon and verifies the commits are pushed
 - `human commits for <KEY>` — the commits referencing a ticket; `human commits prefix <PM> [<ENG>]` — the canonical commit-subject prefix
 
 ## Ask the pipeline what to do next — before you stop and ask a person
-The pipeline is a state machine compiled into `human`, so these answer with no daemon and no credentials:
-- `human fsm next <state>` — every way out of a state: what records it, who causes it, and which are **yours**. Only your own carry a runnable `command`; the rest are listed so you know who you are waiting for. Posting another actor's marker does not advance the item, it puts it somewhere nothing drove it to
-- `human fsm show <state>` — what must hold there, who may act, and `if_nothing_happens` — read that before concluding you are stuck, because most states are recovered by the daemon on a timer
-- `human fsm marker <name>` — what a marker means, where it moves an item, and the fields it requires
-- `human fsm states` / `human fsm constants` — the whole machine; the real budgets (retries, graces, bounds)
+The pipeline is a state machine, and `human` answers questions about it:
+- `human fsm where <KEY>` — where a ticket is, what must hold there, who may move it, `if_nothing_happens` if nobody does, and every way out. Read `if_nothing_happens` before concluding you are stuck: most states are recovered by the daemon on a timer. Only a way out marked `"yours": true` carries a runnable `command`; the rest are listed so you know who you are waiting for. Posting another actor's marker does not advance the item, it puts it somewhere nothing drove it to
+- `human fsm marker <name>` — what a marker records, where posting it moves an item, and the fields it requires
+- `human fsm constants` — the real budgets: retries, graces, bounds
+
+Ask with the ticket key you already hold — you do not need to know which state you are in, because that is what `where` tells you. It needs the running daemon, since where an item is depends on its agents' liveness and its spent retries; `marker` and `constants` read the machine compiled into the binary and answer with no daemon and no credentials.
 
 ## Pull product context
 - `human notion search "<query>"` — docs, specs, notes

--- a/cmd_agent_context_test.go
+++ b/cmd_agent_context_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/cmd/cmdagentcontext"
+)
+
+// The fragment is injected into every coding-agent session as instructions, so
+// a command named in it that the binary does not have is an instruction the
+// agent cannot carry out — and one it cannot detect having failed, because a
+// group command answers an unknown subcommand with its own help text. It named
+// `human fsm next`, `fsm show` and `fsm states` for as long as it took someone
+// to try one by hand.
+func TestAgentContext_EveryCommandItNamesResolves(t *testing.T) {
+	root := newRootCmd()
+	invocations := agentContextInvocations(t)
+	require.NotEmpty(t, invocations, "no `human …` invocation was extracted — the parser proves nothing")
+
+	for _, args := range invocations {
+		cmd, rest, err := root.Find(args)
+		if assert.NoError(t, err, "human %s", strings.Join(args, " ")) {
+			assert.Empty(t, rest, "the fragment names `human %s`, but %q resolves no further than `%s`",
+				strings.Join(args, " "), strings.Join(rest, " "), cmd.CommandPath())
+		}
+	}
+}
+
+// A count, so deleting the fragment's whole command surface cannot pass as
+// "every command it names resolves".
+func TestAgentContext_NamesTheToolItIsFor(t *testing.T) {
+	invocations := agentContextInvocations(t)
+	assert.GreaterOrEqual(t, len(invocations), 20,
+		"the fragment stopped naming most of the commands it exists to teach")
+
+	paths := make(map[string]bool, len(invocations))
+	for _, args := range invocations {
+		paths[strings.Join(args, " ")] = true
+	}
+	// The four surfaces the fragment is written around; each has its own section
+	// and losing one silently is the failure this guards.
+	for _, want := range []string{"codenav def", "get", "marker post", "fsm where", "deploy"} {
+		assert.True(t, paths[want], "the fragment no longer names `human %s`", want)
+	}
+}
+
+// agentContextInvocations reads the fragment through the command that ships it,
+// not from disk, so the test covers the bytes an agent is actually given.
+func agentContextInvocations(t *testing.T) [][]string {
+	t.Helper()
+	cmd := cmdagentcontext.BuildAgentContextCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs(nil)
+	require.NoError(t, cmd.Execute())
+	return parseHumanInvocations(buf.String())
+}
+
+var backtickSpan = regexp.MustCompile("`([^`]+)`")
+
+// parseHumanInvocations pulls the resolvable subcommand path out of every
+// `human …` span in the fragment. It walks words while they are literal
+// subcommand names and stops at the first placeholder, flag or argument —
+// everything after that is for the reader, not for cobra. A word carrying
+// `a|b` alternatives expands into one invocation per alternative.
+func parseHumanInvocations(text string) [][]string {
+	var out [][]string
+	for _, m := range backtickSpan.FindAllStringSubmatch(text, -1) {
+		words := strings.Fields(m[1])
+		if len(words) < 2 || words[0] != "human" {
+			continue
+		}
+		if path := literalPath(words[1:]); len(path) > 0 {
+			out = append(out, expandAlternatives(path)...)
+		}
+	}
+	return out
+}
+
+// literalPath keeps the leading run of words that name commands.
+func literalPath(words []string) [][]string {
+	var path [][]string
+	for _, w := range words {
+		// The fragment teaches the tracker commands generically, and every
+		// tracker has the same subcommands under it — so resolve the rest of
+		// the path against one real tracker rather than abandoning the line.
+		if w == "<tracker>" {
+			path = append(path, []string{"jira"})
+			continue
+		}
+		alts := strings.Split(w, "|")
+		if !allCommandNames(alts) {
+			break
+		}
+		path = append(path, alts)
+	}
+	return path
+}
+
+var commandName = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+
+func allCommandNames(words []string) bool {
+	for _, w := range words {
+		if !commandName.MatchString(w) {
+			return false
+		}
+	}
+	return true
+}
+
+// expandAlternatives turns a path of per-position alternatives into one
+// invocation per combination.
+func expandAlternatives(path [][]string) [][]string {
+	out := [][]string{{}}
+	for _, alts := range path {
+		next := make([][]string, 0, len(out)*len(alts))
+		for _, prefix := range out {
+			for _, alt := range alts {
+				next = append(next, append(append([]string{}, prefix...), alt))
+			}
+		}
+		out = next
+	}
+	return out
+}
+
+// The parser is the load-bearing half of the guard above: if it silently
+// stopped extracting anything, every fragment would pass.
+func TestParseHumanInvocations(t *testing.T) {
+	got := parseHumanInvocations(strings.Join([]string{
+		"- `human codenav def <name>` — go-to-definition (`--outline` for names)",
+		"- `human marker post|show|list <KEY> [TYPE]` — markers",
+		"- `human <tracker> issue create|edit` — tickets",
+		"- `human pr create --head <branch> --title \"…\"` — open a PR",
+		"- `human codenav index .` — index",
+		"- backticked prose with no command at all",
+	}, "\n"))
+
+	assert.Equal(t, [][]string{
+		{"codenav", "def"},
+		{"marker", "post"}, {"marker", "show"}, {"marker", "list"},
+		{"jira", "issue", "create"}, {"jira", "issue", "edit"},
+		{"pr", "create"},
+		{"codenav", "index"},
+	}, got)
+}
+
+// Placeholders differ only by punctuation from the words around them, so the
+// stop rule gets its own case: a path must never absorb one as a subcommand.
+func TestParseHumanInvocations_StopsAtPlaceholders(t *testing.T) {
+	for _, span := range []string{
+		"`human get <KEY>`",
+		"`human search \"<query>\"`",
+		"`human commits prefix <PM> [<ENG>]`",
+		"`human deploy <KEY>`",
+	} {
+		got := parseHumanInvocations(span)
+		require.Len(t, got, 1, span)
+		for _, word := range got[0] {
+			assert.True(t, commandName.MatchString(word), "%s yielded the placeholder %q", span, word)
+		}
+	}
+}
+
+// Guard the guard: a fragment naming a command that does not exist must fail
+// the check above, whatever cobra does with the leftover word.
+func TestAgentContextGuard_CatchesAMissingCommand(t *testing.T) {
+	root := newRootCmd()
+	_, rest, err := root.Find([]string{"fsm", "next"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"next"}, rest, "an unknown subcommand must be left over, not swallowed")
+}

--- a/internal/marker/marker.go
+++ b/internal/marker/marker.go
@@ -183,7 +183,7 @@ func RequiredFields(markerType string) []string {
 // order the contract prefers them — so a caller that has to name exactly one
 // names the first. Empty when the type has no such contract.
 //
-// Exported for the same reason as RequiredFields: `human fsm next` builds the
+// Exported for the same reason as RequiredFields: `human fsm where` builds the
 // runnable `human marker post` command from these lists, and a contract it
 // cannot read is a command that posts a marker Validate then rejects.
 func AnyOfFields(markerType string) []string {


### PR DESCRIPTION
The block `human agent-context` injects into every coding-agent session told agents to run `human fsm next <state>`, `human fsm show <state>` and `human fsm states`. None of the three exists — `human fsm` has `where`, `marker` and `constants`.

The instruction failed silently: a command group answers an unknown subcommand with its own help text and exit 0, so an agent that followed it read a wall of plausible text and moved on. (SC-4153 fixes that half.)

- the fsm block is rewritten against the real surface, framed the way `internal/claude/embed/shared/fsm.md` already frames `where`: ask with the ticket key you hold
- the header no longer claims the whole block answers with no daemon — `where` needs one, `marker` and `constants` do not
- the three split forms (`codenav callers` / `callees`, `codenav overview` / `outline`, `handoff post` / `show`) now spell out both commands
- `internal/marker/marker.go` credited `fsm next` for reading its field contract; it is `fsm where`

**Guard:** `TestAgentContext_EveryCommandItNamesResolves` extracts every `human …` command the fragment names and resolves it against the real command tree. On the fragment as it was:

```
the fragment names `human fsm next`, but "next" resolves no further than `human fsm`
the fragment names `human fsm show`, but "show" resolves no further than `human fsm`
the fragment names `human fsm states`, but "states" resolves no further than `human fsm`
```

`make check`: green.