### PR TITLE
[SC-4151] A red card whose agent is still working says so

### DIFF
--- a/desktop/frontend/dist/board-queue.js
+++ b/desktop/frontend/dist/board-queue.js
@@ -108,8 +108,8 @@ export const RUNNING_LABELS = {
 };
 // The badge word per half of the pre-merge review→fix loop. Both halves used to
 // read "PR review…", so a card whose live container was -prfix running the PR
-// fixer said the reviewer was working (SC-4151 F15). The daemon carries the
-// datum (BoardViewCard.deployPhase); the copy lives here, as with
+// fixer said the reviewer was working (SC-4151 F15, SC-3569). The daemon
+// carries the datum (BoardViewCard.deployPhase); the copy lives here, as with
 // STOP_DECISION_LABELS.
 export const DEPLOY_PHASE_LABELS = {
     "pr-review": "PR review…",
@@ -138,6 +138,35 @@ export const STOP_DECISION_LABELS = {
         title: "The pre-planning gate concluded this is not a real problem, with the evidence on the card",
     },
 };
+// failedBadge renders a stage's recorded failure — and declines to render it as
+// the last word while an agent for that stage is still working here.
+//
+// A failure marker is durable and a run is not required to have ended when one
+// lands: the loop can record a step dead while its container goes on to finish.
+// Observed on SC-3852 (2026-08-10), where a pr-review-failed marker sat on the
+// card for an hour while the reviewer it described kept making tool calls and
+// then recorded `changes-requested`. The red asked a person to check a pull
+// request, about work that was still being done, and the card lost its running
+// badge in the same instant it gained the error (SC-4151 A1).
+//
+// This is the mirror of livenessBadge: that one refuses to claim work is
+// happening when no agent is behind it, this one refuses to declare it over
+// while one is. The marker is not hidden — the recorded reason stays on the
+// card and in the detail panel — but the badge says the work is still going,
+// because a person sent to intervene on a live run is being sent for nothing.
+// Unknown liveness leaves the plain failure exactly as before.
+function failedBadge(card) {
+    const reason = card.error || "Stage failed";
+    if (card.agentLiveness === "live") {
+        return {
+            cls: "fixing",
+            text: "still working — earlier failure recorded",
+            title: `A failure was recorded for this stage, but an agent is still running it here. Nothing to do yet; the run may still finish. Recorded reason: ${reason}`,
+            spinner: true,
+        };
+    }
+    return { cls: "failed", text: "✕", title: reason };
+}
 // livenessBadge folds the viewer's liveness overlay into a badge that would
 // otherwise assert work is happening.
 //
@@ -295,7 +324,7 @@ export function badgeInfo(card, nowMs = Date.now(), runningLabels = RUNNING_LABE
         };
     }
     if (card.state === "failed")
-        return { cls: "failed", text: "✕", title: card.error || "Stage failed" };
+        return failedBadge(card);
     if (card.state === "resolved") {
         if (card.stage === "planning") {
             // The planner verified the ticket's work is already merged, so there is

--- a/desktop/frontend/scripts/board-queue.test.mjs
+++ b/desktop/frontend/scripts/board-queue.test.mjs
@@ -734,3 +734,33 @@ test("queued and fixing badges also drop the spinner for a dead agent (SC-3569)"
   assert.equal(fixing.spinner, false);
   assert.match(fixing.text, /no fixer running/);
 });
+
+// --- A red card whose agent is working says so (SC-4151 A1) ---
+
+test("a failed card with a live agent reads as still working, not as over", () => {
+  const info = badgeInfo({
+    stage: "done",
+    state: "failed",
+    error: "the PR reviewer stopped before recording a verdict",
+    agentLiveness: "live",
+  });
+  assert.equal(info.cls, "fixing", "the machine register, never the failure register");
+  assert.match(info.text, /still working/);
+  assert.equal(info.spinner, true);
+  // The recorded reason is not hidden — it is just no longer the last word.
+  assert.match(info.title, /the PR reviewer stopped before recording a verdict/);
+  assert.match(info.title, /Nothing to do yet/);
+});
+
+test("a failed card with no agent behind it keeps the plain red", () => {
+  for (const liveness of ["dead", "elsewhere", "recovering", undefined]) {
+    const info = badgeInfo({ stage: "done", state: "failed", error: "boom", agentLiveness: liveness });
+    assert.equal(info.cls, "failed", String(liveness));
+    assert.equal(info.text, "✕", String(liveness));
+    assert.equal(info.title, "boom", String(liveness));
+  }
+});
+
+test("a failed card with no recorded reason still says something", () => {
+  assert.equal(badgeInfo({ stage: "planning", state: "failed" }).title, "Stage failed");
+});

--- a/desktop/frontend/src/board-queue.ts
+++ b/desktop/frontend/src/board-queue.ts
@@ -210,6 +210,36 @@ export const STOP_DECISION_LABELS: Record<string, { text: string; title: string 
   },
 };
 
