### PR TITLE
[SC-3630] Stop asking a question with one answer

### DIFF
--- a/internal/claude/embed/human-pr-fixer-agent.md
+++ b/internal/claude/embed/human-pr-fixer-agent.md
@@ -68,7 +68,10 @@ EOF
 
 - `head` — record the branch tip after your commit (`git rev-parse <branch>`). The daemon compares it to the head the reviewer read: an unchanged head means you added no commit, so the loop escalates instead of re-reviewing.
 - `done` — every blocking finding addressed and committed; the reviewer runs again on your new commit. Omit `options` on `done`.
-- `needs-input` — a finding names a decision only a human can make. State the question and stop; do not invent an answer to keep the loop moving. On `needs-input`, list 2+ concrete directions in `options` — each becomes a clickable board decision button, and the human's pick re-runs the build with that direction injected (the still-open draft PR is re-adopted, never merged while draft). When you cannot enumerate distinct directions the daemon falls back to a single generic "rebuild" option, so `options` is optional — but naming the real choices is what makes the escalation actionable.
+- `needs-input` — a finding names a decision only a human can make. State the question and stop; do not invent an answer to keep the loop moving. On `needs-input`, list 2+ concrete directions in `options` — each becomes a clickable board decision button, and the human's pick re-runs the build with that direction injected (the still-open draft PR is re-adopted, never merged while draft). What you write decides what the board does, and there is no generic fallback to catch a thin report:
+  - **2 or more directions** — the board asks the human, showing exactly your labels.
+  - **exactly 1** — the daemon takes it without asking, because one answer is not a choice. Write one only when you mean "do this"; write two when the point is that a human must pick.
+  - **none** — the card reds with your `summary` as the reason. That is the right outcome for a fixer that is genuinely stuck, so make `summary` say what you were stuck on; it is all the human gets.
 
 Do NOT use `AskUserQuestion` — you cannot interact with a human.
 

