### PR TITLE
[SC-4153] Fail on an unknown subcommand instead of exiting 0

### DIFF
--- a/cmd_unknown_subcommand_test.go
+++ b/cmd_unknown_subcommand_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The whole tree, not a list of groups: a group added later would not be on a
+// list, and the hole this closes is exactly the one nobody remembered to check.
+func TestUnknownSubcommand_EveryGroupRejectsOne(t *testing.T) {
+	groups := commandGroups(newRootCmd())
+	require.NotEmpty(t, groups, "no command group was found — the walk proves nothing")
+
+	for _, group := range groups {
+		args := append(group, "definitely-not-a-subcommand")
+
+		root := newRootCmd()
+		var out bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&out)
+		root.SetArgs(args)
+
+		assert.Error(t, root.Execute(), "`human %s` is accepted as a success", strings.Join(args, " "))
+	}
+}
+
+// End to end through Execute, because ValidateArgs passing is not the same as
+// the process reporting a failure: the bug was a non-zero-looking run that
+// exited 0.
+func TestUnknownSubcommand_ExecuteFails(t *testing.T) {
+	for _, args := range [][]string{
+		{"fsm", "next", "stopped"},
+		{"marker", "bogus"},
+		{"codenav", "bogus"},
+		{"bogus"},
+	} {
+		root := newRootCmd()
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		root.SetArgs(args)
+
+		err := root.Execute()
+		require.Error(t, err, "human %s exited without an error", strings.Join(args, " "))
+		assert.Contains(t, err.Error(), "unknown command",
+			"human %s failed, but not by naming the unknown command", strings.Join(args, " "))
+	}
+}
+
+// The group's own help must keep working — it is how a caller recovers from the
+// error above, and turning that into an error too would trade one bad answer
+// for another.
+func TestUnknownSubcommand_BareGroupStillPrintsHelp(t *testing.T) {
+	for _, group := range []string{"fsm", "marker", "codenav"} {
+		root := newRootCmd()
+		var out bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&out)
+		root.SetArgs([]string{group})
+
+		require.NoError(t, root.Execute(), "human %s", group)
+		assert.Contains(t, out.String(), "Available Commands:", "human %s printed no help", group)
+	}
+}
+
+// A group that decides its own Args keeps that decision; the walk must not
+// overwrite one.
+func TestRejectUnknownSubcommands_LeavesADeclaredArgsAlone(t *testing.T) {
+	parent := &cobra.Command{Use: "parent", Args: cobra.ArbitraryArgs}
+	parent.AddCommand(&cobra.Command{Use: "child", Run: func(*cobra.Command, []string) {}})
+
+	rejectUnknownSubcommands(parent)
+
+	assert.NoError(t, parent.ValidateArgs([]string{"anything"}))
+}
+
+// A runnable command's arguments are its own input, not subcommand names.
+func TestRejectUnknownSubcommands_LeavesARunnableParentAlone(t *testing.T) {
+	parent := &cobra.Command{Use: "parent", RunE: func(*cobra.Command, []string) error { return nil }}
+	parent.AddCommand(&cobra.Command{Use: "child", Run: func(*cobra.Command, []string) {}})
+
+	rejectUnknownSubcommands(parent)
+
+	assert.Nil(t, parent.Args, "a runnable parent must keep cobra's default argument handling")
+}
+
+// commandGroups returns the argument path of every command that holds
+// subcommands, root's own empty path included: root was already the only group
+// that rejected an unknown word, and it has to keep doing so.
+func commandGroups(root *cobra.Command) [][]string {
+	var out [][]string
+	var walk func(*cobra.Command, []string)
+	walk = func(cmd *cobra.Command, path []string) {
+		if cmd.HasSubCommands() {
+			out = append(out, path)
+		}
+		for _, child := range cmd.Commands() {
+			walk(child, append(append([]string{}, path...), child.Name()))
+		}
+	}
+	walk(root, nil)
+	return out
+}

--- a/main.go
+++ b/main.go
@@ -446,7 +446,39 @@ Configure trackers and tools in .humanconfig.yaml or pass credentials via flags/
 	}
 	rootCmd.AddCommand(hookEventCmd)
 
+	rejectUnknownSubcommands(rootCmd)
+
 	return rootCmd
+}
+
+// rejectUnknownSubcommands makes a mistyped or non-existent subcommand fail.
+//
+// A command group holds subcommands and does no work of its own, and cobra's
+// default for one is to accept any positional argument, print the group's help
+// on stdout and exit 0. So `human fsm next` — a command that has never existed
+// — reads as a success carrying a wall of plausible text. Callers that check
+// the exit code see nothing wrong, and an agent acting on a stale instruction
+// proceeds believing it consulted the tool. Only the root command rejected the
+// unknown word; every group below it swallowed one.
+//
+// cobra.NoArgs alone does not fix it: cobra returns ErrHelp for a command that
+// is not runnable before it ever validates the arguments, so the check would
+// never run. The group is therefore given a RunE that prints its help — which
+// is what running a group bare should do anyway — and that makes it runnable,
+// which is what lets NoArgs report `unknown command "next" for "human fsm"`
+// and exit non-zero.
+//
+// A group that already declares Args or a Run has decided the question for
+// itself and is left alone.
+func rejectUnknownSubcommands(cmd *cobra.Command) {
+	for _, child := range cmd.Commands() {
+		rejectUnknownSubcommands(child)
+	}
+	if cmd.Runnable() || !cmd.HasSubCommands() || cmd.Args != nil {
+		return
+	}
+	cmd.Args = cobra.NoArgs
+	cmd.RunE = func(c *cobra.Command, _ []string) error { return c.Help() }
 }
 
 func buildInstallCmd() *cobra.Command {


### PR DESCRIPTION
`human fsm next stopped` printed the fsm help to stdout, wrote nothing to stderr, and exited 0. Every command group did the same — `human marker bogus`, `human codenav bogus` — and only root rejected an unknown word. A caller checking the exit code could not tell a real answer from a command that does not exist, which is how the stale instruction fixed in SC-4152 went unnoticed for as long as it did.

Cobra returns `ErrHelp` for a command that is not runnable *before* it validates arguments, and `ErrHelp` is a success — so `cobra.NoArgs` on a group would never have run. Every group therefore gets `NoArgs` **and** a `RunE` that prints its help. The RunE is what makes the group runnable, which is what lets NoArgs run at all.

Applied once by walking the tree in `newRootCmd`, not hand-added per group: a group added later is covered by construction. A group that already declares its own `Args` or `Run` is left alone.

After:

```
$ human fsm next stopped
Error: unknown command "next" for "human fsm"
$ echo $?
1
$ human fsm          # unchanged: prints its help, exit 0
```

**Tests.** The walk covers the whole tree rather than a list of groups; without the fix it names every group that swallows an unknown word (`human agent`, `human amplitude`, `human audit`, … 60-odd of them). Bare-group help is asserted to still work, and the two unit cases pin the exclusions.

**One visible change:** a group's help now carries an extra `Usage: human fsm [flags]` line, because the group is runnable. It is true — running a group bare prints its help.

`make check`: green. `go test ./cmd/...` (which check skips): green.