### PR TITLE
[SC-4151] Time on the board is only claimed where something confirms it

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -2052,8 +2052,35 @@ func serveLastGoodView(cache *boardcache.Store, project string, cause error, log
 		return daemon.BoardView{}, cause
 	}
 	logger.Warn().Err(cause).Msg("board view: refresh failed, serving the last good board marked stale")
-	view.Error = "showing the last board that loaded — this refresh failed: " + cause.Error()
+	view.Error = staleBoardBanner(view.CachedAt, time.Now(), cause)
 	return view, nil
+}
+
+// staleBoardBanner says which board is being shown and HOW OLD it is. Without
+// the age the sentence is the same one whether the snapshot is a minute or a
+// week old, while its cards go on showing spinners for agents that finished
+// long ago (SC-4151). A snapshot with no stamp — written before it was kept —
+// reads exactly as it did.
+func staleBoardBanner(cachedAt string, now time.Time, cause error) string {
+	banner := "showing the last board that loaded"
+	if t, err := time.Parse(time.RFC3339, cachedAt); err == nil {
+		banner += " (" + humanizeAge(now.Sub(t)) + " old)"
+	}
+	return banner + " — this refresh failed: " + cause.Error()
+}
+
+// humanizeAge renders a duration in the board's compact house form.
+func humanizeAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
 }
 
 // rememberBoardView keeps the last board that actually carried work, so a later