--- a/internal/daemon/board_options.go
+++ b/internal/daemon/board_options.go
@@ -153,18 +153,35 @@ func optionChosenQueued(comments []tracker.Comment) (BoardStage, tracker.Comment
 	if hasLaterMarker(comments, chosen) {
 		return "", tracker.Comment{}, false
 	}
-	block, ok := latestOptionsBlockAtOrBefore(comments, chosen)
-	if !ok {
-		return "", tracker.Comment{}, false
-	}
-	stage, _, opts := parseOptionsBlock(block.Body)
+	stage, ok := chosenStage(comments, chosen)
 	// Only a resumable stage synthesizes a queued placement — an unrecognized
 	// stage cannot be relaunched, so there is no pending relaunch to represent
 	// (it surfaces as a card error instead, SC-2137).
-	if len(opts) == 0 || !optionStages[stage] {
+	if !ok || !optionStages[stage] {
 		return "", tracker.Comment{}, false
 	}
 	return stage, chosen, true
+}
+
+// chosenStage reports which stage a recorded choice resumes.
+//
+// The record says so itself: pursueDecision writes the stage onto the
+// option-chosen marker, so a choice is readable without its neighbours. The
+// block is still consulted for choices recorded before that field existed, and
+// for those the block remains the only source (SC-3630).
+func chosenStage(comments []tracker.Comment, chosen tracker.Comment) (BoardStage, bool) {
+	if s := parsePrefixedLine(chosen.Body, "stage:"); s != "" {
+		return BoardStage(s), true
+	}
+	block, ok := latestOptionsBlockAtOrBefore(comments, chosen)
+	if !ok {
+		return "", false
+	}
+	stage, _, opts := parseOptionsBlock(block.Body)
+	if len(opts) == 0 {
+		return "", false
+	}
+	return stage, true
 }
 
 // latestOptionChosen returns the newest [human:option-chosen] comment.
@@ -248,16 +265,33 @@ func (d BoardTransitionDeps) ApplyOption(ctx context.Context, req BoardOptionReq
 	if !ok {
 		return errors.WithDetails("unknown option id", "pm", req.PMKey, "option", req.OptionID)
 	}
+	return d.pursueDecision(ctx, req.PMKey, comments, stage, chosen)
+}
 
+// pursueDecision records one answer and relaunches its stage with the direction
+// injected. Shared with the loop's sole-direction path (SC-3630) so that a
+// decision the daemon takes for itself leaves the same trail as one a human
+// clicks: the record is the audit AND the consumption signal, and a second
+// caller writing its own variant of it is how a resumed card ends up with no
+// record of why.
+func (d BoardTransitionDeps) pursueDecision(ctx context.Context, pmKey string, comments []tracker.Comment, stage BoardStage, chosen BoardOption) error {
 	// The pick rides in the head token, where the readers already look for it
-	// (parseOptionChosen splits id from label on the header line).
-	chosenMarker := marker.Marker{Type: MarkerOptionChosen, Head: chosen.ID + ": " + chosen.Label}
-	if err := postMarker(ctx, d.Commenter, req.PMKey, chosenMarker); err != nil {
-		return errors.WrapWithDetails(err, "recording option choice", "pm", req.PMKey)
+	// (parseOptionChosen splits id from label on the header line). The stage
+	// rides in a field because the record has to stand on its own: the loop's
+	// sole-direction path records a choice with no block in front of it at all,
+	// so a reader that recovers the stage from the neighbouring block would find
+	// nothing and place the card as if no decision had been taken.
+	chosenMarker := marker.Marker{
+		Type:   MarkerOptionChosen,
+		Head:   chosen.ID + ": " + chosen.Label,
+		Fields: fields("stage", string(stage)),
+	}
+	if err := postMarker(ctx, d.Commenter, pmKey, chosenMarker, "stage"); err != nil {
+		return errors.WrapWithDetails(err, "recording option choice", "pm", pmKey)
 	}
 
 	card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
-	prompt := stagePrompt(stage, req.PMKey, card) +
+	prompt := stagePrompt(stage, pmKey, card) +
 		" — a decision was made on this ticket: pursue the direction in the latest " +
 		OptionChosenHeader + " comment (" + chosen.Label + ")"
 	// A decision click is human-initiated, like the Fix/Retry entry points: the
@@ -265,7 +299,7 @@ func (d BoardTransitionDeps) ApplyOption(ctx context.Context, req BoardOptionReq
 	// not a pipeline wait, so it is suppressed (empty cause, SC-2462). Resuming an
 	// implementation-stage decision still executes a plan, so it is plan-gated
 	// like any other implementation launch (SC-2596).
-	_, err = d.startAgentStage(ctx, req.PMKey, stage, startedHeaderFor(stage), prompt, WaitCause(""), stage == BoardImplementation)
+	_, err := d.startAgentStage(ctx, pmKey, stage, startedHeaderFor(stage), prompt, WaitCause(""), stage == BoardImplementation)
 	return err
 }
 

--- a/internal/daemon/board_options_test.go
+++ b/internal/daemon/board_options_test.go
@@ -126,7 +126,8 @@ func TestApplyOptionPostsChoiceAndRelaunches(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, c.added, 2)
-	assert.Equal(t, OptionChosenHeader+" 2: Remove the Retry plan menu item and defer criterion 3", c.added[0])
+	assert.Equal(t, OptionChosenHeader+" 2: Remove the Retry plan menu item and defer criterion 3\nstage: implementation", c.added[0],
+		"the record names the stage it resumes, so a reader never has to find the block it came from")
 	assert.Equal(t, ImplementationStartedHeader, c.added[1])
 	assert.Equal(t, 1, l.calls)
 	assert.Equal(t, "board-SC-9-implementation", l.name)
@@ -265,7 +266,8 @@ func TestApplyOptionTicketReviewResumesGate(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, c.added, 2)
-	assert.Equal(t, OptionChosenHeader+" 2: fix the cause", c.added[0])
+	assert.Equal(t, OptionChosenHeader+" 2: fix the cause\nstage: planning", c.added[0],
+		"the alias is resolved before it is recorded — the record names the stage the board resumes")
 	assert.Equal(t, PlanningStartedHeader, c.added[1], "resuming the gate re-runs the planning dispatch")
 	assert.Equal(t, "board-SC-9-planning", l.name)
 	assert.Contains(t, l.prompt, "/human-ticket-review SC-9", "the relaunch re-runs the gate")
@@ -328,6 +330,37 @@ func TestOptionChosenQueued_UnresumableStageNotQueued(t *testing.T) {
 	}
 	_, _, ok := optionChosenQueued(comments)
 	assert.False(t, ok, "an unresumable chosen stage has no queued placement to synthesize")
+}
+
+// SC-3630: the loop pursues a sole direction without ever posting a block, so
+// the choice it records stands alone. The record names its own stage — without
+// that, the window between recording the choice and the stage's started marker
+// (and any launch that fails inside it) would place the card as if no decision
+// had been taken.
+func TestOptionChosenQueued_NoBlock_ReadsTheStageFromTheRecord(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	comments := []tracker.Comment{
+		optComment(PRFixStartedHeader, base),
+		optComment(OptionChosenHeader+" 1: Rebuild without the cache layer\nstage: implementation", base.Add(time.Minute)),
+	}
+
+	stage, _, ok := optionChosenQueued(comments)
+	require.True(t, ok, "a choice with no block in front of it is still a choice")
+	assert.Equal(t, BoardImplementation, stage)
+}
+
+// A choice recorded before the stage field existed still reads, from the block
+// it consumed.
+func TestOptionChosenQueued_NoStageField_FallsBackToTheBlock(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	comments := []tracker.Comment{
+		optComment("[human:options]\nstage: planning\n1: a\n2: b", base),
+		optComment(OptionChosenHeader+" 1: a", base.Add(time.Minute)),
+	}
+
+	stage, _, ok := optionChosenQueued(comments)
+	require.True(t, ok)
+	assert.Equal(t, BoardPlanning, stage)
 }
 
 // SC-2137: the ticket-review gate's own decision is a genuine pause of the

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -1072,11 +1072,24 @@ func (d BoardTransitionDeps) AdvancePRLoop(ctx context.Context, pmKey string, ou
 	}
 }
 
-// escalatePRLoop routes a non-converging loop to the right surface: a fixer
-// needs-input is a DECISION, posted as a [human:options] block whose stage is
-// implementation so choosing rebuilds through the normal chain (which re-adopts
-// the still-open draft PR); everything else — a spent round budget, an
-// unreviewable PR, an outcome the daemon cannot classify — reds the done stage.
+// escalatePRLoop routes a non-converging loop to the right surface, and what
+// decides the surface is what the fixer actually named:
+//
+//   - two or more directions — a genuine fork. It becomes a [human:options]
+//     block naming the implementation stage, so choosing rebuilds through the
+//     normal chain and re-adopts the still-open draft PR.
+//   - exactly one direction — not a fork. The daemon pursues it (SC-3630).
+//   - none — not a decision either. The fixer stopped without naming a way
+//     forward, which is a failure with a reason, and reds the done stage.
+//
+// Everything else — a spent round budget, an unreviewable PR, an outcome the
+// daemon cannot classify — reds the done stage as before.
+//
+// The card used to ask in all three cases, filling an empty block with invented
+// answers so it stayed well-formed. Nothing about the real problem survived
+// that, and the user was left clicking a fabricated button to re-run a loop
+// with no new information.
+//
 // Idempotent: a durable re-drive must never re-post the block, so an already-open
 // options block short-circuits.
 func (d BoardTransitionDeps) escalatePRLoop(ctx context.Context, pmKey string, comments []tracker.Comment, outcome PRLoopOutcome) error {
@@ -1093,30 +1106,46 @@ func (d BoardTransitionDeps) escalatePRLoop(ctx context.Context, pmKey string, c
 	}
 	stage := latestPRLoopStage(comments)
 	if stage == PRStageFix && outcome.FixExit != PRFixDone {
-		ctxLine := outcome.FixSummary
-		if ctxLine == "" {
-			ctxLine = "the PR review→fix loop needs a decision the fixer could not make"
+		switch opts := outcome.FixOptions; {
+		case len(opts) >= marker.MinDecisionOptions:
+			m, order := optionsMarker(BoardImplementation, decisionContext(outcome), opts)
+			return postMarker(ctx, d.Commenter, pmKey, m, order...)
+		case len(opts) == 1 && prReviewRounds(comments) < DefaultPRReviewRounds:
+			return d.pursueSoleDirection(ctx, pmKey, comments, opts[0])
 		}
-		opts := outcome.FixOptions
-		if len(opts) == 0 {
-			// The fallback offers the two answers a human actually has here.
-			// It used to offer one, with a comment explaining that one was
-			// enough to keep the block parseable — but the protocol forbids a
-			// single-answer block on purpose: it parks the card until someone
-			// clicks the only thing on offer, which is a dead end dressed as a
-			// choice (marker.MinDecisionOptions). Posting it anyway meant the
-			// daemon wrote the exact shape `human marker post` rejects.
-			opts = []BoardOption{
-				{ID: "1", Label: "Rebuild the branch to resolve the decision the fixer raised"},
-				{ID: "2", Label: "Take it over by hand — stop the loop and leave the branch as it is"},
-			}
-		}
-		m, order := optionsMarker(BoardImplementation, ctxLine, opts)
-		return postMarker(ctx, d.Commenter, pmKey, m, order...)
+		// No directions — or one the round budget can no longer afford to
+		// pursue. Both fall through to the failed marker, which says what the
+		// fixer reported and offers the retry the card already knows how to run.
 	}
 	_, _ = d.Commenter.AddComment(ctx, pmKey,
 		markerBody(failureMarker(MarkerPRReviewFailed, prEscalationReason(stage, outcome, d.Diagnose))))
 	return nil
+}
+
+// decisionContext is the line the block leads with: what the fixer said it was
+// stuck on. It has a generic fallback only because a fork with real answers and
+// no summary is still answerable — unlike an empty block, whose generic context
+// described nothing at all.
+func decisionContext(outcome PRLoopOutcome) string {
+	if outcome.FixSummary != "" {
+		return outcome.FixSummary
+	}
+	return "the PR fixer stopped on a decision and named the directions below"
+}
+
+// pursueSoleDirection takes the only answer on offer instead of asking for it.
+//
+// A choice between one thing is not a choice — it is a continue button dressed
+// as a fork, and it stops the board on something no human judgment can improve.
+// The protocol already refuses to POST such a block (marker.MinDecisionOptions);
+// this is the other half, so the loop does not merely avoid writing a dead end
+// but actually moves.
+//
+// It records the choice exactly as a human's click records it — same
+// [human:option-chosen] marker, same relaunch — so the trail reads the same
+// whoever made the call, and the card is never resumed without a record.
+func (d BoardTransitionDeps) pursueSoleDirection(ctx context.Context, pmKey string, comments []tracker.Comment, only BoardOption) error {
+	return d.pursueDecision(ctx, pmKey, comments, BoardImplementation, only)
 }
 
 // prEscalationReason renders the actionable headline the failed marker's badge
@@ -1137,7 +1166,7 @@ func prEscalationReason(stage PRLoopStage, outcome PRLoopOutcome, diagnose Board
 	case stage == PRStageFix && outcome.FixExit == PRFixDone && outcome.headStalled():
 		return "the PR fixer recorded done but added no commit — the reviewed head is unchanged, so another review would loop; check the fixer's log and the PR, then re-run Deploy"
 	case outcome.FixExit == string(ExitNeedsInput):
-		return "the PR fixer needs a human decision — read the PR review comments, decide, then re-run Deploy"
+		return needsInputReason(outcome)
 	case outcome.ReviewVerdict == PRVerdictChanges:
 		return "the machine review did not converge within the round budget — review the PR yourself, then re-run Deploy"
 	case outcome.ReviewVerdict == PRVerdictUnreviewable:
@@ -1147,6 +1176,23 @@ func prEscalationReason(stage PRLoopStage, outcome PRLoopOutcome, diagnose Board
 	default:
 		return "the PR review→fix loop stopped on an outcome it could not classify — check the PR and its review, then re-run Deploy"
 	}
+}
+
+// needsInputReason explains a fixer that stopped for a decision without naming
+// one (SC-3630). It reaches the failed marker only when the fixer listed no
+// directions — with directions the loop asks instead, and with exactly one it
+// pursues it — so the card's job here is to say what the fixer reported, not to
+// invent a question out of the fact that it reported nothing.
+//
+// The fixer's own summary leads when it wrote one. Without it the line says the
+// step ended without naming what it was stuck on, which is the honest reading:
+// sending a human to "read the review comments and decide" implies a question
+// was recorded there, and none was.
+func needsInputReason(outcome PRLoopOutcome) string {
+	if s := strings.TrimSpace(outcome.FixSummary); s != "" {
+		return "the PR fixer stopped for a decision it could not make: " + s + " — decide, then re-run Deploy"
+	}
+	return "the PR fixer stopped for a decision but named neither the question nor a way forward — read the PR review comments and the fixer's log, then re-run Deploy"
 }
 
 // staleStepReason names the record the loop could not confirm was current

--- a/internal/daemon/pr_loop_exec_test.go
+++ b/internal/daemon/pr_loop_exec_test.go
@@ -148,28 +148,102 @@ func TestAdvancePRLoop_budgetExhausted_escalates(t *testing.T) {
 	assert.Zero(t, p.merged, "escalation must never merge")
 }
 
-func TestAdvancePRLoop_fixNeedsInput_escalates(t *testing.T) {
-	c := &fakeCommenter{comments: []tracker.Comment{
-		cmt("[human:ready-for-review]\nbranch: feat/x", time.Unix(1, 0)),
-		cmt(prReviewStartedBody("https://example/pr/7", 7, "feat/x"), time.Unix(2, 0)),
-		cmt(PRFixStartedHeader, time.Unix(3, 0)),
-	}}
+// A fixer that stops for a decision but names no direction has not found a
+// fork — it has failed, and saying so is the only thing that carries
+// information. The card used to ask a question assembled entirely out of
+// placeholders, whose one answer re-ran the same loop with nothing new
+// (SC-3630).
+func TestAdvancePRLoop_fixNeedsInput_noDirections_reds(t *testing.T) {
+	c := &fakeCommenter{comments: prFixExitComments()}
 	l := &fakeLauncher{}
 	deps := newDeps(c, l, &fakeDeployer{})
 
 	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", PRLoopOutcome{ReviewVerdict: "", ReviewRecorded: true, FixExit: string(ExitNeedsInput), FixRecorded: true}))
 
-	// A fixer needs-input is a DECISION: it escalates to a [human:options] block,
-	// not a red failed marker, so each direction is a clickable board choice.
+	_, asked := posted(c, OptionsHeader)
+	assert.False(t, asked, "a decision with no answers is not a decision — it must not be asked")
+	failed, ok := posted(c, PRReviewFailedHeader)
+	require.True(t, ok, "a fixer that named nothing must red the card")
+	assert.Contains(t, failed, "named neither the question nor a way forward")
+	assert.Zero(t, l.calls, "reding the card launches nothing")
+}
+
+// What the fixer reported is the reason. The generic line stands in only when
+// the fixer wrote nothing at all.
+func TestAdvancePRLoop_fixNeedsInput_noDirections_carriesTheFixersSummary(t *testing.T) {
+	c := &fakeCommenter{comments: prFixExitComments()}
+	deps := newDeps(c, &fakeLauncher{}, &fakeDeployer{})
+
+	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", PRLoopOutcome{
+		FixExit:     string(ExitNeedsInput),
+		FixRecorded: true,
+		FixSummary:  "the review wants the retry budget moved, which changes the deploy contract",
+	}))
+
+	failed, ok := posted(c, PRReviewFailedHeader)
+	require.True(t, ok)
+	assert.Contains(t, failed, "the review wants the retry budget moved, which changes the deploy contract")
+}
+
+// One direction is not a fork. The daemon takes it and records the choice the
+// same way a human's click would, so the trail is unchanged and the card is
+// never resumed without a record.
+func TestAdvancePRLoop_fixNeedsInput_soleDirection_isPursued(t *testing.T) {
+	c := &fakeCommenter{comments: append(
+		[]tracker.Comment{cmt(PlanReadyHeader, time.Unix(1, 0))}, prFixExitComments()...)}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+
+	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", PRLoopOutcome{
+		FixExit:     string(ExitNeedsInput),
+		FixRecorded: true,
+		FixOptions:  []BoardOption{{ID: "1", Label: "Rebuild the branch without the cache layer"}},
+	}))
+
+	_, asked := posted(c, OptionsHeader)
+	assert.False(t, asked, "a single answer must never be posted as a question")
 	_, failedPosted := posted(c, PRReviewFailedHeader)
