### PR TITLE
[SC-4151] Labels, omissions and a diagnosis the board never ran

### DIFF
--- a/desktop/frontend/dist/board-queue.js
+++ b/desktop/frontend/dist/board-queue.js
@@ -106,6 +106,15 @@ export const RUNNING_LABELS = {
     verification: "reviewing…",
     done: "deploying…",
 };
+// The badge word per half of the pre-merge review→fix loop. Both halves used to
+// read "PR review…", so a card whose live container was -prfix running the PR
+// fixer said the reviewer was working (SC-4151 F15). The daemon carries the
+// datum (BoardViewCard.deployPhase); the copy lives here, as with
+// STOP_DECISION_LABELS.
+export const DEPLOY_PHASE_LABELS = {
+    "pr-review": "PR review…",
+    "pr-fix": "fixing PR findings…",
+};
 // The verb per chosen stage for a card a recorded decision has (re)queued but
 // whose fresh agent has not yet posted its started marker (SC-1320).
 export const QUEUED_LABELS = {
@@ -200,8 +209,8 @@ export function badgeInfo(card, nowMs = Date.now()) {
         return { cls: "decided", text, title: label.title };
     }
     if (card.state === "running") {
-        const stageText = card.stage === "done" && card.deployPhase === "pr-review"
-            ? "PR review…"
+        const stageText = card.stage === "done" && card.deployPhase
+            ? (DEPLOY_PHASE_LABELS[card.deployPhase] ?? "PR review…")
             : (RUNNING_LABELS[card.stage] ?? "working…");
         // The run's own phase, when it recorded one. Without it the badge says the
         // same word for the whole of a fix run — triage, the challenge, the plan,
@@ -437,12 +446,19 @@ export function deployableCards(cards, side) {
 // when nothing is ready, enabled with a "ship every…" tooltip otherwise.
 export function deployControlView(cards, side) {
     const count = deployableCards(cards, side).length;
+    // queueOf sends every done-stage card to the deploy lane whatever its state,
+    // while isReadyToDeploy takes only a reviewed verification/done card with a
+    // branch. So the lane can hold cards the control refuses, and it said "none to
+    // deploy yet" with those cards visible beside it — a flat contradiction the
+    // reader has to resolve by guessing (SC-4151 F16). Counting them lets the
+    // empty state say which of the two things is true.
+    const waiting = cards.filter((c) => deployMatches(deploySideOf(c), side) && inDeployLaneNotReady(c)).length;
     if (side === "defects") {
         return {
             count,
             disabled: count === 0,
             label: `Deploy${count ? ` (${count})` : ""}`,
-            tooltip: count === 0 ? "No fixed bugs or vulnerabilities to deploy yet" : "Ship every fixed bug and vulnerability",
+            tooltip: count === 0 ? emptyTooltip(waiting, "fixed bugs or vulnerabilities") : "Ship every fixed bug and vulnerability",
         };
     }
     const noun = side === "bugs" ? "fixed bug" : side === "security" ? "fixed vulnerability" : "ready-to-deploy card";
@@ -450,8 +466,22 @@ export function deployControlView(cards, side) {
         count,
         disabled: count === 0,
         label: `Deploy${count ? ` (${count})` : ""}`,
-        tooltip: count === 0 ? `No ${noun}s to deploy yet` : `Ship every ${noun}`,
+        tooltip: count === 0 ? emptyTooltip(waiting, `${noun}s`) : `Ship every ${noun}`,
     };
+}
+// inDeployLaneNotReady reports a card sitting in the deploy lane that the Deploy
+// control will not take — still shipping, or stopped on the way.
+function inDeployLaneNotReady(card) {
+    return queueOf(card) === "deploy" && !isReadyToDeploy(card);
+}
+// emptyTooltip explains a disabled Deploy control. "Nothing to deploy yet" is
+// true only when the lane is empty; with cards in it the control is disabled
+// because those cards are not ready, which is a different sentence. plural is
+// the already-pluralised noun phrase, so each caller keeps its own wording.
+function emptyTooltip(waiting, plural) {
+    if (waiting === 0)
+        return `No ${plural} to deploy yet`;
+    return `${waiting} card${waiting === 1 ? "" : "s"} here ${waiting === 1 ? "is" : "are"} still finishing or stopped — none is ready to ship`;
 }
 // safetyPollShouldReconcile decides whether the 90s safety poll runs its
 // reconcile on a given tick. It intentionally does NOT gate on daemon
@@ -472,7 +502,10 @@ export function safetyReconcileError(prev, message) {
     if (prev.cards.length > 0) {
         return { ...prev, error: `Board may be stale — ${message}` };
     }
-    return { cards: [], dockerAvailable: false, error: message };
+    // Docker was not what failed and was not probed, so the last known answer
+    // stands. Reporting it unavailable here disabled every agent-launching
+    // gesture with the tooltip "Docker required" (SC-4151 G17).
+    return { cards: [], dockerAvailable: prev.dockerAvailable, error: message };
 }
 // isReopenable reports a card the pipeline RESOLVED: it concluded there is
 // nothing to plan ([human:nothing-to-do]) or no fix is needed

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -186,6 +186,21 @@ function renderCard(card) {
         const keys = card.blockers.join(", ");
         meta.push(`<span class="badge blocked" title="${escapeAttr(`Waiting for ${keys} to finish. Remove the link to start this now.`)}">waits for ${escapeHtml(keys)}</span>`);
     }
+    // A card is released into Ready to Deploy on a passing review, and an ABSENT
+    // verdict counts as passing so threads reviewed before verdicts existed keep
+    // flowing (SC-2848). That default is right, but it made "reviewed" and "never
+    // reviewed" look identical in the one lane where the difference decides
+    // whether to ship (SC-4151 F14). The default stands; the card says which it is.
+    if (queueOf(card) === "deploy" && card.stage === "verification" && !card.verdict) {
+        meta.push(`<span class="badge unreviewed" title="${escapeAttr("No review verdict was recorded. This card reached Ready to Deploy on the pre-verdict default, not on a review that passed.")}">no review recorded</span>`);
+    }
+    // A blocker this board cannot show — another tracker, or past the fetch cap —
+    // still holds the card. It used to be dropped, so the card read as unblocked
+    // (SC-4151 E11). Named, not linked: there is no card here to draw an arrow to.
+    if (card.blockersOffBoard?.length) {
+        const keys = card.blockersOffBoard.join(", ");
+        meta.push(`<span class="badge blocked" title="${escapeAttr(`Waiting for ${keys}, which is not on this board — another tracker, or beyond the fetch cap.`)}">waits for ${escapeHtml(keys)} (off board)</span>`);
+    }
     // A shipped-partial trace: the card shipped less than its ticket asked, with
     // the rest carried by the named follow-on. Informational (machine register, no
     // spinner, not "your turn") and additive to the stage badge, since it is true
@@ -2099,19 +2114,27 @@ async function reconcile(opts = {}) {
         if (epoch !== reconcileEpoch)
             return;
         current = boardStateFromPayload(data);
+        // A probe that FAILED says nothing about whether a sweep is running, so the
+        // previous answer stands rather than flipping the indicator to "not
+        // scanning" on a transient error (SC-4151 E12).
         findbugsHunting = await go()
             .FindbugsHunting()
-            .catch(() => false);
+            .catch(() => findbugsHunting);
         securityHunting = await go()
             .SecurityHunting()
-            .catch(() => false);
+            .catch(() => securityHunting);
     }
     catch (err) {
         if (epoch !== reconcileEpoch)
             return;
+        // A board fetch that failed says nothing about Docker, which was never
+        // probed. Reporting it as unavailable disabled every drop and every menu
+        // item with the tooltip "Docker required", sending the reader to debug a
+        // container runtime that is fine (SC-4151 G17). The last known answer
+        // stands; the fetch failure is surfaced as itself, in the banner.
         current = opts.safety
             ? safetyReconcileError(current, errMessage(err))
-            : { cards: [], dockerAvailable: false, error: errMessage(err) };
+            : { cards: [], dockerAvailable: current.dockerAvailable, error: errMessage(err) };
     }
     if (pendingIdeas.length) {
         // A fetched Ideas card whose key matches the pending capture's key IS

--- a/desktop/frontend/dist/style.css
+++ b/desktop/frontend/dist/style.css
@@ -970,6 +970,13 @@ body {
   color: var(--muted);
   font-weight: 600;
 }
+/* A card that reached Ready to Deploy on the pre-verdict default rather than on
+   a recorded pass. Not a failure — nothing went wrong — so it takes the muted
+   register and simply states the gap (SC-4151 F14). */
+.badge.unreviewed {
+  color: var(--muted);
+  font-weight: 600;
+}
 
 /* An open decision block (ticket 534): the pipeline is deliberately waiting on
    the human — amber, because the ball is in play and in the user's court

--- a/desktop/frontend/scripts/board-queue.test.mjs
+++ b/desktop/frontend/scripts/board-queue.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { queueOf, isReworkable, isReopenable, verdictFailed, forwardDropAllowed, planReady, badgeInfo, sinceText, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReviewRetryable, STOP_DECISION_LABELS } from "../build/board-queue.js";
+import { queueOf, isReworkable, isReopenable, verdictFailed, forwardDropAllowed, planReady, badgeInfo, sinceText, safetyReconcileError, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReviewRetryable, STOP_DECISION_LABELS } from "../build/board-queue.js";
 import { DAEMON_FORWARDED_STATES } from "../build/board-states.js";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -612,4 +612,70 @@ test("sinceText refuses to render an age it could not read", () => {
   assert.equal(sinceText("nonsense", now), "");
   assert.equal(sinceText("2026-08-10T11:59:30Z", now), "30s ago");
   assert.equal(sinceText("2026-08-08T12:00:00Z", now), "2d ago");
+});
+
+// --- The badge names the half of the loop that is running (SC-4151 F15) ---
+
+test("a pr-fix card says the fixer is working, not the reviewer", () => {
+  const info = badgeInfo({ stage: "done", state: "running", deployPhase: "pr-fix" });
+  assert.equal(info.text, "fixing PR findings…");
+});
+
+test("a pr-review card is unchanged", () => {
+  assert.equal(badgeInfo({ stage: "done", state: "running", deployPhase: "pr-review" }).text, "PR review…");
+});
+
+test("an unknown deploy phase falls back to the review wording rather than blanking", () => {
+  assert.equal(badgeInfo({ stage: "done", state: "running", deployPhase: "something-new" }).text, "PR review…");
+});
+
+// --- The Deploy control and its lane agree (SC-4151 F16) ---
+
+test("an empty deploy lane still says there is nothing to deploy yet", () => {
+  const view = deployControlView([{ stage: "planning", state: "done" }], "features");
+  assert.ok(view.disabled);
+  assert.match(view.tooltip, /No ready-to-deploy cards to deploy yet/);
+});
+
+test("cards in the lane that the control refuses are counted, not denied", () => {
+  // A done-stage card sits in the deploy lane whatever its state, but
+  // isReadyToDeploy takes only a reviewed verification/done card with a branch.
+  const cards = [
+    { stage: "done", state: "running" },
+    { stage: "done", state: "failed" },
+  ];
+  const view = deployControlView(cards, "features");
+  assert.equal(view.count, 0);
+  assert.ok(view.disabled);
+  assert.match(view.tooltip, /2 cards here are still finishing or stopped/);
+  assert.doesNotMatch(view.tooltip, /No ready-to-deploy cards to deploy yet/);
+});
+
+test("one waiting card reads in the singular", () => {
+  const view = deployControlView([{ stage: "done", state: "running" }], "features");
+  assert.match(view.tooltip, /1 card here is still finishing or stopped/);
+});
+
+test("a ready card still ships and says so", () => {
+  const view = deployControlView(
+    [{ stage: "verification", state: "done", branch: "b", verdictFailed: false }, { stage: "done", state: "failed" }],
+    "features",
+  );
+  assert.equal(view.count, 1);
+  assert.ok(!view.disabled);
+  assert.match(view.tooltip, /Ship every ready-to-deploy card/);
+});
+
+// --- A failed fetch is not a Docker verdict (SC-4151 G17) ---
+
+test("an empty board after a fetch failure keeps the last known Docker answer", () => {
+  const got = safetyReconcileError({ cards: [], dockerAvailable: true }, "daemon unreachable");
+  assert.equal(got.dockerAvailable, true, "Docker was never probed by this failure");
+  assert.equal(got.error, "daemon unreachable");
+});
+
+test("a populated board on a hiccup is unchanged", () => {
+  const got = safetyReconcileError({ cards: [{ key: "SC-1" }], dockerAvailable: false }, "hiccup");
+  assert.equal(got.dockerAvailable, false);
+  assert.match(got.error, /Board may be stale/);
 });

--- a/desktop/frontend/src/board-queue.ts
+++ b/desktop/frontend/src/board-queue.ts
@@ -164,6 +164,16 @@ export const RUNNING_LABELS: Record<string, string> = {
   done: "deploying…",
 };
 
+// The badge word per half of the pre-merge review→fix loop. Both halves used to
+// read "PR review…", so a card whose live container was -prfix running the PR
+// fixer said the reviewer was working (SC-4151 F15). The daemon carries the
+// datum (BoardViewCard.deployPhase); the copy lives here, as with
+// STOP_DECISION_LABELS.
+export const DEPLOY_PHASE_LABELS: Record<string, string> = {
+  "pr-review": "PR review…",
+  "pr-fix": "fixing PR findings…",
+};
+
 // The verb per chosen stage for a card a recorded decision has (re)queued but
 // whose fresh agent has not yet posted its started marker (SC-1320).
 export const QUEUED_LABELS: Record<string, string> = {
@@ -257,8 +267,8 @@ export function badgeInfo(card: QueueCard, nowMs: number = Date.now()): BadgeInf
   }
   if (card.state === "running") {
     const stageText =
-      card.stage === "done" && card.deployPhase === "pr-review"
-        ? "PR review…"
+      card.stage === "done" && card.deployPhase
+        ? (DEPLOY_PHASE_LABELS[card.deployPhase] ?? "PR review…")
         : (RUNNING_LABELS[card.stage] ?? "working…");
     // The run's own phase, when it recorded one. Without it the badge says the
     // same word for the whole of a fix run — triage, the challenge, the plan,
@@ -538,12 +548,19 @@ export interface DeployControlView {
 // when nothing is ready, enabled with a "ship every…" tooltip otherwise.
 export function deployControlView(cards: QueueCard[], side: DeploySide): DeployControlView {
   const count = deployableCards(cards, side).length;
+  // queueOf sends every done-stage card to the deploy lane whatever its state,
+  // while isReadyToDeploy takes only a reviewed verification/done card with a
+  // branch. So the lane can hold cards the control refuses, and it said "none to
+  // deploy yet" with those cards visible beside it — a flat contradiction the
+  // reader has to resolve by guessing (SC-4151 F16). Counting them lets the
+  // empty state say which of the two things is true.
+  const waiting = cards.filter((c) => deployMatches(deploySideOf(c), side) && inDeployLaneNotReady(c)).length;
   if (side === "defects") {
     return {
       count,
       disabled: count === 0,
       label: `Deploy${count ? ` (${count})` : ""}`,
-      tooltip: count === 0 ? "No fixed bugs or vulnerabilities to deploy yet" : "Ship every fixed bug and vulnerability",
+      tooltip: count === 0 ? emptyTooltip(waiting, "fixed bugs or vulnerabilities") : "Ship every fixed bug and vulnerability",
     };
   }
   const noun =
@@ -552,8 +569,23 @@ export function deployControlView(cards: QueueCard[], side: DeploySide): DeployC
     count,
     disabled: count === 0,
     label: `Deploy${count ? ` (${count})` : ""}`,
-    tooltip: count === 0 ? `No ${noun}s to deploy yet` : `Ship every ${noun}`,
+    tooltip: count === 0 ? emptyTooltip(waiting, `${noun}s`) : `Ship every ${noun}`,
   };
+}
+
+// inDeployLaneNotReady reports a card sitting in the deploy lane that the Deploy
+// control will not take — still shipping, or stopped on the way.
+function inDeployLaneNotReady(card: QueueCard): boolean {
+  return queueOf(card) === "deploy" && !isReadyToDeploy(card);
+}
+
+// emptyTooltip explains a disabled Deploy control. "Nothing to deploy yet" is
+// true only when the lane is empty; with cards in it the control is disabled
+// because those cards are not ready, which is a different sentence. plural is
+// the already-pluralised noun phrase, so each caller keeps its own wording.
+function emptyTooltip(waiting: number, plural: string): string {
+  if (waiting === 0) return `No ${plural} to deploy yet`;
+  return `${waiting} card${waiting === 1 ? "" : "s"} here ${waiting === 1 ? "is" : "are"} still finishing or stopped — none is ready to ship`;
 }
 
 // safetyPollShouldReconcile decides whether the 90s safety poll runs its
@@ -579,7 +611,10 @@ export function safetyReconcileError<C>(
   if (prev.cards.length > 0) {
     return { ...prev, error: `Board may be stale — ${message}` };
   }
-  return { cards: [], dockerAvailable: false, error: message };
+  // Docker was not what failed and was not probed, so the last known answer
+  // stands. Reporting it unavailable here disabled every agent-launching
+  // gesture with the tooltip "Docker required" (SC-4151 G17).
+  return { cards: [], dockerAvailable: prev.dockerAvailable, error: message };
 }
 
 // isReopenable reports a card the pipeline RESOLVED: it concluded there is

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -139,6 +139,8 @@ interface Card {
   // different columns, so this renders as a badge naming the key rather than a
   // line drawn between two cards.
   blockers?: string[];
+  // Blockers this board cannot show; named on the card, never linked.
+  blockersOffBoard?: string[];
   // Set when the daemon could not read this ticket's markers this scan (a
   // comment-fetch error). Rendered locked: non-draggable, no launch actions,
   // with an "unreadable" badge — never presented as idle Backlog work (1700).
@@ -612,6 +614,25 @@ function renderCard(card: Card): HTMLElement {
     const keys = card.blockers.join(", ");
     meta.push(
       `<span class="badge blocked" title="${escapeAttr(`Waiting for ${keys} to finish. Remove the link to start this now.`)}">waits for ${escapeHtml(keys)}</span>`,
+    );
+  }
+  // A card is released into Ready to Deploy on a passing review, and an ABSENT
+  // verdict counts as passing so threads reviewed before verdicts existed keep
+  // flowing (SC-2848). That default is right, but it made "reviewed" and "never
+  // reviewed" look identical in the one lane where the difference decides
+  // whether to ship (SC-4151 F14). The default stands; the card says which it is.
+  if (queueOf(card) === "deploy" && card.stage === "verification" && !card.verdict) {
+    meta.push(
+      `<span class="badge unreviewed" title="${escapeAttr("No review verdict was recorded. This card reached Ready to Deploy on the pre-verdict default, not on a review that passed.")}">no review recorded</span>`,
+    );
+  }
+  // A blocker this board cannot show — another tracker, or past the fetch cap —
+  // still holds the card. It used to be dropped, so the card read as unblocked
+  // (SC-4151 E11). Named, not linked: there is no card here to draw an arrow to.
+  if (card.blockersOffBoard?.length) {
+    const keys = card.blockersOffBoard.join(", ");
+    meta.push(
+      `<span class="badge blocked" title="${escapeAttr(`Waiting for ${keys}, which is not on this board — another tracker, or beyond the fetch cap.`)}">waits for ${escapeHtml(keys)} (off board)</span>`,
     );
   }
   // A shipped-partial trace: the card shipped less than its ticket asked, with
@@ -2634,17 +2655,25 @@ async function reconcile(opts: { safety?: boolean } = {}): Promise<void> {
     const data = await go().Cards();
     if (epoch !== reconcileEpoch) return;
     current = boardStateFromPayload(data);
+    // A probe that FAILED says nothing about whether a sweep is running, so the
+    // previous answer stands rather than flipping the indicator to "not
+    // scanning" on a transient error (SC-4151 E12).
     findbugsHunting = await go()
       .FindbugsHunting()
-      .catch(() => false);
+      .catch(() => findbugsHunting);
     securityHunting = await go()
       .SecurityHunting()
-      .catch(() => false);
+      .catch(() => securityHunting);
   } catch (err) {
     if (epoch !== reconcileEpoch) return;
+    // A board fetch that failed says nothing about Docker, which was never
+    // probed. Reporting it as unavailable disabled every drop and every menu
+    // item with the tooltip "Docker required", sending the reader to debug a
+    // container runtime that is fine (SC-4151 G17). The last known answer
+    // stands; the fetch failure is surfaced as itself, in the banner.
     current = opts.safety
       ? safetyReconcileError(current, errMessage(err))
-      : { cards: [], dockerAvailable: false, error: errMessage(err) };
+      : { cards: [], dockerAvailable: current.dockerAvailable, error: errMessage(err) };
   }
   if (pendingIdeas.length) {
     // A fetched Ideas card whose key matches the pending capture's key IS

--- a/desktop/frontend/static/style.css
+++ b/desktop/frontend/static/style.css
@@ -970,6 +970,13 @@ body {
   color: var(--muted);
   font-weight: 600;
 }
+/* A card that reached Ready to Deploy on the pre-verdict default rather than on
+   a recorded pass. Not a failure — nothing went wrong — so it takes the muted
+   register and simply states the gap (SC-4151 F14). */
+.badge.unreviewed {
+  color: var(--muted);
+  font-weight: 600;
+}
 
 /* An open decision block (ticket 534): the pipeline is deliberately waiting on
    the human — amber, because the ball is in play and in the user's court

--- a/internal/board/compose.go
+++ b/internal/board/compose.go
@@ -106,7 +106,15 @@ func markBlocked(cards []daemon.BoardViewCard, blockedBy map[string][]string) {
 		for _, key := range blockedBy[c.Key] {
 			if onBoard[key] {
 				cards[i].Blockers = append(cards[i].Blockers, key)
+				continue
 			}
+			// A blocker the board cannot draw is still a blocker. Dropping it
+			// rendered the card as unblocked while a real, open dependency stood
+			// — the blocker living on another tracker, or beyond the fetch cap,
+			// is a fact about this view, not about the work (SC-4151 E11). The
+			// arrow layer only links keys it can find, so these are carried
+			// separately and named rather than pointed at.
+			cards[i].BlockersOffBoard = append(cards[i].BlockersOffBoard, key)
 		}
 	}
 }

--- a/internal/board/compose_test.go
+++ b/internal/board/compose_test.go
@@ -424,3 +424,23 @@ func TestCompose_CarriesTheOwningMachine(t *testing.T) {
 	assert.Empty(t, cardByKey(t, view, "SC-2").StageDaemonID,
 		"a single-daemon install stamps nothing, and absence must not read as a machine named \"\"")
 }
+
+// TestMarkBlocked_OffBoardBlockerIsNamed covers SC-4151 E11: a dependency the
+// board cannot draw was dropped, so a card with a real open blocker rendered as
+// unblocked. The blocker's absence is a fact about this view, not about the work.
+func TestMarkBlocked_OffBoardBlockerIsNamed(t *testing.T) {
+	cards := []daemon.BoardViewCard{{Key: "SC-1"}, {Key: "SC-2"}}
+	markBlocked(cards, map[string][]string{"SC-1": {"SC-2", "JIRA-9", "SC-999"}})
+
+	assert.Equal(t, []string{"SC-2"}, cards[0].Blockers, "a blocker on the board is still linked")
+	assert.Equal(t, []string{"JIRA-9", "SC-999"}, cards[0].BlockersOffBoard, "the rest are named, not dropped")
+	assert.Empty(t, cards[1].Blockers)
+	assert.Empty(t, cards[1].BlockersOffBoard)
+}
+
+func TestMarkBlocked_NoBlockersLeavesBothEmpty(t *testing.T) {
+	cards := []daemon.BoardViewCard{{Key: "SC-1"}}
+	markBlocked(cards, map[string][]string{})
+	assert.Empty(t, cards[0].Blockers)
+	assert.Empty(t, cards[0].BlockersOffBoard)
+}

--- a/internal/daemon/board_reconcile.go
+++ b/internal/daemon/board_reconcile.go
@@ -241,9 +241,28 @@ func stageStalled(progress AgentProgressProbe, agentName string, now time.Time) 
 // deploy. Used to hand loop cards to the re-drive pass, to keep the generic
 // stuck-running pass from redding them, and (board_state.go) to badge the loop.
 func doneStageLoopActive(comments []tracker.Comment) bool {
+	return doneStageLoopHalf(comments) != ""
+}
+
+// doneStageLoopHalf names WHICH half of the review→fix loop the card's newest
+// done-stage marker started: "pr-review", "pr-fix", or "" when the newest marker
+// is not a loop-started marker at all.
+//
+// The distinction exists everywhere else — prReviewAgentStage and
+// prFixAgentStage are separate agents in separate containers — and the badge
+// alone collapsed it, so a card whose live container was -prfix running the PR
+// fixer read "PR review…" for the whole loop (SC-4151 F15).
+func doneStageLoopHalf(comments []tracker.Comment) string {
 	_, latest := latestStateInStage(comments, BoardDoneStage)
 	t := strings.TrimSpace(latest.Body)
-	return strings.HasPrefix(t, PRReviewStartedHeader) || strings.HasPrefix(t, PRFixStartedHeader)
+	switch {
+	case strings.HasPrefix(t, PRReviewStartedHeader):
+		return DeployPhasePRReview
+	case strings.HasPrefix(t, PRFixStartedHeader):
+		return DeployPhasePRFix
+	default:
+		return ""
+	}
 }
 
 // reconcilePRLoops re-drives a loop card the live exit hook missed: a

--- a/internal/daemon/board_state.go
+++ b/internal/daemon/board_state.go
@@ -293,13 +293,22 @@ func supersededByNewerMarker(placed Placement, comments []tracker.Comment) bool 
 		(placed.Stage() == BoardDoneStage && doneStageLoopActive(comments))
 }
 
-// deployPhaseFor names the done-stage sub-phase of a running card: "pr-review"
-// while the pre-merge review→fix loop is mid-flight, empty for a plain deploy so
-// the board badge reads "PR review…" rather than "deploying…" while the loop
-// runs.
+// DeployPhasePRReview and DeployPhasePRFix name the two halves of the pre-merge
+// review→fix loop, as the board badge reads them. They are separate agents in
+// separate containers everywhere else in the machine; the badge used to call
+// both of them the review (SC-4151 F15).
+const (
+	DeployPhasePRReview = "pr-review"
+	DeployPhasePRFix    = "pr-fix"
+)
+
+// deployPhaseFor names the done-stage sub-phase of a running card: which half of
+// the pre-merge review→fix loop is mid-flight, empty for a plain deploy so the
+// board badge reads "PR review…" or "fixing PR findings…" rather than
+// "deploying…" while the loop runs.
 func deployPhaseFor(card BoardCard, comments []tracker.Comment) string {
-	if card.Stage == BoardDoneStage && card.State == BoardRunning && doneStageLoopActive(comments) {
-		return "pr-review"
+	if card.Stage == BoardDoneStage && card.State == BoardRunning {
+		return doneStageLoopHalf(comments)
 	}
 	return ""
 }

--- a/internal/daemon/board_state_test.go
+++ b/internal/daemon/board_state_test.go
@@ -903,3 +903,30 @@ func TestDispatchedFailure_TakesTheNewestDispatch(t *testing.T) {
 	assert.Equal(t, "the second failure", dispatchedFailure(comments))
 	assert.Empty(t, dispatchedFailure(nil), "no dispatch recorded means nothing to quote")
 }
+
+// TestDeriveBoardCard_DeployPhasePRFix covers SC-4151 F15: the loop's two halves
+// are separate agents in separate containers everywhere else, and the badge
+// called both of them the review — so a card whose live container was -prfix
+// running the PR fixer read "PR review…" for the whole loop.
+func TestDeriveBoardCard_DeployPhasePRFix(t *testing.T) {
+	comments := []tracker.Comment{
+		cmt(prReviewStartedBody("https://example/pr/7", 7, "feat/x"), time.Unix(2, 0)),
+		cmt(PRFixStartedHeader, time.Unix(3, 0)),
+	}
+	card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
+
+	assert.Equal(t, BoardDoneStage, card.Stage)
+	assert.Equal(t, BoardRunning, card.State)
+	assert.Equal(t, DeployPhasePRFix, card.DeployPhase)
+}
+
+// The loop swinging back to a second review round names the review again.
+func TestDeriveBoardCard_DeployPhaseFollowsTheNewestHalf(t *testing.T) {
+	comments := []tracker.Comment{
+		cmt(prReviewStartedBody("https://example/pr/7", 7, "feat/x"), time.Unix(2, 0)),
+		cmt(PRFixStartedHeader, time.Unix(3, 0)),
+		cmt(prReviewStartedBody("https://example/pr/7", 7, "feat/x"), time.Unix(4, 0)),
+	}
+	card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
+	assert.Equal(t, DeployPhasePRReview, card.DeployPhase)
+}

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -236,6 +236,13 @@ type BoardViewCard struct {
 	// the card it holds usually sit in different columns, which is why this is
 	// a badge naming the key and not a line drawn between two cards.
 	Blockers []string `json:"blockers,omitempty"`
+	// BlockersOffBoard names blockers this board cannot show: on another
+	// tracker, or past the fetch cap. They were dropped, so a card with a real
+	// open dependency rendered as unblocked — a fact about the view told as a
+	// fact about the work (SC-4151 E11). Kept apart from Blockers because the
+	// arrow layer can only link keys it can find, so these are named on the card
+	// rather than pointed at.
+	BlockersOffBoard []string `json:"blockersOffBoard,omitempty"`
 	// Tracker/TrackerKind are the instance name and provider kind the issue
 	// was listed from. The detail panel passes them back to GetIssueDetail so
 	// the daemon resolves the exact instance — bare numeric keys are ambiguous


### PR DESCRIPTION
Classes F, E and G of SC-4151 — six claims where the board stated something it had not established.

**F15 — the badge named the wrong half of the loop.** `deployPhaseFor` returned `pr-review` for the whole review→fix loop, so a card whose live container was `-prfix` running `human-pr-fixer` said the reviewer was working. `doneStageLoopActive` already had to read which marker started the current half; it now reports which.

**F16 — the Deploy control contradicted its own lane.** `queueOf` sends every done-stage card to Ready to Deploy whatever its state; `isReadyToDeploy` takes only a reviewed `verification/done` card with a branch. The control said "No ready-to-deploy cards to deploy yet" with those cards visible beside it. It now counts what it is refusing and says they are still finishing or stopped.

**F14 — an absent verdict looked like a passing one.** The pre-verdict default (SC-2848) is kept; the card now says which of the two released it, in the one lane where the difference decides whether to ship.

**E11 — a blocker off the board was no blocker.** `markBlocked` appended a dependency only `if onBoard[key]`, so a blocker on another tracker or past the fetch cap was dropped and the card read as unblocked. Carried separately from `Blockers` because the arrow layer can only link keys it can find — named on the card, not pointed at.

**E12 — a failed probe read as "not scanning".** `FindbugsHunting().catch(() => false)` turned an RPC error into a claim. The previous answer stands.

**G17 — "Docker required" for a failure Docker had no part in.** `reconcile()`'s catch set `dockerAvailable: false`, disabling every drop and every menu item with that tooltip after a *board fetch* failed. Docker was never probed.

## Verification
`make check` exit 0, `go test ./cmd/...` exit 0, `go vet -tags wailsapp ./desktop/...` clean, 253 frontend tests pass (12 new), `dist/` matches its rebuild.

## Remaining on SC-4151
E10 (a close that kills a live agent leaves no record) ships next — it adds a marker, so the FSM document and `docs/reaper.md` move with it. Class A's render half waits on #414 (SC-3569). A's write half needed no change: every failure path is already gated by the discriminator that suits it, and a liveness guard on `escalatePRLoop` would suppress legitimate escalations because `ListMetas` still reports the exiting agent as running when its Stop hook fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)