### PR TITLE
[SC-4118] Derive what was stored; key by struct, not by joined string

### DIFF
--- a/internal/config/document.go
+++ b/internal/config/document.go
@@ -57,7 +57,7 @@ type Document struct {
 	// inherited are the errors this file already had when it was read. They are
 	// remembered so a write can refuse what this change broke without holding
 	// an unrelated edit hostage to a fault that was already there — see Write.
-	inherited map[string]bool
+	inherited map[problemID]bool
 }
 
 // Load reads the config file dir resolves to. A missing file is not an error:
@@ -167,15 +167,26 @@ func (d *Document) Write() error {
 	return d.WriteAllowingErrors()
 }
 
-// problemKey identifies a problem across edits, so "the same fault as before"
-// can be told from a new one.
-func problemKey(p Problem) string {
-	return p.Rule + "\x00" + p.Section + "\x00" + p.Instance
+// problemID identifies a problem across edits, so "the same fault as before"
+// can be told from a new one. It is the identifying subset of Problem — the
+// message and the fix may be reworded without making it a different fault.
+//
+// A struct, not the three fields joined by a separator: Go compares struct keys
+// field by field, so there is no separator to choose and no way for a section
+// name carrying it to collide with a different problem.
+type problemID struct {
+	Rule     string
+	Section  string
+	Instance string
+}
+
+func problemKey(p Problem) problemID {
+	return problemID{Rule: p.Rule, Section: p.Section, Instance: p.Instance}
 }
 
 // rememberInheritedErrors records what was already wrong when the file was read.
 func (d *Document) rememberInheritedErrors() {
-	d.inherited = map[string]bool{}
+	d.inherited = map[problemID]bool{}
 	for _, p := range d.Validate() {
 		if p.Severity == Error {
 			d.inherited[problemKey(p)] = true

--- a/internal/daemon/board_reconcile_test.go
+++ b/internal/daemon/board_reconcile_test.go
@@ -546,7 +546,7 @@ func TestReconcileStuckRunning_sparesARunningDeployInsideItsOwnGrace(t *testing.
 		Comments: []tracker.Comment{cmt(DeployStartedHeader, now.Add(-20*time.Minute))},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted)}, now)
 
 	assert.Equal(t, 0, n, "a deploy 20 minutes in is still well inside deployTimeout + StuckRunningGrace")
 	assert.Empty(t, posted)
@@ -561,7 +561,7 @@ func TestReconcileStuckRunning_redsADeployPastItsOwnGrace(t *testing.T) {
 		Comments: []tracker.Comment{cmt(DeployStartedHeader, now.Add(-61*time.Minute))},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted)}, now)
 
 	assert.Equal(t, 1, n)
 	require.Len(t, posted, 1)
@@ -577,7 +577,7 @@ func TestReconcileStuckRunning_ordinaryStagesKeepTheShortGrace(t *testing.T) {
 		Comments: []tracker.Comment{cmt("[human:implementation-started]", now.Add(-20*time.Minute))},
 	}}
 	var posted []struct{ Key, Body string }
-	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), liveAgents(), capturingPoster(&posted), StageRetry{}, nil, nil, "", now, zerolog.Nop())
+	n := reconcileStuckRunning(context.Background(), takeoverSet(cards, alwaysReachable), ReconcileDeps{LiveAgents: liveAgents(), PostFailed: capturingPoster(&posted)}, now)
 
 	assert.Equal(t, 1, n, "20 minutes is past the ordinary 15-minute grace")
 	require.Len(t, posted, 1)

