### PR TITLE
[SC-4151] Numbers on the board belong to their subject

### DIFF
--- a/cmd/cmdusage/usage.go
+++ b/cmd/cmdusage/usage.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
+	"github.com/gethuman-sh/human/internal/agent"
 	"github.com/gethuman-sh/human/internal/claude"
 	"github.com/gethuman-sh/human/internal/daemon"
 )
@@ -125,7 +126,7 @@ func buildFinder() claude.InstanceFinder {
 		&claude.HostFinder{Runner: claude.OSCommandRunner{}, HomeDir: home},
 	}
 	if dc, dcErr := claude.NewEngineDockerClient(); dcErr == nil {
-		finders = append(finders, &claude.DockerFinder{Client: dc})
+		finders = append(finders, &claude.DockerFinder{Client: dc, SessionForContainer: agent.SessionForContainer})
 	}
 	return &claude.CombinedFinder{Finders: finders}
 }

--- a/desktop/frontend/dist/board-detail.js
+++ b/desktop/frontend/dist/board-detail.js
@@ -103,18 +103,48 @@ function fmtDuration(ms) {
 // injected for tests.
 export function buildCostSection(c, currentStage, stageEnteredAt, nowMs) {
     if (!c || !c.hasSpend) {
+        // "No spend" is a claim about the TICKET and may only be made when the
+        // ledger was actually read. An older daemon (no ledgerRead field) still
+        // reads as before; a daemon that says it could not consult the ledger says
+        // so instead of attributing its own gap to the work (SC-4151 C8).
+        const unread = c !== null && c.ledgerRead === false;
+        const text = unread
+            ? "Cost could not be read for this ticket — the ledger was not available."
+            : "No spend recorded for this ticket yet.";
         return `<section class="detail-section detail-cost"><h3 class="detail-section-title">Cost &amp; time</h3>` +
-            `<div class="detail-cost-empty">No spend recorded for this ticket yet.</div></section>`;
+            `<div class="detail-cost-empty">${text}</div></section>`;
     }
+    // Calls that carried no token counts cannot be priced. Pricing them at zero
+    // and printing the sum states that the run was free; when EVERY call is
+    // unmeasured the figure is not a cost at all, so it is not shown as one
+    // (SC-4151 C7). A partial gap keeps the figure and qualifies it.
+    const calls = c.calls ?? 0;
+    const unmeasured = c.unmeasuredCalls ?? 0;
+    const allUnmeasured = calls > 0 && unmeasured === calls;
+    const totalLine = allUnmeasured
+        ? `cost not measured · ${escapeText(fmtDuration(c.totalDurationMs))}`
+        : `${escapeText(fmtUSD(c.totalCostUSD))} · ${escapeText(fmtDuration(c.totalDurationMs))}`;
+    const unmeasuredNote = unmeasured > 0 && !allUnmeasured
+        ? `<div class="detail-cost-unmeasured">${unmeasured} of ${calls} calls recorded no tokens — not included above.</div>`
+        : allUnmeasured
+            ? `<div class="detail-cost-unmeasured">${calls} call${calls === 1 ? "" : "s"} recorded no tokens, so what this cost is not known.</div>`
+            : "";
     const curElapsed = stageEnteredAt
         ? `<div class="detail-cost-current">Current stage (${escapeText(currentStage ?? "")}): ` +
             `${escapeText(fmtDuration(Math.max(0, nowMs - Date.parse(stageEnteredAt))))} running</div>`
         : "";
+    // The per-stage rows carry the same honesty as the total: with nothing
+    // measured anywhere, a stage's "$0.0000" is the same false claim in smaller
+    // type, so the row shows the duration alone.
     const stageRows = c.stages.map((s) => `<div class="detail-cost-stage"><span>${escapeText(s.stage || "—")}</span>` +
-        `<span>${escapeText(fmtUSD(s.costUSD))} · ${escapeText(fmtDuration(s.durationMs))}</span></div>`).join("");
+        `<span>${allUnmeasured ? "" : escapeText(fmtUSD(s.costUSD)) + " · "}${escapeText(fmtDuration(s.durationMs))}</span></div>`).join("");
+    const split = allUnmeasured
+        ? ""
+        : `<div class="detail-cost-split">answers ${escapeText(fmtUSD(c.answersCostUSD))} · context ${escapeText(fmtUSD(c.contextCostUSD))}</div>`;
     return `<section class="detail-section detail-cost"><h3 class="detail-section-title">Cost &amp; time</h3>` +
-        `<div class="detail-cost-total">${escapeText(fmtUSD(c.totalCostUSD))} · ${escapeText(fmtDuration(c.totalDurationMs))}</div>` +
-        `<div class="detail-cost-split">answers ${escapeText(fmtUSD(c.answersCostUSD))} · context ${escapeText(fmtUSD(c.contextCostUSD))}</div>` +
+        `<div class="detail-cost-total">${totalLine}</div>` +
+        split +
+        unmeasuredNote +
         curElapsed +
         `<div class="detail-cost-stages">${stageRows}</div></section>`;
 }

