### PR TITLE
[SC-4118] Give the board exit and reconcile paths their domain objects

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -901,19 +901,32 @@ func runDaemonForeground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string,
 		defer cancel()
 		return (&dockerAgentCleaner{}).DeleteAgent(stopCtx, agentName)
 	}
-	go daemon.RunBoardReconcile(ctx,
-		boardReconcileListerFunc(ds.srv.Projects, ds.vaultResolver, logger),
+	go daemon.RunBoardReconcile(ctx, daemon.ReconcileDeps{
+		ListCards: boardReconcileListerFunc(ds.srv.Projects, ds.vaultResolver, logger),
+		Reachable: branchReachable,
 		// A nil participation predicate means "participate in every visible
 		// project" — the backward-compatible default. A machine that opts into a
 		// narrower set supplies a predicate here (SC-2047 opt-in participation).
-		branchReachable, boardParticipation(ds.srv.Projects), boardTicketIdentity(ds.srv.Projects), commitsPresent, prMerged, postDeployed,
-		liveBoardAgents, postFailedMarkerFunc(ds.srv.Projects, ds.vaultResolver, ds.daemonID),
-		closedTicketProbeFunc(ds.srv.Projects, ds.vaultResolver),
+		Participates:   boardParticipation(ds.srv.Projects),
+		IdentityFor:    boardTicketIdentity(ds.srv.Projects),
+		CommitsPresent: commitsPresent,
+		MergedProbe:    prMerged,
+		PostDeployed:   postDeployed,
+		LiveAgents:     liveBoardAgents,
+		PostFailed:     postFailedMarkerFunc(ds.srv.Projects, ds.vaultResolver, ds.daemonID),
+		ClosedProbe:    closedTicketProbeFunc(ds.srv.Projects, ds.vaultResolver),
+		ChainReview:    durableChainReview,
 		// The durable re-drive has no exiting agent to attribute — the run it is
 		// recovering from is long gone — so it drives the loop with no run identity
 		// and any escalation falls back to its generic line.
-		durableChainReview, func(pmKey string) error { return advancePRLoop(pmKey, "", "") },
-		stageRetry, agentProgress, stopHungAgent, ds.daemonID, daemon.BoardReconcileInterval, logger)
+		DriveLoop: func(pmKey string) error { return advancePRLoop(pmKey, "", "") },
+		Retry:     stageRetry,
+		Progress:  agentProgress,
+		StopAgent: stopHungAgent,
+		DaemonID:  ds.daemonID,
+		Interval:  daemon.BoardReconcileInterval,
+		Logger:    logger,
+	})
 
 	// Surface tickets created or edited outside the board (tracker web UI, CLI,
 	// another teammate or daemon) — none raise a board event — by polling the