+// failedBadge renders a stage's recorded failure — and declines to render it as
+// the last word while an agent for that stage is still working here.
+//
+// A failure marker is durable and a run is not required to have ended when one
+// lands: the loop can record a step dead while its container goes on to finish.
+// Observed on SC-3852 (2026-08-10), where a pr-review-failed marker sat on the
+// card for an hour while the reviewer it described kept making tool calls and
+// then recorded `changes-requested`. The red asked a person to check a pull
+// request, about work that was still being done, and the card lost its running
+// badge in the same instant it gained the error (SC-4151 A1).
+//
+// This is the mirror of livenessBadge: that one refuses to claim work is
+// happening when no agent is behind it, this one refuses to declare it over
+// while one is. The marker is not hidden — the recorded reason stays on the
+// card and in the detail panel — but the badge says the work is still going,
+// because a person sent to intervene on a live run is being sent for nothing.
+// Unknown liveness leaves the plain failure exactly as before.
+function failedBadge(card: QueueCard): BadgeInfo {
+  const reason = card.error || "Stage failed";
+  if (card.agentLiveness === "live") {
+    return {
+      cls: "fixing",
+      text: "still working — earlier failure recorded",
+      title: `A failure was recorded for this stage, but an agent is still running it here. Nothing to do yet; the run may still finish. Recorded reason: ${reason}`,
+      spinner: true,
+    };
+  }
+  return { cls: "failed", text: "✕", title: reason };
+}
+
 // livenessBadge folds the viewer's liveness overlay into a badge that would
 // otherwise assert work is happening.
 //
@@ -378,7 +408,7 @@ export function badgeInfo(
       spinner: false,
     };
   }
