### PR TITLE
[SC-4281] Notice when an agent has exited

### DIFF
--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -4309,45 +4309,7 @@ func (s *dockerAgentSweeper) IsProcessRunning(ctx context.Context, containerID s
 	}
 	defer func() { _ = docker.Close() }()
 
-	execID, err := docker.ExecCreate(ctx, containerID, []string{"pgrep", "-x", process}, devcontainer.ExecOptions{})
-	if err != nil {
-		return false, err
-	}
-	resp, err := docker.ExecAttach(ctx, execID)
-	if err != nil {
-		return false, err
-	}
-	// Drain the multiplexed stream to EOF before inspecting: ExecInspect's exit
-	// code is only reliable once the exec has finished and the stream closed.
-	// A stalled stream must not park this call (it runs inline on the single
-	// zombie-sweep goroutine): the watchdog closes resp on ctx.Done, unblocking
-	// the drain (SC-427).
-	stop := closeExecOnContextDone(ctx, resp)
-	_, _ = io.Copy(io.Discard, resp.Reader)
-	stop()
-	_ = resp.Close()
-
-	inspect, err := docker.ExecInspect(ctx, execID)
-	if err != nil {
-		return false, err
-	}
-	return inspect.ExitCode == 0, nil
-}
-
-// closeExecOnContextDone starts a watchdog that closes the exec attachment when
-// ctx is cancelled, unblocking a drain parked on a stalled stream (closing
-// resp closes its underlying conn). It returns a stop func the caller invokes
-// once the drain has finished, tearing the watchdog down.
-func closeExecOnContextDone(ctx context.Context, resp devcontainer.ExecAttachResponse) (stop func()) {
-	done := make(chan struct{})
-	go func() {
-		select {
-		case <-ctx.Done():
-			_ = resp.Close()
-		case <-done:
-		}
-	}()
-	return func() { close(done) }
+	return devcontainer.ProcessRunning(ctx, docker, containerID, process)
 }
 
 // agentClaudeAlive reports whether the named agent's claude process is still

--- a/docs/reaper.md
+++ b/docs/reaper.md
@@ -95,6 +95,18 @@ An agent is reaped when its container is running, it is older than the 10-second
 `zombieGracePeriod`, and `pgrep -x claude` reports nothing. This catches claude
 failing to start, crashing without firing hooks, or a killed tmux pane.
 
+**How the probe asks** (`devcontainer.ProcessRunning`). The exec attaches stdout
+and stderr and drains them to EOF, then reads the exit code only once
+`ExecInspect` reports the exec is no longer `Running`, polling up to
+`execSettleTimeout` = 5s for that. Both halves are load-bearing: the stream is
+what says the process ended, so it only synchronises if the output is attached,
+and a still-running exec carries `ExitCode` 0 — indistinguishable from "pgrep
+found claude". An exec created without attachment therefore reported *every*
+container's claude as alive, and no agent was ever reaped by this rule; the
+containers outlived their agents for hours while the board rendered them live
+(SC-4281). A probe that never settles is an error, not an absence, and escalates
+through § 3 rather than answering.
+
 **Spared:** an agent started without a prompt (bare `human agent start NAME`)
 never launches claude at all. It is reaped only once claude has been *observed*
 running for it at least once (`seenClaude`) — otherwise a deliberately idle
@@ -338,6 +350,7 @@ waiting on.
 | `zombieGracePeriod` | 10s | same |
 | `zombieMaxProcessCheckFailures` | 3 (~15s) | same |
 | `zombieReapHardDeadline` | 45s | same |
+| `execSettleTimeout` | 5s | `internal/devcontainer/exec_probe.go` |
 | delete timeout inside a reap | 30s | same |
 | `IdleGrace` | 3m | `internal/daemon/agentprogress.go` |
 | `WorkingIdleGrace` | 30m | same |

--- a/docs/reaper.md
+++ b/docs/reaper.md
@@ -5,6 +5,12 @@ a private git worktree, and an execution log directory. Something has to end
 that run. This document lists **every condition under which the machine ends an
 agent**, what it spares, what it costs the ticket, and what it leaves behind.
 