--- a/desktop/frontend/scripts/board-detail.test.mjs
+++ b/desktop/frontend/scripts/board-detail.test.mjs
@@ -190,3 +190,98 @@ test("no stageEnteredAt omits the live current-stage clock", () => {
   );
   assert.doesNotMatch(html, /Current stage/);
 });
+
+// --- Cost the ledger could not measure or could not read (SC-4151 C7/C8) ---
+
+test("a roll-up whose every call recorded no tokens says the cost is unknown, not $0.0000", () => {
+  // The shape of SC-1542 (85 calls, 8m40s) and SC-3339 (222 calls, 80m37s): real
+  // duration, real calls, no token counts on any of them, so nothing to price.
+  const html = buildCostSection(
+    {
+      ticket: "SC-3339",
+      ledgerRead: true,
+      hasSpend: true,
+      totalCostUSD: 0,
+      contextCostUSD: 0,
+      answersCostUSD: 0,
+      totalDurationMs: 4_836_948,
+      calls: 222,
+      unmeasuredCalls: 222,
+      stages: [{ stage: "implementation", costUSD: 0, contextCostUSD: 0, answersCostUSD: 0, durationMs: 4_836_948 }],
+    },
+    "implementation",
+    undefined,
+    Date.now(),
+  );
+  assert.match(html, /cost not measured/);
+  assert.match(html, /222 calls recorded no tokens/);
+  assert.doesNotMatch(html, /\$0\.0000/);
+  // The duration is real and still shown — only the price is unknown.
+  assert.match(html, /1h 20m/);
+});
+
+test("a partial measurement gap keeps the figure and qualifies it", () => {
+  const html = buildCostSection(
+    {
+      ticket: "SC-1",
+      ledgerRead: true,
+      hasSpend: true,
+      totalCostUSD: 1.23,
+      contextCostUSD: 0.8,
+      answersCostUSD: 0.43,
+      totalDurationMs: 5000,
+      calls: 10,
+      unmeasuredCalls: 4,
+      stages: [],
+    },
+    "implementation",
+    undefined,
+    Date.now(),
+  );
+  assert.match(html, /\$1\.23/);
+  assert.match(html, /4 of 10 calls recorded no tokens/);
+});
+
+test("a ledger that could not be read says so, instead of claiming the ticket is unspent", () => {
+  const html = buildCostSection(
+    { ticket: "SC-1", ledgerRead: false, hasSpend: false, totalCostUSD: 0, contextCostUSD: 0, answersCostUSD: 0, totalDurationMs: 0, stages: [] },
+    "implementation",
+    undefined,
+    Date.now(),
+  );
+  assert.match(html, /ledger was not available/);
+  assert.doesNotMatch(html, /No spend recorded/);
+});
+
+test("a payload from a daemon predating ledgerRead still reads as no spend", () => {
+  const html = buildCostSection(
+    { ticket: "SC-1", hasSpend: false, totalCostUSD: 0, contextCostUSD: 0, answersCostUSD: 0, totalDurationMs: 0, stages: [] },
+    "implementation",
+    undefined,
+    Date.now(),
+  );
+  assert.match(html, /No spend recorded/);
+});
+
+test("a fully measured roll-up is unchanged — no note, full split", () => {
+  const html = buildCostSection(
+    {
+      ticket: "SC-1",
+      ledgerRead: true,
+      hasSpend: true,
+      totalCostUSD: 2.5,
+      contextCostUSD: 1.5,
+      answersCostUSD: 1.0,
+      totalDurationMs: 1000,
+      calls: 7,
+      unmeasuredCalls: 0,
+      stages: [],
+    },
+    "planning",
+    undefined,
+    Date.now(),
+  );
+  assert.match(html, /\$2\.50/);
+  assert.match(html, /answers/);
+  assert.doesNotMatch(html, /recorded no tokens/);
+});