-	assert.False(t, failedPosted, "needs-input must not red the card")
-	block, ok := posted(c, OptionsHeader)
-	require.True(t, ok, "needs-input must post an options block")
-	stage, _, opts := parseOptionsBlock(block)
-	assert.Equal(t, BoardImplementation, stage)
-	require.GreaterOrEqual(t, len(opts), 1, "the fallback rebuild option keeps the block valid")
-	assert.Contains(t, opts[0].Label, "Rebuild")
+	assert.False(t, failedPosted, "a direction the daemon can pursue is not a failure")
+
+	chosen, ok := posted(c, OptionChosenHeader)
+	require.True(t, ok, "the choice the daemon made for itself must still be recorded")
+	assert.Contains(t, chosen, "1: Rebuild the branch without the cache layer")
+	assert.Equal(t, 1, l.calls, "the sole direction must actually be pursued")
+	assert.Equal(t, "board-SC-1-implementation", l.name)
+	assert.Contains(t, l.prompt, "Rebuild the branch without the cache layer")
+}
+
+// The automatic pursuit spends the loop's own budget: past it, the sole
+// direction is reported rather than taken, so it can never drive an unbounded
+// rebuild loop.
+func TestAdvancePRLoop_fixNeedsInput_soleDirection_stopsAtTheRoundBudget(t *testing.T) {
+	comments := reviewStartedComments(DefaultPRReviewRounds, "https://example/pr/7", 7, "feat/x")
+	comments = append(comments, cmt(PlanReadyHeader, time.Unix(1, 0)), cmt(PRFixStartedHeader, time.Unix(9, 0)))
+	c := &fakeCommenter{comments: comments}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+
+	require.NoError(t, deps.AdvancePRLoop(context.Background(), "SC-1", PRLoopOutcome{
+		FixExit:     string(ExitNeedsInput),
+		FixRecorded: true,
+		FixOptions:  []BoardOption{{ID: "1", Label: "Rebuild the branch without the cache layer"}},
+	}))
+
+	_, chosenPosted := posted(c, OptionChosenHeader)
+	assert.False(t, chosenPosted, "a spent budget must not be spent again")
+	_, ok := posted(c, PRReviewFailedHeader)
+	assert.True(t, ok, "a direction the budget cannot afford must red the card")
 	assert.Zero(t, l.calls)
+}
+
+// prFixExitComments is the thread a fixer's exit lands on: the handoff, the
+// review round that asked for changes, and the fix round that just ended.
+func prFixExitComments() []tracker.Comment {
+	return []tracker.Comment{
+		cmt("[human:ready-for-review]\nbranch: feat/x", time.Unix(1, 0)),
+		cmt(prReviewStartedBody("https://example/pr/7", 7, "feat/x"), time.Unix(2, 0)),
+		cmt(PRFixStartedHeader, time.Unix(3, 0)),
+	}
 }
 
 func TestAdvancePRLoop_fixNeedsInput_withOptions(t *testing.T) {

--- a/internal/pipelinefsm/pipeline-fsm.json
+++ b/internal/pipelinefsm/pipeline-fsm.json
@@ -822,7 +822,7 @@
       "dst": "stopped",
       "actor": "daemon",
       "marker": "[human:pr-review-failed]",
-      "doc": "Budget spent, unreviewable, or an outcome it cannot parse. It never merges on a state it cannot read. What does NOT fire it: a substrate failure mid-run. The hook reports a model API error as StopFailure and Claude Code retries through it, so the run carries on — driving the loop there read a verdict the reviewer had not written yet and reddened a review that went on to approve (SC-4026). Such an event is consumed and ignored; a run that genuinely dies on one is recovered by the durable re-drive, on the machine that owns the stage. It also fires at most once per dead round: one run can raise both a StopFailure and a Stop, and an escalation with nothing changed since the last one is not restated.",
+      "doc": "Budget spent, unreviewable, an outcome it cannot parse, or a fixer that stopped for a decision without naming one. That last case used to be raised as a question instead, assembled out of placeholders; a step that reports it is stuck and names neither the question nor a way forward has failed, and the reason carries the fixer's own summary so the card says what actually happened (SC-3630). It never merges on a state it cannot read. What does NOT fire it: a substrate failure mid-run. The hook reports a model API error as StopFailure and Claude Code retries through it, so the run carries on — driving the loop there read a verdict the reviewer had not written yet and reddened a review that went on to approve (SC-4026). Such an event is consumed and ignored; a run that genuinely dies on one is recovered by the durable re-drive, on the machine that owns the stage. It also fires at most once per dead round: one run can raise both a StopFailure and a Stop, and an escalation with nothing changed since the last one is not restated.",
       "where": "internal/daemon/board_transition.go AdvancePRLoop — prEscalationReason names which of the three it was"
     },
     {
@@ -907,8 +907,8 @@
       "dst": "queued",
       "actor": "user",
       "marker": "[human:option-chosen]",
-      "where": "board_options.go ApplyOption — records the choice, then starts the stage; board_state.go optionChosenQueued reads the window between the two",
-      "doc": "A human picked an answer. This records it and nothing more: ApplyOption posts the choice comment and only then calls startAgentStage, so the item is queued for a stage before it is running in one. The stage that gets queued is the one the block NAMES, not the one the item sits in — planning is the common case, while a PR-loop escalation deliberately names implementation even though the item is in the deploy stage, because the fixer raised a question only a code change can answer and the rebuild re-adopts the still-open draft PR. The item pauses correctly meanwhile, because an open block pauses every card whose own stage ranks at or after the one named. The stage is derived; the state is not — every answered decision lands here first.",
+      "where": "board_options.go ApplyOption → pursueDecision — records the choice, then starts the stage; board_state.go optionChosenQueued reads the window between the two",
+      "doc": "A human picked an answer. This records it and nothing more: pursueDecision posts the choice comment and only then calls startAgentStage, so the item is queued for a stage before it is running in one. The stage that gets queued is the one the RECORD names — written onto the option-chosen marker itself, with the block read only for choices recorded before that field existed — not the one the item sits in — planning is the common case, while a PR-loop escalation deliberately names implementation even though the item is in the deploy stage, because the fixer raised a question only a code change can answer and the rebuild re-adopts the still-open draft PR. The item pauses correctly meanwhile, because an open block pauses every card whose own stage ranks at or after the one named. The stage is derived; the state is not — every answered decision lands here first.",
       "dst_is_derived": false
     },
     {
@@ -1059,8 +1059,21 @@
       "dst": "awaiting-decision",
       "actor": "daemon",
       "marker": "[human:options]",
+      "guard": "the fixer named two or more directions",
       "where": "internal/daemon/board_transition.go escalatePRLoop — a fixer that ends needing input becomes a decision rather than a red card",
-      "doc": "The PR fixer hit something only a person can settle. Unlike every other stage-asks, the daemon raises this one rather than the agent: the fixer records its need on exit and the loop turns that into the block, naming the implementation stage so choosing rebuilds through the normal chain and re-adopts the still-open draft PR."
+      "doc": "The PR fixer hit something only a person can settle. Unlike every other stage-asks, the daemon raises this one rather than the agent: the fixer records its need on exit and the loop turns that into the block, naming the implementation stage so choosing rebuilds through the normal chain and re-adopts the still-open draft PR. The guard is the whole of what makes this a fork: the block carries the fixer's own directions and nothing else. It used to fire on every needs-input exit, filling an empty block with invented answers so it stayed well-formed — which asked a question no one had raised and parked the item on it (SC-3630). A needs-input naming one direction fires pr-fix-takes-sole-direction instead, and one naming none fires pr-loop-escalates."
+    },
+    {
+      "name": "pr-fix-takes-sole-direction",
+      "src": [
+        "pr-fix"
+      ],
+      "dst": "queued",
+      "actor": "daemon",
+      "marker": "[human:option-chosen]",
+      "guard": "the fixer named exactly one direction, and the review round budget is not spent",
+      "where": "internal/daemon/board_transition.go escalatePRLoop → pursueSoleDirection, which shares board_options.go pursueDecision with the human path",
+      "doc": "The fixer named one way forward, so there is nothing to decide and the daemon pursues it. A choice between one thing is not a choice — it is a continue button dressed as a fork, and awaiting-decision is the one state the machine may not resolve for itself, so the item must never enter it on a single answer (SC-3630). The choice is recorded with the same marker a human's click records, which is why this lands in queued exactly like decision-made: the record is the audit trail and the consumption signal both, and the item is queued for the implementation stage before it is running in one. Bounded by the loop's own review-round budget — past it the direction is reported through pr-loop-escalates rather than taken, so this can never drive an unbounded rebuild loop."
     }
   ],
   "ownership": {


### PR DESCRIPTION
A fixer that ended needing input always became a `[human:options]` block. When it named no directions the daemon invented them so the block stayed well-formed — the block's context line and its answers were both placeholders, and nothing about the real problem survived. The path fires on the *exit*, not on what the exit reported, so every block it posted had that shape.

```
DECISION NEEDED — the PR review→fix loop needs a decision the fixer could not make
1. Rebuild the branch to resolve the decision the fixer raised
```

What the fixer names now decides the surface:

| `options` | Surface |
|---|---|
| 2 or more | a fork — `[human:options]`, exactly as before |
| exactly 1 | not a fork. The daemon pursues it and records the choice |
| none | not a decision. The card reds with the fixer's summary as the reason |

**The sole-direction path** records `[human:option-chosen]` — the same marker a human's click records — and relaunches implementation with the direction injected. It is bounded by the loop's own review-round budget, so it can never drive an unbounded rebuild loop; past the budget the direction is reported instead of taken. Never entering `awaiting-decision` on a single answer keeps that state what the machine says it is: the one state the machine may not resolve for itself.

**The choice record now names its own stage.** The sole-direction path posts no block, so a reader recovering the stage from the neighbouring block would find none and place the card as if nothing had been decided. `ApplyOption` writes the same field; the block is read only for choices recorded before the field existed. Both paths share `pursueDecision`, so a decision the daemon takes leaves the same trail as one a person clicks.

**Prompt.** `human-pr-fixer-agent.md` told the fixer `options` was optional because the daemon would fall back. It no longer does, and the prompt now states what each of the three shapes causes.

**FSM document.** `pr-fix-asks` gains the guard that makes it a fork; `pr-fix-takes-sole-direction` (pr-fix → queued, daemon, `[human:option-chosen]`) is new; `pr-loop-escalates` gains the named-nothing case; `decision-made` records where the stage now comes from. `make fsm`: well-formed.

**Not in scope.** A one-answer block already sitting on a ticket — written by a daemon from before SC-2804 — is untouched: it still reds the card with `decision block offers only 1 answer`, which is visible and retryable. This change removes the source; it does not rewrite history.

`make check`: green. `go test ./cmd/...`: green.