+The container's PID 1 is `sleep infinity` — claude runs as an exec beside it, so
+the container survives its agent by design and the rules below are what end it.
+Docker's init runs in front of that `sleep` for the one thing a plain command
+cannot do: reap the processes an exiting agent orphans, which otherwise stay
+defunct for as long as the container lives (SC-4281).
+
 It describes the system **as it is**. Its companion is
 [`pipeline-fsm.json`](pipeline-fsm.json): that document follows one *ticket*
 through its states; this one follows one *container*. They meet at the marker a

--- a/internal/devcontainer/docker.go
+++ b/internal/devcontainer/docker.go
@@ -93,6 +93,11 @@ type ContainerCreateOptions struct {
 	Privileged  bool
 	NetworkMode string
 	ShmSize     int64
+	// Init runs an init process as PID 1 that forwards signals and reaps
+	// orphans. A container whose PID 1 is a plain command reaps nothing, so
+	// every process orphaned inside it — the children an exited agent leaves
+	// behind — stays a zombie for as long as the container lives (SC-4281).
+	Init bool
 }
 
 // ContainerRemoveOptions configures container removal.

--- a/internal/devcontainer/docker_engine.go
+++ b/internal/devcontainer/docker_engine.go
@@ -118,6 +118,9 @@ func (e *engineClient) ContainerCreate(ctx context.Context, opts ContainerCreate
 	if opts.NetworkMode != "" {
 		hostConfig.NetworkMode = container.NetworkMode(opts.NetworkMode)
 	}
+	if opts.Init {
+		hostConfig.Init = &opts.Init
+	}
 
 	resp, err := e.cli.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Config:     config,

--- a/internal/devcontainer/exec_probe.go
+++ b/internal/devcontainer/exec_probe.go
@@ -1,0 +1,112 @@
+package devcontainer
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/gethuman-sh/human/errors"
+)
+
+// execSettleTimeout bounds how long a finished exec may take to publish its exit
+// code. The stream EOF already means the process ended, so this is only the gap
+// between that and the daemon's bookkeeping catching up; a probe still running
+// when it expires is reported as unaskable rather than answered from a field
+// that has no meaning yet.
+//
+// execSettlePoll is how often that is re-checked. Both are variables so tests
+// can drive the settle loop without real waiting.
+var (
+	execSettleTimeout = 5 * time.Second
+	execSettlePoll    = 20 * time.Millisecond
+)
+
+// ProcessRunning reports whether a process with exactly this name is running
+// inside the container, by exit code of `pgrep -x`.
+//
+// An error means the question could not be asked — never that the process is
+// absent. Callers act on absence (reaping an agent, tearing down a container),
+// so a probe that cannot answer must say so and let them decide, rather than
+// hand back a false negative that reads as death.
+func ProcessRunning(ctx context.Context, docker DockerClient, containerID, process string) (bool, error) {
+	if docker == nil {
+		return false, errors.WithDetails("no docker client to probe with", "process", process)
+	}
+	code, err := execExitCode(ctx, docker, containerID, []string{"pgrep", "-x", process})
+	if err != nil {
+		return false, err
+	}
+	return code == 0, nil
+}
+
+// execExitCode runs cmd to completion in the container and returns its exit
+// code.
+//
+// Attaching stdout and stderr is what makes the code readable at all: the
+// attachment is the only signal that says the process ended, because its stream
+// EOFs when it does. An exec created without them yields an empty stream that
+// EOFs immediately, and the inspect below then reads ExitCode while the process
+// is still Running — where it is 0, the zero value, and indistinguishable from
+// success (SC-4281).
+func execExitCode(ctx context.Context, docker DockerClient, containerID string, cmd []string) (int, error) {
+	execID, err := docker.ExecCreate(ctx, containerID, cmd, ExecOptions{AttachStdout: true, AttachStderr: true})
+	if err != nil {
+		return 0, errors.WrapWithDetails(err, "creating exec", "container", containerID, "cmd", fmt.Sprint(cmd))
+	}
+	attach, err := docker.ExecAttach(ctx, execID)
+	if err != nil {
+		return 0, errors.WrapWithDetails(err, "attaching to exec", "container", containerID, "cmd", fmt.Sprint(cmd))
+	}
+	// A stalled stream must not park the caller — the zombie sweep drains inline
+	// on its single goroutine — so the watchdog closes the attachment when ctx
+	// expires, unblocking the drain (SC-427).
+	stop := closeExecOnContextDone(ctx, attach)
+	_, _ = StdCopy(io.Discard, io.Discard, attach.Reader)
+	stop()
+	_ = attach.Close()
+
+	return settledExitCode(ctx, docker, execID, cmd)
+}
+
+// settledExitCode reads the exec's exit code once the exec has actually
+// finished, polling until it has. A still-Running exec carries no exit code, so
+// waiting is the only way to get an answer and a timeout is the honest report
+// when it never arrives.
+func settledExitCode(ctx context.Context, docker DockerClient, execID string, cmd []string) (int, error) {
+	deadline := time.Now().Add(execSettleTimeout)
+	for {
+		inspect, err := docker.ExecInspect(ctx, execID)
+		if err != nil {
+			return 0, errors.WrapWithDetails(err, "inspecting exec result", "cmd", fmt.Sprint(cmd))
+		}
+		if !inspect.Running {
+			return inspect.ExitCode, nil
+		}
+		if !time.Now().Before(deadline) {
+			return 0, errors.WithDetails("exec did not finish in time to report an exit code",
+				"cmd", fmt.Sprint(cmd), "waited", execSettleTimeout.String())
+		}
+		select {
+		case <-ctx.Done():
+			return 0, errors.WrapWithDetails(ctx.Err(), "waiting for exec to finish", "cmd", fmt.Sprint(cmd))
+		case <-time.After(execSettlePoll):
+		}
+	}
+}
+
+// closeExecOnContextDone starts a watchdog that closes the exec attachment when
+// ctx is cancelled, unblocking a drain parked on a stalled stream (closing the
+// attachment closes its underlying conn). It returns a stop func the caller
+// invokes once the drain has finished, tearing the watchdog down.
+func closeExecOnContextDone(ctx context.Context, attach ExecAttachResponse) (stop func()) {
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = attach.Close()
+		case <-done:
+		}
+	}()
+	return func() { close(done) }
+}