--- a/desktop/frontend/src/board-detail.ts
+++ b/desktop/frontend/src/board-detail.ts
@@ -126,11 +126,18 @@ export function buildDetailSections(d: DetailSections): string {
 // priced roll-up with the answers/context split and per-stage breakdown.
 export interface TicketCost {
   ticket: string;
+  // Whether the ledger was consulted at all. False means the answer says
+  // nothing about the ticket — see buildCostSection.
+  ledgerRead?: boolean;
   hasSpend: boolean;
   totalCostUSD: number;
   contextCostUSD: number;
   answersCostUSD: number;
   totalDurationMs: number;
+  // How many calls the roll-up covers, and how many of those carried no token
+  // counts so could not be priced.
+  calls?: number;
+  unmeasuredCalls?: number;
   stages: { stage: string; costUSD: number; contextCostUSD: number; answersCostUSD: number; durationMs: number }[];
 }
 
@@ -160,20 +167,51 @@ export function buildCostSection(
   nowMs: number,
 ): string {
   if (!c || !c.hasSpend) {
+    // "No spend" is a claim about the TICKET and may only be made when the
+    // ledger was actually read. An older daemon (no ledgerRead field) still
+    // reads as before; a daemon that says it could not consult the ledger says
+    // so instead of attributing its own gap to the work (SC-4151 C8).
+    const unread = c !== null && c.ledgerRead === false;
+    const text = unread
+      ? "Cost could not be read for this ticket — the ledger was not available."
+      : "No spend recorded for this ticket yet.";
     return `<section class="detail-section detail-cost"><h3 class="detail-section-title">Cost &amp; time</h3>` +
-      `<div class="detail-cost-empty">No spend recorded for this ticket yet.</div></section>`;
+      `<div class="detail-cost-empty">${text}</div></section>`;
   }
+  // Calls that carried no token counts cannot be priced. Pricing them at zero
+  // and printing the sum states that the run was free; when EVERY call is
+  // unmeasured the figure is not a cost at all, so it is not shown as one
+  // (SC-4151 C7). A partial gap keeps the figure and qualifies it.
+  const calls = c.calls ?? 0;
+  const unmeasured = c.unmeasuredCalls ?? 0;
+  const allUnmeasured = calls > 0 && unmeasured === calls;
+  const totalLine = allUnmeasured
+    ? `cost not measured · ${escapeText(fmtDuration(c.totalDurationMs))}`
+    : `${escapeText(fmtUSD(c.totalCostUSD))} · ${escapeText(fmtDuration(c.totalDurationMs))}`;
+  const unmeasuredNote =
+    unmeasured > 0 && !allUnmeasured
+      ? `<div class="detail-cost-unmeasured">${unmeasured} of ${calls} calls recorded no tokens — not included above.</div>`
+      : allUnmeasured
+        ? `<div class="detail-cost-unmeasured">${calls} call${calls === 1 ? "" : "s"} recorded no tokens, so what this cost is not known.</div>`
+        : "";
   const curElapsed = stageEnteredAt
     ? `<div class="detail-cost-current">Current stage (${escapeText(currentStage ?? "")}): ` +
       `${escapeText(fmtDuration(Math.max(0, nowMs - Date.parse(stageEnteredAt))))} running</div>`
     : "";
+  // The per-stage rows carry the same honesty as the total: with nothing
+  // measured anywhere, a stage's "$0.0000" is the same false claim in smaller
+  // type, so the row shows the duration alone.
   const stageRows = c.stages.map((s) =>
     `<div class="detail-cost-stage"><span>${escapeText(s.stage || "—")}</span>` +
-    `<span>${escapeText(fmtUSD(s.costUSD))} · ${escapeText(fmtDuration(s.durationMs))}</span></div>`,
+    `<span>${allUnmeasured ? "" : escapeText(fmtUSD(s.costUSD)) + " · "}${escapeText(fmtDuration(s.durationMs))}</span></div>`,
   ).join("");
+  const split = allUnmeasured
+    ? ""
+    : `<div class="detail-cost-split">answers ${escapeText(fmtUSD(c.answersCostUSD))} · context ${escapeText(fmtUSD(c.contextCostUSD))}</div>`;
   return `<section class="detail-section detail-cost"><h3 class="detail-section-title">Cost &amp; time</h3>` +
-    `<div class="detail-cost-total">${escapeText(fmtUSD(c.totalCostUSD))} · ${escapeText(fmtDuration(c.totalDurationMs))}</div>` +
-    `<div class="detail-cost-split">answers ${escapeText(fmtUSD(c.answersCostUSD))} · context ${escapeText(fmtUSD(c.contextCostUSD))}</div>` +
+    `<div class="detail-cost-total">${totalLine}</div>` +
+    split +
+    unmeasuredNote +
     curElapsed +
     `<div class="detail-cost-stages">${stageRows}</div></section>`;
 }

--- a/desktop/instances.go
+++ b/desktop/instances.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/gethuman-sh/human/internal/agent"
 	"github.com/gethuman-sh/human/internal/claude"
 	"github.com/gethuman-sh/human/internal/claude/logparser"
 	"github.com/gethuman-sh/human/internal/claude/monitor"
@@ -101,7 +102,7 @@ func buildInstanceFinder() (claude.InstanceFinder, claude.DockerClient) {
 	var dc claude.DockerClient
 	if client, dcErr := claude.NewEngineDockerClient(); dcErr == nil {
 		dc = client
-		finders = append(finders, &claude.DockerFinder{Client: dc})
+		finders = append(finders, &claude.DockerFinder{Client: dc, SessionForContainer: agent.SessionForContainer})
 	}
 	return &claude.CombinedFinder{Finders: finders}, dc
 }

--- a/internal/agent/agentlog.go
+++ b/internal/agent/agentlog.go
@@ -8,6 +8,7 @@ package agent
 // agent name and listed newest-first, mirroring the audit trail's UX.
 
 import (
+	"bufio"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -16,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/gethuman-sh/human/errors"
@@ -339,6 +341,55 @@ func LatestOutputPath(agentName string) (string, error) {
 		return "", err
 	}
 	return filepath.Join(exe.Dir(), "output.log"), nil
+}
+
+// LatestSessionID returns the Claude session the agent's newest run is writing,
+// read from the run's own hook trail — every event carries agent_name and
+// session_id together, so the pairing is already recorded and needs no probe.
+//
+// It exists because agent containers share one transcript directory: every
+// board agent mounts the same .devcontainer/claude as ~/.claude, so a container
+// asked what it has been doing answers with every agent's transcripts at once.
+// Without this, four containers reported one identical token figure and one
+// container's session state could be read out of another's file (SC-4151 C6).
+//
+// An agent with no runs, an unreadable trail, or a trail with no session yet
+// returns "" — the caller then leaves its behaviour unnarrowed rather than
+// guessing which session is the agent's.
+func LatestSessionID(agentName string) string {
+	exe, err := LatestExecution(agentName)
+	if err != nil {
+		return ""
+	}
+	f, err := os.Open(filepath.Join(exe.Dir(), "hooks.jsonl")) // #nosec G304 -- path derived from validated agent name + hex id
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		var evt hookevents.Event
+		if err := json.Unmarshal(scanner.Bytes(), &evt); err != nil {
+			continue
+		}
+		if evt.SessionID != "" {
+			return evt.SessionID
+		}
+	}
+	return ""
+}
+
+// SessionForContainer is LatestSessionID keyed by CONTAINER name, which is what
+// instance discovery holds. It is the value to hand to
+// claude.DockerFinder.SessionForContainer; a container this package did not
+// name is not a managed agent and resolves to "".
+func SessionForContainer(containerName string) string {
+	name, ok := strings.CutPrefix(strings.TrimSpace(containerName), ContainerPrefix)
+	if !ok || name == "" {
+		return ""
+	}
+	return LatestSessionID(name)
 }
 
 // StreamOutput writes the contents of the file at path to w. When follow is