--- a/internal/daemon/issue_detail.go
+++ b/internal/daemon/issue_detail.go
@@ -43,33 +43,33 @@ func RenderDescriptionHTML(md string) string {
 // removes the per-open tracker round-trip from the reading experience without
 // the panel ever going more than one open stale. Cache size is bounded by the
 // board itself (a fetch caps at 200 issues per project), so no eviction.
+//
+// The cache is keyed by the request itself. Its three fields are exactly the
+// identity of a fetch and all comparable, so Go's own struct-key equality does
+// the work a hand-built "kind\x00tracker\x00key" string was doing — with no
+// separator to choose, no escaping question, and no way for a field carrying
+// the separator to collide with a different request.
 func NewCachedIssueGetter(inner func(IssueDetailRequest) (*IssueDetailFetch, error)) func(IssueDetailRequest) (*IssueDetailFetch, error) {
 	var mu sync.Mutex
-	cache := make(map[string]*IssueDetailFetch)
-	inflight := make(map[string]bool)
-
-	cacheKey := func(req IssueDetailRequest) string {
-		return req.Kind + "\x00" + req.Tracker + "\x00" + req.Key
-	}
+	cache := make(map[IssueDetailRequest]*IssueDetailFetch)
+	inflight := make(map[IssueDetailRequest]bool)
 
 	return func(req IssueDetailRequest) (*IssueDetailFetch, error) {
-		key := cacheKey(req)
-
 		mu.Lock()
-		if cached, ok := cache[key]; ok {
+		if cached, ok := cache[req]; ok {
 			// Single-flight: one refresh per key at a time, so a burst of
 			// opens doesn't stampede the tracker API.
-			if !inflight[key] {
-				inflight[key] = true
+			if !inflight[req] {
+				inflight[req] = true
 				go func() {
 					fresh, err := inner(req)
 					mu.Lock()
 					if err == nil {
 						// A failed refresh keeps the stale copy: readable
 						// beats gone when the tracker blips.
-						cache[key] = fresh
+						cache[req] = fresh
 					}
-					inflight[key] = false
+					inflight[req] = false
 					mu.Unlock()
 				}()
 			}
@@ -83,7 +83,7 @@ func NewCachedIssueGetter(inner func(IssueDetailRequest) (*IssueDetailFetch, err
 			return nil, err
 		}
 		mu.Lock()
-		cache[key] = fresh
+		cache[req] = fresh
 		mu.Unlock()
 		return fresh, nil
 	}

--- a/internal/daemon/modeloutcomestore.go
+++ b/internal/daemon/modeloutcomestore.go
@@ -48,9 +48,8 @@ type ModelOutcomeSink struct {
 	ch      chan proxy.ModelCallOutcome
 	dropped atomic.Int64
 
-	mu          sync.Mutex
-	byKey       map[outcomeKey][]proxy.ModelCallOutcome
-	latestClass map[outcomeKey]string
+	mu    sync.Mutex
+	byKey map[outcomeKey][]proxy.ModelCallOutcome
 
 	// ledger persists attributed outcomes durably per ticket; nil keeps the sink
 	// memory-only. resolveProject maps a ticket key to its project identity so two
@@ -76,9 +75,8 @@ func (s *ModelOutcomeSink) WithLedger(ledger costLedger, resolveProject func(tic
 // until ctx is cancelled.
 func NewModelOutcomeSink(ctx context.Context) *ModelOutcomeSink {
 	s := &ModelOutcomeSink{
-		ch:          make(chan proxy.ModelCallOutcome, modelOutcomeChanCap),
-		byKey:       make(map[outcomeKey][]proxy.ModelCallOutcome),
-		latestClass: make(map[outcomeKey]string),
+		ch:    make(chan proxy.ModelCallOutcome, modelOutcomeChanCap),
+		byKey: make(map[outcomeKey][]proxy.ModelCallOutcome),
 	}
 	go s.run(ctx)
 	return s
@@ -109,8 +107,8 @@ func (s *ModelOutcomeSink) run(ctx context.Context) {
 	}
 }
 
-// store appends an outcome to its per-key history (bounded to the newest
-// maxOutcomesPerKey) and records the key's latest class.
+// store appends an outcome to its per-key history, bounded to the newest
+// maxOutcomesPerKey.
 func (s *ModelOutcomeSink) store(o proxy.ModelCallOutcome) {
 	k := outcomeKey{ticket: o.Ticket, stage: o.Stage}
 	s.mu.Lock()
@@ -120,7 +118,6 @@ func (s *ModelOutcomeSink) store(o proxy.ModelCallOutcome) {
 		hist = hist[len(hist)-maxOutcomesPerKey:]
 	}
 	s.byKey[k] = hist
-	s.latestClass[k] = o.Class
 	s.mu.Unlock()
 
 	// Persist attributed outcomes durably (SC-2847). An unattributed outcome
@@ -177,12 +174,21 @@ func (s *ModelOutcomeSink) Outcomes() []proxy.ModelCallOutcome {
 // whether one has been recorded. This is the seam a failure marker can read to
 // state why a run failed — an auth lapse, an overload, a spend problem — from
 // the live boundary rather than after the fact.
+//
+// It reads the history's newest entry rather than a summary kept beside it. A
+// stored copy is a second thing to update on every write, and the one question
+// it raises — which of the two did this path forget — has no answer a reader
+// can check. The bound in store() drops the OLDEST, so the newest entry is
+// always the newest outcome.
 func (s *ModelOutcomeSink) LatestClass(ticket, stage string) (string, bool) {
 	if s == nil {
 		return "", false
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	c, ok := s.latestClass[outcomeKey{ticket: ticket, stage: stage}]
-	return c, ok
+	hist := s.byKey[outcomeKey{ticket: ticket, stage: stage}]
+	if len(hist) == 0 {
+		return "", false
+	}
+	return hist[len(hist)-1].Class, true
 }

--- a/internal/daemon/modeloutcomestore_test.go
+++ b/internal/daemon/modeloutcomestore_test.go
@@ -112,9 +112,8 @@ func TestModelOutcomeSink_DropsWhenFull(t *testing.T) {
 	// A sink whose drain goroutine never runs: the channel fills and further
 	// records drop rather than block (constraint: recording must not slow a call).
 	s := &ModelOutcomeSink{
-		ch:          make(chan proxy.ModelCallOutcome, 2),
-		byKey:       map[outcomeKey][]proxy.ModelCallOutcome{},
-		latestClass: map[outcomeKey]string{},
+		ch:    make(chan proxy.ModelCallOutcome, 2),
+		byKey: map[outcomeKey][]proxy.ModelCallOutcome{},
 	}
 	for i := 0; i < 5; i++ {
 		s.Record(proxy.ModelCallOutcome{Ticket: "SC-1"})
@@ -124,8 +123,7 @@ func TestModelOutcomeSink_DropsWhenFull(t *testing.T) {
 
 func TestModelOutcomeSink_BoundsPerKeyHistory(t *testing.T) {
 	s := &ModelOutcomeSink{
-		byKey:       map[outcomeKey][]proxy.ModelCallOutcome{},
-		latestClass: map[outcomeKey]string{},
+		byKey: map[outcomeKey][]proxy.ModelCallOutcome{},
 	}
 	for i := 0; i < maxOutcomesPerKey+50; i++ {
 		s.store(proxy.ModelCallOutcome{Ticket: "SC-1", Stage: "impl", StatusCode: i})
@@ -137,10 +135,26 @@ func TestModelOutcomeSink_BoundsPerKeyHistory(t *testing.T) {
 	assert.Equal(t, maxOutcomesPerKey+49, got[len(got)-1].StatusCode)
 }
 
+// LatestClass is derived from the history rather than kept beside it, so the
+// eviction that bounds the history must not be able to change what it answers:
+// the bound drops the OLDEST, and the newest outcome is the one it reports.
+func TestModelOutcomeSink_LatestClassSurvivesEviction(t *testing.T) {
+	s := &ModelOutcomeSink{
+		byKey: map[outcomeKey][]proxy.ModelCallOutcome{},
+	}
+	for i := 0; i < maxOutcomesPerKey+50; i++ {
+		s.store(proxy.ModelCallOutcome{Ticket: "SC-1", Stage: "impl", Class: proxy.ClassOK})
+	}
+	s.store(proxy.ModelCallOutcome{Ticket: "SC-1", Stage: "impl", Class: proxy.ClassRateLimit})
+
+	c, ok := s.LatestClass("SC-1", "impl")
+	assert.True(t, ok)
+	assert.Equal(t, proxy.ClassRateLimit, c, "the newest outcome's class, not one an eviction left behind")
+}
+
 func TestModelOutcomeSink_UnattributedGroupsSeparately(t *testing.T) {
 	s := &ModelOutcomeSink{
-		byKey:       map[outcomeKey][]proxy.ModelCallOutcome{},
-		latestClass: map[outcomeKey]string{},
+		byKey: map[outcomeKey][]proxy.ModelCallOutcome{},
 	}
 	s.store(proxy.ModelCallOutcome{Class: proxy.ClassNetwork})
 	c, ok := s.LatestClass("", "")


### PR DESCRIPTION
`domain.md` entries **#9** and **#11**. **#10 was measured and declined** — see below.

## #9 — a derived summary stored beside the thing it summarises

`ModelOutcomeSink` held `byKey map[outcomeKey][]ModelCallOutcome` and `latestClass map[outcomeKey]string`. The second was written on every store from the element just appended to the first, and read in exactly one place. Two structures for one fact, and "which of the two did this path forget to update" has no answer a reader can check.

`LatestClass` reads the history's newest entry now. The per-key bound drops the **oldest**, so the newest entry is always the newest outcome — a test pins that, since it is the one thing that could make the derivation disagree with what the map held.

## #11 — composite keys built by string concatenation

Two maps joined fields with a NUL separator. A separator convention has to answer what happens when a field contains it; neither had an answer, and a tracker key arriving as JSON can carry one.

- `issue_detail.go` needs **no new type**: `IssueDetailRequest` is already exactly `{Tracker, Kind, Key}`, so the cache is keyed by the request itself and `cacheKey` disappears.
- `config/document.go` gets `problemID`, the identifying subset of `Problem` — a message or a fix may be reworded without making it a different fault.

## #10 declined — the survey's premise does not hold

domain.md calls the four single-flight caches "same concept four times, four slightly different failure policies". Measured against the tree, it is **three concepts across five sites**:

| shape | sites |
|---|---|
| blocking single-flight (`done chan struct{}`, callers wait) | `vault/vault.go`, `proxy/ca.go` — and `grep -l "done chan struct{}"` returns **exactly** these two |
| background stampede guard (`map[string]bool`, nobody waits) | `daemon/issue_detail.go`, `cmddaemon/codenav_watch.go` — the second is **not in the survey** |
| permanent memo on a `sync.Cond`, caches a decision, no refresh | `proxy/interactive.go` |

The cache halves differ in kind, not in policy: sealed values with a sliding TTL, an absolute ceiling and a failure backoff (vault) · an LRU bounded by capacity and expiring on the cert's own `NotAfter` (leaf certs) · a session-lifetime `bool` (interactive) · stale-while-revalidate that never blocks (issue detail). One `singleflight[K, V]` with an `OnRefreshError` policy would put three different behaviours behind one name — the failure domain.md's own second framing correction names: *a parameter object that merely bundles unrelated arguments relocates the mess behind a struct name*.

The residue worth having — sharing the blocking primitive between vault and the leaf cache — is two sites, both security-adjacent, and neither expresses an illegal state. That is domain.md's reason 2 (duplication), at the document's own stated threshold for leaving something alone.

## Also: main was already red

PR #469 branched before `ReconcileDeps` landed and merged after it, leaving three stuck-running tests on the ten-parameter form. Both branches were green; `origin/main` did not compile. Repaired here in its own commit — verified by building `origin/main` directly, not inferred.

## Verification

```
make check                              exit 0
go test ./cmd/...                       clean
go vet/test -tags wailsapp ./desktop/…  ok
make coverage-check                     83.6%
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)