--- a/internal/devcontainer/exec_probe_test.go
+++ b/internal/devcontainer/exec_probe_test.go
@@ -1,0 +1,146 @@
+package devcontainer
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// settleDocker models the one behaviour the real engine has and the plain mock
+// does not: an exec that is still Running for its first inspections, carrying no
+// exit code, before it settles on one.
+type settleDocker struct {
+	*mockDockerClient
+	runningFor  int // inspections that report Running before the exec settles
+	settledExit int
+	inspects    int
+	inspectErr  error
+}
+
+func (s *settleDocker) ExecInspect(_ context.Context, _ string) (ExecInspectResponse, error) {
+	if s.inspectErr != nil {
+		return ExecInspectResponse{}, s.inspectErr
+	}
+	s.inspects++
+	if s.inspects <= s.runningFor {
+		// A running exec's ExitCode field is the zero value, which is exactly
+		// what makes reading it early indistinguishable from success.
+		return ExecInspectResponse{Running: true, ExitCode: 0}, nil
+	}
+	return ExecInspectResponse{Running: false, ExitCode: s.settledExit}, nil
+}
+
+func newSettleDocker(runningFor, settledExit int) *settleDocker {
+	return &settleDocker{mockDockerClient: &mockDockerClient{}, runningFor: runningFor, settledExit: settledExit}
+}
+
+// withFastSettle shrinks the settle budget so a test drives the loop without
+// waiting in real time. Restores the package defaults on cleanup.
+func withFastSettle(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	oldTimeout, oldPoll := execSettleTimeout, execSettlePoll
+	execSettleTimeout, execSettlePoll = timeout, time.Millisecond
+	t.Cleanup(func() { execSettleTimeout, execSettlePoll = oldTimeout, oldPoll })
+}
+
+// The exit code is only readable because the stream EOFs when the process ends,
+// and it only EOFs if the output is attached. An unattached exec is the SC-4281
+// defect itself, so the flags are asserted rather than assumed.
+func TestProcessRunning_AttachesOutputSoTheDrainSynchronises(t *testing.T) {
+	withFastSettle(t, time.Second)
+	docker := newSettleDocker(0, 0)
+
+	_, err := ProcessRunning(context.Background(), docker, "cid", "claude")
+
+	require.NoError(t, err)
+	require.Len(t, docker.execCalls, 1)
+	assert.True(t, docker.execCalls[0].Opts.AttachStdout, "stdout must be attached")
+	assert.True(t, docker.execCalls[0].Opts.AttachStderr, "stderr must be attached")
+	assert.Equal(t, []string{"pgrep", "-x", "claude"}, docker.execCalls[0].Cmd)
+}
+
+func TestProcessRunning_ExitCodeDecides(t *testing.T) {
+	tests := []struct {
+		name string
+		exit int
+		want bool
+	}{
+		{"pgrep found the process", 0, true},
+		{"pgrep found nothing", 1, false},
+		{"pgrep failed", 2, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withFastSettle(t, time.Second)
+			running, err := ProcessRunning(context.Background(), newSettleDocker(0, tc.exit), "cid", "claude")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, running)
+		})
+	}
+}
+
+// The regression: a still-running exec reports ExitCode 0, which read as an
+// answer means "the process is alive" for every container ever probed — the
+// zombie sweep then never reaps a dead agent and the board spins forever.
+func TestProcessRunning_WaitsForTheExecInsteadOfReadingAZeroExitCode(t *testing.T) {
+	withFastSettle(t, time.Second)
+	docker := newSettleDocker(3, 1)
+
+	running, err := ProcessRunning(context.Background(), docker, "cid", "claude")
+
+	require.NoError(t, err)
+	assert.False(t, running, "the settled exit code 1 is the answer, not the running exec's 0")
+	assert.Equal(t, 4, docker.inspects, "should have polled until the exec settled")
+}
+
+// An exec that never finishes has no exit code to report. Answering "not
+// running" would be a false death — the caller reaps live work on it — so the
+// probe reports that it could not ask.
+func TestProcessRunning_UnsettledExecIsAnErrorNotAbsence(t *testing.T) {
+	withFastSettle(t, 10*time.Millisecond)
+	docker := newSettleDocker(1_000_000, 0)
+
+	running, err := ProcessRunning(context.Background(), docker, "cid", "claude")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exec did not finish")
+	assert.False(t, running)
+}
+
+func TestProcessRunning_CancelledContextIsAnError(t *testing.T) {
+	withFastSettle(t, time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := ProcessRunning(ctx, newSettleDocker(1_000_000, 0), "cid", "claude")
+
+	require.Error(t, err)
+}
+
+func TestProcessRunning_ProbeFailuresSurfaceAsErrors(t *testing.T) {
+	withFastSettle(t, time.Second)
+	boom := errors.New("docker is unwell")
+
+	t.Run("exec cannot be created", func(t *testing.T) {
+		docker := newSettleDocker(0, 0)
+		docker.execErr = boom
+		_, err := ProcessRunning(context.Background(), docker, "cid", "claude")
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("exec cannot be inspected", func(t *testing.T) {
+		docker := newSettleDocker(0, 0)
+		docker.inspectErr = boom
+		_, err := ProcessRunning(context.Background(), docker, "cid", "claude")
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("no client at all", func(t *testing.T) {
+		_, err := ProcessRunning(context.Background(), nil, "cid", "claude")
+		require.Error(t, err)
+	})
+}

--- a/internal/devcontainer/manager.go
+++ b/internal/devcontainer/manager.go
@@ -369,9 +369,13 @@ func (m *Manager) buildCreateOptions(cfg *DevcontainerConfig, projectDir, config
 	labels := ManagedLabels(projectDir, containerName, hash)
 
 	opts := ContainerCreateOptions{
-		Name:        containerName,
-		Image:       imageName,
-		Cmd:         []string{"sleep", "infinity"},
+		Name:  containerName,
+		Image: imageName,
+		Cmd:   []string{"sleep", "infinity"},
+		// `sleep` is PID 1 here and reaps nothing, so an agent that exits leaves
+		// its children — the git and human processes it spawned — defunct until
+		// the container is removed. An init reaps them as they die (SC-4281).
+		Init:        true,
 		Env:         env,
 		Labels:      labels,
 		WorkingDir:  workspaceDir,

--- a/internal/devcontainer/manager_init_test.go
+++ b/internal/devcontainer/manager_init_test.go
@@ -1,0 +1,21 @@
+package devcontainer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// An agent container's PID 1 is `sleep infinity`, which never calls wait(), so
+// without an init every process the agent orphans stays defunct for the life of
+// the container — measured at eight zombie git processes in one seven-hour
+// container (SC-4281).
+func TestBuildCreateOptions_RunsAnInitThatReapsOrphans(t *testing.T) {
+	m := &Manager{}
+	dir := t.TempDir()
+
+	opts := m.buildCreateOptions(&DevcontainerConfig{}, dir, dir, "human-agent-board-SC-1-implementation", "img", "/workspace", "hash", nil, "", nil)
+
+	assert.Equal(t, []string{"sleep", "infinity"}, opts.Cmd, "PID 1 is the command that cannot reap")
+	assert.True(t, opts.Init, "an init must reap what PID 1 will not")
+}


### PR DESCRIPTION
The board keeps a spinner on cards whose agent is gone. Measured on this board: three cards spinning, one live agent, one container up seven hours after its claude exited with eight zombie git processes inside it.

## The defect

`dockerAgentSweeper.IsProcessRunning` creates the `pgrep -x claude` exec with `ExecOptions{}` — neither stdout nor stderr attached. The drain that is supposed to mean "the process ended" returns immediately on an empty stream, and `ExecInspect` is then read while the exec is still `Running`, where `ExitCode` is 0 — the same value pgrep uses for "found it".

Measured against the two live containers before the fix:

| exec | container | result |
| --- | --- | --- |
| `pgrep -x claude` | claude alive | exit=0 running=true (right by accident) |
| `pgrep -x claude` | claude gone 7h | exit=0 running=true (**wrong**) |
| `sh -c "exit 3"` | both | exit=3 running=false |
| polled to settle | claude gone | exit=1 after 102ms |

So the daemon answered "claude is running" for every container it ever probed. The zombie sweep's claude-gone reap (`docs/reaper.md` § 2) therefore never fired, `agentClaudeAlive` told the cleanup listener the same thing so the Stop/SessionEnd teardown spared the run, and the board — which reads a surviving container as a live agent — spun on the card.

## The fix

`devcontainer.ProcessRunning` attaches the output, drains it, and waits for the exec to stop being `Running` before reading the code. An exec that never settles within `execSettleTimeout` = 5s is an error, not an absence: callers reap on absence, so a probe that cannot answer must say so rather than report a false death — it escalates through the existing three-strike path in § 3.

Verified against the real containers after the fix: `running=false` for the seven-hour one (124ms), `running=true` for the working one (48ms).

Second commit: agent containers get an init. PID 1 is `sleep infinity`, which never calls `wait()`, so everything an exiting agent orphans stays defunct for the life of the container.

Not in scope: the board's own liveness overlay still reads container existence rather than probing each card. With this fix the container stops outliving its agent, so that signal is truthful again; changing it would add an exec per card per refresh and buy a false `dead` badge on any docker hiccup, which `livenessOf` deliberately reports as unknown today.

## Also here

`[SC-3852]` — main did not compile. Three deploy-grace tests landed on the pre-SC-4118 ten-argument `reconcileStuckRunning`, so no test in `internal/daemon` ran at all. Repaired in its own commit; the gate cannot pass without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)