--- a/internal/agent/agentlog_test.go
+++ b/internal/agent/agentlog_test.go
@@ -15,7 +15,17 @@ import (
 	"github.com/gethuman-sh/human/internal/claude/hookevents"
 	"github.com/gethuman-sh/human/internal/devcontainer"
 	"github.com/gethuman-sh/human/internal/gitrepo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// withTempLogs redirects the execution-log root at the package-level override,
+// the same way the stream and regression tests do.
+func withTempLogs(t *testing.T) {
+	t.Helper()
+	agentLogsDirOverride = t.TempDir()
+	t.Cleanup(func() { agentLogsDirOverride = "" })
+}
 
 // stderrFrame wraps payload in a Docker stdcopy multiplexed stderr frame.
 func stderrFrame(payload string) []byte {
@@ -401,4 +411,34 @@ func TestHookEventSink_AppendsJSONL(t *testing.T) {
 
 	// Empty agent name is a no-op (no panic, nothing written).
 	HookEventSink(hookevents.Event{EventName: "Stop", Timestamp: time.Now()})
+}
+
+// TestLatestSessionID covers the join SC-4151 C6 needs: every agent container
+// mounts the SAME transcript directory as ~/.claude, so the only record of
+// which session belongs to which agent is the run's own hook trail.
+func TestLatestSessionID(t *testing.T) {
+	withTempLogs(t)
+
+	assert.Empty(t, LatestSessionID("never-ran"), "an agent with no runs names no session")
+
+	exe, err := NewExecution(LaunchRecord{ID: "e1", Agent: "board-SC-1-implementation", StartedAt: time.Now()})
+	require.NoError(t, err)
+	assert.Empty(t, LatestSessionID("board-SC-1-implementation"), "a run with no hook trail yet names no session")
+
+	HookEventSink(hookevents.Event{EventName: "SessionStart", AgentName: "board-SC-1-implementation", SessionID: "c2848539-5efe-4fe2-b60d-9c73807417ff"})
+	assert.Equal(t, "c2848539-5efe-4fe2-b60d-9c73807417ff", LatestSessionID("board-SC-1-implementation"))
+	assert.DirExists(t, exe.Dir())
+}
+
+func TestSessionForContainer(t *testing.T) {
+	withTempLogs(t)
+	_, err := NewExecution(LaunchRecord{ID: "e1", Agent: "board-SC-1-prreview", StartedAt: time.Now()})
+	require.NoError(t, err)
+	HookEventSink(hookevents.Event{EventName: "SessionStart", AgentName: "board-SC-1-prreview", SessionID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"})
+
+	assert.Equal(t, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", SessionForContainer(ContainerPrefix+"board-SC-1-prreview"))
+	// Anything this package did not name is not a managed agent.
+	assert.Empty(t, SessionForContainer("some-other-container"))
+	assert.Empty(t, SessionForContainer(ContainerPrefix))
+	assert.Empty(t, SessionForContainer(""))
 }

--- a/internal/claude/discovery.go
+++ b/internal/claude/discovery.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -482,6 +483,20 @@ type DockerFinder struct {
 	Client   DockerClient
 	CacheTTL time.Duration // TTL for container data cache; defaults to 2s
 
+	// SessionForContainer names the transcript session belonging to one
+	// container, given its container name. Board agents mount ONE shared
+	// transcript directory as ~/.claude, so a container's own transcripts cannot
+	// be told from its siblings' by looking inside it — usage and session state
+	// both end up read from whichever file was written last, by whichever agent
+	// (SC-4151 C6). The daemon's own hook trail already pairs agent with session,
+	// so the answer is injected rather than probed: internal/agent owns both the
+	// trail and the container-name prefix, and it imports this package's
+	// hookevents, so depending on it here would close a cycle.
+	//
+	// nil, or a container it cannot resolve, leaves that container unnarrowed —
+	// today's behaviour exactly, per the package's "nil disables" convention.
+	SessionForContainer func(containerName string) string
+
 	mu    sync.Mutex
 	cache map[string]*dockerCacheEntry
 }
@@ -552,7 +567,7 @@ func (d *DockerFinder) buildContainerInstance(ctx context.Context, ctr Container
 
 	data := d.getCached(ctr.ID, ttl)
 	if data == nil {
-		data = d.fetchContainerData(ctx, ctr.ID)
+		data = d.fetchContainerData(ctx, ctr.ID, d.sessionFor(ctr.Name))
 		if data == nil {
 			return Instance{}, false
 		}
@@ -596,9 +611,38 @@ func (d *DockerFinder) buildContainerInstance(ctx context.Context, ctr Container
 // (currently active) session for code-navigation discovery.
 const transcriptStatCommand = `find /root/.claude/projects /home -maxdepth 6 -name '*.jsonl' -exec stat -c '%Y %n' {} + 2>/dev/null`
 
-func (d *DockerFinder) fetchContainerData(ctx context.Context, containerID string) []byte {
+// sessionIDPattern is what may be interpolated into the container-side find.
+// The ids come from our own hook trail, but a value reaching a shell must be
+// constrained by shape rather than by where it was supposed to have come from.
+var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9-]{8,64}$`)
+
+// sessionFor resolves the transcript session for one container, or "" when the
+// question cannot be answered — see DockerFinder.SessionForContainer.
+func (d *DockerFinder) sessionFor(containerName string) string {
+	if d.SessionForContainer == nil {
+		return ""
+	}
+	id := strings.TrimSpace(d.SessionForContainer(containerName))
+	if !sessionIDPattern.MatchString(id) {
+		return ""
+	}
+	return id
+}
+
+// transcriptStatFor narrows the transcript listing to one session's file when
+// the caller could name it. Every agent container sees every agent's
+// transcripts through the shared mount, so without the narrowing this returns
+// the whole fleet's history for each container in turn.
+func transcriptStatFor(sessionID string) string {
+	if sessionID == "" {
+		return transcriptStatCommand
+	}
+	return `find /root/.claude/projects /home -maxdepth 6 -name '` + sessionID + `.jsonl' -exec stat -c '%Y %n' {} + 2>/dev/null`
+}
+
+func (d *DockerFinder) fetchContainerData(ctx context.Context, containerID, sessionID string) []byte {
 	// List JSONL files with modification times from the container.
-	_, listReader, err := d.Client.Exec(ctx, containerID, []string{"sh", "-c", transcriptStatCommand})
+	_, listReader, err := d.Client.Exec(ctx, containerID, []string{"sh", "-c", transcriptStatFor(sessionID)})
 	if err != nil {
 		return nil
 	}

--- a/internal/claude/usage.go
+++ b/internal/claude/usage.go
@@ -530,16 +530,38 @@ type InstanceUsage struct {
 }
 
 // CollectInstanceUsage calculates usage for each instance and returns results.
+//
+// Per instance means per instance. Root is the whole project transcript tree
+// (~/.claude/projects/<project>), which every agent with the same cwd shares, so
+// scanning it attributes the PROJECT's tokens to each row: three host agents on
+// this repo all printed `in: 1.3K out: 413K`, the same figure three times, as if
+// each had spent it (SC-4151 C6). usageScope prefers the instance's own resolved
+// transcript, and only an instance that has none falls back to the tree.
 func CollectInstanceUsage(instances []Instance, now time.Time) []InstanceUsage {
 	var results []InstanceUsage
 	for _, inst := range instances {
-		summary, err := CalculateUsage(inst.Walker, inst.Root, now)
+		summary, err := CalculateUsage(inst.Walker, usageScope(inst), now)
 		if err != nil {
 			continue
 		}
 		results = append(results, InstanceUsage{Instance: inst, Summary: summary, State: StateUnknown})
 	}
 	return results
+}
+
+// usageScope names what one instance's usage is calculated over: its own
+// session transcript when discovery resolved one (host instances carry FilePath
+// for exactly this file — the one fsnotify watches), otherwise Root.
+//
+// Passing a file to a DirWalker is safe by construction: OSDirWalker walks it
+// with filepath.Walk, which yields a plain file once, and ByteWalker ignores the
+// path entirely — a container's usage comes from the bytes it was given, so
+// naming a path could not narrow it anyway.
+func usageScope(inst Instance) string {
+	if inst.FilePath != "" {
+		return inst.FilePath
+	}
+	return inst.Root
 }
 
 // MergeUsage adds all model usage from src into dst.

--- a/internal/claude/usage_test.go
+++ b/internal/claude/usage_test.go
@@ -4,9 +4,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // must returns v unchanged, failing the test when it is nil. Centralizing the
@@ -767,5 +773,61 @@ func TestScanTokens_byModel_empty(t *testing.T) {
 	}
 	if len(scan.ByModel) != 0 {
 		t.Errorf("ByModel = %+v, want empty", scan.ByModel)
+	}
+}
+
+// TestUsageScope_PrefersTheInstancesOwnTranscript covers SC-4151 C6: Root is the
+// whole project transcript tree, shared by every agent with the same cwd, so
+// scanning it reports the project's tokens once per row.
+func TestUsageScope_PrefersTheInstancesOwnTranscript(t *testing.T) {
+	own := Instance{Root: "/home/u/.claude/projects/proj", FilePath: "/home/u/.claude/projects/proj/sess.jsonl"}
+	assert.Equal(t, own.FilePath, usageScope(own), "an instance that knows its own transcript is scoped to it")
+
+	shared := Instance{Root: "/home/u/.claude/projects/proj"}
+	assert.Equal(t, shared.Root, usageScope(shared), "without one, the tree is all there is")
+}
+
+// TestCollectInstanceUsage_ScopesPerInstance is the regression the measured bug
+// left: two instances rooted in the same tree must not report the same tokens.
+func TestCollectInstanceUsage_ScopesPerInstance(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format(time.RFC3339Nano)
+	write := func(name string, out int) string {
+		p := filepath.Join(dir, name)
+		line := fmt.Sprintf(`{"type":"assistant","timestamp":%q,"message":{"model":"claude-opus-4-8","usage":{"input_tokens":1,"output_tokens":%d}}}`, ts, out)
+		require.NoError(t, os.WriteFile(p, []byte(line+"\n"), 0o600))
+		return p
+	}
+	a := write("a.jsonl", 10)
+	b := write("b.jsonl", 200)
+
+	got := CollectInstanceUsage([]Instance{
+		{Walker: OSDirWalker{}, Root: dir, FilePath: a},
+		{Walker: OSDirWalker{}, Root: dir, FilePath: b},
+	}, now)
+	require.Len(t, got, 2)
+	assert.Equal(t, 10, got[0].Summary.Models["opus 4.8"].OutputTokens)
+	assert.Equal(t, 200, got[1].Summary.Models["opus 4.8"].OutputTokens)
+}
+
+func TestTranscriptStatFor(t *testing.T) {
+	assert.Equal(t, transcriptStatCommand, transcriptStatFor(""), "unnarrowed when no session is known")
+	narrowed := transcriptStatFor("c2848539-5efe-4fe2-b60d-9c73807417ff")
+	assert.Contains(t, narrowed, "-name 'c2848539-5efe-4fe2-b60d-9c73807417ff.jsonl'")
+	assert.NotContains(t, narrowed, "'*.jsonl'")
+}
+
+func TestDockerFinder_SessionFor(t *testing.T) {
+	var d DockerFinder
+	assert.Empty(t, d.sessionFor("human-agent-x"), "nil resolver disables narrowing")
+
+	d.SessionForContainer = func(string) string { return "c2848539-5efe-4fe2-b60d-9c73807417ff" }
+	assert.Equal(t, "c2848539-5efe-4fe2-b60d-9c73807417ff", d.sessionFor("human-agent-x"))
+
+	// A value of the wrong shape never reaches the container-side shell.
+	for _, bad := range []string{"", "a", "sess id", "x'; rm -rf /;'", "../../etc/passwd"} {
+		d.SessionForContainer = func(string) string { return bad }
+		assert.Empty(t, d.sessionFor("human-agent-x"), bad)
 	}
 }

--- a/internal/costledger/store.go
+++ b/internal/costledger/store.go
@@ -48,12 +48,27 @@ type StageCost struct {
 // split (criterion 3) and per-stage breakdown (criterion 4). HasSpend is false
 // when no call was ever recorded, driving the plain empty state (criterion 5).
 type TicketCost struct {
-	Ticket          string      `json:"ticket"`
-	HasSpend        bool        `json:"hasSpend"`
-	TotalCostUSD    float64     `json:"totalCostUSD"`
-	ContextCostUSD  float64     `json:"contextCostUSD"`
-	AnswersCostUSD  float64     `json:"answersCostUSD"`
-	TotalDurationMs int64       `json:"totalDurationMs"`
+	Ticket string `json:"ticket"`
+	// LedgerRead reports that the ledger was actually consulted. Without it a
+	// ticket nobody spent on and a ledger that would not open are the same
+	// empty answer, and the panel states "no spend recorded for this ticket" —
+	// a claim about the ticket made from a fact about the reader (SC-4151 C8).
+	LedgerRead      bool    `json:"ledgerRead"`
+	HasSpend        bool    `json:"hasSpend"`
+	TotalCostUSD    float64 `json:"totalCostUSD"`
+	ContextCostUSD  float64 `json:"contextCostUSD"`
+	AnswersCostUSD  float64 `json:"answersCostUSD"`
+	TotalDurationMs int64   `json:"totalDurationMs"`
+	// Calls is how many recorded calls the roll-up is made of, and
+	// UnmeasuredCalls how many of them carried no token counts at all — the
+	// zero-token rows written before the proxy could read usage off a
+	// compressed body (SC-3440). They price at nothing because nothing was
+	// measured, not because nothing was spent, and a dollar figure that does
+	// not say so asserts a run was free (SC-4151 C7). Two tickets on this
+	// board consist of nothing else: SC-1542 (85 calls, 8m40s) and SC-3339
+	// (222 calls, 80m37s), both rendering $0.0000 beside a real duration.
+	Calls           int         `json:"calls"`
+	UnmeasuredCalls int         `json:"unmeasuredCalls"`
 	Stages          []StageCost `json:"stages"`
 }
 
@@ -136,9 +151,11 @@ func (s *Store) InsertCall(ctx context.Context, r CallRecord) error {
 // (criterion 4). Each token class feeds its own claude.CostUSD argument slot —
 // collapsing classes mis-rates by up to 20x.
 func (s *Store) TicketCost(ctx context.Context, project, ticket string) (TicketCost, error) {
-	out := TicketCost{Ticket: ticket}
+	out := TicketCost{Ticket: ticket, LedgerRead: true}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT stage, model, SUM(input_tokens), SUM(output_tokens), SUM(cache_create_tokens), SUM(cache_read_tokens), SUM(duration_ms)
+		`SELECT stage, model, SUM(input_tokens), SUM(output_tokens), SUM(cache_create_tokens), SUM(cache_read_tokens), SUM(duration_ms),
+		        COUNT(*),
+		        SUM(CASE WHEN input_tokens + output_tokens + cache_create_tokens + cache_read_tokens = 0 THEN 1 ELSE 0 END)
 		 FROM ticket_calls WHERE project = ? AND ticket = ? GROUP BY stage, model`,
 		project, ticket)
 	if err != nil {
@@ -149,12 +166,14 @@ func (s *Store) TicketCost(ctx context.Context, project, ticket string) (TicketC
 	byStage := map[string]*StageCost{}
 	for rows.Next() {
 		var stage, model string
-		var in, outTok, cc, cr int
+		var in, outTok, cc, cr, calls, unmeasured int
 		var durMs int64
-		if err := rows.Scan(&stage, &model, &in, &outTok, &cc, &cr, &durMs); err != nil {
+		if err := rows.Scan(&stage, &model, &in, &outTok, &cc, &cr, &durMs, &calls, &unmeasured); err != nil {
 			return out, errors.WrapWithDetails(err, "scan ticket cost row", "ticket", ticket)
 		}
 		out.HasSpend = true
+		out.Calls += calls
+		out.UnmeasuredCalls += unmeasured
 		cost := claude.CostUSD(model, in, outTok, cc, cr)
 		ctxCost := claude.CostUSD(model, in, 0, cc, cr)
 		ansCost := claude.CostUSD(model, 0, outTok, 0, 0)

--- a/internal/costledger/store_test.go
+++ b/internal/costledger/store_test.go
@@ -264,3 +264,46 @@ func TestTopTicketSpend_limitKeepsTheMostExpensive(t *testing.T) {
 	assert.Equal(t, "SC-3", got[0].Ticket, "90000 output tokens is the most expensive")
 	assert.Equal(t, "SC-1", got[1].Ticket)
 }
+
+// TestStore_UnmeasuredCallsCounted covers the SC-4151 C7 case: calls recorded
+// with no token counts at all (the SC-3440 zero-token rows) price at nothing
+// because nothing was measured. The roll-up must say how many, so the reader is
+// never shown a dollar figure that means "not known".
+func TestStore_UnmeasuredCallsCounted(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// The shape of SC-3339: every call recorded, none measured.
+	for range 3 {
+		require.NoError(t, s.InsertCall(ctx, CallRecord{Ticket: "SC-UNMEASURED", Stage: "implementation", DurationMs: 1000}))
+	}
+	rollup, err := s.TicketCost(ctx, "", "SC-UNMEASURED")
+	require.NoError(t, err)
+	assert.True(t, rollup.HasSpend, "calls were recorded")
+	assert.True(t, rollup.LedgerRead, "the ledger answered")
+	assert.Equal(t, 3, rollup.Calls)
+	assert.Equal(t, 3, rollup.UnmeasuredCalls, "no call carried tokens")
+	assert.Zero(t, rollup.TotalCostUSD, "nothing to price")
+	assert.Equal(t, int64(3000), rollup.TotalDurationMs, "the time is real even when the cost is unknown")
+}
+
+func TestStore_PartialMeasurementGap(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.InsertCall(ctx, CallRecord{Ticket: "SC-MIXED", Stage: "planning", Model: testModel, InputTokens: 100, OutputTokens: 200, DurationMs: 1000}))
+	require.NoError(t, s.InsertCall(ctx, CallRecord{Ticket: "SC-MIXED", Stage: "planning", Model: testModel, DurationMs: 500}))
+
+	rollup, err := s.TicketCost(ctx, "", "SC-MIXED")
+	require.NoError(t, err)
+	assert.Equal(t, 2, rollup.Calls)
+	assert.Equal(t, 1, rollup.UnmeasuredCalls)
+	assert.Positive(t, rollup.TotalCostUSD, "the measured call still prices")
+}
+
+// TestTicketCost_ZeroValueIsNotAnAnswer pins the C8 distinction: the zero value
+// must not claim the ledger was consulted, because handleTicketCost returns it
+// verbatim when there is no ledger to consult.
+func TestTicketCost_ZeroValueIsNotAnAnswer(t *testing.T) {
+	assert.False(t, TicketCost{Ticket: "SC-1"}.LedgerRead)
+}


### PR DESCRIPTION
Class C of SC-4151 — three claims the board made about things it had not measured.

**C6 — an agent's tokens were the project's.** Per-instance usage was calculated over the whole `~/.claude/projects/<project>` tree, which every agent with the same cwd shares. Three host agents on this repo printed `in: 1.3K out: 413K`, the same figure three times. Containers were worse: every board agent mounts the same `.devcontainer/claude` as `~/.claude`, so a container listing its transcripts lists the whole fleet's — which also let one container's session state be parsed out of another's file.

Host instances already resolve their own transcript for fsnotify. Containers are narrowed by the pairing the run's hook trail already records (`agent_name` + `session_id` on every event), injected into `DockerFinder` rather than probed, because `internal/agent` imports this package's `hookevents` and a direct dependency would close a cycle. An unresolvable agent is left exactly as before.

Measured after: two containers that both read `118 in / 37.9K out` now read `104 in / 35.0K out` and `12 in / 2.9K out`.

**C7 — `$0.0000` for a run that cost money.** Calls with no token counts (the SC-3440 zero-token rows) price at nothing, and that nothing was printed as a dollar figure beside a real duration. SC-1542 (85 calls, 8m40s) and SC-3339 (222 calls, 80m37s) consist of nothing else. The roll-up now counts measured and unmeasured calls separately; a wholly unmeasured ticket says the cost is not known, in the total and in its per-stage rows.

**C8 — "No spend recorded for this ticket yet" when there was no ledger.** `handleTicketCost` conflated the two in its own comment. `TicketCost` now reports whether it was read at all, and the zero value the daemon returns when it has no ledger does not claim it was.

## Verification
`make check` exit 0, `go test ./cmd/...` exit 0, 235 frontend tests pass, `dist/` matches its rebuild. Verified live with `human usage`: host rows and container rows now each carry their own figure.

## Not in this PR
The other six classes on SC-4151, shipping separately. Class A's render half waits on #414 (SC-3569), which owns the liveness overlay this must not duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)