@@ -2064,6 +2091,10 @@ func rememberBoardView(cache *boardcache.Store, project string, view daemon.Boar
 	if len(view.Cards) == 0 {
 		return
 	}
+	// Stamped on the stored copy only: the live board is current by definition,
+	// and a served board carrying a compose time would invite the frontend to
+	// treat every refresh as dated.
+	view.CachedAt = time.Now().UTC().Format(time.RFC3339)
 	raw, err := json.Marshal(view)
 	if err != nil {
 		return

--- a/cmd/cmddaemon/staleboard_test.go
+++ b/cmd/cmddaemon/staleboard_test.go
@@ -1,0 +1,46 @@
+package cmddaemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gethuman-sh/human/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestStaleBoardBanner covers SC-4151: a served snapshot said only that it was
+// "the last board that loaded", so a minute-old board and a week-old one read
+// identically while both went on showing spinners.
+func TestStaleBoardBanner(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	cause := errors.WithDetails("tracker unreachable")
+
+	for _, tc := range []struct {
+		name     string
+		cachedAt string
+		want     string
+	}{
+		{"seconds", now.Add(-30 * time.Second).Format(time.RFC3339), "(30s old)"},
+		{"minutes", now.Add(-45 * time.Minute).Format(time.RFC3339), "(45m old)"},
+		{"hours", now.Add(-5 * time.Hour).Format(time.RFC3339), "(5h old)"},
+		{"days", now.Add(-72 * time.Hour).Format(time.RFC3339), "(3d old)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := staleBoardBanner(tc.cachedAt, now, cause)
+			assert.Contains(t, got, tc.want)
+			assert.Contains(t, got, "showing the last board that loaded")
+			assert.Contains(t, got, "tracker unreachable")
+		})
+	}
+}
+
+// A snapshot written before the stamp existed must read exactly as it did.
+func TestStaleBoardBanner_UnstampedSnapshot(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	cause := errors.WithDetails("tracker unreachable")
+
+	for _, cachedAt := range []string{"", "not-a-time"} {
+		got := staleBoardBanner(cachedAt, now, cause)
+		assert.Equal(t, "showing the last board that loaded — this refresh failed: tracker unreachable", got)
+	}
+}

--- a/desktop/frontend/dist/board-detail.js
+++ b/desktop/frontend/dist/board-detail.js
@@ -96,12 +96,25 @@ function fmtDuration(ms) {
     const h = Math.floor(m / 60);
     return `${h}h ${m % 60}m`;
 }
+// stageClockLine phrases the current-stage clock for the state the card is
+// actually in. Only a running card is running; every other state gets the same
+// measurement stated as what it is — when the stage was entered — so the number
+// stops asserting work is in progress behind it. An absent state (a payload
+// from a daemon predating the field) keeps the original wording.
+function stageClockLine(stage, state, elapsedMs) {
+    const elapsed = escapeText(fmtDuration(Math.max(0, elapsedMs)));
+    const named = escapeText(stage ?? "");
+    if (state === undefined || state === "running") {
+        return `Current stage (${named}): ${elapsed} running`;
+    }
+    return `Stage (${named}): entered ${elapsed} ago`;
+}
 // buildCostSection renders the ticket's whole-life cost (with the answers/context
 // split) and elapsed time (per-stage plus the live current-stage clock). A ticket
 // with no recorded spend says so plainly rather than showing $0.00 (SC-2847
 // criterion 5). currentStage/stageEnteredAt come from the open card; nowMs is
 // injected for tests.
-export function buildCostSection(c, currentStage, stageEnteredAt, nowMs) {
+export function buildCostSection(c, currentStage, stageEnteredAt, nowMs, currentState) {
     if (!c || !c.hasSpend) {
         // "No spend" is a claim about the TICKET and may only be made when the
         // ledger was actually read. An older daemon (no ledgerRead field) still
@@ -129,9 +142,14 @@ export function buildCostSection(c, currentStage, stageEnteredAt, nowMs) {
         : allUnmeasured
             ? `<div class="detail-cost-unmeasured">${calls} call${calls === 1 ? "" : "s"} recorded no tokens, so what this cost is not known.</div>`
             : "";
+    // The elapsed figure measures the same thing whatever the card is doing — the
+    // time since its newest stage marker landed — but "running" is a claim about
+    // the work, and this section was making it for every state. A card that failed
+    // three days ago read "72h 4m running", and the longer it had been dead the
+    // more impressive its number (SC-4151 B3). The clock stays; only the state
+    // that earns the word "running" keeps it.
     const curElapsed = stageEnteredAt
-        ? `<div class="detail-cost-current">Current stage (${escapeText(currentStage ?? "")}): ` +
-            `${escapeText(fmtDuration(Math.max(0, nowMs - Date.parse(stageEnteredAt))))} running</div>`
+        ? `<div class="detail-cost-current">${stageClockLine(currentStage, currentState, nowMs - Date.parse(stageEnteredAt))}</div>`
         : "";
     // The per-stage rows carry the same honesty as the total: with nothing
     // measured anywhere, a stage's "$0.0000" is the same false claim in smaller

--- a/desktop/frontend/dist/board-queue.js
+++ b/desktop/frontend/dist/board-queue.js
@@ -134,7 +134,42 @@ export const STOP_DECISION_LABELS = {
 // completion. A review that found problems is machine-fixing work, not a demand
 // on the user: the daemon auto-launches a fixer, so it reads as in-flight
 // (gray + spinner), never the amber "your turn" register (SC-1830).
-export function badgeInfo(card) {
+// activityStaleAfterMs is how long a recorded phase may stand before the badge
+// starts saying how old it is. Short enough that a stall shows within a coffee
+// break; long enough that an ordinary phase — a plan, a build, a review — is
+// not decorated with an age for merely taking its normal time.
+const activityStaleAfterMs = 10 * 60 * 1000;
+// sinceText renders how long ago an RFC3339 instant was, in the board's compact
+// house form. An absent or unparseable timestamp yields "" — an age the board
+// could not read must never be printed as an age of zero.
+export function sinceText(at, nowMs) {
+    if (!at)
+        return "";
+    const t = Date.parse(at);
+    if (Number.isNaN(t))
+        return "";
+    const secs = Math.max(0, Math.floor((nowMs - t) / 1000));
+    if (secs < 60)
+        return `${secs}s ago`;
+    const mins = Math.floor(secs / 60);
+    if (mins < 60)
+        return `${mins}m ago`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24)
+        return `${hours}h ago`;
+    return `${Math.floor(hours / 24)}d ago`;
+}
+// activityAge is the parenthesised age the badge carries, and only once the
+// phase is old enough to be worth reading.
+function activityAge(at, nowMs) {
+    if (!at)
+        return "";
+    const t = Date.parse(at);
+    if (Number.isNaN(t) || nowMs - t < activityStaleAfterMs)
+        return "";
+    return `(${sinceText(at, nowMs)})`;
+}
+export function badgeInfo(card, nowMs = Date.now()) {
     // An open decision block outranks EVERY other classification, including a
     // stale failed marker: a card parked on a deliberate human fork must never
     // paint red, even if a *-failed marker also landed on it (the daemon's twin
@@ -173,13 +208,18 @@ export function badgeInfo(card) {
         // the fix, verification — so it reads identically at thirty seconds and at
         // fourteen hours, and identically again when the agent behind it is dead.
         // The phase changing is the only thing on the card that shows movement.
-        const text = card.activity ? `${card.activity}…` : stageText;
-        return {
-            cls: "running",
-            text,
-            title: card.activity ? `Agent running — ${card.activity}` : "Agent running",
-            spinner: true,
-        };
+        //
+        // Its changing was still the only signal: a phase that STOPPED changing read
+        // exactly like one that never had to. The daemon has always sent the
+        // timestamp beside the phase and the card dropped it on the floor
+        // (SC-4151 B4), so a badge could say "triaging…" over a record six hours
+        // old. The age now rides the badge once it is old enough to mean something.
+        const age = activityAge(card.activityAt, nowMs);
+        const text = card.activity ? `${card.activity}…${age !== "" ? ` ${age}` : ""}` : stageText;
+        const title = card.activity
+            ? `Agent running — ${card.activity}${card.activityAt ? `, last recorded ${sinceText(card.activityAt, nowMs)}` : ""}`
+            : "Agent running";
+        return { cls: "running", text, title, spinner: true };
     }
     // A recorded decision has (re)queued the chosen stage but the relaunched
     // agent has not posted its started marker yet — or the launch was deferred to

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -2685,7 +2685,7 @@ function renderTicketDetail() {
     ${shippedPartial}
     ${desc}
     ${detailSections}
-    ${buildCostSection(detailCost, detailCard.stage, detailCard.stageEnteredAt, Date.now())}
+    ${buildCostSection(detailCost, detailCard.stage, detailCard.stageEnteredAt, Date.now(), detailCard.state)}
     ${link}
   `;
     const url = detailCard.url;
@@ -3141,6 +3141,7 @@ function agentRow(v) {
         currentTool: str(o.currentTool),
         blockedTool: str(o.blockedTool),
         errorType: str(o.errorType),
+        lastActivityUnix: num(o.lastActivityUnix),
         startedAtUnix: num(o.startedAtUnix),
         daemonConnected: bool(o.daemonConnected),
         proxyConfigured: bool(o.proxyConfigured),
@@ -3203,10 +3204,29 @@ function formatDurationMs(ms) {
         return `${secs}s`;
     return `${Math.floor(secs / 60)}m ${secs % 60}s`;
 }
+// agentSilentAfterMs is how long a "working" session may produce nothing before
+// the panel stops spinning for it. The status comes from the last transcript
+// entry's stop_reason and has no staleness rule of its own, so without this an
+// agent that hung an hour ago is indistinguishable from one mid-thought
+// (SC-4151 B5). Set above the daemon's own silence budget so the panel never
+// contradicts a reaper that has not yet had its turn.
+const agentSilentAfterMs = 10 * 60 * 1000;
+// agentSilent reports a session whose last sign of life is old enough that
+// "working" is no longer something the panel can claim. An unknown last
+// activity (0) is never silent: absence of a signal is not proof.
+function agentSilent(a, nowMs = Date.now()) {
+    if (a.status !== "working" || !a.lastActivityUnix)
+        return false;
+    return nowMs - a.lastActivityUnix * 1000 >= agentSilentAfterMs;
+}
 function agentStatusDot(a) {
     // Mirrors the TUI sessionIcon: a spinner while working, ⚠ on error, and a
     // coloured ● otherwise — with idle splitting on whether the session has seen
     // any activity (● active vs ○ never-active).
+    if (agentSilent(a)) {
+        const since = formatElapsedUnix(a.lastActivityUnix);
+        return `<span class="agent-dot silent" title="Working, but nothing recorded for ${escapeAttr(since)} — it may be hung">◍</span>`;
+    }
     if (a.status === "working")
         return `<span class="agent-dot working"><span class="spinner"></span></span>`;
     if (a.status === "error")

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -2098,6 +2098,13 @@ body {
 .agent-dot.error {
   color: var(--failed);
 }
+/* A session still reporting "working" that has produced nothing for a while.
+   Not an error — nothing has failed and it may yet continue — so it takes the
+   muted register rather than the failure red, and simply stops spinning
+   (SC-4151 B5). */
+.agent-dot.silent {
+  color: var(--muted);
+}
 
 .agent-label {
   font-weight: 600;

--- a/desktop/frontend/scripts/board-detail.test.mjs
+++ b/desktop/frontend/scripts/board-detail.test.mjs
@@ -285,3 +285,57 @@ test("a fully measured roll-up is unchanged — no note, full split", () => {
   assert.match(html, /answers/);
   assert.doesNotMatch(html, /recorded no tokens/);
 });
+
+// --- The current-stage clock only says "running" when it is (SC-4151 B3) ---
+
+test("a failed card's stage clock states when it was entered, not that it is running", () => {
+  const now = Date.now();
+  const enteredAt = new Date(now - 3 * 3600_000).toISOString();
+  const html = buildCostSection(
+    { ticket: "SC-1", ledgerRead: true, hasSpend: true, totalCostUSD: 1, contextCostUSD: 0.5, answersCostUSD: 0.5, totalDurationMs: 1000, calls: 2, unmeasuredCalls: 0, stages: [] },
+    "done",
+    enteredAt,
+    now,
+    "failed",
+  );
+  assert.match(html, /Stage \(done\): entered 3h 0m ago/);
+  assert.doesNotMatch(html, /running/);
+});
+
+test("a running card keeps the live clock", () => {
+  const now = Date.now();
+  const html = buildCostSection(
+    { ticket: "SC-1", ledgerRead: true, hasSpend: true, totalCostUSD: 1, contextCostUSD: 0.5, answersCostUSD: 0.5, totalDurationMs: 1000, calls: 2, unmeasuredCalls: 0, stages: [] },
+    "implementation",
+    new Date(now - 90_000).toISOString(),
+    now,
+    "running",
+  );
+  assert.match(html, /Current stage \(implementation\): 1m 30s running/);
+});
+
+test("an omitted state keeps the original wording, for a payload predating it", () => {
+  const now = Date.now();
+  const html = buildCostSection(
+    { ticket: "SC-1", hasSpend: true, totalCostUSD: 1, contextCostUSD: 0.5, answersCostUSD: 0.5, totalDurationMs: 1000, stages: [] },
+    "implementation",
+    new Date(now - 90_000).toISOString(),
+    now,
+  );
+  assert.match(html, /Current stage \(implementation\): 1m 30s running/);
+});
+
+test("outage and stopped cards do not claim to be running either", () => {
+  const now = Date.now();
+  for (const state of ["outage", "queued", "done", "resolved"]) {
+    const html = buildCostSection(
+      { ticket: "SC-1", hasSpend: true, totalCostUSD: 1, contextCostUSD: 0.5, answersCostUSD: 0.5, totalDurationMs: 1000, stages: [] },
+      "planning",
+      new Date(now - 60_000).toISOString(),
+      now,
+      state,
+    );
+    assert.doesNotMatch(html, /running/, state);
+    assert.match(html, /entered 1m 0s ago/, state);
+  }
+});

--- a/desktop/frontend/scripts/board-queue.test.mjs
+++ b/desktop/frontend/scripts/board-queue.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { queueOf, isReworkable, isReopenable, verdictFailed, forwardDropAllowed, planReady, badgeInfo, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReviewRetryable, STOP_DECISION_LABELS } from "../build/board-queue.js";
+import { queueOf, isReworkable, isReopenable, verdictFailed, forwardDropAllowed, planReady, badgeInfo, sinceText, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReviewRetryable, STOP_DECISION_LABELS } from "../build/board-queue.js";
 import { DAEMON_FORWARDED_STATES } from "../build/board-states.js";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -566,4 +566,50 @@ test("a running badge shows the recorded phase when there is one", () => {
 test("a run that recorded no phase keeps the stage word", () => {
   const badge = badgeInfo({ stage: "implementation", state: "running" });
   assert.equal(badge.text, "building…", "no invented phase — absence stays absent");
+});
+
+// --- The phase badge carries its own age (SC-4151 B4) ---
+
+test("a fresh phase reads as it always did, with no age", () => {
+  const now = Date.parse("2026-08-10T12:00:00Z");
+  const info = badgeInfo(
+    { stage: "implementation", state: "running", activity: "triaging", activityAt: "2026-08-10T11:58:00Z" },
+    now,
+  );
+  assert.equal(info.text, "triaging…");
+  assert.match(info.title, /Agent running — triaging, last recorded 2m ago/);
+});
+
+test("a phase that has stood too long says how long", () => {
+  const now = Date.parse("2026-08-10T12:00:00Z");
+  const info = badgeInfo(
+    { stage: "implementation", state: "running", activity: "triaging", activityAt: "2026-08-10T06:00:00Z" },
+    now,
+  );
+  assert.equal(info.text, "triaging… (6h ago)");
+  assert.equal(info.spinner, true, "still running — the age is information, not a verdict");
+});
+
+test("an unreadable or absent activity time prints no age", () => {
+  const now = Date.parse("2026-08-10T12:00:00Z");
+  assert.equal(badgeInfo({ stage: "implementation", state: "running", activity: "fixing" }, now).text, "fixing…");
+  assert.equal(
+    badgeInfo({ stage: "implementation", state: "running", activity: "fixing", activityAt: "not-a-time" }, now).text,
+    "fixing…",
+  );
+});
+
+test("a running card with no recorded phase is unchanged", () => {
+  const now = Date.parse("2026-08-10T12:00:00Z");
+  const info = badgeInfo({ stage: "implementation", state: "running", activityAt: "2026-08-10T06:00:00Z" }, now);
+  assert.equal(info.text, "building…");
+  assert.equal(info.title, "Agent running");
+});
+
+test("sinceText refuses to render an age it could not read", () => {
+  const now = Date.parse("2026-08-10T12:00:00Z");
+  assert.equal(sinceText(undefined, now), "");
+  assert.equal(sinceText("nonsense", now), "");
+  assert.equal(sinceText("2026-08-10T11:59:30Z", now), "30s ago");
+  assert.equal(sinceText("2026-08-08T12:00:00Z", now), "2d ago");
 });

--- a/desktop/frontend/src/board-detail.ts
+++ b/desktop/frontend/src/board-detail.ts
@@ -155,6 +155,20 @@ function fmtDuration(ms: number): string {
   return `${h}h ${m % 60}m`;
 }
 
+// stageClockLine phrases the current-stage clock for the state the card is
+// actually in. Only a running card is running; every other state gets the same
+// measurement stated as what it is — when the stage was entered — so the number
+// stops asserting work is in progress behind it. An absent state (a payload
+// from a daemon predating the field) keeps the original wording.
+function stageClockLine(stage: string | undefined, state: string | undefined, elapsedMs: number): string {
+  const elapsed = escapeText(fmtDuration(Math.max(0, elapsedMs)));
+  const named = escapeText(stage ?? "");
+  if (state === undefined || state === "running") {
+    return `Current stage (${named}): ${elapsed} running`;
+  }
+  return `Stage (${named}): entered ${elapsed} ago`;
+}
+
 // buildCostSection renders the ticket's whole-life cost (with the answers/context
 // split) and elapsed time (per-stage plus the live current-stage clock). A ticket
 // with no recorded spend says so plainly rather than showing $0.00 (SC-2847
@@ -165,6 +179,7 @@ export function buildCostSection(
   currentStage: string | undefined,
   stageEnteredAt: string | undefined,
   nowMs: number,
+  currentState?: string,
 ): string {
   if (!c || !c.hasSpend) {
     // "No spend" is a claim about the TICKET and may only be made when the
@@ -194,9 +209,14 @@ export function buildCostSection(
       : allUnmeasured
         ? `<div class="detail-cost-unmeasured">${calls} call${calls === 1 ? "" : "s"} recorded no tokens, so what this cost is not known.</div>`
         : "";
+  // The elapsed figure measures the same thing whatever the card is doing — the
+  // time since its newest stage marker landed — but "running" is a claim about
+  // the work, and this section was making it for every state. A card that failed
+  // three days ago read "72h 4m running", and the longer it had been dead the
+  // more impressive its number (SC-4151 B3). The clock stays; only the state
+  // that earns the word "running" keeps it.
   const curElapsed = stageEnteredAt
-    ? `<div class="detail-cost-current">Current stage (${escapeText(currentStage ?? "")}): ` +
-      `${escapeText(fmtDuration(Math.max(0, nowMs - Date.parse(stageEnteredAt))))} running</div>`
+    ? `<div class="detail-cost-current">${stageClockLine(currentStage, currentState, nowMs - Date.parse(stageEnteredAt))}</div>`
     : "";
   // The per-stage rows carry the same honesty as the total: with nothing
   // measured anywhere, a stage's "$0.0000" is the same false claim in smaller

--- a/desktop/frontend/src/board-queue.ts
+++ b/desktop/frontend/src/board-queue.ts
@@ -194,7 +194,38 @@ export const STOP_DECISION_LABELS: Record<string, { text: string; title: string 
 // completion. A review that found problems is machine-fixing work, not a demand
 // on the user: the daemon auto-launches a fixer, so it reads as in-flight
 // (gray + spinner), never the amber "your turn" register (SC-1830).
-export function badgeInfo(card: QueueCard): BadgeInfo | null {
+// activityStaleAfterMs is how long a recorded phase may stand before the badge
+// starts saying how old it is. Short enough that a stall shows within a coffee
+// break; long enough that an ordinary phase — a plan, a build, a review — is
+// not decorated with an age for merely taking its normal time.
+const activityStaleAfterMs = 10 * 60 * 1000;
+
+// sinceText renders how long ago an RFC3339 instant was, in the board's compact
+// house form. An absent or unparseable timestamp yields "" — an age the board
+// could not read must never be printed as an age of zero.
+export function sinceText(at: string | undefined, nowMs: number): string {
+  if (!at) return "";
+  const t = Date.parse(at);
+  if (Number.isNaN(t)) return "";
+  const secs = Math.max(0, Math.floor((nowMs - t) / 1000));
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+// activityAge is the parenthesised age the badge carries, and only once the
+// phase is old enough to be worth reading.
+function activityAge(at: string | undefined, nowMs: number): string {
+  if (!at) return "";
+  const t = Date.parse(at);
+  if (Number.isNaN(t) || nowMs - t < activityStaleAfterMs) return "";
+  return `(${sinceText(at, nowMs)})`;
+}
+
+export function badgeInfo(card: QueueCard, nowMs: number = Date.now()): BadgeInfo | null {
   // An open decision block outranks EVERY other classification, including a
   // stale failed marker: a card parked on a deliberate human fork must never
   // paint red, even if a *-failed marker also landed on it (the daemon's twin
@@ -234,13 +265,18 @@ export function badgeInfo(card: QueueCard): BadgeInfo | null {
     // the fix, verification — so it reads identically at thirty seconds and at
     // fourteen hours, and identically again when the agent behind it is dead.
     // The phase changing is the only thing on the card that shows movement.
-    const text = card.activity ? `${card.activity}…` : stageText;
-    return {
-      cls: "running",
-      text,
-      title: card.activity ? `Agent running — ${card.activity}` : "Agent running",
-      spinner: true,
-    };
+    //
+    // Its changing was still the only signal: a phase that STOPPED changing read
+    // exactly like one that never had to. The daemon has always sent the
+    // timestamp beside the phase and the card dropped it on the floor
+    // (SC-4151 B4), so a badge could say "triaging…" over a record six hours
+    // old. The age now rides the badge once it is old enough to mean something.
+    const age = activityAge(card.activityAt, nowMs);
+    const text = card.activity ? `${card.activity}…${age !== "" ? ` ${age}` : ""}` : stageText;
+    const title = card.activity
+      ? `Agent running — ${card.activity}${card.activityAt ? `, last recorded ${sinceText(card.activityAt, nowMs)}` : ""}`
+      : "Agent running";
+    return { cls: "running", text, title, spinner: true };
   }
   // A recorded decision has (re)queued the chosen stage but the relaunched
   // agent has not posted its started marker yet — or the launch was deferred to

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -248,6 +248,9 @@ interface AgentInstance {
   currentTool?: string;
   blockedTool?: string;
   errorType?: string;
+  // When the session last produced anything, as a unix timestamp. 0 when
+  // unknown — the panel then makes no claim about staleness.
+  lastActivityUnix: number;
   startedAtUnix: number;
   daemonConnected: boolean;
   proxyConfigured: boolean;
@@ -3242,7 +3245,7 @@ function renderTicketDetail(): void {
     ${shippedPartial}
     ${desc}
     ${detailSections}
-    ${buildCostSection(detailCost, detailCard.stage, detailCard.stageEnteredAt, Date.now())}
+    ${buildCostSection(detailCost, detailCard.stage, detailCard.stageEnteredAt, Date.now(), detailCard.state)}
     ${link}
   `;
   const url = detailCard.url;
@@ -3721,6 +3724,7 @@ function agentRow(v: unknown): AgentInstance {
     currentTool: str(o.currentTool),
     blockedTool: str(o.blockedTool),
     errorType: str(o.errorType),
+    lastActivityUnix: num(o.lastActivityUnix),
     startedAtUnix: num(o.startedAtUnix),
     daemonConnected: bool(o.daemonConnected),
     proxyConfigured: bool(o.proxyConfigured),
@@ -3784,10 +3788,30 @@ function formatDurationMs(ms: number): string {
   return `${Math.floor(secs / 60)}m ${secs % 60}s`;
 }
 
+// agentSilentAfterMs is how long a "working" session may produce nothing before
+// the panel stops spinning for it. The status comes from the last transcript
+// entry's stop_reason and has no staleness rule of its own, so without this an
+// agent that hung an hour ago is indistinguishable from one mid-thought
+// (SC-4151 B5). Set above the daemon's own silence budget so the panel never
+// contradicts a reaper that has not yet had its turn.
+const agentSilentAfterMs = 10 * 60 * 1000;
+
+// agentSilent reports a session whose last sign of life is old enough that
+// "working" is no longer something the panel can claim. An unknown last
+// activity (0) is never silent: absence of a signal is not proof.
+function agentSilent(a: AgentInstance, nowMs: number = Date.now()): boolean {
+  if (a.status !== "working" || !a.lastActivityUnix) return false;
+  return nowMs - a.lastActivityUnix * 1000 >= agentSilentAfterMs;
+}
+
 function agentStatusDot(a: AgentInstance): string {
   // Mirrors the TUI sessionIcon: a spinner while working, ⚠ on error, and a
   // coloured ● otherwise — with idle splitting on whether the session has seen
   // any activity (● active vs ○ never-active).
+  if (agentSilent(a)) {
+    const since = formatElapsedUnix(a.lastActivityUnix);
+    return `<span class="agent-dot silent" title="Working, but nothing recorded for ${escapeAttr(since)} — it may be hung">◍</span>`;
+  }
   if (a.status === "working") return `<span class="agent-dot working"><span class="spinner"></span></span>`;
   if (a.status === "error") return `<span class="agent-dot error">⚠</span>`;
   if (a.status === "blocked") return `<span class="agent-dot blocked">●</span>`;

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -2098,6 +2098,13 @@ body {
 .agent-dot.error {
   color: var(--failed);
 }
+/* A session still reporting "working" that has produced nothing for a while.
+   Not an error — nothing has failed and it may yet continue — so it takes the
+   muted register rather than the failure red, and simply stops spinning
+   (SC-4151 B5). */
+.agent-dot.silent {
+  color: var(--muted);
+}
 
 .agent-label {
   font-weight: 600;

--- a/desktop/instances.go
+++ b/desktop/instances.go
@@ -39,26 +39,33 @@ type SubagentInfo struct {
 // are mapped; the discovery types carry a DirWalker interface and pointer memory
 // info that do not round-trip through JSON.
 type AgentInstance struct {
-	Label           string         `json:"label"`
-	Source          string         `json:"source"` // "host" or "container"
-	Status          string         `json:"status"` // ready|working|blocked|waiting|error|ended, "" when no session
-	HasActivity     bool           `json:"hasActivity"`
-	Slug            string         `json:"slug,omitempty"`
-	PID             int            `json:"pid"`
-	ContainerID     string         `json:"containerID,omitempty"`
-	Cwd             string         `json:"cwd,omitempty"`
-	Memory          string         `json:"memory,omitempty"`
-	CurrentTool     string         `json:"currentTool,omitempty"`
-	BlockedTool     string         `json:"blockedTool,omitempty"`
-	ErrorType       string         `json:"errorType,omitempty"`
-	StartedAtUnix   int64          `json:"startedAtUnix"`
-	DaemonConnected bool           `json:"daemonConnected"`
-	ProxyConfigured bool           `json:"proxyConfigured"`
-	Models          []ModelUsage   `json:"models"`
-	TasksPending    int            `json:"tasksPending"`
-	TasksInProgress int            `json:"tasksInProgress"`
-	TasksDone       int            `json:"tasksDone"`
-	Subagents       []SubagentInfo `json:"subagents"`
+	Label         string `json:"label"`
+	Source        string `json:"source"` // "host" or "container"
+	Status        string `json:"status"` // ready|working|blocked|waiting|error|ended, "" when no session
+	HasActivity   bool   `json:"hasActivity"`
+	Slug          string `json:"slug,omitempty"`
+	PID           int    `json:"pid"`
+	ContainerID   string `json:"containerID,omitempty"`
+	Cwd           string `json:"cwd,omitempty"`
+	Memory        string `json:"memory,omitempty"`
+	CurrentTool   string `json:"currentTool,omitempty"`
+	BlockedTool   string `json:"blockedTool,omitempty"`
+	ErrorType     string `json:"errorType,omitempty"`
+	StartedAtUnix int64  `json:"startedAtUnix"`
+	// LastActivityUnix is when this session last produced anything at all. The
+	// status is read off the last transcript entry's stop_reason with no
+	// staleness rule, so a hung agent reports "working" for as long as it hangs
+	// and the panel spins for it (SC-4151 B5). Carrying the instant lets the
+	// view say how long ago "working" was last true; 0 means unknown, which is
+	// rendered as no claim rather than as "just now".
+	LastActivityUnix int64          `json:"lastActivityUnix"`
+	DaemonConnected  bool           `json:"daemonConnected"`
+	ProxyConfigured  bool           `json:"proxyConfigured"`
+	Models           []ModelUsage   `json:"models"`
+	TasksPending     int            `json:"tasksPending"`
+	TasksInProgress  int            `json:"tasksInProgress"`
+	TasksDone        int            `json:"tasksDone"`
+	Subagents        []SubagentInfo `json:"subagents"`
 }
 
 // InstancesData is the payload the Agents view renders: the instance list plus an
@@ -135,6 +142,9 @@ func applySessionFields(ai *AgentInstance, sess *logparser.SessionState) {
 	}
 	ai.Status = statusString(sess.Status)
 	ai.HasActivity = !sess.LastActivity.IsZero()
+	if !sess.LastActivity.IsZero() {
+		ai.LastActivityUnix = sess.LastActivity.Unix()
+	}
 	ai.Slug = sess.Slug
 	ai.CurrentTool = sess.CurrentTool
 	ai.BlockedTool = sess.BlockedTool

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -327,4 +327,11 @@ type BoardView struct {
 	// the wire, so a project that configured nothing ships exactly today's
 	// payload and the frontend leaves the stylesheet's :root fallback alone.
 	DimPercent int `json:"dimPercent,omitempty"`
+	// CachedAt is when this board was composed, stamped only on the copy kept as
+	// the last-good snapshot. A refresh that fails serves that snapshot with a
+	// banner saying so — but "the last board that loaded" carries no age, so a
+	// snapshot minutes old and one days old read identically while the cards
+	// keep their spinners (SC-4151). Empty on every live board and on snapshots
+	// written before this existed, which then read exactly as they did.
+	CachedAt string `json:"cachedAt,omitempty"`
 }


### PR DESCRIPTION
Class B of SC-4151 — four claims made from a clock and nothing else.

**B3 — "running" on a card that is not running.** `buildCostSection` takes a stage timestamp and no state, so the detail panel read `Current stage (done): 72h 4m running` on a card that failed three days ago. The measurement is unchanged — time since the stage's newest marker — only the wording follows the state now.

**B4 — a present-tense phase from a record of any age.** `activityAt` has always crossed the wire beside `activity` and was rendered nowhere, so the badge said "triaging…" over a six-hour-old record. The age rides the badge past ten minutes and the tooltip always carries it.

**B5 — the Agents panel asserting about itself.** `StatusWorking` comes from the last transcript entry's `stop_reason` with no staleness rule, so a hung agent spun like one mid-thought. A "working" session silent for ten minutes takes a muted, still dot naming the silence. Not an error — nothing failed and it may yet continue — and the threshold sits above the daemon's own silence budget so the panel never contradicts a reaper that has not had its turn.

**Stale board age.** `serveLastGoodView` bannered the snapshot without saying when it loaded. Stamped on the stored copy only, so a live board carries nothing new.

In all four, a timestamp that could not be read prints no age rather than an age of zero, and a payload from a daemon predating each field reads exactly as it did.

## Verification
`make check` exit 0, `go test ./cmd/...` exit 0, 244 frontend tests pass (9 new), `dist/` matches its rebuild.

## Not in this PR
Classes E, F, G still to come. Class A's render half waits on #414 (SC-3569), which owns the liveness overlay. Class A's write half turned out to need no change — see the PR description note below.

**On A1's write side:** the plan called for a liveness guard before posting a failure. Reading the paths, every one is already gated by the discriminator that suits it — `verificationAgentAlive` (SC-3156), the reconcile passes' `liveAgents` + ownership gates (SC-4025), error classification on the exit path (SC-4026), and the run-registry claim (SC-4082). A liveness guard on `escalatePRLoop` would have suppressed every legitimate escalation, because `ListMetas` still reports the exiting agent as running when its Stop hook fires. No change was made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)