--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -764,7 +764,7 @@ func runDaemonForeground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string,
 			errorType = daemon.ReapSilenceErrorType + ":" + reason.Idle.Round(time.Second).String()
 		}
 		hookEvents.Append(hookevents.Event{
-			EventName: "StopFailure",
+			EventName: hookevents.EventStopFailure,
 			AgentName: agentName,
 			ErrorType: errorType,
 			Timestamp: time.Now().UTC(),

--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -859,9 +859,21 @@ func runDaemonForeground(cmd *cobra.Command, addr, chromeAddr, proxyAddr string,
 			decStageRetries(ctx, boardStateProject(ds.srv.Projects, pmKey), pmKey, stage)
 		},
 	}
-	go daemon.RunBoardFailureWatch(ctx, ds.srv.HookEvents, boardRuns,
-		boardPMCommenterFunc(ds.srv.Projects, ds.vaultResolver, ds.daemonID),
-		liveChainReview, liveBoardAgents, advancePRLoop, advanceDeployFix, branchReachable, commitsPresent, diagnoseFailure, onHandoff, stageRetry, ds.modelSink.LatestClass, ds.daemonID, logger)
+	go daemon.RunBoardFailureWatch(ctx, ds.srv.HookEvents, boardRuns, daemon.FailureDeps{
+		CommenterFor:     boardPMCommenterFunc(ds.srv.Projects, ds.vaultResolver, ds.daemonID),
+		ChainReview:      liveChainReview,
+		LiveAgents:       liveBoardAgents,
+		AdvancePRLoop:    advancePRLoop,
+		AdvanceDeployFix: advanceDeployFix,
+		Reachable:        branchReachable,
+		CommitsPresent:   commitsPresent,
+		Diagnose:         diagnoseFailure,
+		OnHandoff:        onHandoff,
+		Retry:            stageRetry,
+		LatestClass:      ds.modelSink.LatestClass,
+		DaemonID:         ds.daemonID,
+		Logger:           logger,
+	})
 	// The live chain fires only on the one-shot exit hook; this pass re-scans
 	// comments to recover a handoff orphaned by a daemon restart or lost hook
 	// (SC-430).

--- a/internal/claude/hookevents/parser.go
+++ b/internal/claude/hookevents/parser.go
@@ -62,7 +62,7 @@ func ApplyEvent(snap *SessionSnapshot, evt *Event) {
 		snap.BlockedTool = ""
 		snap.Status = logparser.StatusWorking
 
-	case "Stop", "SubagentStop":
+	case EventStop, "SubagentStop":
 		// Stop after StopFailure keeps error visible.
 		if snap.Status != logparser.StatusError {
 			snap.Status = logparser.StatusReady
@@ -70,7 +70,7 @@ func ApplyEvent(snap *SessionSnapshot, evt *Event) {
 		snap.CurrentTool = ""
 		snap.BlockedTool = ""
 
-	case "StopFailure":
+	case EventStopFailure:
 		snap.Status = logparser.StatusError
 		snap.ErrorType = evt.ErrorType
 		snap.CurrentTool = ""
@@ -89,7 +89,7 @@ func ApplyEvent(snap *SessionSnapshot, evt *Event) {
 		snap.BlockedTool = ""
 		snap.ErrorType = ""
 
-	case "SessionEnd":
+	case EventSessionEnd:
 		snap.Status = logparser.StatusEnded
 		snap.CurrentTool = ""
 		snap.BlockedTool = ""

--- a/internal/claude/hookevents/types.go
+++ b/internal/claude/hookevents/types.go
@@ -6,6 +6,29 @@ import (
 	"github.com/gethuman-sh/human/internal/claude/logparser"
 )
 
+// The event names that mean a run ENDED. They are named because the difference
+// between them is load-bearing and invisible in the string: Stop and SessionEnd
+// are a clean exit-0, StopFailure is the zombie sweep's synthesized death, and
+// both kinds carry an empty ErrorType — so the name is the only thing that
+// tells a finished stage from a killed one.
+//
+// Only this subset is named. The rest of the vocabulary (PreToolUse,
+// PostToolUse, Notification, …) is read in one switch in this package, where a
+// literal has nowhere to drift to; these three are matched by four separate
+// readers in the daemon.
+const (
+	EventStop        = "Stop"
+	EventSessionEnd  = "SessionEnd"
+	EventStopFailure = "StopFailure"
+)
+
+// IsRunEnd reports whether an event name means the run ended, cleanly or not.
+// The three readers that used to spell the disjunction by hand are the reason
+// it exists: they must agree, and nothing made them.
+func IsRunEnd(eventName string) bool {
+	return eventName == EventStop || eventName == EventSessionEnd || eventName == EventStopFailure
+}
+
 // Event represents a single hook event line from events.jsonl.
 type Event struct {
 	EventName        string    `json:"event"`

--- a/internal/daemon/agentcleanup.go
+++ b/internal/daemon/agentcleanup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/gethuman-sh/human/internal/claude/hookevents"
 	"github.com/rs/zerolog"
 )
 
@@ -79,7 +80,7 @@ func RunAgentCleanup(ctx context.Context, store *HookEventStore, cleaner AgentCl
 				if evt.AgentName == "" {
 					continue
 				}
-				if evt.EventName != "Stop" && evt.EventName != "SessionEnd" && evt.EventName != "StopFailure" {
+				if !hookevents.IsRunEnd(evt.EventName) {
 					continue
 				}
 				go cleanupAfterExit(ctx, cleaner, alive, evt.AgentName, logger)

--- a/internal/daemon/agentprogress.go
+++ b/internal/daemon/agentprogress.go
@@ -103,7 +103,7 @@ func trackProgress(progress map[string]AgentProgress, evt hookevents.Event) {
 	}
 	// A finished agent is not a stalled one; drop it so a completed run cannot
 	// later be mistaken for a hang.
-	if evt.EventName == "Stop" || evt.EventName == "SessionEnd" || evt.EventName == "StopFailure" {
+	if hookevents.IsRunEnd(evt.EventName) {
 		delete(progress, evt.AgentName)
 		return
 	}

--- a/internal/daemon/board_failure.go
+++ b/internal/daemon/board_failure.go
@@ -49,6 +49,32 @@ type LatestOutcomeClass func(ticket, stage string) (string, bool)
 // empty-handed diagnosers so the marker never posts headerless.
 const genericStageFailure = "agent exited without completing the stage"
 
+// AdvanceDeployFix re-enters the deploy after its fixer exits: the fixer is not
+// a board stage, so its exit is driven here rather than through the generic
+// stage-failure path. A nil value leaves the exit unrouted.
+//
+// It shares an underlying signature with ChainReview and DriveLoop and means
+// something else; see ChainReview for why all three are named types.
+type AdvanceDeployFix func(pmKey string) error
+
+// AdvancePRLoop advances the PR review→fix loop on a step's exit. The exiting
+// run's name and error type travel with the call because a step that died
+// before recording its outcome can only be explained from its artifacts
+// (SC-1892). A nil value leaves the exit unrouted.
+type AdvancePRLoop func(pmKey, agentName, errorType string) error
+
+// CommenterFor resolves the PM-role commenter lazily, per event, so the watcher
+// holds no tracker handle across its lifetime. The PM commenter MUST be
+// resolved by role, never by key prefix — both trackers may share a name.
+type CommenterFor func() (tracker.Commenter, error)
+
+// OnHandoff fires with an exiting agent's name the moment its stage is observed
+// to have ended cleanly. It is the success signal that authorizes reclaiming
+// the run's private worktree; every other exit KEEPS the worktree so
+// uncommitted work is never destroyed (SC-731). Best-effort and idempotent by
+// contract. A nil value skips the authorization.
+type OnHandoff func(agentName string)
+
 // RunBoardFailureWatch watches for SessionEnd-style hook events from board
 // agents and posts the stage's *-failed marker when an agent exits WITHOUT
 // having posted its stage's done-marker. This closes the gap where an agent
@@ -69,7 +95,7 @@ const genericStageFailure = "agent exited without completing the stage"
 // resolved marker). It is the success signal that authorizes reclaiming the
 // run's private worktree — every other exit KEEPS the worktree so uncommitted
 // work is never destroyed (SC-731). Best-effort/idempotent by contract.
-func RunBoardFailureWatch(ctx context.Context, store *HookEventStore, runs *RunRegistry, commenterFor func() (tracker.Commenter, error), chainReview func(pmKey string) error, liveAgents LiveAgentLister, advancePRLoop func(pmKey, agentName, errorType string) error, advanceDeployFix func(pmKey string) error, reachable BranchReachable, commitsPresent CommitsPresent, diagnose BoardFailureDiagnoser, onHandoff func(agentName string), retry StageRetry, latestClass LatestOutcomeClass, daemonID string, logger zerolog.Logger) {
+func RunBoardFailureWatch(ctx context.Context, store *HookEventStore, runs *RunRegistry, commenterFor CommenterFor, chainReview ChainReview, liveAgents LiveAgentLister, advancePRLoop AdvancePRLoop, advanceDeployFix AdvanceDeployFix, reachable BranchReachable, commitsPresent CommitsPresent, diagnose BoardFailureDiagnoser, onHandoff OnHandoff, retry StageRetry, latestClass LatestOutcomeClass, daemonID string, logger zerolog.Logger) {
 	if store == nil || commenterFor == nil {
 		return
 	}
@@ -160,7 +186,7 @@ func claimExit(runs *RunRegistry, runID, agentName string, logger zerolog.Logger
 // is used to derive cleanExit, which in turn guards against misreading a
 // clean finish that merely raced its own review-complete propagation as a
 // mid-review crash (SC-2133).
-func handleBoardAgentExit(ctx context.Context, runs *RunRegistry, runID, agentName, errorType, eventName string, commenterFor func() (tracker.Commenter, error), chainReview func(pmKey string) error, liveAgents LiveAgentLister, advancePRLoop func(pmKey, agentName, errorType string) error, advanceDeployFix func(pmKey string) error, reachable BranchReachable, commitsPresent CommitsPresent, diagnose BoardFailureDiagnoser, onHandoff func(agentName string), retry StageRetry, latestClass LatestOutcomeClass, daemonID string, logger zerolog.Logger) {
+func handleBoardAgentExit(ctx context.Context, runs *RunRegistry, runID, agentName, errorType, eventName string, commenterFor CommenterFor, chainReview ChainReview, liveAgents LiveAgentLister, advancePRLoop AdvancePRLoop, advanceDeployFix AdvanceDeployFix, reachable BranchReachable, commitsPresent CommitsPresent, diagnose BoardFailureDiagnoser, onHandoff OnHandoff, retry StageRetry, latestClass LatestOutcomeClass, daemonID string, logger zerolog.Logger) {
 	pmKey, stage, ok := claimExit(runs, runID, agentName, logger)
 	if !ok {
 		return
@@ -270,7 +296,7 @@ func endedDeliberately(comments []tracker.Comment, stage BoardStage, state Board
 		deliberateStopRecorded(comments)
 }
 
-func handleCleanStageEnding(ctx context.Context, pmKey string, stage BoardStage, agentName, errorType string, cleanExit bool, comments []tracker.Comment, commenter tracker.Commenter, chainReview func(pmKey string) error, liveAgents LiveAgentLister, reachable BranchReachable, commitsPresent CommitsPresent, diagnose BoardFailureDiagnoser, onHandoff func(agentName string), retry StageRetry, daemonID string, logger zerolog.Logger) bool {
+func handleCleanStageEnding(ctx context.Context, pmKey string, stage BoardStage, agentName, errorType string, cleanExit bool, comments []tracker.Comment, commenter tracker.Commenter, chainReview ChainReview, liveAgents LiveAgentLister, reachable BranchReachable, commitsPresent CommitsPresent, diagnose BoardFailureDiagnoser, onHandoff OnHandoff, retry StageRetry, daemonID string, logger zerolog.Logger) bool {
 	_, state := latestStageState(comments, stage)
 	clean := state == BoardDone
 	if !clean && !endedDeliberately(comments, stage, state) {
@@ -311,7 +337,7 @@ func handleCleanStageEnding(ctx context.Context, pmKey string, stage BoardStage,
 // own exit is the correct evidence, so this path posts nothing and lets it be.
 // Otherwise it flows into chainReviewAfterBuild's branch/commit-gated chain. A
 // nil chainReview disables chaining entirely.
-func chainReviewAfterCleanBuild(ctx context.Context, pmKey, agentName, errorType string, cleanExit bool, comments []tracker.Comment, commenter tracker.Commenter, chainReview func(pmKey string) error, liveAgents LiveAgentLister, reachable BranchReachable, commitsPresent CommitsPresent, diagnose BoardFailureDiagnoser, daemonID string, logger zerolog.Logger) {
+func chainReviewAfterCleanBuild(ctx context.Context, pmKey, agentName, errorType string, cleanExit bool, comments []tracker.Comment, commenter tracker.Commenter, chainReview ChainReview, liveAgents LiveAgentLister, reachable BranchReachable, commitsPresent CommitsPresent, diagnose BoardFailureDiagnoser, daemonID string, logger zerolog.Logger) {
 	if chainReview == nil {
 		return
 	}
@@ -467,7 +493,7 @@ func handoffSearchNote(stage BoardStage, header string) string {
 // the flag that authorizes removing the run's worktree, and the FIXER's
 // deliverable is an unpushed local commit by design — waiving that protection on
 // an error the run then recovers from is how the commit would be lost.
-func drivePRLoopExit(pmKey string, stage BoardStage, agentName, errorType string, advancePRLoop func(pmKey, agentName, errorType string) error, onHandoff func(agentName string), logger zerolog.Logger) bool {
+func drivePRLoopExit(pmKey string, stage BoardStage, agentName, errorType string, advancePRLoop AdvancePRLoop, onHandoff OnHandoff, logger zerolog.Logger) bool {
 	if stage != prReviewAgentStage && stage != prFixAgentStage {
 		return false
 	}
@@ -492,7 +518,7 @@ func drivePRLoopExit(pmKey string, stage BoardStage, agentName, errorType string
 // its worktree first (the fixer already pushed its work). It reports whether the
 // exit was the deploy-fix stage and thus fully handled here. A non-deployfix stage
 // returns false so the caller falls through to the PR-loop / stage-failure handling.
-func driveDeployFixExit(pmKey string, stage BoardStage, agentName string, advanceDeployFix func(pmKey string) error, onHandoff func(agentName string), logger zerolog.Logger) bool {
+func driveDeployFixExit(pmKey string, stage BoardStage, agentName string, advanceDeployFix AdvanceDeployFix, onHandoff OnHandoff, logger zerolog.Logger) bool {
 	if stage != deployFixAgentStage {
 		return false
 	}
@@ -551,7 +577,7 @@ func stagePausedOnOptions(comments []tracker.Comment, stage BoardStage) bool {
 // commit gate is wired) the handoff's named commits must actually be present on
 // that branch. Pulled out of handleBoardAgentExit so the exit handler stays a
 // thin stage dispatcher and the chain's gates read as one unit.
-func chainReviewAfterBuild(ctx context.Context, pmKey string, comments []tracker.Comment, commenter tracker.Commenter, chainReview func(pmKey string) error, reachable BranchReachable, commitsPresent CommitsPresent, daemonID string, logger zerolog.Logger) {
+func chainReviewAfterBuild(ctx context.Context, pmKey string, comments []tracker.Comment, commenter tracker.Commenter, chainReview ChainReview, reachable BranchReachable, commitsPresent CommitsPresent, daemonID string, logger zerolog.Logger) {
 	// Only chain a review for a branch this machine can resolve; a board-context
 	// fix leaves its branch local on the machine that produced it, so a daemon
 	// elsewhere must leave the handoff for one that can reach it rather than start

--- a/internal/daemon/board_failure.go
+++ b/internal/daemon/board_failure.go
@@ -76,6 +76,81 @@ type CommenterFor func() (tracker.Commenter, error)
 // contract. A nil value skips the authorization.
 type OnHandoff func(agentName string)
 
+// RunExit is one board agent run's exit: what the hook event said, resolved to
+// the work the daemon's own launch record says it was for, plus the ticket's
+// comment thread as read after the exit.
+//
+// It exists because these values are one event with one lifetime and were
+// threaded through nine functions as separate parameters. Two of them,
+// AgentName and ErrorType, are adjacent strings in five signatures: swapping
+// them compiles, reviews clean, and posts a failure marker naming the error as
+// the agent.
+//
+// Not to be confused with StageExit (board_retry.go), which is what the agent
+// SAID on its way out — the exit class it wrote into its own stage report. This
+// is what the hook OBSERVED, and the two disagree exactly when a run dies
+// before it can report.
+type RunExit struct {
+	PMKey     string
+	Stage     BoardStage
+	AgentName string
+	// ErrorType is the exit event's own error type, "" when it carried none.
+	ErrorType string
+	// Event is the hook event's name — hookevents.EventStop, EventSessionEnd,
+	// or the zombie sweep's synthesized EventStopFailure.
+	Event string
+	// Comments is the PM ticket's thread, read once per exit and settled (see
+	// listStageSettled). Empty until withComments has run: the exits routed to
+	// the PR loop and the deploy fixer are decided before any comment is read,
+	// and making them pay for a tracker round-trip to be dispatched would be a
+	// behaviour change, not a refactor.
+	Comments []tracker.Comment
+}
+
+// CleanExit reports whether the run ended of its own accord rather than being
+// killed. A reap synthesizes StopFailure for a genuinely dead run; a clean
+// exit-0 fires Stop or SessionEnd — and both kinds carry an empty ErrorType, so
+// the event name is the only thing that tells them apart.
+//
+// It is DERIVED, never stored. The value used to be computed once and then
+// travel beside the event it came from, which let a caller pass a cleanExit
+// that contradicted its own eventName; the two could not be checked against
+// each other because only one of them was ever the source.
+func (e RunExit) CleanExit() bool { return e.Event != hookevents.EventStopFailure }
+
+// withComments returns the exit with the ticket thread attached.
+func (e RunExit) withComments(comments []tracker.Comment) RunExit {
+	e.Comments = comments
+	return e
+}
+
+// FailureDeps wires the exit path's collaborators, mirroring
+// BoardTransitionDeps in the same package. Every field follows the package's
+// "nil disables" convention.
+type FailureDeps struct {
+	CommenterFor     CommenterFor
+	ChainReview      ChainReview
+	LiveAgents       LiveAgentLister
+	AdvancePRLoop    AdvancePRLoop
+	AdvanceDeployFix AdvanceDeployFix
+	Reachable        BranchReachable
+	CommitsPresent   CommitsPresent
+	Diagnose         BoardFailureDiagnoser
+	OnHandoff        OnHandoff
+	Retry            StageRetry
+	LatestClass      LatestOutcomeClass
+	// DaemonID stamps this daemon's identity on every marker the exit path posts.
+	DaemonID string
+	Logger   zerolog.Logger
+}
+
+// handoff fires the worktree-reclaim authorization, if one is wired.
+func (d FailureDeps) handoff(agentName string) {
+	if d.OnHandoff != nil {
+		d.OnHandoff(agentName)
+	}
+}
+
 // RunBoardFailureWatch watches for SessionEnd-style hook events from board
 // agents and posts the stage's *-failed marker when an agent exits WITHOUT
 // having posted its stage's done-marker. This closes the gap where an agent
@@ -88,16 +163,11 @@ type OnHandoff func(agentName string)
 // comment-scan, so pre-existing handoffs are not retroactively reviewed on
 // daemon start. nil chainReview disables chaining.
 //
-// commenterFor resolves the PM-role commenter lazily (per event) so the watcher
-// holds no tracker handle across its lifetime; the PM commenter MUST be
-// resolved by role, never by key prefix (both trackers may share a name).
-// onHandoff, when non-nil, is fired with the exiting agent's name the moment
-// its stage is observed to have ended cleanly (a done/handoff or terminal
-// resolved marker). It is the success signal that authorizes reclaiming the
-// run's private worktree — every other exit KEEPS the worktree so uncommitted
-// work is never destroyed (SC-731). Best-effort/idempotent by contract.
-func RunBoardFailureWatch(ctx context.Context, store *HookEventStore, runs *RunRegistry, commenterFor CommenterFor, chainReview ChainReview, liveAgents LiveAgentLister, advancePRLoop AdvancePRLoop, advanceDeployFix AdvanceDeployFix, reachable BranchReachable, commitsPresent CommitsPresent, diagnose BoardFailureDiagnoser, onHandoff OnHandoff, retry StageRetry, latestClass LatestOutcomeClass, daemonID string, logger zerolog.Logger) {
-	if store == nil || commenterFor == nil {
+// The collaborators travel as one FailureDeps: see its doc comment, and
+// RunExit's, for why the exit and its dependencies each became a value.
+func RunBoardFailureWatch(ctx context.Context, store *HookEventStore, runs *RunRegistry, deps FailureDeps) {
+	logger := deps.Logger
+	if store == nil || deps.CommenterFor == nil {
 		return
 	}
 
@@ -126,7 +196,7 @@ func RunBoardFailureWatch(ctx context.Context, store *HookEventStore, runs *RunR
 				if !hookevents.IsRunEnd(evt.EventName) {
 					continue
 				}
-				go handleBoardAgentExit(ctx, runs, evt.RunID, evt.AgentName, evt.ErrorType, evt.EventName, commenterFor, chainReview, liveAgents, advancePRLoop, advanceDeployFix, reachable, commitsPresent, diagnose, onHandoff, retry, latestClass, daemonID, logger)
+				go handleBoardAgentExit(ctx, runs, evt, deps)
 			}
 		}
 	}
@@ -181,61 +251,63 @@ func claimExit(runs *RunRegistry, runID, agentName string, logger zerolog.Logger
 // finished build chains into its review. Pulled out so the watch loop stays a
 // thin event dispatcher.
 //
-// eventName is the hook event's own name ("Stop", "SessionEnd", or the zombie
-// sweep's synthesized "StopFailure") — the only signal that discriminates a
-// clean exit-0 from a genuine death, since both carry an empty ErrorType. It
-// is used to derive cleanExit, which in turn guards against misreading a
-// clean finish that merely raced its own review-complete propagation as a
-// mid-review crash (SC-2133).
-func handleBoardAgentExit(ctx context.Context, runs *RunRegistry, runID, agentName, errorType, eventName string, commenterFor CommenterFor, chainReview ChainReview, liveAgents LiveAgentLister, advancePRLoop AdvancePRLoop, advanceDeployFix AdvanceDeployFix, reachable BranchReachable, commitsPresent CommitsPresent, diagnose BoardFailureDiagnoser, onHandoff OnHandoff, retry StageRetry, latestClass LatestOutcomeClass, daemonID string, logger zerolog.Logger) {
-	pmKey, stage, ok := claimExit(runs, runID, agentName, logger)
+// The exit travels as one RunExit. Its CleanExit — the only signal that
+// discriminates a clean exit-0 from a genuine death, since both carry an empty
+// ErrorType — is derived from the event rather than computed here and passed
+// along beside it. It guards against misreading a clean finish that merely
+// raced its own review-complete propagation as a mid-review crash (SC-2133).
+func handleBoardAgentExit(ctx context.Context, runs *RunRegistry, evt hookevents.Event, deps FailureDeps) {
+	logger := deps.Logger
+	pmKey, stage, ok := claimExit(runs, evt.RunID, evt.AgentName, logger)
 	if !ok {
 		return
 	}
+	exit := RunExit{
+		PMKey:     pmKey,
+		Stage:     stage,
+		AgentName: evt.AgentName,
+		ErrorType: evt.ErrorType,
+		Event:     evt.EventName,
+	}
 	// The deploy-fixer is not a board stage: its exit re-runs the deploy (on `done`)
 	// or reds the card, driven by AdvanceDeployFix — not the generic stage-failure path.
-	if driveDeployFixExit(pmKey, stage, agentName, advanceDeployFix, onHandoff, logger) {
+	if driveDeployFixExit(exit, deps) {
 		return
 	}
 	// The PR review→fix loop steps are not board stages: their exits are driven
 	// by the loop executor, not the generic stage-failure path below.
-	if drivePRLoopExit(pmKey, stage, agentName, errorType, advancePRLoop, onHandoff, logger) {
+	if drivePRLoopExit(exit, deps) {
 		return
 	}
-	commenter, err := commenterFor()
+	commenter, err := deps.CommenterFor()
 	if err != nil {
-		logger.Warn().Err(err).Str("agent", agentName).Msg("board failure: cannot resolve PM commenter")
+		logger.Warn().Err(err).Str("agent", exit.AgentName).Msg("board failure: cannot resolve PM commenter")
 		return
 	}
-	// A reap synthesizes "StopFailure" for a genuinely dead run; a clean exit-0
-	// fires "Stop" or "SessionEnd" — both carry an empty ErrorType, so eventName
-	// is the only thing that tells them apart. cleanExit gates the mid-review
-	// death check below: a clean exit-0 that merely raced its own
-	// review-complete propagation is never a death (SC-2133).
-	cleanExit := eventName != hookevents.EventStopFailure
 	// A clean stage finish leaves the stage's done-marker as the latest marker;
 	// only treat the exit as a failure when that did NOT happen. Re-read with
 	// bounded backoff first: a reap-synthesized exit can be handled before the
 	// just-posted hand-off comment is visible on the tracker (SC-1484's
 	// read-after-write race) — polling briefly for a settled state closes that
 	// window without changing behavior for a genuinely incomplete stage.
-	comments, err := listStageSettled(ctx, commenter, pmKey, stage)
+	comments, err := listStageSettled(ctx, commenter, exit.PMKey, exit.Stage)
 	if err != nil {
-		logger.Warn().Err(err).Str("agent", agentName).Msg("board failure: cannot list comments")
+		logger.Warn().Err(err).Str("agent", exit.AgentName).Msg("board failure: cannot list comments")
 		return
 	}
-	if handleCleanStageEnding(ctx, pmKey, stage, agentName, errorType, cleanExit, comments, commenter, chainReview, liveAgents, reachable, commitsPresent, diagnose, onHandoff, retry, daemonID, logger) {
+	exit = exit.withComments(comments)
+	if handleCleanStageEnding(ctx, exit, commenter, deps) {
 		return
 	}
 	// A refusal that kills the agent before it records an exit (the SC-2856
 	// incident: a session-limit refusal) is classified from the hook errorType
 	// and the model-boundary class BEFORE the outage gate below, so it is
 	// recognised even when retry.recordedOutage sees nothing.
-	kind, reason := classifyUnavailability(errorType, latestClass, pmKey, string(stage))
-	if handleOutageExit(ctx, pmKey, stage, agentName, errorType, comments, commenter, diagnose, retry, kind, reason, daemonID, logger) {
+	kind, reason := classifyUnavailability(exit.ErrorType, deps.LatestClass, exit.PMKey, string(exit.Stage))
+	if handleOutageExit(ctx, exit, commenter, deps, kind, reason) {
 		return
 	}
-	if handleNeedsPersonExit(ctx, pmKey, stage, agentName, kind, reason, commenter, logger) {
+	if handleNeedsPersonExit(ctx, exit, kind, reason, commenter, logger) {
 		return
 	}
 	// A silence reap (the zombie sweep reaping an agent that went quiet — no
@@ -245,12 +317,12 @@ func handleBoardAgentExit(ctx context.Context, runs *RunRegistry, runID, agentNa
 	// the trail must say plainly what was observed and why (SC-2447/SC-3074).
 	// Checked before the generic failure path so the sentinel never falls
 	// through to the charged branch below.
-	if handleSilenceReapExit(ctx, pmKey, stage, agentName, errorType, comments, commenter, retry, logger) {
+	if handleSilenceReapExit(ctx, exit, commenter, deps) {
 		return
 	}
-	diagnosis := appendModelOutcomeNote(failureMarkerBody(diagnose, agentName, errorType), latestClass, pmKey, string(stage))
-	if err := postMarker(ctx, commenter, pmKey, failureMarker(failedTypeFor(stage), diagnosis)); err != nil {
-		logger.Warn().Err(err).Str("agent", agentName).Msg("board failure: cannot post failed marker")
+	diagnosis := appendModelOutcomeNote(failureMarkerBody(deps.Diagnose, exit.AgentName, exit.ErrorType), deps.LatestClass, exit.PMKey, string(exit.Stage))
+	if err := postMarker(ctx, commenter, exit.PMKey, failureMarker(failedTypeFor(exit.Stage), diagnosis)); err != nil {
+		logger.Warn().Err(err).Str("agent", exit.AgentName).Msg("board failure: cannot post failed marker")
 		// Without the failed marker the card does not derive to a failed state,
 		// which is precisely what every in-place retry transition requires — so
 		// an automatic relaunch would be rejected. Leave it for a human.
@@ -259,7 +331,7 @@ func handleBoardAgentExit(ctx context.Context, runs *RunRegistry, runID, agentNa
 	// A stage that failed for a reason another attempt could fix — a flake, a
 	// dead container — is relaunched here rather than waiting for someone to
 	// click Retry. The failure stays on the record either way.
-	retry.tryRelaunch(ctx, pmKey, stage, commenter, daemonID, logger)
+	deps.Retry.tryRelaunch(ctx, exit.PMKey, exit.Stage, commenter, deps.DaemonID, logger)
 }
 
 // handleCleanStageEnding deals with every way a stage exit is NOT a failure, and
@@ -297,23 +369,21 @@ func endedDeliberately(comments []tracker.Comment, stage BoardStage, state Board
 		deliberateStopRecorded(comments)
 }
 
-func handleCleanStageEnding(ctx context.Context, pmKey string, stage BoardStage, agentName, errorType string, cleanExit bool, comments []tracker.Comment, commenter tracker.Commenter, chainReview ChainReview, liveAgents LiveAgentLister, reachable BranchReachable, commitsPresent CommitsPresent, diagnose BoardFailureDiagnoser, onHandoff OnHandoff, retry StageRetry, daemonID string, logger zerolog.Logger) bool {
-	_, state := latestStageState(comments, stage)
+func handleCleanStageEnding(ctx context.Context, exit RunExit, commenter tracker.Commenter, deps FailureDeps) bool {
+	_, state := latestStageState(exit.Comments, exit.Stage)
 	clean := state == BoardDone
-	if !clean && !endedDeliberately(comments, stage, state) {
+	if !clean && !endedDeliberately(exit.Comments, exit.Stage, state) {
 		return false
 	}
 	// A clean finish clears the automatic-retry budget: the next failure on this
 	// stage is a fresh problem and deserves its own attempts, not the remainder
 	// of an older one's.
-	retry.reset(pmKey, stage)
+	deps.Retry.reset(exit.PMKey, exit.Stage)
 	// It is also the positive success signal: authorize reclaiming the run's
 	// worktree (the work is safely committed on its branch).
-	if onHandoff != nil {
-		onHandoff(agentName)
-	}
-	if clean && stage == BoardImplementation {
-		chainReviewAfterCleanBuild(ctx, pmKey, agentName, errorType, cleanExit, comments, commenter, chainReview, liveAgents, reachable, commitsPresent, diagnose, daemonID, logger)
+	deps.handoff(exit.AgentName)
+	if clean && exit.Stage == BoardImplementation {
+		chainReviewAfterCleanBuild(ctx, exit, commenter, deps)
 	}
 	return true
 }
@@ -338,16 +408,17 @@ func handleCleanStageEnding(ctx context.Context, pmKey string, stage BoardStage,
 // own exit is the correct evidence, so this path posts nothing and lets it be.
 // Otherwise it flows into chainReviewAfterBuild's branch/commit-gated chain. A
 // nil chainReview disables chaining entirely.
-func chainReviewAfterCleanBuild(ctx context.Context, pmKey, agentName, errorType string, cleanExit bool, comments []tracker.Comment, commenter tracker.Commenter, chainReview ChainReview, liveAgents LiveAgentLister, reachable BranchReachable, commitsPresent CommitsPresent, diagnose BoardFailureDiagnoser, daemonID string, logger zerolog.Logger) {
-	if chainReview == nil {
+func chainReviewAfterCleanBuild(ctx context.Context, exit RunExit, commenter tracker.Commenter, deps FailureDeps) {
+	logger := deps.Logger
+	if deps.ChainReview == nil {
 		return
 	}
-	if vOK, vState := latestStageState(comments, BoardVerification); vOK {
+	if vOK, vState := latestStageState(exit.Comments, BoardVerification); vOK {
 		// review-complete (pass OR fail verdict) is a recorded outcome the board
 		// acts on; a review-failed marker is already retryable. Either way, do not
 		// chain a second review. Only a mid-review death — the marker still reads
 		// "running" AND the exit itself was not clean — needs a retryable marker.
-		if vState == BoardRunning && !cleanExit {
+		if vState == BoardRunning && !exit.CleanExit() {
 			// A stage is judged dead only on evidence about that stage. In the
 			// chained topology board-<key>-verification is a separate,
 			// independently-alive agent in its own container; the exiting
@@ -357,19 +428,19 @@ func chainReviewAfterCleanBuild(ctx context.Context, pmKey, agentName, errorType
 			// this the SC-782 merged case, where the exiting implementation
 			// container WAS the reviewer and `agentName` therefore correctly names
 			// the run that failed the review.
-			if verificationAgentAlive(pmKey, liveAgents, logger) {
+			if verificationAgentAlive(exit.PMKey, deps.LiveAgents, logger) {
 				return
 			}
-			failed := failureMarker(MarkerReviewFailed, failureMarkerBody(diagnose, agentName, errorType))
+			failed := failureMarker(MarkerReviewFailed, failureMarkerBody(deps.Diagnose, exit.AgentName, exit.ErrorType))
 			failed.Body = strings.TrimSpace(failed.Body + "\n\n" + handoffSearchNote(BoardVerification, ReviewCompleteHeader))
 			body := markerBody(failed)
-			if _, err := commenter.AddComment(ctx, pmKey, body); err != nil {
-				logger.Warn().Err(err).Str("pm", pmKey).Msg("board merged-stage: cannot post review-failed after mid-review exit")
+			if _, err := commenter.AddComment(ctx, exit.PMKey, body); err != nil {
+				logger.Warn().Err(err).Str("pm", exit.PMKey).Msg("board merged-stage: cannot post review-failed after mid-review exit")
 			}
 		}
 		return
 	}
-	chainReviewAfterBuild(ctx, pmKey, comments, commenter, chainReview, reachable, commitsPresent, daemonID, logger)
+	chainReviewAfterBuild(ctx, exit, commenter, deps)
 }
 
 // handleNeedsPersonExit deals with a wall that does not self-heal (a revoked
@@ -378,16 +449,16 @@ func chainReviewAfterCleanBuild(ctx context.Context, pmKey, agentName, errorType
 // exact same wall. Reports whether it handled the exit. Split out of
 // handleBoardAgentExit so this branch's complexity costs its own function
 // rather than the dispatcher's (SC-3024).
-func handleNeedsPersonExit(ctx context.Context, pmKey string, stage BoardStage, agentName string, kind endingKind, reason string, commenter tracker.Commenter, logger zerolog.Logger) bool {
+func handleNeedsPersonExit(ctx context.Context, exit RunExit, kind endingKind, reason string, commenter tracker.Commenter, logger zerolog.Logger) bool {
 	if kind != endingNeedsPerson {
 		return false
 	}
-	failedType := failedTypeFor(stage)
+	failedType := failedTypeFor(exit.Stage)
 	if failedType == "" {
 		return false
 	}
-	if err := postMarker(ctx, commenter, pmKey, failureMarker(failedType, needsPersonReason(reason))); err != nil {
-		logger.Warn().Err(err).Str("agent", agentName).Msg("board failure: cannot post needs-person marker")
+	if err := postMarker(ctx, commenter, exit.PMKey, failureMarker(failedType, needsPersonReason(reason))); err != nil {
+		logger.Warn().Err(err).Str("agent", exit.AgentName).Msg("board failure: cannot post needs-person marker")
 	}
 	return true
 }
@@ -401,31 +472,32 @@ func handleNeedsPersonExit(ctx context.Context, pmKey string, stage BoardStage, 
 // relaunching, naming the count once — silenceReapGaveUp dedups a second
 // daemon reaching the same cap. Split out of handleBoardAgentExit so this
 // branch's complexity costs its own function rather than the dispatcher's.
-func handleSilenceReapExit(ctx context.Context, pmKey string, stage BoardStage, agentName, errorType string, comments []tracker.Comment, commenter tracker.Commenter, retry StageRetry, logger zerolog.Logger) bool {
-	idle, ok := silenceReapIdle(errorType)
-	if !ok || !retry.enabled() {
+func handleSilenceReapExit(ctx context.Context, exit RunExit, commenter tracker.Commenter, deps FailureDeps) bool {
+	logger := deps.Logger
+	idle, ok := silenceReapIdle(exit.ErrorType)
+	if !ok || !deps.Retry.enabled() {
 		return false
 	}
-	failedType := failedTypeFor(stage)
+	failedType := failedTypeFor(exit.Stage)
 	if failedType == "" {
 		return false
 	}
-	if silenceReapGaveUp(comments, stage) {
+	if silenceReapGaveUp(exit.Comments, exit.Stage) {
 		return true
 	}
-	stops := silenceReapCount(comments, stage) + 1
+	stops := silenceReapCount(exit.Comments, exit.Stage) + 1
 	if stops > MaxSilenceReaps {
-		giveUp := failureMarker(failedType, silenceReapGiveUpReason(stage, stops))
-		if err := postMarker(ctx, commenter, pmKey, giveUp); err != nil {
-			logger.Warn().Err(err).Str("agent", agentName).Msg("board failure: cannot post silence-reap give-up marker")
+		giveUp := failureMarker(failedType, silenceReapGiveUpReason(exit.Stage, stops))
+		if err := postMarker(ctx, commenter, exit.PMKey, giveUp); err != nil {
+			logger.Warn().Err(err).Str("agent", exit.AgentName).Msg("board failure: cannot post silence-reap give-up marker")
 		}
 		return true
 	}
-	if err := postMarker(ctx, commenter, pmKey, failureMarker(failedType, silenceReapReason(idle))); err != nil {
-		logger.Warn().Err(err).Str("agent", agentName).Msg("board failure: cannot post silence-reap marker")
+	if err := postMarker(ctx, commenter, exit.PMKey, failureMarker(failedType, silenceReapReason(idle))); err != nil {
+		logger.Warn().Err(err).Str("agent", exit.AgentName).Msg("board failure: cannot post silence-reap marker")
 		return true
 	}
-	retry.relaunchSilenceReap(pmKey, stage, logger)
+	deps.Retry.relaunchSilenceReap(exit.PMKey, exit.Stage, logger)
 	return true
 }
 
@@ -494,22 +566,21 @@ func handoffSearchNote(stage BoardStage, header string) string {
 // the flag that authorizes removing the run's worktree, and the FIXER's
 // deliverable is an unpushed local commit by design — waiving that protection on
 // an error the run then recovers from is how the commit would be lost.
-func drivePRLoopExit(pmKey string, stage BoardStage, agentName, errorType string, advancePRLoop AdvancePRLoop, onHandoff OnHandoff, logger zerolog.Logger) bool {
-	if stage != prReviewAgentStage && stage != prFixAgentStage {
+func drivePRLoopExit(exit RunExit, deps FailureDeps) bool {
+	logger := deps.Logger
+	if exit.Stage != prReviewAgentStage && exit.Stage != prFixAgentStage {
 		return false
 	}
-	if kind, reason := classifyErrorType(errorType); kind == endingPaused {
-		logger.Info().Str("pm", pmKey).Str("stage", string(stage)).Str("agent", agentName).
+	if kind, reason := classifyErrorType(exit.ErrorType); kind == endingPaused {
+		logger.Info().Str("pm", exit.PMKey).Str("stage", string(exit.Stage)).Str("agent", exit.AgentName).
 			Str("reason", reason).
 			Msg("board PR loop: substrate failure mid-run, not treating it as the step's exit")
 		return true
 	}
-	if onHandoff != nil {
-		onHandoff(agentName)
-	}
-	if advancePRLoop != nil {
-		if err := advancePRLoop(pmKey, agentName, errorType); err != nil {
-			logger.Warn().Err(err).Str("pm", pmKey).Str("stage", string(stage)).Msg("board PR loop: advance failed")
+	deps.handoff(exit.AgentName)
+	if deps.AdvancePRLoop != nil {
+		if err := deps.AdvancePRLoop(exit.PMKey, exit.AgentName, exit.ErrorType); err != nil {
+			logger.Warn().Err(err).Str("pm", exit.PMKey).Str("stage", string(exit.Stage)).Msg("board PR loop: advance failed")
 		}
 	}
 	return true
@@ -519,16 +590,14 @@ func drivePRLoopExit(pmKey string, stage BoardStage, agentName, errorType string
 // its worktree first (the fixer already pushed its work). It reports whether the
 // exit was the deploy-fix stage and thus fully handled here. A non-deployfix stage
 // returns false so the caller falls through to the PR-loop / stage-failure handling.
-func driveDeployFixExit(pmKey string, stage BoardStage, agentName string, advanceDeployFix AdvanceDeployFix, onHandoff OnHandoff, logger zerolog.Logger) bool {
-	if stage != deployFixAgentStage {
+func driveDeployFixExit(exit RunExit, deps FailureDeps) bool {
+	if exit.Stage != deployFixAgentStage {
 		return false
 	}
-	if onHandoff != nil {
-		onHandoff(agentName)
-	}
-	if advanceDeployFix != nil {
-		if err := advanceDeployFix(pmKey); err != nil {
-			logger.Warn().Err(err).Str("pm", pmKey).Msg("board deploy fix: advance failed")
+	deps.handoff(exit.AgentName)
+	if deps.AdvanceDeployFix != nil {
+		if err := deps.AdvanceDeployFix(exit.PMKey); err != nil {
+			deps.Logger.Warn().Err(err).Str("pm", exit.PMKey).Msg("board deploy fix: advance failed")
 		}
 	}
 	return true
@@ -578,48 +647,49 @@ func stagePausedOnOptions(comments []tracker.Comment, stage BoardStage) bool {
 // commit gate is wired) the handoff's named commits must actually be present on
 // that branch. Pulled out of handleBoardAgentExit so the exit handler stays a
 // thin stage dispatcher and the chain's gates read as one unit.
-func chainReviewAfterBuild(ctx context.Context, pmKey string, comments []tracker.Comment, commenter tracker.Commenter, chainReview ChainReview, reachable BranchReachable, commitsPresent CommitsPresent, daemonID string, logger zerolog.Logger) {
+func chainReviewAfterBuild(ctx context.Context, exit RunExit, commenter tracker.Commenter, deps FailureDeps) {
+	logger := deps.Logger
 	// Only chain a review for a branch this machine can resolve; a board-context
 	// fix leaves its branch local on the machine that produced it, so a daemon
 	// elsewhere must leave the handoff for one that can reach it rather than start
 	// a review that can never check out the code (SC-652).
-	branch := latestPrefixedLine(comments, ReadyForReviewHeader, "branch:")
-	if reachable != nil {
-		switch r := reachable(branch); r.Status {
+	branch := latestPrefixedLine(exit.Comments, ReadyForReviewHeader, "branch:")
+	if deps.Reachable != nil {
+		switch r := deps.Reachable(branch); r.Status {
 		case ProbeAbsent:
 			// The branch is genuinely not on this machine — a board-context fix
 			// leaves its branch local on the machine that produced it. Leave the
 			// handoff for a daemon that can reach it (SC-652).
-			logger.Debug().Str("pm", pmKey).Str("branch", branch).
+			logger.Debug().Str("pm", exit.PMKey).Str("branch", branch).
 				Msg("board chain: handoff branch not on this machine, leaving for a daemon that can reach it")
 			return
 		case ProbeUnreadable:
 			// The reachability probe could not run (unresolvable dir, git error,
 			// timeout). Do NOT strand the work silently: surface why and leave it to
 			// be retried (SC-2403 sibling).
-			postHandoffCheckUnreadable(ctx, pmKey, branch, r.Detail, commenter, daemonID, logger)
+			postHandoffCheckUnreadable(ctx, exit.PMKey, branch, r.Detail, commenter, logger)
 			return
 		}
 	}
-	switch p := commitPresenceForHandoff(comments, branch, commitsPresent); p.Status {
+	switch p := commitPresenceForHandoff(exit.Comments, branch, deps.CommitsPresent); p.Status {
 	case ProbeAbsent:
 		// A definite phantom-commit handoff (a retry that never pushed its work) —
 		// the loud failure the ticket wants: red the card, do not review nothing.
 		phantom := failureMarker(MarkerImplementationFailed,
 			"handoff names commits absent from branch "+branch+" on this machine — re-run the fix")
-		if err := postMarker(ctx, commenter, pmKey, phantom); err != nil {
-			logger.Warn().Err(err).Str("pm", pmKey).Msg("board chain: cannot post phantom-commit failure")
+		if err := postMarker(ctx, commenter, exit.PMKey, phantom); err != nil {
+			logger.Warn().Err(err).Str("pm", exit.PMKey).Msg("board chain: cannot post phantom-commit failure")
 		}
 		return
 	case ProbeUnreadable:
 		// The commit-presence check could not be performed. Never red good work on
 		// a check that did not complete — surface which probe and why, and leave it
 		// for reconcile to retry (SC-2403).
-		postHandoffCheckUnreadable(ctx, pmKey, branch, p.Detail, commenter, daemonID, logger)
+		postHandoffCheckUnreadable(ctx, exit.PMKey, branch, p.Detail, commenter, logger)
 		return
 	}
-	if err := chainReview(pmKey); err != nil {
-		logger.Warn().Err(err).Str("pm", pmKey).Msg("board chain: cannot start review after build")
+	if err := deps.ChainReview(exit.PMKey); err != nil {
+		logger.Warn().Err(err).Str("pm", exit.PMKey).Msg("board chain: cannot start review after build")
 	}
 }
 
@@ -627,7 +697,7 @@ func chainReviewAfterBuild(ctx context.Context, pmKey string, comments []tracker
 // and why, without reddening the card. The card keeps its ready-for-review
 // state, so the durable reconcile pass retries the check — an unreadable probe
 // is left/retried, never treated as evidence of missing work (SC-2403).
-func postHandoffCheckUnreadable(ctx context.Context, pmKey, branch, detail string, commenter tracker.Commenter, daemonID string, logger zerolog.Logger) {
+func postHandoffCheckUnreadable(ctx context.Context, pmKey, branch, detail string, commenter tracker.Commenter, logger zerolog.Logger) {
 	unreadable := marker.Marker{
 		Type: MarkerHandoffCheckUnreadable,
 		Body: "could not verify the handoff for branch " + branch + " on this machine — " + detail +

--- a/internal/daemon/board_failure.go
+++ b/internal/daemon/board_failure.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/gethuman-sh/human/internal/claude/hookevents"
 	"github.com/gethuman-sh/human/internal/marker"
 	"github.com/gethuman-sh/human/internal/proxy"
 	"github.com/gethuman-sh/human/internal/tracker"
@@ -122,7 +123,7 @@ func RunBoardFailureWatch(ctx context.Context, store *HookEventStore, runs *RunR
 				if !strings.HasPrefix(evt.AgentName, "board-") {
 					continue
 				}
-				if evt.EventName != "Stop" && evt.EventName != "SessionEnd" && evt.EventName != "StopFailure" {
+				if !hookevents.IsRunEnd(evt.EventName) {
 					continue
 				}
 				go handleBoardAgentExit(ctx, runs, evt.RunID, evt.AgentName, evt.ErrorType, evt.EventName, commenterFor, chainReview, liveAgents, advancePRLoop, advanceDeployFix, reachable, commitsPresent, diagnose, onHandoff, retry, latestClass, daemonID, logger)
@@ -211,7 +212,7 @@ func handleBoardAgentExit(ctx context.Context, runs *RunRegistry, runID, agentNa
 	// is the only thing that tells them apart. cleanExit gates the mid-review
 	// death check below: a clean exit-0 that merely raced its own
 	// review-complete propagation is never a death (SC-2133).
-	cleanExit := eventName != "StopFailure"
+	cleanExit := eventName != hookevents.EventStopFailure
 	// A clean stage finish leaves the stage's done-marker as the latest marker;
 	// only treat the exit as a failure when that did NOT happen. Re-read with
 	// bounded backoff first: a reap-synthesized exit can be handled before the

--- a/internal/daemon/board_failure_retry_test.go
+++ b/internal/daemon/board_failure_retry_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gethuman-sh/human/internal/claude/hookevents"
 	"github.com/gethuman-sh/human/internal/tracker"
 )
 
@@ -33,8 +34,7 @@ func TestHandleBoardAgentExit_RetryableFailureRelaunchesTheStage(t *testing.T) {
 	var relaunched, resets []BoardStage
 	policy := retryPolicyFor(ExitRetryable, true, &relaunched, &resets)
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-planning", "", "", commenterFor,
-		nil, nil, nil, nil, alwaysReachable, nil, nil, nil, policy, nil, "d1", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-planning"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Retry: policy, DaemonID: "d1", Logger: zerolog.Nop()})
 
 	require.Equal(t, []BoardStage{BoardPlanning}, relaunched)
 
@@ -59,8 +59,7 @@ func TestHandleBoardAgentExit_OutagePostsOutageMarkerAndDoesNotRelaunch(t *testi
 	var relaunched, resets []BoardStage
 	policy := retryPolicyFor(ExitOutage, true, &relaunched, &resets)
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "", commenterFor,
-		nil, nil, nil, nil, alwaysReachable, nil, nil, nil, policy, nil, "d1", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Retry: policy, DaemonID: "d1", Logger: zerolog.Nop()})
 
 	require.Empty(t, relaunched, "the live path must not relaunch an outage — the reconcile backoff does")
 
@@ -88,8 +87,7 @@ func TestHandleBoardAgentExit_CrashStillFailsBounded(t *testing.T) {
 	var relaunched, resets []BoardStage
 	policy := retryPolicyFor(ExitRetryable, true, &relaunched, &resets)
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "", commenterFor,
-		nil, nil, nil, nil, alwaysReachable, nil, nil, nil, policy, nil, "d1", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Retry: policy, DaemonID: "d1", Logger: zerolog.Nop()})
 
 	require.Equal(t, []BoardStage{BoardImplementation}, relaunched)
 	var sawFailed, sawOutage bool
@@ -116,8 +114,7 @@ func TestHandleBoardAgentExit_TerminalFailureIsNotRelaunched(t *testing.T) {
 	var relaunched, resets []BoardStage
 	policy := retryPolicyFor(ExitNeedsHumanWork, true, &relaunched, &resets)
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-planning", "", "", commenterFor,
-		nil, nil, nil, nil, alwaysReachable, nil, nil, nil, policy, nil, "d1", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-planning"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Retry: policy, DaemonID: "d1", Logger: zerolog.Nop()})
 
 	require.Empty(t, relaunched)
 }
@@ -132,8 +129,7 @@ func TestHandleBoardAgentExit_CleanFinishResetsTheRetryBudget(t *testing.T) {
 	var relaunched, resets []BoardStage
 	policy := retryPolicyFor(ExitDone, true, &relaunched, &resets)
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-planning", "", "", commenterFor,
-		nil, nil, nil, nil, alwaysReachable, nil, nil, nil, policy, nil, "d1", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-planning"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Retry: policy, DaemonID: "d1", Logger: zerolog.Nop()})
 
 	require.Equal(t, []BoardStage{BoardPlanning}, resets)
 	require.Empty(t, relaunched, "a clean finish is not a failure to retry")

--- a/internal/daemon/board_failure_test.go
+++ b/internal/daemon/board_failure_test.go
@@ -125,7 +125,7 @@ func TestRunBoardFailureWatch_ReapAfterHandoffRechecksAndChains(t *testing.T) {
 		chain := func(pmKey string) error { chained <- pmKey; return nil }
 
 		ctx := t.Context()
-		go RunBoardFailureWatch(ctx, store, nil, commenterFor, chain, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+		go RunBoardFailureWatch(ctx, store, nil, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 		time.Sleep(50 * time.Millisecond)
 
 		// Reap-synthesized event: no SessionID, carries only name + time.
@@ -157,7 +157,7 @@ func TestRunBoardFailureWatch_PostsFailedOnIncompleteStage(t *testing.T) {
 		commenterFor := func() (tracker.Commenter, error) { return c, nil }
 
 		ctx := t.Context()
-		go RunBoardFailureWatch(ctx, store, nil, commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+		go RunBoardFailureWatch(ctx, store, nil, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 		time.Sleep(50 * time.Millisecond)
 
 		store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: "board-SC-1-planning", Timestamp: time.Now()})
@@ -187,7 +187,7 @@ func TestRunBoardFailureWatch_ReusedNameSecondIncompleteExitPostsAgain(t *testin
 		commenterFor := func() (tracker.Commenter, error) { return c, nil }
 
 		ctx := t.Context()
-		go RunBoardFailureWatch(ctx, store, nil, commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+		go RunBoardFailureWatch(ctx, store, nil, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 		time.Sleep(50 * time.Millisecond)
 
 		// First exit of the reused name posts a failed marker.
@@ -223,7 +223,7 @@ func TestRunBoardFailureWatch_ReusedNameSecondCleanBuildChainsAgain(t *testing.T
 		chain := func(pmKey string) error { chained <- pmKey; return nil }
 
 		ctx := t.Context()
-		go RunBoardFailureWatch(ctx, store, nil, commenterFor, chain, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+		go RunBoardFailureWatch(ctx, store, nil, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 		time.Sleep(50 * time.Millisecond)
 
 		store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: "board-SC-1-implementation", Timestamp: time.Now()})
@@ -254,7 +254,7 @@ func TestRunBoardFailureWatch_NoPostWhenStageDone(t *testing.T) {
 		commenterFor := func() (tracker.Commenter, error) { return c, nil }
 
 		ctx := t.Context()
-		go RunBoardFailureWatch(ctx, store, nil, commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+		go RunBoardFailureWatch(ctx, store, nil, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 		time.Sleep(50 * time.Millisecond)
 
 		store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: "board-SC-1-planning", Timestamp: time.Now()})
@@ -278,7 +278,7 @@ func TestHandleBoardAgentExit_MalformedName(t *testing.T) {
 		return &syncCommenter{}, nil
 	}
 	// A name that does not parse must short-circuit before resolving a commenter.
-	handleBoardAgentExit(context.Background(), nil, "", "board-", "", "", commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 	assert.False(t, called)
 }
 
@@ -298,7 +298,7 @@ func TestHandleBoardAgentExit_prReviewStage_drivesLoop(t *testing.T) {
 	var reclaimed string
 	onHandoff := func(agentName string) { reclaimed = agentName }
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-prreview", "crashed", "", commenterFor, nil, nil, advance, nil, alwaysReachable, nil, nil, onHandoff, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-prreview", ErrorType: "crashed"}, FailureDeps{CommenterFor: commenterFor, AdvancePRLoop: advance, Reachable: alwaysReachable, OnHandoff: onHandoff, Logger: zerolog.Nop()})
 
 	assert.Equal(t, []string{"SC-1"}, advanced, "the PR loop driver must be invoked once")
 	// A step that dies before recording an outcome can only be explained from its
@@ -314,7 +314,7 @@ func TestHandleBoardAgentExit_CommenterError(t *testing.T) {
 		return nil, assertErr{}
 	}
 	// Must not panic when the commenter cannot be resolved.
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-planning", "", "", commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-planning"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 }
 
 type assertErr struct{}
@@ -334,7 +334,7 @@ func TestHandleBoardAgentExit_PhantomCommitFailsLoudly(t *testing.T) {
 	chain := func(string) error { chained = true; return nil }
 	commitsPresent := func(string, []string) ProbeResult { return ProbeResult{Status: ProbeAbsent} }
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "", commenterFor, chain, nil, nil, nil, alwaysReachable, commitsPresent, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation"}, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, Reachable: alwaysReachable, CommitsPresent: commitsPresent, Logger: zerolog.Nop()})
 
 	assert.False(t, chained, "a phantom-commit handoff must not chain a review")
 	c.mu.Lock()
@@ -356,7 +356,7 @@ func TestHandleBoardAgentExit_PresentCommitsChainReview(t *testing.T) {
 	chain := func(string) error { chained = true; return nil }
 	commitsPresent := func(string, []string) ProbeResult { return ProbeResult{Status: ProbePresent} }
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "", commenterFor, chain, nil, nil, nil, alwaysReachable, commitsPresent, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation"}, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, Reachable: alwaysReachable, CommitsPresent: commitsPresent, Logger: zerolog.Nop()})
 
 	assert.True(t, chained, "a handoff whose commits are present must chain its review")
 	c.mu.Lock()
@@ -379,7 +379,7 @@ func TestHandleBoardAgentExit_UnreadableCommitCheckDoesNotFail(t *testing.T) {
 		return ProbeResult{Status: ProbeUnreadable, Detail: "probe timed out"}
 	}
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "", commenterFor, chain, nil, nil, nil, alwaysReachable, commitsPresent, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation"}, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, Reachable: alwaysReachable, CommitsPresent: commitsPresent, Logger: zerolog.Nop()})
 
 	assert.False(t, chained, "an unreadable check must not chain a review")
 	c.mu.Lock()
@@ -406,7 +406,7 @@ func TestHandleBoardAgentExit_UnreadableBranchCheckDoesNotFail(t *testing.T) {
 		return ProbeResult{Status: ProbeUnreadable, Detail: "project dir unresolved"}
 	}
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "", commenterFor, chain, nil, nil, nil, reachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation"}, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, Reachable: reachable, Logger: zerolog.Nop()})
 
 	assert.False(t, chained, "an unreadable branch check must not chain a review")
 	c.mu.Lock()
@@ -434,7 +434,7 @@ func TestHandleBoardAgentExit_InContainerReviewCompleteDoesNotChain(t *testing.T
 	var chained bool
 	chain := func(string) error { chained = true; return nil }
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "", commenterFor, chain, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation"}, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 
 	assert.False(t, chained, "an in-container review-complete must not chain a second review")
 	c.mu.Lock()
@@ -456,7 +456,7 @@ func TestHandleBoardAgentExit_InContainerReviewFailedDoesNotChain(t *testing.T) 
 	var chained bool
 	chain := func(string) error { chained = true; return nil }
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "", commenterFor, chain, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation"}, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 
 	assert.False(t, chained, "an in-container review-complete (fail verdict) must not chain a second review")
 	c.mu.Lock()
@@ -482,7 +482,7 @@ func TestHandleBoardAgentExit_ChainedReviewAliveNoReviewFailed(t *testing.T) {
 	chain := func(string) error { chained = true; return nil }
 	live := liveAgents(agentNameFor("SC-1", BoardVerification)) // the chained reviewer is alive
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "StopFailure", commenterFor, chain, live, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation", EventName: "StopFailure"}, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, LiveAgents: live, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 
 	assert.False(t, chained, "a live chained review must not be re-chained")
 	c.mu.Lock()
@@ -508,7 +508,7 @@ func TestHandleBoardAgentExit_MergedReviewCrashPostsReviewFailed(t *testing.T) {
 	chain := func(string) error { chained = true; return nil }
 	live := liveAgents() // no separate verification agent alive
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "StopFailure", commenterFor, chain, live, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation", EventName: "StopFailure"}, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, LiveAgents: live, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 
 	assert.False(t, chained, "a mid-review crash must not chain a second review")
 	c.mu.Lock()
@@ -537,7 +537,7 @@ func TestHandleBoardAgentExit_MergedReviewCrash_PostsDiagnosedReason(t *testing.
 		return FailureDiagnosis{Headline: "command not found: gh", Detail: "exit code: 127"}
 	}
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "StopFailure", commenterFor, chain, live, nil, nil, alwaysReachable, nil, diagnose, nil, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation", EventName: "StopFailure"}, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, LiveAgents: live, Reachable: alwaysReachable, Diagnose: diagnose, Logger: zerolog.Nop()})
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -592,7 +592,7 @@ func TestRunBoardFailureWatch_CleanExitLateReviewCompleteNoReviewFailed(t *testi
 		chain := func(pmKey string) error { chained <- pmKey; return nil }
 
 		ctx := t.Context()
-		go RunBoardFailureWatch(ctx, store, nil, commenterFor, chain, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+		go RunBoardFailureWatch(ctx, store, nil, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 		time.Sleep(50 * time.Millisecond)
 
 		// A clean exit-0, not a reap: the container ran the review in place and
@@ -631,7 +631,7 @@ func TestHandleBoardAgentExit_CleanExitReviewNeverCompletesNoReviewFailed(t *tes
 	var chained bool
 	chain := func(string) error { chained = true; return nil }
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "SessionEnd", commenterFor, chain, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation", EventName: "SessionEnd"}, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 
 	assert.False(t, chained, "a clean exit must never chain a second review")
 	c.mu.Lock()
@@ -650,7 +650,7 @@ func TestRunBoardFailureWatch_ChainsReviewAfterCleanBuild(t *testing.T) {
 		chain := func(pmKey string) error { chained <- pmKey; return nil }
 
 		ctx := t.Context()
-		go RunBoardFailureWatch(ctx, store, nil, commenterFor, chain, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+		go RunBoardFailureWatch(ctx, store, nil, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 		time.Sleep(50 * time.Millisecond)
 
 		store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: "board-SC-1-implementation", Timestamp: time.Now()})
@@ -680,7 +680,7 @@ func TestRunBoardFailureWatch_SkipsChainWhenBranchUnreachable(t *testing.T) {
 		unreachable := func(string) ProbeResult { return ProbeResult{Status: ProbeAbsent} }
 
 		ctx := t.Context()
-		go RunBoardFailureWatch(ctx, store, nil, commenterFor, chain, nil, nil, nil, unreachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+		go RunBoardFailureWatch(ctx, store, nil, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, Reachable: unreachable, Logger: zerolog.Nop()})
 		time.Sleep(50 * time.Millisecond)
 
 		store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: "board-SC-1-implementation", Timestamp: time.Now()})
@@ -705,7 +705,7 @@ func TestRunBoardFailureWatch_NoChainForOtherStages(t *testing.T) {
 		chain := func(pmKey string) error { chained <- pmKey; return nil }
 
 		ctx := t.Context()
-		go RunBoardFailureWatch(ctx, store, nil, commenterFor, chain, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+		go RunBoardFailureWatch(ctx, store, nil, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 		time.Sleep(50 * time.Millisecond)
 
 		store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: "board-SC-1-planning", Timestamp: time.Now()})
@@ -733,7 +733,7 @@ func TestRunBoardFailureWatch_SyntheticStopFailurePostsImplementationFailed(t *t
 		commenterFor := func() (tracker.Commenter, error) { return c, nil }
 
 		ctx := t.Context()
-		go RunBoardFailureWatch(ctx, store, nil, commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+		go RunBoardFailureWatch(ctx, store, nil, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 		time.Sleep(50 * time.Millisecond)
 
 		// The reap-synthesized event carries no SessionID — only name + time.
@@ -769,7 +769,7 @@ func TestRunBoardFailureWatch_NoFixNeededIsCleanStop(t *testing.T) {
 		chain := func(pmKey string) error { chained <- pmKey; return nil }
 
 		ctx := t.Context()
-		go RunBoardFailureWatch(ctx, store, nil, commenterFor, chain, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+		go RunBoardFailureWatch(ctx, store, nil, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 		time.Sleep(50 * time.Millisecond)
 
 		store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: "board-SC-1-implementation", Timestamp: time.Now()})
@@ -806,7 +806,7 @@ func TestRunBoardFailureWatch_UndeterminedIsCleanStop(t *testing.T) {
 		chain := func(pmKey string) error { chained <- pmKey; return nil }
 
 		ctx := t.Context()
-		go RunBoardFailureWatch(ctx, store, nil, commenterFor, chain, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+		go RunBoardFailureWatch(ctx, store, nil, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 		time.Sleep(50 * time.Millisecond)
 
 		store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: "board-SC-1-implementation", Timestamp: time.Now()})
@@ -847,7 +847,7 @@ func TestRunBoardFailureWatch_NothingToDoIsCleanStop(t *testing.T) {
 		chain := func(pmKey string) error { chained <- pmKey; return nil }
 
 		ctx := t.Context()
-		go RunBoardFailureWatch(ctx, store, nil, commenterFor, chain, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+		go RunBoardFailureWatch(ctx, store, nil, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 		time.Sleep(50 * time.Millisecond)
 
 		store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: "board-SC-1-planning", Timestamp: time.Now()})
@@ -886,7 +886,7 @@ func TestRunBoardFailureWatch_OpenPlanningOptionsIsCleanPause(t *testing.T) {
 		commenterFor := func() (tracker.Commenter, error) { return c, nil }
 
 		ctx := t.Context()
-		go RunBoardFailureWatch(ctx, store, nil, commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+		go RunBoardFailureWatch(ctx, store, nil, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 		time.Sleep(50 * time.Millisecond)
 
 		store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: "board-SC-1-planning", Timestamp: time.Now()})
@@ -921,7 +921,7 @@ func TestRunBoardFailureWatch_OpenOptionsForOtherStageStillFails(t *testing.T) {
 		commenterFor := func() (tracker.Commenter, error) { return c, nil }
 
 		ctx := t.Context()
-		go RunBoardFailureWatch(ctx, store, nil, commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+		go RunBoardFailureWatch(ctx, store, nil, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 		time.Sleep(50 * time.Millisecond)
 
 		store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: "board-SC-1-planning", Timestamp: time.Now()})
@@ -952,7 +952,7 @@ func TestHandleBoardAgentExit_UsesDiagnoserHeadlineAndDetail(t *testing.T) {
 		}
 	}
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "", commenterFor, nil, nil, nil, nil, alwaysReachable, nil, diag, nil, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Diagnose: diag, Logger: zerolog.Nop()})
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -971,7 +971,7 @@ func TestHandleBoardAgentExit_NilDiagnoserFallsBackToGeneric(t *testing.T) {
 	}
 	commenterFor := func() (tracker.Commenter, error) { return c, nil }
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-planning", "", "", commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-planning"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -1000,7 +1000,7 @@ func TestHandleBoardAgentExit_AppendsModelOutcomeClass(t *testing.T) {
 		return proxy.ClassOther, true
 	}
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "", commenterFor, nil, nil, nil, nil, alwaysReachable, nil, diag, nil, StageRetry{}, latest, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Diagnose: diag, LatestClass: latest, Logger: zerolog.Nop()})
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -1031,7 +1031,7 @@ func TestHandleBoardAgentExit_ModelOutcomeAdditiveWhenOKOrAbsent(t *testing.T) {
 			}
 			commenterFor := func() (tracker.Commenter, error) { return c, nil }
 
-			handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-planning", "", "", commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, tc.latest, "", zerolog.Nop())
+			handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-planning"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, LatestClass: tc.latest, Logger: zerolog.Nop()})
 
 			c.mu.Lock()
 			defer c.mu.Unlock()
@@ -1050,7 +1050,7 @@ func TestHandleBoardAgentExit_EmptyHeadlineFallsBackToGeneric(t *testing.T) {
 	commenterFor := func() (tracker.Commenter, error) { return c, nil }
 	diag := func(string, string) FailureDiagnosis { return FailureDiagnosis{} }
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-planning", "", "", commenterFor, nil, nil, nil, nil, alwaysReachable, nil, diag, nil, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-planning"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Diagnose: diag, Logger: zerolog.Nop()})
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -1076,7 +1076,7 @@ func TestRunBoardFailureWatch_PassesErrorTypeToDiagnoser(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		go RunBoardFailureWatch(ctx, store, nil, commenterFor, nil, nil, nil, nil, alwaysReachable, nil, diag, nil, StageRetry{}, nil, "", zerolog.Nop())
+		go RunBoardFailureWatch(ctx, store, nil, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Diagnose: diag, Logger: zerolog.Nop()})
 		time.Sleep(50 * time.Millisecond)
 
 		store.Append(hookevents.Event{EventName: "StopFailure", AgentName: "board-SC-1-planning", ErrorType: "rate_limit", Timestamp: time.Now()})
@@ -1108,7 +1108,7 @@ func TestRunBoardFailureWatch_IgnoresNonBoardAgents(t *testing.T) {
 		commenterFor := func() (tracker.Commenter, error) { return c, nil }
 
 		ctx := t.Context()
-		go RunBoardFailureWatch(ctx, store, nil, commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+		go RunBoardFailureWatch(ctx, store, nil, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 		time.Sleep(50 * time.Millisecond)
 
 		store.Append(hookevents.Event{EventName: "SessionEnd", AgentName: "some-other-agent", Timestamp: time.Now()})
@@ -1144,7 +1144,7 @@ func assertTicketReviewVerdictIsCleanStop(t *testing.T, verdict string) {
 	var reclaimed string
 	onHandoff := func(agentName string) { reclaimed = agentName }
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-planning", "crashed", "", commenterFor, chain, nil, nil, nil, alwaysReachable, nil, nil, onHandoff, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-planning", ErrorType: "crashed"}, FailureDeps{CommenterFor: commenterFor, ChainReview: chain, Reachable: alwaysReachable, OnHandoff: onHandoff, Logger: zerolog.Nop()})
 
 	c.mu.Lock()
 	assert.Empty(t, c.added, "a deliberate %s stop must post no failed marker", verdict)
@@ -1181,7 +1181,7 @@ func TestRunBoardFailureWatch_TicketReviewReadyThenCrashStillFails(t *testing.T)
 	}
 	commenterFor := func() (tracker.Commenter, error) { return c, nil }
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-planning", "crashed", "", commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-planning", ErrorType: "crashed"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Logger: zerolog.Nop()})
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -1207,8 +1207,7 @@ func TestHandleBoardAgentExit_SilenceReapDoesNotChargeRetry(t *testing.T) {
 		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 	}
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", ReapSilenceErrorType+":18m0s", "StopFailure",
-		commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, retry, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation", ErrorType: ReapSilenceErrorType + ":18m0s", EventName: "StopFailure"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Retry: retry, Logger: zerolog.Nop()})
 
 	assert.False(t, attemptsCalled, "a silence reap must never read/bump the charged attempt counter")
 	assert.Equal(t, []BoardStage{BoardImplementation}, relaunched, "the stage is still relaunched")
@@ -1238,8 +1237,7 @@ func TestHandleBoardAgentExit_SilenceReapGivesUpAfterCap(t *testing.T) {
 		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 	}
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", ReapSilenceErrorType+":18m0s", "StopFailure",
-		commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, retry, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation", ErrorType: ReapSilenceErrorType + ":18m0s", EventName: "StopFailure"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Retry: retry, Logger: zerolog.Nop()})
 
 	assert.Empty(t, relaunched, "the cap is spent — the stage must not be relaunched again")
 
@@ -1267,8 +1265,7 @@ func TestHandleBoardAgentExit_SilenceReapGiveUpDedup(t *testing.T) {
 		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 	}
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", ReapSilenceErrorType+":18m0s", "StopFailure",
-		commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, retry, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation", ErrorType: ReapSilenceErrorType + ":18m0s", EventName: "StopFailure"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Retry: retry, Logger: zerolog.Nop()})
 
 	assert.Empty(t, relaunched, "still must not relaunch")
 	c.mu.Lock()
@@ -1293,8 +1290,7 @@ func TestHandleBoardAgentExit_SilenceReapRelaunchesUnderCap(t *testing.T) {
 		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 	}
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", ReapSilenceErrorType+":18m0s", "StopFailure",
-		commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, retry, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation", ErrorType: ReapSilenceErrorType + ":18m0s", EventName: "StopFailure"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Retry: retry, Logger: zerolog.Nop()})
 
 	assert.False(t, attemptsCalled, "still uncharged")
 	assert.Equal(t, []BoardStage{BoardImplementation}, relaunched, "under the cap the stage keeps relaunching")
@@ -1315,8 +1311,7 @@ func TestHandleBoardAgentExit_GenuineStopFailureStillCharges(t *testing.T) {
 		Relaunch: func(string, BoardStage) (bool, error) { return true, nil },
 	}
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "StopFailure",
-		commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, retry, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation", EventName: "StopFailure"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Retry: retry, Logger: zerolog.Nop()})
 
 	assert.True(t, attemptsCalled, "an empty-ErrorType StopFailure must still charge the retry budget")
 }
@@ -1332,7 +1327,7 @@ func TestHandleBoardAgentExit_DeployFixStage_RoutesToAdvance(t *testing.T) {
 	var reclaimed string
 	onHandoff := func(agentName string) { reclaimed = agentName }
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-deployfix", "", "", commenterFor, nil, nil, nil, advanceDeployFix, alwaysReachable, nil, nil, onHandoff, StageRetry{}, nil, "", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-deployfix"}, FailureDeps{CommenterFor: commenterFor, AdvanceDeployFix: advanceDeployFix, Reachable: alwaysReachable, OnHandoff: onHandoff, Logger: zerolog.Nop()})
 
 	assert.Equal(t, []string{"SC-1"}, advanced, "the deploy-fix driver must be invoked once")
 	assert.Equal(t, "board-SC-1-deployfix", reclaimed, "the fixer's worktree must be reclaimed")

--- a/internal/daemon/board_outage.go
+++ b/internal/daemon/board_outage.go
@@ -123,24 +123,25 @@ func handOverOutage(ctx context.Context, pmKey string, derived BoardCard, postFa
 //
 // Split out of handleBoardAgentExit so the say-once guard costs this function's
 // complexity budget rather than that one's.
-func handleOutageExit(ctx context.Context, pmKey string, stage BoardStage, agentName, errorType string, comments []tracker.Comment, commenter tracker.Commenter, diagnose BoardFailureDiagnoser, retry StageRetry, kind endingKind, reason string, daemonID string, logger zerolog.Logger) bool {
-	outageType := outageTypeFor(stage)
-	if outageType == "" || (!retry.recordedOutage(pmKey, stage) && kind != endingPaused) {
+func handleOutageExit(ctx context.Context, exit RunExit, commenter tracker.Commenter, deps FailureDeps, kind endingKind, reason string) bool {
+	logger := deps.Logger
+	outageType := outageTypeFor(exit.Stage)
+	if outageType == "" || (!deps.Retry.recordedOutage(exit.PMKey, exit.Stage) && kind != endingPaused) {
 		return false
 	}
-	body := markerBody(pausedOutageMarker(outageType, diagnose, agentName, errorType, reason))
+	body := markerBody(pausedOutageMarker(outageType, deps.Diagnose, exit.AgentName, exit.ErrorType, reason))
 	// Say it once and leave it standing: every relaunch that re-hits the same
 	// outage lands here, so re-posting an identical marker would spam the ticket
 	// for as long as the substrate stays down (SC-2851). The standing marker also
 	// anchors how long the wait has lasted (outageRunSince), so leaving it in
 	// place is what makes the wait measurable at all.
-	if outageAlreadyStated(comments, stage, body) {
-		logger.Info().Str("agent", agentName).Str("pm", pmKey).
+	if outageAlreadyStated(exit.Comments, exit.Stage, body) {
+		logger.Info().Str("agent", exit.AgentName).Str("pm", exit.PMKey).
 			Msg("board failure: the card already says the substrate is down, not repeating it")
 		return true
 	}
-	if _, err := commenter.AddComment(ctx, pmKey, body); err != nil {
-		logger.Warn().Err(err).Str("agent", agentName).Msg("board failure: cannot post outage marker")
+	if _, err := commenter.AddComment(ctx, exit.PMKey, body); err != nil {
+		logger.Warn().Err(err).Str("agent", exit.AgentName).Msg("board failure: cannot post outage marker")
 	}
 	return true
 }

--- a/internal/daemon/board_outage.go
+++ b/internal/daemon/board_outage.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rs/zerolog"
-
 	"github.com/gethuman-sh/human/internal/marker"
 	"github.com/gethuman-sh/human/internal/tracker"
 )
@@ -92,12 +90,13 @@ func outageHandoverBody(stage BoardStage, reason string, waited time.Duration, s
 // is finally told. It charges nothing: SC-2307's rule that an outage never
 // spends the budget a genuine failure needs is untouched by this — the wait is
 // ended, not reclassified as a failure of the work.
-func handOverOutage(ctx context.Context, pmKey string, derived BoardCard, postFailed FailedMarkerPoster, waited time.Duration, since time.Time, daemonID string, logger zerolog.Logger) bool {
+func handOverOutage(ctx context.Context, pmKey string, derived BoardCard, deps ReconcileDeps, waited time.Duration, since time.Time) bool {
+	logger := deps.Logger
 	body := outageHandoverBody(derived.Stage, derived.Error, waited, since)
 	if body == "" {
 		return false
 	}
-	if err := postFailed(ctx, pmKey, body); err != nil {
+	if err := deps.PostFailed(ctx, pmKey, body); err != nil {
 		logger.Warn().Err(err).Str("pm", pmKey).
 			Msg("board reconcile: cannot hand an unending outage to a person, leaving the card waiting")
 		return false

--- a/internal/daemon/board_outage_test.go
+++ b/internal/daemon/board_outage_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gethuman-sh/human/internal/claude/hookevents"
 	"github.com/gethuman-sh/human/internal/marker"
 	"github.com/gethuman-sh/human/internal/tracker"
 )
@@ -50,8 +51,7 @@ func TestHandleBoardAgentExit_OutageIsStatedOnce(t *testing.T) {
 	policy := retryPolicyFor(ExitOutage, true, &relaunched, &resets)
 
 	for range 3 {
-		handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "", commenterFor,
-			nil, nil, nil, nil, alwaysReachable, nil, nil, nil, policy, nil, "d1", zerolog.Nop())
+		handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Retry: policy, DaemonID: "d1", Logger: zerolog.Nop()})
 	}
 
 	require.Len(t, c.added, 1, "the card says the substrate is down once, not once per attempt")

--- a/internal/daemon/board_outage_test.go
+++ b/internal/daemon/board_outage_test.go
@@ -80,8 +80,7 @@ func TestReconcileOutage_HandsAnUnendingWaitToAPerson(t *testing.T) {
 	}
 	var posted []struct{ Key, Body string }
 
-	redriven, handedOver := reconcileOutage(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
-		capturingPoster(&posted), retry, "d1", now, zerolog.Nop())
+	redriven, handedOver := reconcileOutage(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), Retry: retry, DaemonID: "d1"}, now)
 
 	require.Zero(t, redriven, "a wait past the bound is not relaunched again")
 	require.Equal(t, 1, handedOver)
@@ -116,8 +115,7 @@ func TestReconcileOutage_HandoverIsIdempotent(t *testing.T) {
 	}
 	var posted []struct{ Key, Body string }
 
-	redriven, handedOver := reconcileOutage(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
-		capturingPoster(&posted), retry, "d1", now, zerolog.Nop())
+	redriven, handedOver := reconcileOutage(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), Retry: retry, DaemonID: "d1"}, now)
 
 	require.Zero(t, redriven)
 	require.Zero(t, handedOver)
@@ -140,8 +138,7 @@ func TestReconcileOutage_WithoutAPosterKeepsWaiting(t *testing.T) {
 		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 	}
 
-	redriven, handedOver := reconcileOutage(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
-		nil, retry, "d1", now, zerolog.Nop())
+	redriven, handedOver := reconcileOutage(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), Retry: retry, DaemonID: "d1"}, now)
 
 	require.Equal(t, 1, redriven)
 	require.Zero(t, handedOver)

--- a/internal/daemon/board_reconcile.go
+++ b/internal/daemon/board_reconcile.go
@@ -108,6 +108,25 @@ type LiveAgentLister func() ([]string, error)
 // the headline. A nil poster disables the stuck-running pass.
 type FailedMarkerPoster func(ctx context.Context, pmKey, body string) error
 
+// ChainReview starts the review stage for a card whose build finished and
+// handed off — the live chain's continuation and the durable pass's recovery of
+// it. A nil value disables chaining.
+//
+// It, DriveLoop and AdvanceDeployFix are three DIFFERENT actions that share one
+// underlying signature, and they sat as bare `func(pmKey string) error`
+// parameters in adjacent positions: RunBoardReconcile took chainReview and
+// driveLoop next to each other, so swapping the two arguments compiled and
+// reviewed clean. Named types make the mistake unspellable at the call site.
+type ChainReview func(pmKey string) error
+
+// DriveLoop re-drives the PR review→fix loop from its recorded state, advancing
+// or escalating it idempotently. A nil value disables the re-drive pass.
+type DriveLoop func(pmKey string) error
+
+// StopAgent stops a board agent's container on THIS machine by name. A nil
+// value disables every pass that would kill a run.
+type StopAgent func(agentName string) error
+
 // RunBoardReconcile is the durable counterpart to RunBoardFailureWatch's live
 // fix→review chain. The live chain fires only on the one-shot Stop/SessionEnd
 // hook event; if the daemon restarts or the hook is lost, that trigger is gone
@@ -119,7 +138,7 @@ type FailedMarkerPoster func(ctx context.Context, pmKey, body string) error
 // It runs one pass immediately at start (recovers a restart-orphaned handoff
 // without waiting a full interval) then on a ticker, mirroring
 // RunAgentZombieSweep. nil deps disable it.
-func RunBoardReconcile(ctx context.Context, listCards ReconcileLister, reachable BranchReachable, participates ProjectParticipation, identityFor TicketIdentity, commitsPresent CommitsPresent, mergedProbe PRMergedProbe, postDeployed DeployedPoster, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, closedProbe ClosedTicketProbe, chainReview func(pmKey string) error, driveLoop func(pmKey string) error, retry StageRetry, progress AgentProgressProbe, stopAgent func(agentName string) error, daemonID string, interval time.Duration, logger zerolog.Logger) {
+func RunBoardReconcile(ctx context.Context, listCards ReconcileLister, reachable BranchReachable, participates ProjectParticipation, identityFor TicketIdentity, commitsPresent CommitsPresent, mergedProbe PRMergedProbe, postDeployed DeployedPoster, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, closedProbe ClosedTicketProbe, chainReview ChainReview, driveLoop DriveLoop, retry StageRetry, progress AgentProgressProbe, stopAgent StopAgent, daemonID string, interval time.Duration, logger zerolog.Logger) {
 	if listCards == nil || chainReview == nil {
 		return
 	}
@@ -161,7 +180,7 @@ func JitteredInterval(d time.Duration, fraction float64) time.Duration {
 
 // reconcileOnce runs a single reconcile pass. A transient list error is logged
 // and skipped so a momentary tracker blip never kills the loop.
-func reconcileOnce(ctx context.Context, listCards ReconcileLister, gate WorkGate, commitsPresent CommitsPresent, mergedProbe PRMergedProbe, postDeployed DeployedPoster, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, closedProbe ClosedTicketProbe, chainReview func(pmKey string) error, driveLoop func(pmKey string) error, retry StageRetry, progress AgentProgressProbe, stopAgent func(agentName string) error, daemonID string, logger zerolog.Logger) {
+func reconcileOnce(ctx context.Context, listCards ReconcileLister, gate WorkGate, commitsPresent CommitsPresent, mergedProbe PRMergedProbe, postDeployed DeployedPoster, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, closedProbe ClosedTicketProbe, chainReview ChainReview, driveLoop DriveLoop, retry StageRetry, progress AgentProgressProbe, stopAgent StopAgent, daemonID string, logger zerolog.Logger) {
 	cards, err := listCards(ctx)
 	if err != nil {
 		logger.Warn().Err(err).Msg("board reconcile: cannot list PM cards")
@@ -334,7 +353,7 @@ func doneStageStartedHalf(comments []tracker.Comment) string {
 // started marker carries the machine: stamp that arm reads. The daemon id is
 // persisted across restarts (LoadOrCreateDaemonID), so the restart-orphan case
 // this pass exists for still matches its own stamp and is still re-driven.
-func reconcilePRLoops(ctx context.Context, drivable DrivableCards, liveAgents LiveAgentLister, driveLoop func(pmKey string) error, logger zerolog.Logger) int {
+func reconcilePRLoops(ctx context.Context, drivable DrivableCards, liveAgents LiveAgentLister, driveLoop DriveLoop, logger zerolog.Logger) int {
 	if driveLoop == nil || liveAgents == nil {
 		return 0
 	}
@@ -500,7 +519,7 @@ func stuckRunningCandidate(derived BoardCard, comments []tracker.Comment) bool {
 // this pass's own judgement (silenced) plus the idle duration to report.
 // Pulled out of reconcileStuckRunning to keep that function's branching
 // inside the complexity gate.
-func hungLiveAgent(progress AgentProgressProbe, agentName string, now time.Time, stopAgent func(agentName string) error, pmKey string, stage BoardStage, logger zerolog.Logger) (proceed, silenced bool, idleReason string) {
+func hungLiveAgent(progress AgentProgressProbe, agentName string, now time.Time, stopAgent StopAgent, pmKey string, stage BoardStage, logger zerolog.Logger) (proceed, silenced bool, idleReason string) {
 	// A live container is not the same as a working agent: a hung agent looks
 	// perfectly healthy here, which is why a hang was previously never
 	// detected at all. Ask whether it is still making progress.
@@ -525,7 +544,7 @@ func hungLiveAgent(progress AgentProgressProbe, agentName string, now time.Time,
 	return true, true, idle.Round(time.Second).String()
 }
 
-func reconcileStuckRunning(ctx context.Context, drivable DrivableCards, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, retry StageRetry, progress AgentProgressProbe, stopAgent func(agentName string) error, daemonID string, now time.Time, logger zerolog.Logger) int {
+func reconcileStuckRunning(ctx context.Context, drivable DrivableCards, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, retry StageRetry, progress AgentProgressProbe, stopAgent StopAgent, daemonID string, now time.Time, logger zerolog.Logger) int {
 	if liveAgents == nil || postFailed == nil {
 		return 0
 	}
@@ -554,7 +573,7 @@ func reconcileStuckRunning(ctx context.Context, drivable DrivableCards, liveAgen
 // and reports whether it was reddened. Split out of reconcileStuckRunning so
 // that function's per-card branching costs its own function rather than the
 // loop's complexity budget.
-func reconcileOneStuckCard(ctx context.Context, card ReconcileCard, alive map[string]struct{}, postFailed FailedMarkerPoster, retry StageRetry, progress AgentProgressProbe, stopAgent func(agentName string) error, daemonID string, now time.Time, logger zerolog.Logger) bool {
+func reconcileOneStuckCard(ctx context.Context, card ReconcileCard, alive map[string]struct{}, postFailed FailedMarkerPoster, retry StageRetry, progress AgentProgressProbe, stopAgent StopAgent, daemonID string, now time.Time, logger zerolog.Logger) bool {
 	derived := DeriveBoardCard(card.Comments, tracker.CategoryUnstarted, false)
 	if !stuckCardIsOursToRed(derived, card) {
 		return false
@@ -789,7 +808,7 @@ func reconcileShippedFailures(ctx context.Context, drivable DrivableCards, merge
 // the branch — never starting a review it could never satisfy (SC-652, now
 // enforced by construction rather than a per-path check, SC-2047). Returns the
 // number of reviews launched.
-func reconcileOrphanedHandoffs(drivable DrivableCards, commitsPresent CommitsPresent, chainReview func(pmKey string) error, logger zerolog.Logger) int {
+func reconcileOrphanedHandoffs(drivable DrivableCards, commitsPresent CommitsPresent, chainReview ChainReview, logger zerolog.Logger) int {
 	launched := 0
 	for _, card := range drivable.cards {
 		derived := DeriveBoardCard(card.Comments, tracker.CategoryUnstarted, false)

--- a/internal/daemon/board_reconcile.go
+++ b/internal/daemon/board_reconcile.go
@@ -127,6 +127,78 @@ type DriveLoop func(pmKey string) error
 // value disables every pass that would kill a run.
 type StopAgent func(agentName string) error
 
+// ReconcileDeps wires the durable reconcile pass's collaborators, mirroring
+// BoardTransitionDeps and FailureDeps in the same package. Every field follows
+// the "nil disables" convention.
+//
+// It exists because these values were threaded positionally through
+// RunBoardReconcile, reconcileOnce and every pass below them, and two of them —
+// ChainReview and DriveLoop — are adjacent parameters of what used to be the
+// same bare type. Naming the types made the swap unspellable; the struct means
+// adding a collaborator is one field rather than an edit to every signature
+// between the wiring and the pass that needs it.
+type ReconcileDeps struct {
+	ListCards      ReconcileLister
+	Reachable      BranchReachable
+	Participates   ProjectParticipation
+	IdentityFor    TicketIdentity
+	CommitsPresent CommitsPresent
+	MergedProbe    PRMergedProbe
+	PostDeployed   DeployedPoster
+	LiveAgents     LiveAgentLister
+	PostFailed     FailedMarkerPoster
+	ClosedProbe    ClosedTicketProbe
+	ChainReview    ChainReview
+	DriveLoop      DriveLoop
+	Retry          StageRetry
+	Progress       AgentProgressProbe
+	StopAgent      StopAgent
+	// DaemonID is this machine's identity: it tells this daemon's own running
+	// stage from a peer's, and signs every marker the passes post.
+	DaemonID string
+	// Interval is how long to wait between passes after the immediate one at start.
+	Interval time.Duration
+	Logger   zerolog.Logger
+}
+
+// gate is the work gate these deps describe — the choke point every writing
+// pass takes its cards through.
+//
+// Derived on each call rather than built once and stored, for the same reason
+// RunExit.CleanExit is: a stored copy is a second source that can disagree with
+// the fields it came from, and a caller constructing ReconcileDeps directly
+// (every test does) would hold a zero gate that silently admits nothing. It is
+// a four-field value; constructing it costs nothing.
+func (d ReconcileDeps) gate() WorkGate {
+	return WorkGate{
+		reachable:    d.Reachable,
+		participates: d.Participates,
+		daemonID:     d.DaemonID,
+		identityFor:  d.IdentityFor,
+	}
+}
+
+// aliveAgents reads the board agents running on this machine into a set. Every
+// relaunching pass needs it and each used to build it from the same six lines.
+// The bool reports whether the answer is usable at all: a nil lister or a failed
+// lookup cannot establish liveness, and a pass that cannot establish liveness
+// must do nothing rather than assume a card is dead.
+func (d ReconcileDeps) aliveAgents(what string) (map[string]struct{}, bool) {
+	if d.LiveAgents == nil {
+		return nil, false
+	}
+	names, err := d.LiveAgents()
+	if err != nil {
+		d.Logger.Warn().Err(err).Msg("board reconcile: cannot list live agents for " + what)
+		return nil, false
+	}
+	alive := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		alive[n] = struct{}{}
+	}
+	return alive, true
+}
+
 // RunBoardReconcile is the durable counterpart to RunBoardFailureWatch's live
 // fix→review chain. The live chain fires only on the one-shot Stop/SessionEnd
 // hook event; if the daemon restarts or the hook is lost, that trigger is gone
@@ -138,26 +210,24 @@ type StopAgent func(agentName string) error
 // It runs one pass immediately at start (recovers a restart-orphaned handoff
 // without waiting a full interval) then on a ticker, mirroring
 // RunAgentZombieSweep. nil deps disable it.
-func RunBoardReconcile(ctx context.Context, listCards ReconcileLister, reachable BranchReachable, participates ProjectParticipation, identityFor TicketIdentity, commitsPresent CommitsPresent, mergedProbe PRMergedProbe, postDeployed DeployedPoster, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, closedProbe ClosedTicketProbe, chainReview ChainReview, driveLoop DriveLoop, retry StageRetry, progress AgentProgressProbe, stopAgent StopAgent, daemonID string, interval time.Duration, logger zerolog.Logger) {
-	if listCards == nil || chainReview == nil {
+func RunBoardReconcile(ctx context.Context, deps ReconcileDeps) {
+	if deps.ListCards == nil || deps.ChainReview == nil {
 		return
 	}
 
-	logger.Info().Msg("board reconcile started")
-
-	gate := WorkGate{reachable: reachable, participates: participates, daemonID: daemonID, identityFor: identityFor}
+	deps.Logger.Info().Msg("board reconcile started")
 
 	// Recover a restart-orphaned handoff immediately, before the first wait. The
 	// jitter applies only to subsequent cycles, so a restart-orphan is never made
 	// to wait a full interval.
-	reconcileOnce(ctx, listCards, gate, commitsPresent, mergedProbe, postDeployed, liveAgents, postFailed, closedProbe, chainReview, driveLoop, retry, progress, stopAgent, daemonID, logger)
+	reconcileOnce(ctx, deps)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(JitteredInterval(interval, BoardReconcileJitter)):
-			reconcileOnce(ctx, listCards, gate, commitsPresent, mergedProbe, postDeployed, liveAgents, postFailed, closedProbe, chainReview, driveLoop, retry, progress, stopAgent, daemonID, logger)
+		case <-time.After(JitteredInterval(deps.Interval, BoardReconcileJitter)):
+			reconcileOnce(ctx, deps)
 		}
 	}
 }
@@ -180,8 +250,10 @@ func JitteredInterval(d time.Duration, fraction float64) time.Duration {
 
 // reconcileOnce runs a single reconcile pass. A transient list error is logged
 // and skipped so a momentary tracker blip never kills the loop.
-func reconcileOnce(ctx context.Context, listCards ReconcileLister, gate WorkGate, commitsPresent CommitsPresent, mergedProbe PRMergedProbe, postDeployed DeployedPoster, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, closedProbe ClosedTicketProbe, chainReview ChainReview, driveLoop DriveLoop, retry StageRetry, progress AgentProgressProbe, stopAgent StopAgent, daemonID string, logger zerolog.Logger) {
-	cards, err := listCards(ctx)
+func reconcileOnce(ctx context.Context, deps ReconcileDeps) {
+	logger := deps.Logger
+	gate := deps.gate()
+	cards, err := deps.ListCards(ctx)
 	if err != nil {
 		logger.Warn().Err(err).Msg("board reconcile: cannot list PM cards")
 		return
@@ -198,16 +270,16 @@ func reconcileOnce(ctx context.Context, listCards ReconcileLister, gate WorkGate
 	// which is this machine's business whoever owns the ticket — leaving a
 	// container alive because its ticket is someone else's would strand a process
 	// nobody else can reach.
-	if n := reconcileOrphanedHandoffs(gate.forReview(cards), commitsPresent, chainReview, logger); n > 0 {
+	if n := reconcileOrphanedHandoffs(gate.forReview(cards), deps); n > 0 {
 		logger.Info().Int("launched", n).Msg("board reconcile: chained review for orphaned handoffs")
 	}
-	if n := reconcileShippedFailures(ctx, gate.forOwnWork(cards), mergedProbe, postDeployed, logger); n > 0 {
+	if n := reconcileShippedFailures(ctx, gate.forOwnWork(cards), deps); n > 0 {
 		logger.Info().Int("cleared", n).Msg("board reconcile: confirmed shipped, cleared stale deploy-failed red")
 	}
 	// The PR-loop re-drive runs BEFORE the stuck-running pass so a loop card
 	// stranded by a restart is re-driven rather than reddened — the stuck pass
 	// also skips it (doneStageLoopActive), but ordering makes the ownership clear.
-	if n := reconcilePRLoops(ctx, gate.forTakeover(cards), liveAgents, driveLoop, logger); n > 0 {
+	if n := reconcilePRLoops(ctx, gate.forTakeover(cards), deps); n > 0 {
 		logger.Info().Int("redriven", n).Msg("board reconcile: re-drove stalled PR review→fix loops")
 	}
 	// An outage card is re-driven BEFORE the stuck-running pass: it is not a hang
@@ -215,11 +287,11 @@ func reconcileOnce(ctx context.Context, listCards ReconcileLister, gate WorkGate
 	// each tick (the backoff) until the substrate returns (SC-2307). It rides the
 	// same forTakeover gate — an outage relaunch takes over the stage on this
 	// machine exactly as a stuck-running reclaim does.
-	if redriven, handedOver := reconcileOutage(ctx, gate.forTakeover(cards), liveAgents, postFailed, retry, daemonID, time.Now(), logger); redriven > 0 || handedOver > 0 {
+	if redriven, handedOver := reconcileOutage(ctx, gate.forTakeover(cards), deps, time.Now()); redriven > 0 || handedOver > 0 {
 		logger.Info().Int("redriven", redriven).Int("handed_over", handedOver).
 			Msg("board reconcile: re-drove stages waiting on the substrate")
 	}
-	if n := reconcileStuckRunning(ctx, gate.forTakeover(cards), liveAgents, postFailed, retry, progress, stopAgent, daemonID, time.Now(), logger); n > 0 {
+	if n := reconcileStuckRunning(ctx, gate.forTakeover(cards), deps, time.Now()); n > 0 {
 		logger.Info().Int("reddened", n).Msg("board reconcile: reddened stuck-running cards with no live agent")
 	}
 	// After the stuck pass, because a queued card is the one thing that pass is
@@ -227,13 +299,13 @@ func reconcileOnce(ctx context.Context, listCards ReconcileLister, gate WorkGate
 	// (SC-1320), which left it watched by nothing at all (SC-3865). It takes the
 	// same forTakeover gate as the other relaunching passes — starting the stage a
 	// decision queued takes that stage over on this machine.
-	if n := reconcileQueuedLaunch(ctx, gate.forTakeover(cards), liveAgents, retry, daemonID, time.Now(), logger); n > 0 {
+	if n := reconcileQueuedLaunch(ctx, gate.forTakeover(cards), deps, time.Now()); n > 0 {
 		logger.Info().Int("launched", n).Msg("board reconcile: started stages left queued by an answered decision")
 	}
 	// Last: the passes above all act on cards that are still ON the board, while
 	// this one reaches the runs whose card has left it — the orphan the close
 	// gate cannot cover because the ticket was closed outside the board (1698).
-	if n := reconcileOrphanedAgents(ctx, cards, liveAgents, closedProbe, stopAgent, postFailed, logger); n > 0 {
+	if n := reconcileOrphanedAgents(ctx, cards, deps); n > 0 {
 		logger.Info().Int("stopped", n).Msg("board reconcile: stopped agents orphaned on closed tickets")
 	}
 }
@@ -353,18 +425,14 @@ func doneStageStartedHalf(comments []tracker.Comment) string {
 // started marker carries the machine: stamp that arm reads. The daemon id is
 // persisted across restarts (LoadOrCreateDaemonID), so the restart-orphan case
 // this pass exists for still matches its own stamp and is still re-driven.
-func reconcilePRLoops(ctx context.Context, drivable DrivableCards, liveAgents LiveAgentLister, driveLoop DriveLoop, logger zerolog.Logger) int {
-	if driveLoop == nil || liveAgents == nil {
+func reconcilePRLoops(ctx context.Context, drivable DrivableCards, deps ReconcileDeps) int {
+	logger := deps.Logger
+	if deps.DriveLoop == nil {
 		return 0
 	}
-	names, err := liveAgents()
-	if err != nil {
-		logger.Warn().Err(err).Msg("board reconcile: cannot list live agents for PR loops")
+	alive, ok := deps.aliveAgents("PR loops")
+	if !ok {
 		return 0
-	}
-	alive := make(map[string]struct{}, len(names))
-	for _, n := range names {
-		alive[n] = struct{}{}
 	}
 	redriven := 0
 	for _, card := range drivable.cards {
@@ -383,7 +451,7 @@ func reconcilePRLoops(ctx context.Context, drivable DrivableCards, liveAgents Li
 		if _, ok := alive[agentNameFor(card.Key, prFixAgentStage)]; ok {
 			continue
 		}
-		if err := driveLoop(card.Key); err != nil {
+		if err := deps.DriveLoop(card.Key); err != nil {
 			logger.Warn().Err(err).Str("pm", card.Key).Msg("board reconcile: cannot re-drive PR loop")
 			continue
 		}
@@ -414,18 +482,14 @@ func reconcilePRLoops(ctx context.Context, drivable DrivableCards, liveAgents Li
 // indefinite wait rather than stranding the card with neither.
 //
 // Returns how many cards were re-driven and how many were handed to a human.
-func reconcileOutage(ctx context.Context, drivable DrivableCards, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, retry StageRetry, daemonID string, now time.Time, logger zerolog.Logger) (redriven, handedOver int) {
-	if liveAgents == nil || !retry.enabled() {
+func reconcileOutage(ctx context.Context, drivable DrivableCards, deps ReconcileDeps, now time.Time) (redriven, handedOver int) {
+	logger := deps.Logger
+	if !deps.Retry.enabled() {
 		return 0, 0
 	}
-	names, err := liveAgents()
-	if err != nil {
-		logger.Warn().Err(err).Msg("board reconcile: cannot list live agents for outage re-drive")
+	alive, ok := deps.aliveAgents("outage re-drive")
+	if !ok {
 		return 0, 0
-	}
-	alive := make(map[string]struct{}, len(names))
-	for _, n := range names {
-		alive[n] = struct{}{}
 	}
 	for _, card := range drivable.cards {
 		derived := DeriveBoardCard(card.Comments, tracker.CategoryUnstarted, false)
@@ -436,8 +500,8 @@ func reconcileOutage(ctx context.Context, drivable DrivableCards, liveAgents Liv
 		if _, ok := alive[agentNameFor(card.Key, derived.Stage)]; ok {
 			continue
 		}
-		if since, ok := outageRunSince(card.Comments, derived.Stage); ok && postFailed != nil && now.Sub(since) > OutageWaitBound {
-			if handOverOutage(ctx, card.Key, derived, postFailed, now.Sub(since), since, daemonID, logger) {
+		if since, ok := outageRunSince(card.Comments, derived.Stage); ok && deps.PostFailed != nil && now.Sub(since) > OutageWaitBound {
+			if handOverOutage(ctx, card.Key, derived, deps, now.Sub(since), since) {
 				handedOver++
 			}
 			continue
@@ -453,7 +517,7 @@ func reconcileOutage(ctx context.Context, drivable DrivableCards, liveAgents Liv
 			// Still inside the stated wait — do not relaunch this tick.
 			continue
 		}
-		if retry.relaunchOutage(card.Key, derived.Stage, logger) {
+		if deps.Retry.relaunchOutage(card.Key, derived.Stage, logger) {
 			redriven++
 		}
 	}
@@ -519,11 +583,12 @@ func stuckRunningCandidate(derived BoardCard, comments []tracker.Comment) bool {
 // this pass's own judgement (silenced) plus the idle duration to report.
 // Pulled out of reconcileStuckRunning to keep that function's branching
 // inside the complexity gate.
-func hungLiveAgent(progress AgentProgressProbe, agentName string, now time.Time, stopAgent StopAgent, pmKey string, stage BoardStage, logger zerolog.Logger) (proceed, silenced bool, idleReason string) {
+func hungLiveAgent(deps ReconcileDeps, agentName string, now time.Time, pmKey string, stage BoardStage) (proceed, silenced bool, idleReason string) {
+	logger := deps.Logger
 	// A live container is not the same as a working agent: a hung agent looks
 	// perfectly healthy here, which is why a hang was previously never
 	// detected at all. Ask whether it is still making progress.
-	stalled, idle := stageStalled(progress, agentName, now)
+	stalled, idle := stageStalled(deps.Progress, agentName, now)
 	if !stalled {
 		return false, false, "" // genuinely working, however long it has been running
 	}
@@ -533,10 +598,10 @@ func hungLiveAgent(progress AgentProgressProbe, agentName string, now time.Time,
 	// stopped before anything relaunches — otherwise two agents work the same
 	// stage. A stop that fails (or is unwired) leaves the card alone rather
 	// than risking that.
-	if stopAgent == nil {
+	if deps.StopAgent == nil {
 		return false, false, ""
 	}
-	if err := stopAgent(agentName); err != nil {
+	if err := deps.StopAgent(agentName); err != nil {
 		logger.Warn().Err(err).Str("agent", agentName).
 			Msg("board reconcile: cannot stop hung agent, leaving the card as-is")
 		return false, false, ""
@@ -544,25 +609,20 @@ func hungLiveAgent(progress AgentProgressProbe, agentName string, now time.Time,
 	return true, true, idle.Round(time.Second).String()
 }
 
-func reconcileStuckRunning(ctx context.Context, drivable DrivableCards, liveAgents LiveAgentLister, postFailed FailedMarkerPoster, retry StageRetry, progress AgentProgressProbe, stopAgent StopAgent, daemonID string, now time.Time, logger zerolog.Logger) int {
-	if liveAgents == nil || postFailed == nil {
+func reconcileStuckRunning(ctx context.Context, drivable DrivableCards, deps ReconcileDeps, now time.Time) int {
+	if deps.PostFailed == nil {
 		return 0
 	}
-	names, err := liveAgents()
-	if err != nil {
-		// Without a trustworthy liveness picture the pass must not red anything —
-		// a probe blip is not evidence a card is dead.
-		logger.Warn().Err(err).Msg("board reconcile: cannot list live agents, leaving running cards as-is")
+	// Without a trustworthy liveness picture the pass must not red anything — a
+	// probe blip is not evidence a card is dead.
+	alive, ok := deps.aliveAgents("stuck-running")
+	if !ok {
 		return 0
-	}
-	alive := make(map[string]struct{}, len(names))
-	for _, n := range names {
-		alive[n] = struct{}{}
 	}
 
 	reddened := 0
 	for _, card := range drivable.cards {
-		if reconcileOneStuckCard(ctx, card, alive, postFailed, retry, progress, stopAgent, daemonID, now, logger) {
+		if reconcileOneStuckCard(ctx, card, alive, deps, now) {
 			reddened++
 		}
 	}
@@ -573,7 +633,8 @@ func reconcileStuckRunning(ctx context.Context, drivable DrivableCards, liveAgen
 // and reports whether it was reddened. Split out of reconcileStuckRunning so
 // that function's per-card branching costs its own function rather than the
 // loop's complexity budget.
-func reconcileOneStuckCard(ctx context.Context, card ReconcileCard, alive map[string]struct{}, postFailed FailedMarkerPoster, retry StageRetry, progress AgentProgressProbe, stopAgent StopAgent, daemonID string, now time.Time, logger zerolog.Logger) bool {
+func reconcileOneStuckCard(ctx context.Context, card ReconcileCard, alive map[string]struct{}, deps ReconcileDeps, now time.Time) bool {
+	logger := deps.Logger
 	derived := DeriveBoardCard(card.Comments, tracker.CategoryUnstarted, false)
 	if !stuckCardIsOursToRed(derived, card) {
 		return false
@@ -595,7 +656,7 @@ func reconcileOneStuckCard(ctx context.Context, card ReconcileCard, alive map[st
 	var silenced bool
 	var idleReason string
 	if _, ok := alive[agentName]; ok {
-		proceed, s, reason := hungLiveAgent(progress, agentName, now, stopAgent, card.Key, derived.Stage, logger)
+		proceed, s, reason := hungLiveAgent(deps, agentName, now, card.Key, derived.Stage)
 		if !proceed {
 			return false
 		}
@@ -617,7 +678,7 @@ func reconcileOneStuckCard(ctx context.Context, card ReconcileCard, alive map[st
 	if cause := latestStageWaitCause(card.Comments); cause != "" {
 		failed.Body = strings.TrimSpace(failed.Body + "\nafter wait cause: " + cause)
 	}
-	if err := postFailed(ctx, card.Key, markerBody(failed)); err != nil {
+	if err := deps.PostFailed(ctx, card.Key, markerBody(failed)); err != nil {
 		logger.Warn().Err(err).Str("pm", card.Key).
 			Msg("board reconcile: cannot red stuck-running card")
 		return false
@@ -627,7 +688,7 @@ func reconcileOneStuckCard(ctx context.Context, card ReconcileCard, alive map[st
 			// A live agent this pass judged hung and stopped itself: uncharged,
 			// like the live failure watcher's silence-reap path (SC-2447) — the
 			// work did not fail, a judgement about the work did.
-			retry.relaunchSilenceReap(card.Key, derived.Stage, logger)
+			deps.Retry.relaunchSilenceReap(card.Key, derived.Stage, logger)
 		}
 		// givingUp: the cap is spent, leave the card as the give-up marker just
 		// routed it, for a person to look at — no further relaunch.
@@ -641,7 +702,7 @@ func reconcileOneStuckCard(ctx context.Context, card ReconcileCard, alive map[st
 	// failed marker is the trail record, so no separate retry note (nil
 	// commenter); the shared per-stage budget bounds this path and the
 	// watcher's together.
-	retry.tryRelaunch(ctx, card.Key, derived.Stage, nil, daemonID, logger)
+	deps.Retry.tryRelaunch(ctx, card.Key, derived.Stage, nil, deps.DaemonID, logger)
 	return true
 }
 
@@ -752,8 +813,9 @@ func stuckRunningReason(stage BoardStage) string {
 // write (SC-4063). It must NOT take forReview — that arm demands a reachable
 // branch, and the branch of a merged PR is deleted at merge, so reachability would
 // filter out exactly the cards this pass exists to clear.
-func reconcileShippedFailures(ctx context.Context, drivable DrivableCards, mergedProbe PRMergedProbe, postDeployed DeployedPoster, logger zerolog.Logger) int {
-	if mergedProbe == nil || postDeployed == nil {
+func reconcileShippedFailures(ctx context.Context, drivable DrivableCards, deps ReconcileDeps) int {
+	logger := deps.Logger
+	if deps.MergedProbe == nil || deps.PostDeployed == nil {
 		return 0
 	}
 	cleared := 0
@@ -765,7 +827,7 @@ func reconcileShippedFailures(ctx context.Context, drivable DrivableCards, merge
 		if derived.State != BoardFailed || derived.Stage != BoardDoneStage || derived.PRURL == "" {
 			continue
 		}
-		merged, err := mergedProbe(ctx, derived.PRURL)
+		merged, err := deps.MergedProbe(ctx, derived.PRURL)
 		if err != nil {
 			logger.Warn().Err(err).Str("pm", card.Key).Str("pr", derived.PRURL).
 				Msg("board reconcile: cannot probe PR merge status, leaving card as-is")
@@ -775,7 +837,7 @@ func reconcileShippedFailures(ctx context.Context, drivable DrivableCards, merge
 			// A genuinely-open failure must stay red — never clear on unknown state.
 			continue
 		}
-		if err := postDeployed(ctx, card.Key, derived.PRURL); err != nil {
+		if err := deps.PostDeployed(ctx, card.Key, derived.PRURL); err != nil {
 			logger.Warn().Err(err).Str("pm", card.Key).
 				Msg("board reconcile: cannot post deployed marker for shipped PR")
 			continue
@@ -808,7 +870,8 @@ func reconcileShippedFailures(ctx context.Context, drivable DrivableCards, merge
 // the branch — never starting a review it could never satisfy (SC-652, now
 // enforced by construction rather than a per-path check, SC-2047). Returns the
 // number of reviews launched.
-func reconcileOrphanedHandoffs(drivable DrivableCards, commitsPresent CommitsPresent, chainReview ChainReview, logger zerolog.Logger) int {
+func reconcileOrphanedHandoffs(drivable DrivableCards, deps ReconcileDeps) int {
+	logger := deps.Logger
 	launched := 0
 	for _, card := range drivable.cards {
 		derived := DeriveBoardCard(card.Comments, tracker.CategoryUnstarted, false)
@@ -820,12 +883,12 @@ func reconcileOrphanedHandoffs(drivable DrivableCards, commitsPresent CommitsPre
 		// cannot reach the repo). A periodic scan must never red a card another
 		// machine can serve; the loud failure lives on the live chain, and only on
 		// a definite absence (SC-2403).
-		if commitPresenceForHandoff(card.Comments, derived.Branch, commitsPresent).Status != ProbePresent {
+		if commitPresenceForHandoff(card.Comments, derived.Branch, deps.CommitsPresent).Status != ProbePresent {
 			logger.Warn().Str("pm", card.Key).Str("branch", derived.Branch).
 				Msg("board reconcile: handoff commits not verifiable on this machine, leaving it")
 			continue
 		}
-		if err := chainReview(card.Key); err != nil {
+		if err := deps.ChainReview(card.Key); err != nil {
 			logger.Warn().Err(err).Str("pm", card.Key).Msg("board reconcile: cannot chain review for orphaned handoff")
 			continue
 		}

--- a/internal/daemon/board_reconcile_gate_test.go
+++ b/internal/daemon/board_reconcile_gate_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/gethuman-sh/human/internal/marker"
@@ -124,13 +123,15 @@ func TestReconcileOnce_UnreachableWorkIsUntouchedAcrossEveryPass(t *testing.T) {
 	}
 	var chained, driven []string
 	var posted []struct{ Key, Body string }
-	gate := WorkGate{reachable: neverReachable, daemonID: "d1"}
-
-	reconcileOnce(context.Background(), lister, gate,
-		nil, nil, nil, liveAgents(), capturingPoster(&posted), nil,
-		func(k string) error { chained = append(chained, k); return nil },
-		func(k string) error { driven = append(driven, k); return nil },
-		StageRetry{}, nil, nil, "d1", zerolog.Nop())
+	reconcileOnce(context.Background(), ReconcileDeps{
+		ListCards:   lister,
+		Reachable:   neverReachable,
+		LiveAgents:  liveAgents(),
+		PostFailed:  capturingPoster(&posted),
+		ChainReview: func(k string) error { chained = append(chained, k); return nil },
+		DriveLoop:   func(k string) error { driven = append(driven, k); return nil },
+		DaemonID:    "d1",
+	})
 
 	assert.Empty(t, chained, "an unreachable handoff is not reviewed")
 	assert.Empty(t, driven, "an unreachable loop is not re-driven")

--- a/internal/daemon/board_reconcile_hang_test.go
+++ b/internal/daemon/board_reconcile_hang_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gethuman-sh/human/internal/tracker"
@@ -64,11 +63,7 @@ func TestReconcileStuckRunning_HungAgentIsStoppedReddenedAndRelaunched(t *testin
 		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 	}
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(runningCard(now), alwaysReachable),
-		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), retry,
-		progressAt(now.Add(-IdleGrace-time.Minute), false, false),
-		func(name string) error { stopped = append(stopped, name); return nil },
-		"d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(runningCard(now), alwaysReachable), ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), PostFailed: capturingPoster(&posted), Retry: retry, Progress: progressAt(now.Add(-IdleGrace-time.Minute), false, false), StopAgent: func(name string) error { stopped = append(stopped, name); return nil }, DaemonID: "d1"}, now)
 
 	require.Equal(t, 1, n, "the hung card is reddened")
 	require.Equal(t, []string{"board-SC-1-implementation"}, stopped,
@@ -96,11 +91,7 @@ func TestReconcileStuckRunning_DeadNoAgentStillCharges(t *testing.T) {
 		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 	}
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(runningCard(now), alwaysReachable),
-		liveAgents(), capturingPoster(&posted), retry,
-		progressAt(now.Add(-time.Hour), false, false),
-		func(string) error { t.Fatal("no live agent to stop"); return nil },
-		"d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(runningCard(now), alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), Retry: retry, Progress: progressAt(now.Add(-time.Hour), false, false), StopAgent: func(string) error { t.Fatal("no live agent to stop"); return nil }, DaemonID: "d1"}, now)
 
 	require.Equal(t, 1, n, "the dead-end card is still reddened")
 	require.True(t, attemptsCalled, "a vanished agent is a genuine death and stays charged")
@@ -117,11 +108,7 @@ func TestReconcileStuckRunning_ActiveAgentIsLeftAlone(t *testing.T) {
 	var posted []struct{ Key, Body string }
 	var stopped []string
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(runningCard(now), alwaysReachable),
-		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), StageRetry{},
-		progressAt(now.Add(-10*time.Second), false, false),
-		func(name string) error { stopped = append(stopped, name); return nil },
-		"d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(runningCard(now), alwaysReachable), ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), PostFailed: capturingPoster(&posted), Progress: progressAt(now.Add(-10*time.Second), false, false), StopAgent: func(name string) error { stopped = append(stopped, name); return nil }, DaemonID: "d1"}, now)
 
 	require.Equal(t, 0, n)
 	require.Empty(t, posted)
@@ -135,11 +122,8 @@ func TestReconcileStuckRunning_LongToolCallIsNotAHang(t *testing.T) {
 	var posted []struct{ Key, Body string }
 	var stopped []string
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(runningCard(now), alwaysReachable),
-		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), StageRetry{},
-		progressAt(now.Add(-10*time.Minute), true, false), // inside a tool call
-		func(name string) error { stopped = append(stopped, name); return nil },
-		"d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(runningCard(now), alwaysReachable), ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), PostFailed: capturingPoster(&posted), Progress: progressAt(now.Add(-10*time.Minute), true, false), StopAgent: // inside a tool call
+	func(name string) error { stopped = append(stopped, name); return nil }, DaemonID:                                                                                                                                                                                                "d1"}, now)
 
 	require.Equal(t, 0, n, "a running suite must not be killed")
 	require.Empty(t, stopped)
@@ -151,11 +135,8 @@ func TestReconcileStuckRunning_BlockedAgentIsNotHung(t *testing.T) {
 	var posted []struct{ Key, Body string }
 	var stopped []string
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(runningCard(now), alwaysReachable),
-		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), StageRetry{},
-		progressAt(now.Add(-time.Hour), false, true), // blocked on a human
-		func(name string) error { stopped = append(stopped, name); return nil },
-		"d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(runningCard(now), alwaysReachable), ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), PostFailed: capturingPoster(&posted), Progress: progressAt(now.Add(-time.Hour), false, true), StopAgent: // blocked on a human
+	func(name string) error { stopped = append(stopped, name); return nil }, DaemonID:                                                                                                                                                                                           "d1"}, now)
 
 	require.Equal(t, 0, n)
 	require.Empty(t, stopped)
@@ -168,16 +149,12 @@ func TestReconcileStuckRunning_UnknownProgressLeavesLiveWorkAlone(t *testing.T) 
 	var posted []struct{ Key, Body string }
 
 	unknown := func(string) (AgentProgress, bool) { return AgentProgress{}, false }
-	n := reconcileStuckRunning(context.Background(), takeoverSet(runningCard(now), alwaysReachable),
-		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), StageRetry{},
-		unknown, func(string) error { return nil }, "d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(runningCard(now), alwaysReachable), ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), PostFailed: capturingPoster(&posted), Progress: unknown, StopAgent: func(string) error { return nil }, DaemonID: "d1"}, now)
 
 	require.Equal(t, 0, n)
 
 	// Same when no probe is wired at all — previous behaviour, unchanged.
-	n = reconcileStuckRunning(context.Background(), takeoverSet(runningCard(now), alwaysReachable),
-		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), StageRetry{},
-		nil, nil, "d1", now, zerolog.Nop())
+	n = reconcileStuckRunning(context.Background(), takeoverSet(runningCard(now), alwaysReachable), ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), PostFailed: capturingPoster(&posted), DaemonID: "d1"}, now)
 	require.Equal(t, 0, n)
 }
 
@@ -196,11 +173,7 @@ func TestReconcileStuckRunning_SilenceReapGivesUpAfterCap(t *testing.T) {
 		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 	}
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(runningCardWithPriorReaps(now, MaxSilenceReaps), alwaysReachable),
-		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), retry,
-		progressAt(now.Add(-IdleGrace-time.Minute), false, false),
-		func(name string) error { stopped = append(stopped, name); return nil },
-		"d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(runningCardWithPriorReaps(now, MaxSilenceReaps), alwaysReachable), ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), PostFailed: capturingPoster(&posted), Retry: retry, Progress: progressAt(now.Add(-IdleGrace-time.Minute), false, false), StopAgent: func(name string) error { stopped = append(stopped, name); return nil }, DaemonID: "d1"}, now)
 
 	require.Equal(t, 1, n, "the card is still reddened with the give-up marker")
 	require.Empty(t, relaunched, "the cap is spent — the stage must not be relaunched again")
@@ -224,11 +197,7 @@ func TestReconcileStuckRunning_SilenceReapGiveUpDedup(t *testing.T) {
 		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 	}
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable),
-		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), retry,
-		progressAt(now.Add(-IdleGrace-time.Minute), false, false),
-		func(string) error { return nil },
-		"d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), PostFailed: capturingPoster(&posted), Retry: retry, Progress: progressAt(now.Add(-IdleGrace-time.Minute), false, false), StopAgent: func(string) error { return nil }, DaemonID: "d1"}, now)
 
 	require.Equal(t, 0, n, "already given up — nothing more is posted")
 	require.Empty(t, relaunched)
@@ -248,11 +217,7 @@ func TestReconcileStuckRunning_FailedStopDoesNotRelaunch(t *testing.T) {
 		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 	}
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(runningCard(now), alwaysReachable),
-		liveAgents("board-SC-1-implementation"), capturingPoster(&posted), retry,
-		progressAt(now.Add(-time.Hour), false, false),
-		func(string) error { return errors.New("docker unavailable") },
-		"d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(runningCard(now), alwaysReachable), ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), PostFailed: capturingPoster(&posted), Retry: retry, Progress: progressAt(now.Add(-time.Hour), false, false), StopAgent: func(string) error { return errors.New("docker unavailable") }, DaemonID: "d1"}, now)
 
 	require.Equal(t, 0, n)
 	require.Empty(t, relaunched, "never relaunch while the hung agent may still be running")

--- a/internal/daemon/board_reconcile_orphan.go
+++ b/internal/daemon/board_reconcile_orphan.go
@@ -30,7 +30,7 @@ type ClosedTicketProbe func(ctx context.Context, pmKey string) (bool, error)
 // uncertainty resolves to "leave it running" — an unparseable name, a probe
 // error, or a ticket that is merely absent rather than confirmed closed — because
 // killing live work on absent evidence is the one failure this must never risk.
-func reconcileOrphanedAgents(ctx context.Context, cards []ReconcileCard, liveAgents LiveAgentLister, closed ClosedTicketProbe, stopAgent func(agentName string) error, postRecord FailedMarkerPoster, logger zerolog.Logger) int {
+func reconcileOrphanedAgents(ctx context.Context, cards []ReconcileCard, liveAgents LiveAgentLister, closed ClosedTicketProbe, stopAgent StopAgent, postRecord FailedMarkerPoster, logger zerolog.Logger) int {
 	if liveAgents == nil || closed == nil || stopAgent == nil {
 		return 0
 	}

--- a/internal/daemon/board_reconcile_orphan.go
+++ b/internal/daemon/board_reconcile_orphan.go
@@ -2,8 +2,6 @@ package daemon
 
 import (
 	"context"
-
-	"github.com/rs/zerolog"
 )
 
 // ClosedTicketProbe reports whether pmKey's ticket has left the board as
@@ -30,11 +28,12 @@ type ClosedTicketProbe func(ctx context.Context, pmKey string) (bool, error)
 // uncertainty resolves to "leave it running" — an unparseable name, a probe
 // error, or a ticket that is merely absent rather than confirmed closed — because
 // killing live work on absent evidence is the one failure this must never risk.
-func reconcileOrphanedAgents(ctx context.Context, cards []ReconcileCard, liveAgents LiveAgentLister, closed ClosedTicketProbe, stopAgent StopAgent, postRecord FailedMarkerPoster, logger zerolog.Logger) int {
-	if liveAgents == nil || closed == nil || stopAgent == nil {
+func reconcileOrphanedAgents(ctx context.Context, cards []ReconcileCard, deps ReconcileDeps) int {
+	logger := deps.Logger
+	if deps.LiveAgents == nil || deps.ClosedProbe == nil || deps.StopAgent == nil {
 		return 0
 	}
-	names, err := liveAgents()
+	names, err := deps.LiveAgents()
 	if err != nil {
 		logger.Warn().Err(err).Msg("board reconcile: cannot list live agents for orphan sweep")
 		return 0
@@ -50,7 +49,7 @@ func reconcileOrphanedAgents(ctx context.Context, cards []ReconcileCard, liveAge
 
 	stopped := 0
 	for _, key := range order {
-		isClosed, probeErr := closed(ctx, key)
+		isClosed, probeErr := deps.ClosedProbe(ctx, key)
 		if probeErr != nil {
 			logger.Warn().Err(probeErr).Str("pm", key).
 				Msg("board reconcile: cannot confirm ticket is closed, leaving its run alone")
@@ -60,14 +59,14 @@ func reconcileOrphanedAgents(ctx context.Context, cards []ReconcileCard, liveAge
 			continue
 		}
 		for _, name := range candidates[key] {
-			if err := stopAgent(name); err != nil {
+			if err := deps.StopAgent(name); err != nil {
 				logger.Warn().Err(err).Str("pm", key).Str("agent", name).
 					Msg("board reconcile: cannot stop agent orphaned on a closed ticket")
 				continue
 			}
 			logger.Info().Str("pm", key).Str("agent", name).
 				Msg("board reconcile: stopped agent orphaned on a closed ticket")
-			recordCancelledRun(ctx, key, name, postRecord, logger)
+			recordCancelledRun(ctx, key, name, deps)
 			stopped++
 		}
 	}
@@ -108,15 +107,16 @@ func orphanCandidates(names []string, open map[string]struct{}) (map[string][]st
 // safety property this pass exists for, and a tracker that will not take a
 // comment — which a just-closed ticket may well refuse — must never leave an
 // agent running against called-off work.
-func recordCancelledRun(ctx context.Context, pmKey, agentName string, postRecord FailedMarkerPoster, logger zerolog.Logger) {
-	if postRecord == nil {
+func recordCancelledRun(ctx context.Context, pmKey, agentName string, deps ReconcileDeps) {
+	logger := deps.Logger
+	if deps.PostFailed == nil {
 		return
 	}
 	_, stage, ok := parseAgentName(agentName)
 	if !ok {
 		return
 	}
-	if err := postRecord(ctx, pmKey, RunCancelledBody(stage, agentName)); err != nil {
+	if err := deps.PostFailed(ctx, pmKey, RunCancelledBody(stage, agentName)); err != nil {
 		logger.Warn().Err(err).Str("pm", pmKey).Str("agent", agentName).
 			Msg("board reconcile: stopped the orphaned agent but could not record the cancellation")
 	}

--- a/internal/daemon/board_reconcile_orphan_test.go
+++ b/internal/daemon/board_reconcile_orphan_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,10 +37,7 @@ func closedKeys(keys ...string) ClosedTicketProbe {
 func TestReconcileOrphanedAgents_StopsAgentOnTicketClosedOutsideTheBoard(t *testing.T) {
 	var stopped []string
 
-	n := reconcileOrphanedAgents(context.Background(), openCards("SC-2"),
-		liveAgents("board-SC-1-implementation"), closedKeys("SC-1"),
-		func(name string) error { stopped = append(stopped, name); return nil },
-		nil, zerolog.Nop())
+	n := reconcileOrphanedAgents(context.Background(), openCards("SC-2"), ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), ClosedProbe: closedKeys("SC-1"), StopAgent: func(name string) error { stopped = append(stopped, name); return nil }})
 
 	require.Equal(t, 1, n)
 	require.Equal(t, []string{"board-SC-1-implementation"}, stopped,
@@ -57,10 +53,7 @@ func TestReconcileOrphanedAgents_StopsEveryStageOfTheClosedTicket(t *testing.T) 
 		return key == "SC-1", nil
 	}
 
-	n := reconcileOrphanedAgents(context.Background(), nil,
-		liveAgents("board-SC-1-implementation", "board-SC-1-verification"), probe,
-		func(name string) error { stopped = append(stopped, name); return nil },
-		nil, zerolog.Nop())
+	n := reconcileOrphanedAgents(context.Background(), nil, ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation", "board-SC-1-verification"), ClosedProbe: probe, StopAgent: func(name string) error { stopped = append(stopped, name); return nil }})
 
 	require.Equal(t, 2, n)
 	require.ElementsMatch(t, []string{"board-SC-1-implementation", "board-SC-1-verification"}, stopped)
@@ -76,10 +69,7 @@ func TestReconcileOrphanedAgents_OpenCardIsNeverProbed(t *testing.T) {
 		return true, nil
 	}
 
-	n := reconcileOrphanedAgents(context.Background(), openCards("SC-1"),
-		liveAgents("board-SC-1-implementation"), probe,
-		func(string) error { t.Fatal("a live run on an open card must never be stopped"); return nil },
-		nil, zerolog.Nop())
+	n := reconcileOrphanedAgents(context.Background(), openCards("SC-1"), ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), ClosedProbe: probe, StopAgent: func(string) error { t.Fatal("a live run on an open card must never be stopped"); return nil }})
 
 	require.Zero(t, n)
 	require.False(t, probed, "an agent matching an open card needs no tracker call")
@@ -88,10 +78,7 @@ func TestReconcileOrphanedAgents_OpenCardIsNeverProbed(t *testing.T) {
 // Absence from the open-card list is NOT proof of a close: a flaky per-ticket
 // comment fetch drops a healthy card too, so only a confirmed close may kill.
 func TestReconcileOrphanedAgents_AbsentButOpenTicketIsLeftRunning(t *testing.T) {
-	n := reconcileOrphanedAgents(context.Background(), nil,
-		liveAgents("board-SC-1-implementation"), closedKeys(),
-		func(string) error { t.Fatal("a ticket that is merely absent must not stop its run"); return nil },
-		nil, zerolog.Nop())
+	n := reconcileOrphanedAgents(context.Background(), nil, ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), ClosedProbe: closedKeys(), StopAgent: func(string) error { t.Fatal("a ticket that is merely absent must not stop its run"); return nil }})
 
 	require.Zero(t, n)
 }
@@ -103,10 +90,7 @@ func TestReconcileOrphanedAgents_ProbeErrorLeavesTheRunAlone(t *testing.T) {
 		return false, errors.New("tracker unreachable")
 	}
 
-	n := reconcileOrphanedAgents(context.Background(), nil,
-		liveAgents("board-SC-1-implementation"), probe,
-		func(string) error { t.Fatal("an unconfirmed close must not stop a run"); return nil },
-		nil, zerolog.Nop())
+	n := reconcileOrphanedAgents(context.Background(), nil, ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), ClosedProbe: probe, StopAgent: func(string) error { t.Fatal("an unconfirmed close must not stop a run"); return nil }})
 
 	require.Zero(t, n)
 }
@@ -123,9 +107,7 @@ func TestReconcileOrphanedAgents_FailedStopIsNotCountedAndDoesNotAbort(t *testin
 		return nil
 	}
 
-	n := reconcileOrphanedAgents(context.Background(), nil,
-		liveAgents("board-SC-1-implementation", "board-SC-1-verification"),
-		closedKeys("SC-1"), stop, nil, zerolog.Nop())
+	n := reconcileOrphanedAgents(context.Background(), nil, ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation", "board-SC-1-verification"), ClosedProbe: closedKeys("SC-1"), StopAgent: stop})
 
 	require.Equal(t, 1, n, "only the confirmed stop counts")
 	require.Len(t, attempted, 2, "a failed stop must not abort the remaining agents")
@@ -139,10 +121,7 @@ func TestReconcileOrphanedAgents_NonBoardAgentsAreIgnored(t *testing.T) {
 		return false, nil
 	}
 
-	n := reconcileOrphanedAgents(context.Background(), nil,
-		liveAgents("some-other-container", "board-"), probe,
-		func(string) error { t.Fatal("a non-board container must never be stopped"); return nil },
-		nil, zerolog.Nop())
+	n := reconcileOrphanedAgents(context.Background(), nil, ReconcileDeps{LiveAgents: liveAgents("some-other-container", "board-"), ClosedProbe: probe, StopAgent: func(string) error { t.Fatal("a non-board container must never be stopped"); return nil }})
 
 	require.Zero(t, n)
 }
@@ -152,9 +131,7 @@ func TestReconcileOrphanedAgents_NonBoardAgentsAreIgnored(t *testing.T) {
 func TestReconcileOrphanedAgents_ListErrorIsNotAnEmptyFleet(t *testing.T) {
 	lister := func() ([]string, error) { return nil, errors.New("docker down") }
 
-	n := reconcileOrphanedAgents(context.Background(), nil, lister, closedKeys("SC-1"),
-		func(string) error { t.Fatal("nothing may be stopped without a live-agent list"); return nil },
-		nil, zerolog.Nop())
+	n := reconcileOrphanedAgents(context.Background(), nil, ReconcileDeps{LiveAgents: lister, ClosedProbe: closedKeys("SC-1"), StopAgent: func(string) error { t.Fatal("nothing may be stopped without a live-agent list"); return nil }})
 
 	require.Zero(t, n)
 }
@@ -164,9 +141,9 @@ func TestReconcileOrphanedAgents_ListErrorIsNotAnEmptyFleet(t *testing.T) {
 func TestReconcileOrphanedAgents_NilDepsDisableTheSweep(t *testing.T) {
 	stop := func(string) error { t.Fatal("a disabled sweep must stop nothing"); return nil }
 
-	require.Zero(t, reconcileOrphanedAgents(context.Background(), nil, nil, closedKeys("SC-1"), stop, nil, zerolog.Nop()))
-	require.Zero(t, reconcileOrphanedAgents(context.Background(), nil, liveAgents("board-SC-1-implementation"), nil, stop, nil, zerolog.Nop()))
-	require.Zero(t, reconcileOrphanedAgents(context.Background(), nil, liveAgents("board-SC-1-implementation"), closedKeys("SC-1"), nil, nil, zerolog.Nop()))
+	require.Zero(t, reconcileOrphanedAgents(context.Background(), nil, ReconcileDeps{ClosedProbe: closedKeys("SC-1"), StopAgent: stop}))
+	require.Zero(t, reconcileOrphanedAgents(context.Background(), nil, ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), StopAgent: stop}))
+	require.Zero(t, reconcileOrphanedAgents(context.Background(), nil, ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), ClosedProbe: closedKeys("SC-1")}))
 }
 
 // The open-card match runs through the same sanitize() the launcher used, so a
@@ -177,10 +154,7 @@ func TestReconcileOrphanedAgents_OpenCardMatchesThroughSanitizedKey(t *testing.T
 		return false, nil
 	}
 
-	n := reconcileOrphanedAgents(context.Background(), openCards("proj_1"),
-		liveAgents(agentNameFor("proj_1", BoardImplementation)), probe,
-		func(string) error { t.Fatal("a live run on an open card must never be stopped"); return nil },
-		nil, zerolog.Nop())
+	n := reconcileOrphanedAgents(context.Background(), openCards("proj_1"), ReconcileDeps{LiveAgents: liveAgents(agentNameFor("proj_1", BoardImplementation)), ClosedProbe: probe, StopAgent: func(string) error { t.Fatal("a live run on an open card must never be stopped"); return nil }})
 
 	require.Zero(t, n)
 }
@@ -190,14 +164,10 @@ func TestReconcileOrphanedAgents_OpenCardMatchesThroughSanitizedKey(t *testing.T
 // could go from running to gone with nothing on the thread saying so.
 func TestReconcileOrphanedAgents_RecordsTheCancellation(t *testing.T) {
 	var posted []string
-	n := reconcileOrphanedAgents(context.Background(), openCards("SC-2"),
-		liveAgents("board-SC-1-implementation"), closedKeys("SC-1"),
-		func(string) error { return nil },
-		func(_ context.Context, key, body string) error {
-			posted = append(posted, key+" "+body)
-			return nil
-		},
-		zerolog.Nop())
+	n := reconcileOrphanedAgents(context.Background(), openCards("SC-2"), ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), ClosedProbe: closedKeys("SC-1"), StopAgent: func(string) error { return nil }, PostFailed: func(_ context.Context, key, body string) error {
+		posted = append(posted, key+" "+body)
+		return nil
+	}})
 
 	require.Equal(t, 1, n)
 	require.Len(t, posted, 1)
@@ -212,11 +182,7 @@ func TestReconcileOrphanedAgents_RecordsTheCancellation(t *testing.T) {
 // just-closed ticket may well do — must never leave the agent running.
 func TestReconcileOrphanedAgents_StopsEvenWhenTheRecordFails(t *testing.T) {
 	var stopped []string
-	n := reconcileOrphanedAgents(context.Background(), openCards("SC-2"),
-		liveAgents("board-SC-1-implementation"), closedKeys("SC-1"),
-		func(name string) error { stopped = append(stopped, name); return nil },
-		func(context.Context, string, string) error { return assert.AnError },
-		zerolog.Nop())
+	n := reconcileOrphanedAgents(context.Background(), openCards("SC-2"), ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), ClosedProbe: closedKeys("SC-1"), StopAgent: func(name string) error { stopped = append(stopped, name); return nil }, PostFailed: func(context.Context, string, string) error { return assert.AnError }})
 
 	require.Equal(t, 1, n)
 	assert.Equal(t, []string{"board-SC-1-implementation"}, stopped)
@@ -225,11 +191,7 @@ func TestReconcileOrphanedAgents_StopsEvenWhenTheRecordFails(t *testing.T) {
 // An agent that was never stopped leaves no record either.
 func TestReconcileOrphanedAgents_NoRecordWhenNothingStops(t *testing.T) {
 	var posted int
-	n := reconcileOrphanedAgents(context.Background(), openCards("SC-1"),
-		liveAgents("board-SC-1-implementation"), closedKeys("SC-1"),
-		func(string) error { t.Fatal("an open card's run must never be stopped"); return nil },
-		func(context.Context, string, string) error { posted++; return nil },
-		zerolog.Nop())
+	n := reconcileOrphanedAgents(context.Background(), openCards("SC-1"), ReconcileDeps{LiveAgents: liveAgents("board-SC-1-implementation"), ClosedProbe: closedKeys("SC-1"), StopAgent: func(string) error { t.Fatal("an open card's run must never be stopped"); return nil }, PostFailed: func(context.Context, string, string) error { posted++; return nil }})
 
 	require.Zero(t, n)
 	assert.Zero(t, posted)

--- a/internal/daemon/board_reconcile_ownership_test.go
+++ b/internal/daemon/board_reconcile_ownership_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/gethuman-sh/human/internal/marker"
@@ -30,8 +29,7 @@ func TestReconcileStuckRunning_NeverTakesOverAForeignOwnedStage(t *testing.T) {
 	}}
 	var posted []struct{ Key, Body string }
 
-	n := reconcileStuckRunning(context.Background(), takeoverSetAs(foreign, alwaysReachable, "thisBBBB"),
-		liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "thisBBBB", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSetAs(foreign, alwaysReachable, "thisBBBB"), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), DaemonID: "thisBBBB"}, now)
 
 	assert.Equal(t, 0, n, "a stage owned by a peer daemon is never reddened from a distance")
 	assert.Empty(t, posted, "no failed marker may be posted for a peer machine's running stage")
@@ -51,8 +49,7 @@ func TestReconcileStuckRunning_RedsOwnCardAtLocalGrace(t *testing.T) {
 	}}
 	var posted []struct{ Key, Body string }
 
-	n := reconcileStuckRunning(context.Background(), takeoverSetAs(own, alwaysReachable, "thisBBBB"),
-		liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "thisBBBB", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSetAs(own, alwaysReachable, "thisBBBB"), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), DaemonID: "thisBBBB"}, now)
 
 	assert.Equal(t, 1, n)
 	assert.Len(t, posted, 1)
@@ -72,8 +69,7 @@ func TestReconcileStuckRunning_RedsUnstampedCardAtLocalGrace(t *testing.T) {
 	}}
 	var posted []struct{ Key, Body string }
 
-	n := reconcileStuckRunning(context.Background(), takeoverSetAs(unstamped, alwaysReachable, "thisBBBB"),
-		liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "thisBBBB", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSetAs(unstamped, alwaysReachable, "thisBBBB"), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), DaemonID: "thisBBBB"}, now)
 
 	assert.Equal(t, 1, n, "an unstamped stage has no owner and stays takeable")
 	assert.Len(t, posted, 1)

--- a/internal/daemon/board_reconcile_queued.go
+++ b/internal/daemon/board_reconcile_queued.go
@@ -3,8 +3,6 @@ package daemon
 import (
 	"context"
 	"time"
-
-	"github.com/rs/zerolog"
 )
 
 // QueuedLaunchGrace is how long a decided card may sit unstarted before the
@@ -42,18 +40,14 @@ const QueuedLaunchGrace = 2 * time.Minute
 // reason: the relaunched stage's *-started marker is already the ticket-visible
 // record that work resumed, and a pass on a fixed cycle that comments each time
 // it acts is how a weekend produced hundreds of them (SC-2851).
-func reconcileQueuedLaunch(ctx context.Context, drivable DrivableCards, liveAgents LiveAgentLister, retry StageRetry, daemonID string, now time.Time, logger zerolog.Logger) int {
-	if liveAgents == nil || !retry.enabled() {
+func reconcileQueuedLaunch(ctx context.Context, drivable DrivableCards, deps ReconcileDeps, now time.Time) int {
+	logger := deps.Logger
+	if !deps.Retry.enabled() {
 		return 0
 	}
-	names, err := liveAgents()
-	if err != nil {
-		logger.Warn().Err(err).Msg("board reconcile: cannot list live agents for queued launches")
+	alive, ok := deps.aliveAgents("queued launches")
+	if !ok {
 		return 0
-	}
-	alive := make(map[string]struct{}, len(names))
-	for _, n := range names {
-		alive[n] = struct{}{}
 	}
 
 	launched := 0
@@ -74,9 +68,9 @@ func reconcileQueuedLaunch(ctx context.Context, drivable DrivableCards, liveAgen
 		if _, ok := alive[agentNameFor(card.Key, stage)]; ok {
 			continue
 		}
-		if retry.relaunchBounded(ctx, card.Key, stage,
+		if deps.Retry.relaunchBounded(ctx, card.Key, stage,
 			"the decision was answered but the launch never started",
-			nil, daemonID, logger) {
+			nil, deps.DaemonID, logger) {
 			logger.Info().Str("pm", card.Key).Str("stage", string(stage)).
 				Msg("board reconcile: started the stage a decision had queued")
 			launched++

--- a/internal/daemon/board_reconcile_queued_test.go
+++ b/internal/daemon/board_reconcile_queued_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gethuman-sh/human/internal/tracker"
@@ -44,8 +43,7 @@ func TestReconcileQueuedLaunch_StartsAStageThatNeverLaunched(t *testing.T) {
 	var relaunched []BoardStage
 	attempts := 0
 
-	n := reconcileQueuedLaunch(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
-		queuedRetry(&relaunched, &attempts), "d1", now, zerolog.Nop())
+	n := reconcileQueuedLaunch(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), Retry: queuedRetry(&relaunched, &attempts), DaemonID: "d1"}, now)
 
 	require.Equal(t, 1, n, "the decided card is started")
 	require.Equal(t, []BoardStage{BoardImplementation}, relaunched, "and started at the stage the block named")
@@ -66,8 +64,7 @@ func TestReconcileQueuedLaunch_StartsDespiteANeedsInputExit(t *testing.T) {
 	require.Equal(t, relaunchNone, classifyRelaunch(ExitNeedsInput, true),
 		"precondition: this exit is the one tryRelaunch refuses to act on")
 
-	n := reconcileQueuedLaunch(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
-		retry, "d1", now, zerolog.Nop())
+	n := reconcileQueuedLaunch(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), Retry: retry, DaemonID: "d1"}, now)
 
 	require.Equal(t, 1, n, "the answered decision supersedes the exit that asked the question")
 	require.Equal(t, []BoardStage{BoardPlanning}, relaunched)
@@ -81,8 +78,7 @@ func TestReconcileQueuedLaunch_LeavesALaunchStillInFlight(t *testing.T) {
 	var relaunched []BoardStage
 	attempts := 0
 
-	n := reconcileQueuedLaunch(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
-		queuedRetry(&relaunched, &attempts), "d1", now, zerolog.Nop())
+	n := reconcileQueuedLaunch(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), Retry: queuedRetry(&relaunched, &attempts), DaemonID: "d1"}, now)
 
 	require.Equal(t, 0, n, "inside the grace the launch is presumed on its way")
 	require.Empty(t, relaunched)
@@ -97,9 +93,7 @@ func TestReconcileQueuedLaunch_SkipsWhenTheStageAgentIsAlive(t *testing.T) {
 	var relaunched []BoardStage
 	attempts := 0
 
-	n := reconcileQueuedLaunch(context.Background(), takeoverSet(cards, alwaysReachable),
-		liveAgents(agentNameFor("SC-1", BoardImplementation)),
-		queuedRetry(&relaunched, &attempts), "d1", now, zerolog.Nop())
+	n := reconcileQueuedLaunch(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(agentNameFor("SC-1", BoardImplementation)), Retry: queuedRetry(&relaunched, &attempts), DaemonID: "d1"}, now)
 
 	require.Equal(t, 0, n, "a live agent means the launch is not missing")
 	require.Empty(t, relaunched)
@@ -114,8 +108,7 @@ func TestReconcileQueuedLaunch_StopsAtTheAttemptCap(t *testing.T) {
 	retry := queuedRetry(&relaunched, &attempts)
 
 	for range 4 {
-		reconcileQueuedLaunch(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
-			retry, "d1", now, zerolog.Nop())
+		reconcileQueuedLaunch(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), Retry: retry, DaemonID: "d1"}, now)
 	}
 
 	require.Len(t, relaunched, 2, "DefaultStageRetries bounds it — the card is left for a person after that")
@@ -136,8 +129,7 @@ func TestReconcileQueuedLaunch_DoesNotChargeARefusedLaunch(t *testing.T) {
 		Uncount:  func(string, BoardStage) { uncounted++ },
 	}
 
-	n := reconcileQueuedLaunch(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
-		retry, "d1", now, zerolog.Nop())
+	n := reconcileQueuedLaunch(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), Retry: retry, DaemonID: "d1"}, now)
 
 	require.Equal(t, 0, n, "nothing started, so nothing was recovered")
 	require.Equal(t, 1, uncounted, "and the charged attempt is rolled back")
@@ -158,8 +150,7 @@ func TestReconcileQueuedLaunch_IgnoresCardsThatAreNotQueued(t *testing.T) {
 	var relaunched []BoardStage
 	attempts := 0
 
-	n := reconcileQueuedLaunch(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
-		queuedRetry(&relaunched, &attempts), "d1", now, zerolog.Nop())
+	n := reconcileQueuedLaunch(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), Retry: queuedRetry(&relaunched, &attempts), DaemonID: "d1"}, now)
 
 	require.Equal(t, 0, n)
 	require.Empty(t, relaunched)

--- a/internal/daemon/board_reconcile_reachability_test.go
+++ b/internal/daemon/board_reconcile_reachability_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -38,9 +37,7 @@ func TestReconcileStuckRunning_UnreachableBranchIsLeftToItsOwner(t *testing.T) {
 	now := time.Unix(100_000, 0)
 	var posted []struct{ Key, Body string }
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(peerCard(now), neverReachable),
-		liveAgents(), capturingPoster(&posted),
-		StageRetry{}, nil, nil, "d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(peerCard(now), neverReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), DaemonID: "d1"}, now)
 
 	require.Zero(t, n, "a card this machine cannot act on must not be reddened")
 	assert.Empty(t, posted, "no failed marker may be posted for another machine's work")
@@ -52,9 +49,7 @@ func TestReconcileStuckRunning_ReachableBranchIsStillReddened(t *testing.T) {
 	now := time.Unix(100_000, 0)
 	var posted []struct{ Key, Body string }
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(peerCard(now), alwaysReachable),
-		liveAgents(), capturingPoster(&posted),
-		StageRetry{}, nil, nil, "d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(peerCard(now), alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), DaemonID: "d1"}, now)
 
 	require.Equal(t, 1, n)
 	require.Len(t, posted, 1)
@@ -72,9 +67,7 @@ func TestReconcileStuckRunning_CardWithoutABranchIsUnaffectedByTheGate(t *testin
 		Comments: []tracker.Comment{cmt("[human:implementation-started]", now.Add(-StuckRunningGrace-time.Minute))},
 	}}
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, neverReachable),
-		liveAgents(), capturingPoster(&posted),
-		StageRetry{}, nil, nil, "d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, neverReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), DaemonID: "d1"}, now)
 
 	assert.Equal(t, 1, n, "a branchless card has no reachability fact and keeps the old behaviour")
 }
@@ -85,9 +78,7 @@ func TestReconcileStuckRunning_NilReachableDisablesTheGate(t *testing.T) {
 	now := time.Unix(100_000, 0)
 	var posted []struct{ Key, Body string }
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(peerCard(now), nil),
-		liveAgents(), capturingPoster(&posted),
-		StageRetry{}, nil, nil, "d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(peerCard(now), nil), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), DaemonID: "d1"}, now)
 
 	assert.Equal(t, 1, n)
 }
@@ -107,9 +98,7 @@ func TestReconcileStuckRunning_UnreachableBranchIsNeverRelaunched(t *testing.T) 
 		},
 	}
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(peerCard(now), neverReachable),
-		liveAgents(), capturingPoster(&posted),
-		retry, nil, nil, "d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(peerCard(now), neverReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), Retry: retry, DaemonID: "d1"}, now)
 
 	assert.Zero(t, n)
 }

--- a/internal/daemon/board_reconcile_retry_test.go
+++ b/internal/daemon/board_reconcile_retry_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog"
-
 	"github.com/gethuman-sh/human/internal/tracker"
 	"github.com/stretchr/testify/require"
 )
@@ -32,8 +30,7 @@ func TestReconcileStuckRunning_RelaunchesAfterReddening(t *testing.T) {
 		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 	}
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
-		capturingPoster(&posted), retry, nil, nil, "d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), Retry: retry, DaemonID: "d1"}, now)
 
 	require.Equal(t, 1, n, "the card is reddened")
 	require.Len(t, posted, 1, "the failed marker is the trail record")
@@ -67,8 +64,7 @@ func TestReconcileStuckRunning_OpenSameStageOptionsIsCleanPause(t *testing.T) {
 		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 	}
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
-		capturingPoster(&posted), retry, nil, nil, "d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), Retry: retry, DaemonID: "d1"}, now)
 
 	require.Equal(t, 0, n, "an open same-stage options block is a clean pause, not a hang")
 	require.Empty(t, posted, "no failed marker for a card parked on its own decision")
@@ -103,8 +99,7 @@ func TestReconcileStuckRunning_RecordedStopVerdictIsNotAHang(t *testing.T) {
 				Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 			}
 
-			n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
-				capturingPoster(&posted), retry, nil, nil, "d1", now, zerolog.Nop())
+			n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), Retry: retry, DaemonID: "d1"}, now)
 
 			require.Equal(t, 0, n, "a recorded stop verdict is a deliberate ending, not a hang")
 			require.Empty(t, posted, "no failed marker for work a gate stopped on purpose")
@@ -135,8 +130,7 @@ func TestReconcileStuckRunning_ContinueVerdictStillReds(t *testing.T) {
 		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 	}
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
-		capturingPoster(&posted), retry, nil, nil, "d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), Retry: retry, DaemonID: "d1"}, now)
 
 	require.Equal(t, 1, n, "a ready verdict means the work continues, so a dead stage is still a hang")
 	require.Equal(t, []BoardStage{BoardPlanning}, relaunched)
@@ -165,8 +159,7 @@ func TestReconcileStuckRunning_OpenOptionsForEarlierStageIsCleanPause(t *testing
 		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 	}
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
-		capturingPoster(&posted), retry, nil, nil, "d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), Retry: retry, DaemonID: "d1"}, now)
 
 	require.Equal(t, 0, n, "an open earlier-stage options block is a clean pause, not a hang")
 	require.Empty(t, posted, "no failed marker for a card parked on a question about an earlier phase")
@@ -195,8 +188,7 @@ func TestReconcileOutage_RelaunchesWhenAgentDead(t *testing.T) {
 
 	var posted []struct{ Key, Body string }
 
-	n, handedOver := reconcileOutage(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
-		capturingPoster(&posted), retry, "d1", now, zerolog.Nop())
+	n, handedOver := reconcileOutage(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), Retry: retry, DaemonID: "d1"}, now)
 
 	require.Equal(t, 1, n, "the outage card is re-driven")
 	require.Equal(t, []BoardStage{BoardImplementation}, relaunched)
@@ -225,7 +217,7 @@ func TestReconcileOutage_SkipsWhenAgentAlive(t *testing.T) {
 	}
 	alive := liveAgents(agentNameFor("SC-1", BoardImplementation))
 
-	n, _ := reconcileOutage(context.Background(), takeoverSet(cards, alwaysReachable), alive, nil, retry, "d1", now, zerolog.Nop())
+	n, _ := reconcileOutage(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: alive, Retry: retry, DaemonID: "d1"}, now)
 
 	require.Equal(t, 0, n, "a live agent means the relaunch already happened")
 	require.Empty(t, relaunched)
@@ -255,8 +247,7 @@ func TestReconcileOutage_SignalBasedOutageRedriveDoesNotCharge(t *testing.T) {
 		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 	}
 
-	n, handedOver := reconcileOutage(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
-		nil, retry, "d1", now, zerolog.Nop())
+	n, handedOver := reconcileOutage(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), Retry: retry, DaemonID: "d1"}, now)
 
 	require.Equal(t, 1, n, "a signal-based outage card is still re-driven")
 	require.Equal(t, []BoardStage{BoardImplementation}, relaunched)
@@ -288,7 +279,7 @@ func TestReconcileOutage_WaitsUntilResumeTime(t *testing.T) {
 		var relaunched []BoardStage
 		r := retry
 		r.Relaunch = func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil }
-		reconcileOutage(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(), nil, r, "d1", at, zerolog.Nop())
+		reconcileOutage(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), Retry: r, DaemonID: "d1"}, at)
 		return relaunched
 	}
 
@@ -313,7 +304,7 @@ func TestReconcileOutage_IgnoresNonOutageCards(t *testing.T) {
 		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 	}
 
-	n, _ := reconcileOutage(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(), nil, retry, "d1", now, zerolog.Nop())
+	n, _ := reconcileOutage(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), Retry: retry, DaemonID: "d1"}, now)
 
 	require.Equal(t, 0, n)
 	require.Empty(t, relaunched)
@@ -336,8 +327,7 @@ func TestReconcileStuckRunning_RelaunchRespectsTheBudget(t *testing.T) {
 		Relaunch: func(_ string, s BoardStage) (bool, error) { relaunched = append(relaunched, s); return true, nil },
 	}
 
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(),
-		capturingPoster(&posted), retry, nil, nil, "d1", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted), Retry: retry, DaemonID: "d1"}, now)
 
 	require.Equal(t, 1, n, "the card is still reddened for a human")
 	require.Empty(t, relaunched, "a spent budget stops the automatic relaunch")

--- a/internal/daemon/board_reconcile_test.go
+++ b/internal/daemon/board_reconcile_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/gethuman-sh/human/internal/tracker"
@@ -77,10 +76,10 @@ func TestReconcileOrphanedHandoffs_LaunchesReviewForOrphan(t *testing.T) {
 		Comments: []tracker.Comment{cmt("[human:ready-for-review]\nbranch: feat/x", time.Unix(1, 0))},
 	}}
 	var chained []string
-	n := reconcileOrphanedHandoffs(reviewSet(cards, alwaysReachable), nil, func(pmKey string) error {
+	n := reconcileOrphanedHandoffs(reviewSet(cards, alwaysReachable), ReconcileDeps{ChainReview: func(pmKey string) error {
 		chained = append(chained, pmKey)
 		return nil
-	}, zerolog.Nop())
+	}})
 
 	assert.Equal(t, 1, n)
 	assert.Equal(t, []string{"SC-1"}, chained)
@@ -98,7 +97,7 @@ func TestReconcileOrphanedHandoffs_SkipsWhenReviewStarted(t *testing.T) {
 		},
 	}}
 	called := false
-	n := reconcileOrphanedHandoffs(reviewSet(cards, alwaysReachable), nil, func(string) error { called = true; return nil }, zerolog.Nop())
+	n := reconcileOrphanedHandoffs(reviewSet(cards, alwaysReachable), ReconcileDeps{ChainReview: func(string) error { called = true; return nil }})
 
 	assert.Equal(t, 0, n)
 	assert.False(t, called)
@@ -115,7 +114,7 @@ func TestReconcileOrphanedHandoffs_SkipsWhenReviewComplete(t *testing.T) {
 		},
 	}}
 	called := false
-	n := reconcileOrphanedHandoffs(reviewSet(cards, alwaysReachable), nil, func(string) error { called = true; return nil }, zerolog.Nop())
+	n := reconcileOrphanedHandoffs(reviewSet(cards, alwaysReachable), ReconcileDeps{ChainReview: func(string) error { called = true; return nil }})
 
 	assert.Equal(t, 0, n)
 	assert.False(t, called)
@@ -129,7 +128,7 @@ func TestReconcileOrphanedHandoffs_SkipsRunningBuild(t *testing.T) {
 		Comments: []tracker.Comment{cmt("[human:implementation-started]", time.Unix(1, 0))},
 	}}
 	called := false
-	n := reconcileOrphanedHandoffs(reviewSet(cards, alwaysReachable), nil, func(string) error { called = true; return nil }, zerolog.Nop())
+	n := reconcileOrphanedHandoffs(reviewSet(cards, alwaysReachable), ReconcileDeps{ChainReview: func(string) error { called = true; return nil }})
 
 	assert.Equal(t, 0, n)
 	assert.False(t, called)
@@ -146,7 +145,7 @@ func TestReconcileOrphanedHandoffs_SkipsUnreachableBranch(t *testing.T) {
 	}}
 	unreachable := func(string) ProbeResult { return ProbeResult{Status: ProbeAbsent} }
 	called := false
-	n := reconcileOrphanedHandoffs(reviewSet(cards, unreachable), nil, func(string) error { called = true; return nil }, zerolog.Nop())
+	n := reconcileOrphanedHandoffs(reviewSet(cards, unreachable), ReconcileDeps{ChainReview: func(string) error { called = true; return nil }})
 
 	assert.Equal(t, 0, n)
 	assert.False(t, called)
@@ -161,7 +160,7 @@ func TestReconcileOrphanedHandoffs_PassesHandoffBranchToProbe(t *testing.T) {
 	}}
 	var probed string
 	reachable := func(branch string) ProbeResult { probed = branch; return ProbeResult{Status: ProbePresent} }
-	n := reconcileOrphanedHandoffs(reviewSet(cards, reachable), nil, func(string) error { return nil }, zerolog.Nop())
+	n := reconcileOrphanedHandoffs(reviewSet(cards, reachable), ReconcileDeps{ChainReview: func(string) error { return nil }})
 
 	assert.Equal(t, 1, n)
 	assert.Equal(t, "autofix/sc-1", probed)
@@ -182,7 +181,7 @@ func TestReconcileOrphanedHandoffs_SkipsPhantomCommits(t *testing.T) {
 		return ProbeResult{Status: ProbeAbsent}
 	}
 	called := false
-	n := reconcileOrphanedHandoffs(reviewSet(cards, alwaysReachable), commitsPresent, func(string) error { called = true; return nil }, zerolog.Nop())
+	n := reconcileOrphanedHandoffs(reviewSet(cards, alwaysReachable), ReconcileDeps{CommitsPresent: commitsPresent, ChainReview: func(string) error { called = true; return nil }})
 
 	assert.Equal(t, 0, n)
 	assert.False(t, called, "a phantom-commit handoff must not chain a review")
@@ -199,7 +198,7 @@ func TestReconcileOrphanedHandoffs_ChainsWhenCommitsPresent(t *testing.T) {
 	}}
 	commitsPresent := func(string, []string) ProbeResult { return ProbeResult{Status: ProbePresent} }
 	called := false
-	n := reconcileOrphanedHandoffs(reviewSet(cards, alwaysReachable), commitsPresent, func(string) error { called = true; return nil }, zerolog.Nop())
+	n := reconcileOrphanedHandoffs(reviewSet(cards, alwaysReachable), ReconcileDeps{CommitsPresent: commitsPresent, ChainReview: func(string) error { called = true; return nil }})
 
 	assert.Equal(t, 1, n)
 	assert.True(t, called)
@@ -219,7 +218,7 @@ func TestReconcileOrphanedHandoffs_LeavesUnreadableCommits(t *testing.T) {
 		return ProbeResult{Status: ProbeUnreadable, Detail: "probe timed out"}
 	}
 	called := false
-	n := reconcileOrphanedHandoffs(reviewSet(cards, alwaysReachable), commitsPresent, func(string) error { called = true; return nil }, zerolog.Nop())
+	n := reconcileOrphanedHandoffs(reviewSet(cards, alwaysReachable), ReconcileDeps{CommitsPresent: commitsPresent, ChainReview: func(string) error { called = true; return nil }})
 
 	assert.Equal(t, 0, n)
 	assert.False(t, called, "an unreadable commit check must not chain a review")
@@ -242,7 +241,12 @@ func TestRunBoardReconcile_RecoversOrphanWithNoLiveEvent(t *testing.T) {
 	ctx := t.Context()
 	// A long interval proves the recovery comes from the immediate startup pass,
 	// not a ticker tick.
-	go RunBoardReconcile(ctx, lister, alwaysReachable, nil, nil, nil, nil, nil, nil, nil, nil, chain, nil, StageRetry{}, nil, nil, "", time.Hour, zerolog.Nop())
+	go RunBoardReconcile(ctx, ReconcileDeps{
+		ListCards:   lister,
+		Reachable:   alwaysReachable,
+		ChainReview: chain,
+		Interval:    time.Hour,
+	})
 
 	select {
 	case pmKey := <-chained:
@@ -269,7 +273,7 @@ func TestReconcileShippedFailures_MergedPRClearsRed(t *testing.T) {
 		postedKey, postedURL = pmKey, prURL
 		return nil
 	}
-	n := reconcileShippedFailures(context.Background(), ownWork(cards), merged, post, zerolog.Nop())
+	n := reconcileShippedFailures(context.Background(), ownWork(cards), ReconcileDeps{MergedProbe: merged, PostDeployed: post})
 
 	assert.Equal(t, 1, n)
 	assert.Equal(t, "SC-1", postedKey)
@@ -288,7 +292,7 @@ func TestReconcileShippedFailures_UnmergedPRLeftRed(t *testing.T) {
 	posted := false
 	merged := func(_ context.Context, _ string) (bool, error) { return false, nil }
 	post := func(_ context.Context, _, _ string) error { posted = true; return nil }
-	n := reconcileShippedFailures(context.Background(), ownWork(cards), merged, post, zerolog.Nop())
+	n := reconcileShippedFailures(context.Background(), ownWork(cards), ReconcileDeps{MergedProbe: merged, PostDeployed: post})
 
 	assert.Equal(t, 0, n)
 	assert.False(t, posted)
@@ -304,7 +308,7 @@ func TestReconcileShippedFailures_NoPRURLSkipped(t *testing.T) {
 	probed := false
 	merged := func(_ context.Context, _ string) (bool, error) { probed = true; return true, nil }
 	post := func(_ context.Context, _, _ string) error { return nil }
-	n := reconcileShippedFailures(context.Background(), ownWork(cards), merged, post, zerolog.Nop())
+	n := reconcileShippedFailures(context.Background(), ownWork(cards), ReconcileDeps{MergedProbe: merged, PostDeployed: post})
 
 	assert.Equal(t, 0, n)
 	assert.False(t, probed)
@@ -314,7 +318,7 @@ func TestReconcileShippedFailures_NoPRURLSkipped(t *testing.T) {
 func TestReconcileShippedFailures_NilDepsDisabled(t *testing.T) {
 	cards := []ReconcileCard{{Key: "SC-1", Comments: []tracker.Comment{
 		cmt("[human:deploy-failed]\nx\npr: https://github.com/o/r/pull/7", time.Unix(1, 0))}}}
-	assert.Equal(t, 0, reconcileShippedFailures(context.Background(), ownWork(cards), nil, nil, zerolog.Nop()))
+	assert.Equal(t, 0, reconcileShippedFailures(context.Background(), ownWork(cards), ReconcileDeps{}))
 }
 
 // liveAgents is the test lister: the set of board agent names currently running
@@ -345,7 +349,7 @@ func TestReconcileStuckRunning_FailsAgedRunningOrphanWithNoAgent(t *testing.T) {
 		Comments: []tracker.Comment{cmt("[human:implementation-started]", now.Add(-StuckRunningGrace-time.Minute))},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted)}, now)
 
 	assert.Equal(t, 1, n)
 	assert.Len(t, posted, 1)
@@ -363,7 +367,7 @@ func TestReconcileStuckRunning_SkipsWithinGrace(t *testing.T) {
 		Comments: []tracker.Comment{cmt("[human:implementation-started]", now.Add(-time.Minute))},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted)}, now)
 
 	assert.Equal(t, 0, n)
 	assert.Empty(t, posted)
@@ -379,7 +383,7 @@ func TestReconcileStuckRunning_SkipsWhenAgentAlive(t *testing.T) {
 	}}
 	var posted []struct{ Key, Body string }
 	live := liveAgents(agentNameFor("SC-1", BoardImplementation))
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), live, capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: live, PostFailed: capturingPoster(&posted)}, now)
 
 	assert.Equal(t, 0, n)
 	assert.Empty(t, posted)
@@ -397,7 +401,7 @@ func TestReconcileStuckRunning_SkipsNonRunning(t *testing.T) {
 		},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted)}, now)
 
 	assert.Equal(t, 0, n)
 	assert.Empty(t, posted)
@@ -412,7 +416,7 @@ func TestReconcileStuckRunning_CoversVerificationStage(t *testing.T) {
 		Comments: []tracker.Comment{cmt("[human:review-started]", now.Add(-StuckRunningGrace-time.Minute))},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted)}, now)
 
 	assert.Equal(t, 1, n)
 	assert.Len(t, posted, 1)
@@ -428,7 +432,7 @@ func TestReconcileStuckRunning_NilListerDisables(t *testing.T) {
 		Comments: []tracker.Comment{cmt("[human:implementation-started]", now.Add(-StuckRunningGrace-time.Minute))},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), nil, capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{PostFailed: capturingPoster(&posted)}, now)
 
 	assert.Equal(t, 0, n)
 	assert.Empty(t, posted)
@@ -450,7 +454,7 @@ func TestReconcileStuckRunning_SkipsJustDecidedCard(t *testing.T) {
 		},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted)}, now)
 
 	assert.Equal(t, 0, n, "a just-decided card must never be reddened")
 	assert.Empty(t, posted)
@@ -470,7 +474,7 @@ func TestReconcilePRLoop_RedrivesStalled(t *testing.T) {
 	var driven []string
 	drive := func(pmKey string) error { driven = append(driven, pmKey); return nil }
 
-	n := reconcilePRLoops(context.Background(), reviewSet(cards, alwaysReachable), liveAgents(), drive, zerolog.Nop())
+	n := reconcilePRLoops(context.Background(), reviewSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), DriveLoop: drive})
 
 	assert.Equal(t, 1, n)
 	assert.Equal(t, []string{"SC-1"}, driven)
@@ -490,7 +494,7 @@ func TestReconcilePRLoop_SkipsWhenAgentAlive(t *testing.T) {
 	drive := func(pmKey string) error { driven = append(driven, pmKey); return nil }
 	live := liveAgents(agentNameFor("SC-1", prReviewAgentStage))
 
-	n := reconcilePRLoops(context.Background(), reviewSet(cards, alwaysReachable), live, drive, zerolog.Nop())
+	n := reconcilePRLoops(context.Background(), reviewSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: live, DriveLoop: drive})
 
 	assert.Equal(t, 0, n)
 	assert.Empty(t, driven)
@@ -506,7 +510,7 @@ func TestReconcilePRLoop_SkipsPlainDeploy(t *testing.T) {
 	var driven []string
 	drive := func(pmKey string) error { driven = append(driven, pmKey); return nil }
 
-	n := reconcilePRLoops(context.Background(), reviewSet(cards, alwaysReachable), liveAgents(), drive, zerolog.Nop())
+	n := reconcilePRLoops(context.Background(), reviewSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), DriveLoop: drive})
 
 	assert.Equal(t, 0, n)
 	assert.Empty(t, driven)
@@ -525,7 +529,7 @@ func TestReconcileStuckRunning_SkipsActiveLoop(t *testing.T) {
 		},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted)}, now)
 
 	assert.Equal(t, 0, n, "a mid-flight PR loop must never be reddened by the stuck pass")
 	assert.Empty(t, posted)

--- a/internal/daemon/board_reconcile_ticketowner_test.go
+++ b/internal/daemon/board_reconcile_ticketowner_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/gethuman-sh/human/internal/tracker"
@@ -95,16 +94,18 @@ func TestReconcileOnce_AnotherPersonsWorkIsUntouchedAcrossEveryPass(t *testing.T
 	var chained, driven []string
 	var posted []struct{ Key, Body string }
 	cleared := 0
-	gate := WorkGate{reachable: alwaysReachable, daemonID: "d1", identityFor: asPerson("Alice")}
-
-	reconcileOnce(context.Background(), lister, gate,
-		nil,
-		func(context.Context, string) (bool, error) { return true, nil },
-		func(context.Context, string, string) error { cleared++; return nil },
-		liveAgents(), capturingPoster(&posted), nil,
-		func(k string) error { chained = append(chained, k); return nil },
-		func(k string) error { driven = append(driven, k); return nil },
-		StageRetry{}, nil, nil, "d1", zerolog.Nop())
+	reconcileOnce(context.Background(), ReconcileDeps{
+		ListCards:    lister,
+		Reachable:    alwaysReachable,
+		IdentityFor:  asPerson("Alice"),
+		MergedProbe:  func(context.Context, string) (bool, error) { return true, nil },
+		PostDeployed: func(context.Context, string, string) error { cleared++; return nil },
+		LiveAgents:   liveAgents(),
+		PostFailed:   capturingPoster(&posted),
+		ChainReview:  func(k string) error { chained = append(chained, k); return nil },
+		DriveLoop:    func(k string) error { driven = append(driven, k); return nil },
+		DaemonID:     "d1",
+	})
 
 	assert.Empty(t, chained, "another person's handoff is not reviewed")
 	assert.Empty(t, driven, "another person's loop is not re-driven")
@@ -129,7 +130,7 @@ func TestReconcileShippedFailures_ClearsEvenWhenTheBranchIsGone(t *testing.T) {
 	merged := func(context.Context, string) (bool, error) { return true, nil }
 	post := func(context.Context, string, string) error { posted = true; return nil }
 
-	n := reconcileShippedFailures(context.Background(), gate.forOwnWork(cards), merged, post, zerolog.Nop())
+	n := reconcileShippedFailures(context.Background(), gate.forOwnWork(cards), ReconcileDeps{MergedProbe: merged, PostDeployed: post})
 
 	assert.Equal(t, 1, n)
 	assert.True(t, posted, "an unreachable branch must not hide a shipped PR")
@@ -157,12 +158,15 @@ func TestReconcileOnce_PRLoopStartedElsewhereIsNotRedriven(t *testing.T) {
 	drive := func(cards []ReconcileCard) []string {
 		var driven []string
 		lister := func(context.Context) ([]ReconcileCard, error) { return cards, nil }
-		reconcileOnce(context.Background(), lister,
-			WorkGate{reachable: alwaysReachable, daemonID: "d1", identityFor: asPerson("Alice")},
-			nil, nil, nil, liveAgents(), nil, nil,
-			func(string) error { return nil },
-			func(k string) error { driven = append(driven, k); return nil },
-			StageRetry{}, nil, nil, "d1", zerolog.Nop())
+		reconcileOnce(context.Background(), ReconcileDeps{
+			ListCards:   lister,
+			Reachable:   alwaysReachable,
+			IdentityFor: asPerson("Alice"),
+			LiveAgents:  liveAgents(),
+			ChainReview: func(string) error { return nil },
+			DriveLoop:   func(k string) error { driven = append(driven, k); return nil },
+			DaemonID:    "d1",
+		})
 		return driven
 	}
 

--- a/internal/daemon/board_unavailable_test.go
+++ b/internal/daemon/board_unavailable_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gethuman-sh/human/internal/claude/hookevents"
 	"github.com/gethuman-sh/human/internal/proxy"
 	"github.com/gethuman-sh/human/internal/tracker"
 )
@@ -36,8 +37,7 @@ func TestHandleBoardAgentExit_RateLimitHookRoutesToOutageAndSpendsNoBudget(t *te
 	var attemptCalls int
 	policy := countingPolicy("", false, &relaunched, &resets, &attemptCalls)
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "rate_limit", "StopFailure", commenterFor,
-		nil, nil, nil, nil, alwaysReachable, nil, nil, nil, policy, nil, "d1", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation", ErrorType: "rate_limit", EventName: "StopFailure"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Retry: policy, DaemonID: "d1", Logger: zerolog.Nop()})
 
 	require.Empty(t, relaunched, "the live path never relaunches an outage — reconcile owns the backoff")
 	require.Zero(t, attemptCalls, "an unavailability signal must never be charged against the retry budget")
@@ -68,8 +68,7 @@ func TestHandleBoardAgentExit_RateLimitModelClassRoutesToOutage(t *testing.T) {
 	policy := countingPolicy("", false, &relaunched, &resets, &attemptCalls)
 	latestClass := func(string, string) (string, bool) { return proxy.ClassRateLimit, true }
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "StopFailure", commenterFor,
-		nil, nil, nil, nil, alwaysReachable, nil, nil, nil, policy, latestClass, "d1", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation", EventName: "StopFailure"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Retry: policy, LatestClass: latestClass, DaemonID: "d1", Logger: zerolog.Nop()})
 
 	require.Empty(t, relaunched)
 	require.Zero(t, attemptCalls)
@@ -100,8 +99,7 @@ func TestHandleBoardAgentExit_AuthRoutesToUnchargedRed(t *testing.T) {
 	var attemptCalls int
 	policy := countingPolicy("", false, &relaunched, &resets, &attemptCalls)
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "authentication_error", "StopFailure", commenterFor,
-		nil, nil, nil, nil, alwaysReachable, nil, nil, nil, policy, nil, "d1", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation", ErrorType: "authentication_error", EventName: "StopFailure"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, Retry: policy, DaemonID: "d1", Logger: zerolog.Nop()})
 
 	require.Empty(t, relaunched, "an auth wall must never be auto-relaunched")
 	require.Zero(t, attemptCalls, "and must never charge the retry budget")

--- a/internal/daemon/board_wait_test.go
+++ b/internal/daemon/board_wait_test.go
@@ -148,7 +148,7 @@ func TestReconcileStuckRunning_annotatesWaitCause(t *testing.T) {
 		},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted)}, now)
 
 	require.Equal(t, 1, n)
 	require.Len(t, posted, 1)

--- a/internal/daemon/daemon_stamp_wiring_test.go
+++ b/internal/daemon/daemon_stamp_wiring_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gethuman-sh/human/internal/claude/hookevents"
 	"github.com/gethuman-sh/human/internal/marker"
 	"github.com/gethuman-sh/human/internal/tracker"
 )
@@ -51,8 +52,7 @@ func TestHandleBoardAgentExit_stampsFailedMarker(t *testing.T) {
 	signing := marker.NewSigningCommenter(c, "d1", "rev1")
 	commenterFor := func() (tracker.Commenter, error) { return signing, nil }
 
-	handleBoardAgentExit(context.Background(), nil, "", "board-SC-1-implementation", "", "",
-		commenterFor, nil, nil, nil, nil, alwaysReachable, nil, nil, nil, StageRetry{}, nil, "d1", zerolog.Nop())
+	handleBoardAgentExit(context.Background(), nil, hookevents.Event{AgentName: "board-SC-1-implementation"}, FailureDeps{CommenterFor: commenterFor, Reachable: alwaysReachable, DaemonID: "d1", Logger: zerolog.Nop()})
 
 	require.Len(t, c.added, 1)
 	assert.Contains(t, c.added[0], ImplementationFailedHeader)

--- a/internal/daemon/pr_loop_midrun_test.go
+++ b/internal/daemon/pr_loop_midrun_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,10 +21,12 @@ func TestDrivePRLoopExit_SubstrateFailureIsNotAnExit(t *testing.T) {
 			var advanced []string
 			var reclaimed []string
 
-			handled := drivePRLoopExit("SC-1", prReviewAgentStage, "board-SC-1-prreview", errorType,
-				func(pmKey, _, _ string) error { advanced = append(advanced, pmKey); return nil },
-				func(name string) { reclaimed = append(reclaimed, name) },
-				zerolog.Nop())
+			handled := drivePRLoopExit(
+				RunExit{PMKey: "SC-1", Stage: prReviewAgentStage, AgentName: "board-SC-1-prreview", ErrorType: errorType},
+				FailureDeps{
+					AdvancePRLoop: func(pmKey, _, _ string) error { advanced = append(advanced, pmKey); return nil },
+					OnHandoff:     func(name string) { reclaimed = append(reclaimed, name) },
+				})
 
 			assert.True(t, handled, "the event belongs to the loop and is consumed here")
 			assert.Empty(t, advanced, "a run that is still retrying has not produced an outcome to act on")
@@ -45,10 +46,12 @@ func TestDrivePRLoopExit_RealExitStillDrivesTheLoop(t *testing.T) {
 			var advanced []string
 			var reclaimed []string
 
-			handled := drivePRLoopExit("SC-1", prFixAgentStage, "board-SC-1-prfix", errorType,
-				func(pmKey, _, _ string) error { advanced = append(advanced, pmKey); return nil },
-				func(name string) { reclaimed = append(reclaimed, name) },
-				zerolog.Nop())
+			handled := drivePRLoopExit(
+				RunExit{PMKey: "SC-1", Stage: prFixAgentStage, AgentName: "board-SC-1-prfix", ErrorType: errorType},
+				FailureDeps{
+					AdvancePRLoop: func(pmKey, _, _ string) error { advanced = append(advanced, pmKey); return nil },
+					OnHandoff:     func(name string) { reclaimed = append(reclaimed, name) },
+				})
 
 			assert.True(t, handled)
 			assert.Equal(t, []string{"SC-1"}, advanced)


### PR DESCRIPTION
`domain.md` entries #2 and #3 — the two files where the stuck-card bugs keep landing.

`handleBoardAgentExit` took **19** parameters, `handleCleanStageEnding` 17, `chainReviewAfterCleanBuild` 14; `RunBoardReconcile` took **19**, `reconcileOnce` 16, `reconcileStuckRunning` and `reconcileOneStuckCard` 10 each. `BoardTransitionDeps` had already solved this once in the same package without being applied to either.

Four commits, each compiling and green.

## What stops being expressible

- **`AgentName` / `ErrorType` swap.** Adjacent `string` parameters in five signatures; swapping them compiled and posted a failure marker naming the error as the agent. They are fields of `RunExit` now.
- **A `cleanExit` that contradicts its own event.** It was derived once from `eventName` and then travelled beside it. `RunExit.CleanExit()` is derived on read, so there is no second copy to disagree.
- **A `chainReview` / `driveLoop` swap.** Identical bare `func(pmKey string) error`, adjacent positions in `RunBoardReconcile`. Named types (`ChainReview`, `DriveLoop`, `AdvanceDeployFix`) make it unspellable — that is commit 1 on its own, and it needed no test changes.
- **A zero `WorkGate` that admits nothing.** `ReconcileDeps.gate()` is a method, not a field, so a caller building the struct directly cannot hold an uninitialised one.

## Also

`Stop`, `SessionEnd` and `StopFailure` were bare literals matched by four separate readers that must agree and had nothing making them. `hookevents` owns the grammar, so the constants and `IsRunEnd` live there; the rest of the vocabulary stays literal because it is read in one switch in that same package.

Four of the five hand-rolled "list live agents into a set" preambles collapse onto `ReconcileDeps.aliveAgents`, which puts the rule they each restated in their own words — *a pass that cannot establish liveness must do nothing rather than assume a card is dead* — in one place. The fifth genuinely differs: the orphan sweep needs the raw name list.

**Naming note:** the type is `RunExit`, not the `StageExit` domain.md proposed — that name is taken by what the agent *said* on its way out. This is what the hook *observed*, and the two disagree exactly when a run dies before it can report, which is the case this path exists for.

## Verification

```
make check                              exit 0
go test ./cmd/...                       clean (make check excludes cmd/)
go vet/test -tags wailsapp ./desktop/…  ok (invisible to make check)
make fsm                                well-formed machine
make coverage-check                     83.6%
```

No behaviour change intended: every pass keeps its own nil-guards, ordering and gate. Rebased onto current main and re-verified after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)