-  if (card.state === "failed") return { cls: "failed", text: "✕", title: card.error || "Stage failed" };
+  if (card.state === "failed") return failedBadge(card);
   if (card.state === "resolved") {
     if (card.stage === "planning") {
       // The planner verified the ticket's work is already merged, so there is

--- a/internal/daemon/board_liveness.go
+++ b/internal/daemon/board_liveness.go
@@ -42,16 +42,22 @@ func AgentNamesForCard(card BoardViewCard) []string {
 		// rounds, and which one is running says nothing about whether the other's
 		// container has yet been reaped.
 		//
-		// The deploy FIXER is deliberately absent, and its liveness stays unknown:
-		// DeployPhase only ever names a PR-loop half (donePhaseFromLoopMarker,
-		// board_state.go), so a card whose newest done marker is
-		// DeployFixStartedHeader reports no phase and returns nil above. Naming
-		// the deployfix agent here would therefore only ever be consulted while
-		// deploy-fix is NOT the current work — turning a not-yet-reaped container
-		// from an earlier round into a false "live". Covering it needs a wire
-		// signal the viewer does not have; teaching donePhaseFromLoopMarker the
-		// deploy-fix header instead would silently widen doneStageLoopActive,
-		// which gates the PR-loop re-drive and the stuck-running guard.
+		// A FAILED done-stage card reports a phase too, naming the half that was
+		// last started underneath the failure (deployPhaseFor →
+		// doneStageStartedHalf). That is the SC-3852 case: the loop reds a step
+		// whose container goes on working, and without a phase a red card's agent
+		// was never even looked for (SC-4151 A1).
+		//
+		// The deploy FIXER is deliberately absent from both, and its liveness
+		// stays unknown: DeployPhase only ever names a PR-loop half, so a card
+		// whose done stage last saw a deploy or deploy-fix launch reports no
+		// phase and returns nil here. Naming the deployfix agent would therefore
+		// only ever be consulted while deploy-fix is NOT the current work —
+		// turning a not-yet-reaped container from an earlier round into a false
+		// "live". Covering it needs a wire signal the viewer does not have;
+		// teaching the loop-half derivation the deploy-fix header instead would
+		// silently widen doneStageLoopActive, which gates the PR-loop re-drive
+		// and the stuck-running guard.
 		if card.DeployPhase == "" {
 			return nil
 		}
@@ -64,8 +70,17 @@ func AgentNamesForCard(card BoardViewCard) []string {
 		// (isReworkTransition, board_transition.go:1684), so that is the agent
 		// that owns the card while the board badges it "fixing…".
 		return []string{agentNameFor(card.Key, BoardImplementation)}
-	case state == BoardRunning || state == BoardQueued:
+	case state == BoardRunning || state == BoardQueued || state == BoardFailed:
 		// Only these three stages launch a named agent (launchForwardStage).
+		//
+		// BoardFailed is here for the opposite question to the one this function
+		// was written for. A failure marker is durable and a run is not required
+		// to have ended when one lands, so a card can be red while the agent it
+		// describes is still working — measured on SC-3852, where a
+		// pr-review-failed marker stood for an hour over a reviewer that went on
+		// to record changes-requested (SC-4151 A1). Asking who would be running
+		// this stage is the same question whether the last marker said started or
+		// failed; only the answer's use differs.
 		if stage != BoardPlanning && stage != BoardImplementation && stage != BoardVerification {
 			return nil
 		}

--- a/internal/daemon/board_liveness_test.go
+++ b/internal/daemon/board_liveness_test.go
@@ -3,6 +3,8 @@ package daemon
 import (
 	"slices"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // livenessCard builds the minimum BoardViewCard AgentNamesForCard reads, so a
@@ -96,4 +98,37 @@ func TestAgentNamesForCard_restingCard(t *testing.T) {
 // rather than a name that can never match and would therefore read as dead.
 func TestAgentNamesForCard_runningStageWithoutAnAgent(t *testing.T) {
 	assertNames(t, AgentNamesForCard(livenessCard(BoardBacklog, BoardRunning)), nil)
+}
+
+// TestAgentNamesForCard_FailedCardStillNamesItsAgent covers SC-4151 A1: a
+// failure marker is durable and a run need not have ended when one lands, so a
+// red card's agent must still be looked for. Before this a failed card returned
+// nil and its liveness was never even asked.
+func TestAgentNamesForCard_FailedCardStillNamesItsAgent(t *testing.T) {
+	for _, stage := range []BoardStage{BoardPlanning, BoardImplementation, BoardVerification} {
+		got := AgentNamesForCard(livenessCard(stage, BoardFailed))
+		assert.Equal(t, []string{agentNameFor("SC-1", stage)}, got, string(stage))
+	}
+}
+
+func TestAgentNamesForCard_FailedLoopCardNamesBothHalves(t *testing.T) {
+	got := AgentNamesForCard(BoardViewCard{
+		Key: "SC-3852", Stage: string(BoardDoneStage), State: string(BoardFailed),
+		DeployPhase: DeployPhasePRReview,
+	})
+	assert.Equal(t, []string{agentNameFor("SC-3852", prReviewAgentStage), agentNameFor("SC-3852", prFixAgentStage)}, got)
+}
+
+// A failed done-stage card with no loop half behind it — the deploy path reddened
+// it — stays unknown rather than being answered with a PR-loop container from an
+// earlier round.
+func TestAgentNamesForCard_FailedDeployCardNamesNothing(t *testing.T) {
+	got := AgentNamesForCard(livenessCard(BoardDoneStage, BoardFailed))
+	assert.Nil(t, got)
+}
+
+// A failed BACKLOG card launches no agent, so nothing is named for it.
+func TestAgentNamesForCard_FailedBacklogCardNamesNothing(t *testing.T) {
+	got := AgentNamesForCard(livenessCard(BoardBacklog, BoardFailed))
+	assert.Nil(t, got)
 }

--- a/internal/daemon/board_reconcile.go
+++ b/internal/daemon/board_reconcile.go
@@ -270,6 +270,43 @@ func doneStageLoopHalf(comments []tracker.Comment) string {
 	}
 }
 
+// doneStageStartedHalf names the loop half whose agent was last STARTED in the
+// done stage, looking past a failure marker that landed on top of it.
+//
+// doneStageLoopHalf answers about the newest marker of any kind, which is what
+// "is the loop mid-flight" needs. This answers the different question a red card
+// raises: who would be running this stage, so that whether they still are can be
+// asked at all.
+//
+// It reports nothing when the newest STARTED marker is a deploy or deploy-fix
+// launch rather than a loop half. That is the deliberate narrowing
+// AgentNamesForCard already documents for the deploy fixer: answering a
+// deploy-path failure with a PR-loop container left over from an earlier round
+// would turn an unreaped container into a false "still working".
+func doneStageStartedHalf(comments []tracker.Comment) string {
+	var newest tracker.Comment
+	var half string
+	found := false
+	for _, c := range comments {
+		t := strings.TrimSpace(c.Body)
+		var h string
+		switch {
+		case strings.HasPrefix(t, PRReviewStartedHeader):
+			h = DeployPhasePRReview
+		case strings.HasPrefix(t, PRFixStartedHeader):
+			h = DeployPhasePRFix
+		case strings.HasPrefix(t, DeployStartedHeader), strings.HasPrefix(t, DeployFixStartedHeader):
+			h = "" // a started marker, but not a loop half
+		default:
+			continue
+		}
+		if !found || commentNewer(c, newest) {
+			newest, half, found = c, h, true
+		}
+	}
+	return half
+}
+
 // reconcilePRLoops re-drives a loop card the live exit hook missed: a
 // done/running card whose newest done marker is a loop-started marker and for
 // which no loop half-agent is alive on this machine (a daemon restart lost the

--- a/internal/daemon/board_state.go
+++ b/internal/daemon/board_state.go
@@ -308,8 +308,19 @@ const (
 // board badge reads "PR review…" or "fixing PR findings…" rather than
 // "deploying…" while the loop runs.
 func deployPhaseFor(card BoardCard, comments []tracker.Comment) string {
-	if card.Stage == BoardDoneStage && card.State == BoardRunning {
+	if card.Stage != BoardDoneStage {
+		return ""
+	}
+	if card.State == BoardRunning {
 		return doneStageLoopHalf(comments)
+	}
+	// A FAILED done-stage card still has a loop half behind it, and it is the
+	// case SC-3852 measured: the loop reds a step whose container goes on
+	// working. The badge never reads this — it consults DeployPhase only while
+	// running — but AgentNamesForCard does, and without it a red card's agent is
+	// never even looked for (SC-4151 A1).
+	if card.State == BoardFailed {
+		return doneStageStartedHalf(comments)
 	}
 	return ""
 }

--- a/internal/daemon/board_state_test.go
+++ b/internal/daemon/board_state_test.go
@@ -945,3 +945,44 @@ func TestDeriveBoardCard_DeployPhaseFollowsTheNewestHalf(t *testing.T) {
 	card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
 	assert.Equal(t, DeployPhasePRReview, card.DeployPhase)
 }
+
+// TestDeployPhaseFor_FailedLoopCard covers SC-4151 A1's derivation half: a red
+// done-stage card names the loop half that was started under the failure, so
+// AgentNamesForCard can ask whether it is still running. The badge never reads
+// this — it consults DeployPhase only while running.
+func TestDeployPhaseFor_FailedLoopCard(t *testing.T) {
+	comments := []tracker.Comment{
+		cmt(prReviewStartedBody("https://example/pr/7", 7, "feat/x"), time.Unix(2, 0)),
+		cmt(markerBody(failureMarker(MarkerPRReviewFailed, "the PR reviewer stopped before recording a verdict")), time.Unix(3, 0)),
+	}
+	card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
+
+	assert.Equal(t, BoardDoneStage, card.Stage)
+	assert.Equal(t, BoardFailed, card.State)
+	assert.Equal(t, DeployPhasePRReview, card.DeployPhase, "the half that was running under the red")
+}
+
+// The fix half reddened is named as the fix half.
+func TestDeployPhaseFor_FailedFixHalf(t *testing.T) {
+	comments := []tracker.Comment{
+		cmt(prReviewStartedBody("https://example/pr/7", 7, "feat/x"), time.Unix(2, 0)),
+		cmt(PRFixStartedHeader, time.Unix(3, 0)),
+		cmt(markerBody(failureMarker(MarkerPRReviewFailed, "the PR fixer stopped before recording an exit")), time.Unix(4, 0)),
+	}
+	card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
+	assert.Equal(t, DeployPhasePRFix, card.DeployPhase)
+}
+
+// A deploy-path failure names no loop half: answering it with a PR-loop
+// container left over from an earlier round would be a false "still working".
+func TestDeployPhaseFor_FailedDeployNamesNoHalf(t *testing.T) {
+	comments := []tracker.Comment{
+		cmt(prReviewStartedBody("https://example/pr/7", 7, "feat/x"), time.Unix(2, 0)),
+		cmt(PRFixStartedHeader, time.Unix(3, 0)),
+		cmt(markerBody(marker.Marker{Type: MarkerDeployFixStarted, Fields: fields("pr", "https://example/pr/7", "number", "7", "branch", "feat/x"), Body: "CI failed"}, "pr", "number", "branch"), time.Unix(4, 0)),
+		cmt(markerBody(failureMarker(MarkerDeployFailed, "the deploy fixer could not resolve the conflict")), time.Unix(5, 0)),
+	}
+	card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
+	assert.Equal(t, BoardFailed, card.State)
+	assert.Empty(t, card.DeployPhase, "the deploy path started last, so no loop half is claimed")
+}


### PR DESCRIPTION
The last class of SC-4151 — A1's render half, unblocked now that #414 (SC-3569) has merged. It builds on that PR's liveness overlay rather than duplicating it.

**The case.** A failure marker is durable and a run need not have ended when one lands. On SC-3852 (2026-08-10) a `pr-review-failed` marker stood on the card for an hour while the reviewer it described kept making tool calls and then recorded `changes-requested`. The card asked a person to check a pull request about work that was still being done, and lost its running badge in the same instant it gained the error.

**Why the overlay did not already cover it.** SC-3569 answers the opposite question — it refuses to claim work is happening when no agent is behind the card. It never reached this one because `AgentNamesForCard` returned nil for a failed card, so its liveness was never even asked.

**The change.** A failed card names the agent that would be running its stage, so the overlay can answer. A badge with a live agent behind it moves to the machine register and says the run may still finish. The marker is not hidden — the recorded reason rides the tooltip, the detail panel is untouched — it just stops being the last word.

**The narrowing.** A failed done-stage card names the loop half that was started *underneath* the failure (`doneStageStartedHalf`), and names none when the deploy or deploy-fix path started last. That is the same protection the deploy fixer already has in this function: answering a deploy-path failure with a PR-loop container left over from an earlier round would turn an unreaped container into a false "still working". Covered by a test.

`deployPhaseFor` now reports for failed done-stage cards too. Safe by inspection: the only two consumers are `AgentNamesForCard` and the badge, and the badge reads `deployPhase` solely inside its `state === "running"` branch.

## Verification
`make check` exit 0, `go test ./cmd/...` exit 0, `make fsm` well-formed, `go vet -tags wailsapp ./desktop/...` clean, 267 frontend tests pass (14 new), `dist/` matches its rebuild.

## SC-4151 after this
All 17 findings shipped, across #473, #475, #476, #477 and this one. A1's *write* side needed no change and none was made: every failure path is already gated by the discriminator that suits it, and a liveness guard on `escalatePRLoop` would suppress legitimate escalations because `agent.ListMetas()` still reports the exiting agent as running when its Stop hook fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)