### PR TITLE
[SC-4118] Give bind mounts a type

### DIFF
--- a/internal/devcontainer/docker.go
+++ b/internal/devcontainer/docker.go
@@ -87,7 +87,7 @@ type ContainerCreateOptions struct {
 	WorkingDir  string
 	User        string
 	ExtraHosts  []string // "host:ip" entries for /etc/hosts
-	Binds       []string // "src:dst[:opts]" bind mounts
+	Binds       []Mount  // bind mounts, rendered to Docker's string form at the boundary
 	CapAdd      []string // added capabilities
 	SecurityOpt []string // security options
 	Privileged  bool

--- a/internal/devcontainer/docker_engine.go
+++ b/internal/devcontainer/docker_engine.go
@@ -108,7 +108,7 @@ func (e *engineClient) ContainerCreate(ctx context.Context, opts ContainerCreate
 	}
 
 	hostConfig := &container.HostConfig{
-		Binds:       opts.Binds,
+		Binds:       bindStrings(opts.Binds),
 		ExtraHosts:  opts.ExtraHosts,
 		CapAdd:      opts.CapAdd,
 		SecurityOpt: opts.SecurityOpt,

--- a/internal/devcontainer/manager.go
+++ b/internal/devcontainer/manager.go
@@ -300,21 +300,19 @@ func (m *Manager) buildCreateOptions(cfg *DevcontainerConfig, projectDir, config
 		)
 	}
 
-	binds := []string{
-		projectDir + ":" + workspaceDir,
-	}
+	binds := []Mount{Bind(projectDir, workspaceDir)}
 
 	// Project-declared persistent caches: a bind whose source is not a path is
 	// a named volume, which Docker auto-creates on first use — no extra API.
 	for _, c := range caches {
-		binds = append(binds, c.VolumeName()+":"+c.Path)
+		binds = append(binds, Bind(c.VolumeName(), c.Path))
 	}
 
 	// A worktree workspace resolves git through the parent repo's .git, which
 	// lives outside the mount — bind it at its host-identical path so the
 	// worktree's absolute gitdir pointer works in-container (ticket 482).
 	if gitDir != "" {
-		binds = append(binds, gitDir+":"+gitDir)
+		binds = append(binds, Bind(gitDir, gitDir))
 	}
 
 	// Mount CA cert if it exists.
@@ -323,14 +321,14 @@ func (m *Manager) buildCreateOptions(cfg *DevcontainerConfig, projectDir, config
 
 	caCert := filepath.Join(home, ".human", "ca.crt")
 	if IsValidCACertFile(caCert) {
-		binds = append(binds, caCert+":"+targetHome+"/.human/ca.crt:ro")
+		binds = append(binds, Bind(caCert, targetHome+"/.human/ca.crt").ReadOnly())
 	}
 
 	// Mount project-local Claude config so auth and plugins persist
 	// across container rebuilds without touching the host's ~/.claude.
 	containerClaudeDir := filepath.Join(configDir, ".devcontainer", "claude")
 	if mkErr := os.MkdirAll(containerClaudeDir, 0o750); mkErr == nil {
-		binds = append(binds, containerClaudeDir+":"+targetHome+"/.claude")
+		binds = append(binds, Bind(containerClaudeDir, targetHome+"/.claude"))
 	}
 
 	// Persist ~/.claude.json across container rebuilds. Claude Code stores
@@ -342,11 +340,11 @@ func (m *Manager) buildCreateOptions(cfg *DevcontainerConfig, projectDir, config
 			_ = os.WriteFile(claudeJSON, []byte("{}\n"), 0o600) // #nosec G306
 		}
 	}
-	binds = append(binds, claudeJSON+":"+targetHome+"/.claude.json")
+	binds = append(binds, Bind(claudeJSON, targetHome+"/.claude.json"))
 
 	// Mount host human binary so the container always uses the same version.
 	if humanBin, exeErr := os.Executable(); exeErr == nil {
-		binds = append(binds, humanBin+":/usr/local/bin/human:ro")
+		binds = append(binds, Bind(humanBin, "/usr/local/bin/human").ReadOnly())
 	}
 
 	// Parse config mount strings. Devcontainer.json uses the Docker --mount
@@ -357,14 +355,14 @@ func (m *Manager) buildCreateOptions(cfg *DevcontainerConfig, projectDir, config
 		if !ok {
 			continue
 		}
-		if bind := parseMountString(s); bind != "" {
-			binds = append(binds, bind)
+		if mt, ok := parseMountString(s); ok {
+			binds = append(binds, mt)
 		}
 	}
 
 	// Deduplicate mounts by target path. Later entries (from config) win
 	// over earlier programmatic ones to avoid Docker "Duplicate mount point" errors.
-	binds = deduplicateBinds(binds)
+	binds = dedupeMounts(binds)
 
 	labels := ManagedLabels(projectDir, containerName, hash)
 
@@ -389,14 +387,15 @@ func (m *Manager) buildCreateOptions(cfg *DevcontainerConfig, projectDir, config
 	return opts
 }
 
-// parseMountString converts a devcontainer.json mount string from Docker
-// --mount format ("source=X,target=Y,type=bind,readonly") to Binds format
-// ("X:Y:ro"). If the string already looks like Binds format (contains ":"),
-// it is returned as-is.
-func parseMountString(s string) string {
-	// Already in Binds format (src:dst or src:dst:opts).
+// parseMountString reads a mount as devcontainer.json writes it. The spec's
+// own form is the Docker --mount syntax ("source=X,target=Y,type=bind"); a
+// plain bind string is also accepted, because projects write those too. It
+// reports false for anything this package cannot express as a bind — a volume
+// or tmpfs mount, or a mount naming only one side.
+func parseMountString(s string) (Mount, bool) {
+	// A plain bind string: no --mount keys, so read it as source:target[:opts].
 	if !strings.Contains(s, "source=") && strings.Contains(s, ":") {
-		return s
+		return ParseBind(s)
 	}
 
 	var source, target, mountType string
@@ -420,38 +419,17 @@ func parseMountString(s string) string {
 	// Only bind mounts can be expressed as Binds. Volume and tmpfs mounts
 	// would need the Docker SDK Mounts field which we don't support yet.
 	if mountType != "" && mountType != "bind" {
-		return ""
+		return Mount{}, false
 	}
-
 	if source == "" || target == "" {
-		return ""
+		return Mount{}, false
 	}
 
-	bind := source + ":" + target
+	m := Bind(source, target)
 	if readonly {
-		bind += ":ro"
+		m = m.ReadOnly()
 	}
-	return bind
-}
-
-// deduplicateBinds removes duplicate bind mounts by target path,
-// keeping the last entry for each target.
-func deduplicateBinds(binds []string) []string {
-	seen := make(map[string]int, len(binds))
-	for i, b := range binds {
-		parts := strings.SplitN(b, ":", 3)
-		if len(parts) >= 2 {
-			seen[parts[1]] = i
-		}
-	}
-	result := make([]string, 0, len(seen))
-	for i, b := range binds {
-		parts := strings.SplitN(b, ":", 3)
-		if len(parts) >= 2 && seen[parts[1]] == i {
-			result = append(result, b)
-		}
-	}
-	return result
+	return m, true
 }
 
 // remoteHome returns the home directory path for the devcontainer's remote user.

--- a/internal/devcontainer/manager_test.go
+++ b/internal/devcontainer/manager_test.go
@@ -305,7 +305,7 @@ func TestParseRunArgs(t *testing.T) {
 func TestParseMountString_BindMount(t *testing.T) {
 	tests := []struct {
 		input string
-		want  string
+		want  string // Mount.String(), or "" when the mount is not expressible
 	}{
 		// Standard devcontainer.json mount format.
 		{"source=/host/path,target=/container/path,type=bind", "/host/path:/container/path"},
@@ -317,7 +317,7 @@ func TestParseMountString_BindMount(t *testing.T) {
 		// Already in Binds format (passthrough).
 		{"/host:/container", "/host:/container"},
 		{"/host:/container:ro", "/host:/container:ro"},
-		// Non-bind mount type (volume) should return empty.
+		// Non-bind mount type (volume) should not be expressible.
 		{"source=myvolume,target=/data,type=volume", ""},
 		// Missing source or target.
 		{"target=/container/path,type=bind", ""},
@@ -326,7 +326,11 @@ func TestParseMountString_BindMount(t *testing.T) {
 		{"source=/host/path,target=/container/path", "/host/path:/container/path"},
 	}
 	for _, tt := range tests {
-		got := parseMountString(tt.input)
+		m, ok := parseMountString(tt.input)
+		got := ""
+		if ok {
+			got = m.String()
+		}
 		if got != tt.want {
 			t.Errorf("parseMountString(%q) = %q, want %q", tt.input, got, tt.want)
 		}
@@ -334,30 +338,27 @@ func TestParseMountString_BindMount(t *testing.T) {
 }
 
 func TestParseMountString_WithSpaces(t *testing.T) {
-	input := "source=/host/path , target=/container/path , type=bind"
-	got := parseMountString(input)
-	if got != "/host/path:/container/path" {
-		t.Errorf("parseMountString with spaces = %q, want %q", got, "/host/path:/container/path")
+	m, ok := parseMountString("source=/host/path , target=/container/path , type=bind")
+	if !ok || m.String() != "/host/path:/container/path" {
+		t.Errorf("parseMountString with spaces = %q (ok=%v), want %q", m.String(), ok, "/host/path:/container/path")
 	}
 }
 
-func TestDeduplicateBinds(t *testing.T) {
-	binds := []string{
-		"/first:/target-a",
-		"/second:/target-b",
-		"/third:/target-a", // duplicate target, should replace /first
-	}
-	got := deduplicateBinds(binds)
+func TestDedupeMounts(t *testing.T) {
+	got := dedupeMounts([]Mount{
+		Bind("/first", "/target-a"),
+		Bind("/second", "/target-b"),
+		Bind("/third", "/target-a"), // duplicate target, should replace /first
+	})
 	if len(got) != 2 {
-		t.Fatalf("expected 2 deduped binds, got %d: %v", len(got), got)
+		t.Fatalf("expected 2 deduped mounts, got %d: %v", len(got), got)
 	}
-	// The last entry for /target-a should win.
 	foundA := false
-	for _, b := range got {
-		if strings.Contains(b, "/target-a") {
+	for _, m := range got {
+		if m.Target == "/target-a" {
 			foundA = true
-			if !strings.HasPrefix(b, "/third:") {
-				t.Errorf("expected /third:/target-a to win, got %q", b)
+			if m.Source != "/third" {
+				t.Errorf("expected /third to win /target-a, got %q", m.Source)
 			}
 		}
 	}
@@ -366,29 +367,23 @@ func TestDeduplicateBinds(t *testing.T) {
 	}
 }
 
-func TestDeduplicateBinds_NoConflicts(t *testing.T) {
-	binds := []string{
-		"/a:/x",
-		"/b:/y",
-		"/c:/z",
-	}
-	got := deduplicateBinds(binds)
+func TestDedupeMounts_NoConflicts(t *testing.T) {
+	got := dedupeMounts([]Mount{Bind("/a", "/x"), Bind("/b", "/y"), Bind("/c", "/z")})
 	if len(got) != 3 {
-		t.Errorf("expected 3 binds, got %d", len(got))
+		t.Errorf("expected 3 mounts, got %d", len(got))
 	}
 }
 
-func TestDeduplicateBinds_WithOptions(t *testing.T) {
-	binds := []string{
-		"/first:/target:ro",
-		"/second:/target:rw", // same target, should replace
-	}
-	got := deduplicateBinds(binds)
+func TestDedupeMounts_WithOptions(t *testing.T) {
+	got := dedupeMounts([]Mount{
+		Bind("/first", "/target", "ro"),
+		Bind("/second", "/target", "rw"), // same target, should replace
+	})
 	if len(got) != 1 {
-		t.Fatalf("expected 1 bind, got %d: %v", len(got), got)
+		t.Fatalf("expected 1 mount, got %d: %v", len(got), got)
 	}
-	if got[0] != "/second:/target:rw" {
-		t.Errorf("expected /second:/target:rw, got %q", got[0])
+	if got[0].String() != "/second:/target:rw" {
+		t.Errorf("expected /second:/target:rw, got %q", got[0].String())
 	}
 }
 
@@ -588,7 +583,7 @@ func TestManager_Up_WithMounts(t *testing.T) {
 	if len(mock.createCalls) != 1 {
 		t.Fatalf("expected 1 create call, got %d", len(mock.createCalls))
 	}
-	binds := mock.createCalls[0].Binds
+	binds := bindStrings(mock.createCalls[0].Binds)
 	foundData := false
 	foundConfigRO := false
 	for _, b := range binds {
@@ -630,10 +625,10 @@ func TestManager_Up_WorktreeGitDirBind(t *testing.T) {
 		t.Fatalf("expected 1 create call, got %d", len(mock.createCalls))
 	}
 	want := gitDir + ":" + gitDir
-	if slices.Contains(mock.createCalls[0].Binds, want) {
+	if slices.Contains(bindStrings(mock.createCalls[0].Binds), want) {
 		return
 	}
-	t.Errorf("missing parent-repo git bind %q in binds: %v", want, mock.createCalls[0].Binds)
+	t.Errorf("missing parent-repo git bind %q in binds: %v", want, bindStrings(mock.createCalls[0].Binds))
 }
 
 // Without a GitDir (shared-checkout mount, non-git workspace) no extra bind
@@ -649,7 +644,7 @@ func TestManager_Up_NoGitDirNoExtraBind(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, b := range mock.createCalls[0].Binds {
+	for _, b := range bindStrings(mock.createCalls[0].Binds) {
 		if strings.Contains(b, ".git:") {
 			t.Errorf("unexpected .git bind %q without GitDir", b)
 		}
@@ -676,7 +671,7 @@ func TestManager_Up_WithCACert(t *testing.T) {
 	if len(mock.createCalls) != 1 {
 		t.Fatalf("expected 1 create call, got %d", len(mock.createCalls))
 	}
-	binds := mock.createCalls[0].Binds
+	binds := bindStrings(mock.createCalls[0].Binds)
 	foundCACert := false
 	for _, b := range binds {
 		if strings.Contains(b, "ca.crt") && strings.HasSuffix(b, ":ro") {
@@ -712,9 +707,9 @@ func TestManager_Up_CACertIsDirectory_NoMount(t *testing.T) {
 	if len(mock.createCalls) != 1 {
 		t.Fatalf("expected 1 create call, got %d", len(mock.createCalls))
 	}
-	for _, b := range mock.createCalls[0].Binds {
+	for _, b := range bindStrings(mock.createCalls[0].Binds) {
 		if strings.Contains(b, "/.human/ca.crt") {
-			t.Errorf("ca.crt directory must not be mounted, but found bind: %q in %v", b, mock.createCalls[0].Binds)
+			t.Errorf("ca.crt directory must not be mounted, but found bind: %q in %v", b, bindStrings(mock.createCalls[0].Binds))
 		}
 	}
 }
@@ -744,9 +739,9 @@ func TestManager_Up_CACertEmpty_NoMount(t *testing.T) {
 	if len(mock.createCalls) != 1 {
 		t.Fatalf("expected 1 create call, got %d", len(mock.createCalls))
 	}
-	for _, b := range mock.createCalls[0].Binds {
+	for _, b := range bindStrings(mock.createCalls[0].Binds) {
 		if strings.Contains(b, "/.human/ca.crt") {
-			t.Errorf("empty ca.crt must not be mounted, but found bind: %q in %v", b, mock.createCalls[0].Binds)
+			t.Errorf("empty ca.crt must not be mounted, but found bind: %q in %v", b, bindStrings(mock.createCalls[0].Binds))
 		}
 	}
 }
@@ -773,7 +768,7 @@ func TestManager_Up_WithClaudeDir(t *testing.T) {
 	if len(mock.createCalls) != 1 {
 		t.Fatalf("expected 1 create call, got %d", len(mock.createCalls))
 	}
-	binds := mock.createCalls[0].Binds
+	binds := bindStrings(mock.createCalls[0].Binds)
 	foundClaude := false
 	for _, b := range binds {
 		if strings.Contains(b, ".claude") && !strings.Contains(b, ".claude.json") {
@@ -855,7 +850,7 @@ func TestManager_Up_SourceDir(t *testing.T) {
 		t.Fatalf("expected 1 create call, got %d", len(mock.createCalls))
 	}
 	// The bind mounts should use sourceDir, not projectDir.
-	binds := mock.createCalls[0].Binds
+	binds := bindStrings(mock.createCalls[0].Binds)
 	foundSource := false
 	for _, b := range binds {
 		if strings.HasPrefix(b, sourceDir+":") {
@@ -1045,7 +1040,7 @@ func TestManager_Up_CacheVolumes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	binds := mock.createCalls[0].Binds
+	binds := bindStrings(mock.createCalls[0].Binds)
 	for _, want := range []string{
 		"human-cache-go-build:/home/vscode/.cache/go-build",
 		"human-cache-go-mod:/go/pkg/mod",
@@ -1082,8 +1077,8 @@ func TestManager_Up_CacheVolumes_RootUserSkipsChown(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !slices.Contains(mock.createCalls[0].Binds, "human-cache-go-mod:/go/pkg/mod") {
-		t.Fatalf("volume bind missing: %v", mock.createCalls[0].Binds)
+	if !slices.Contains(bindStrings(mock.createCalls[0].Binds), "human-cache-go-mod:/go/pkg/mod") {
+		t.Fatalf("volume bind missing: %v", bindStrings(mock.createCalls[0].Binds))
 	}
 	for _, c := range mock.execCalls {
 		if len(c.Cmd) > 0 && c.Cmd[0] == "chown" {
@@ -1109,7 +1104,7 @@ func TestManager_Up_CacheVolumes_InvalidSkippedWithWarning(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	binds := mock.createCalls[0].Binds
+	binds := bindStrings(mock.createCalls[0].Binds)
 	if !slices.Contains(binds, "human-cache-good:/data") {
 		t.Errorf("valid entry missing: %v", binds)
 	}
@@ -1136,7 +1131,7 @@ func TestManager_Up_NoCachesNoExtraExecs(t *testing.T) {
 			t.Errorf("no caches declared but ownership exec ran: %+v", c)
 		}
 	}
-	for _, b := range mock.createCalls[0].Binds {
+	for _, b := range bindStrings(mock.createCalls[0].Binds) {
 		if strings.HasPrefix(b, "human-cache-") {
 			t.Errorf("unexpected cache bind: %v", b)
 		}

--- a/internal/devcontainer/mount.go
+++ b/internal/devcontainer/mount.go
@@ -1,0 +1,139 @@
+package devcontainer
+
+import "strings"
+
+// Mount is one bind mount: a host path made visible inside the container at a
+// target path, with the options Docker takes after it.
+//
+// It exists because this package built "src:dst[:opts]" strings and then
+// re-parsed what it had just built, in the same file, to deduplicate them by
+// target. Two states that reachable code could reach:
+//
+//   - A Windows source path splits at its drive letter. `C:\repo:/workspace`
+//     read as three colon-separated fields makes the TARGET `\repo`, so two
+//     mounts to different places dedupe against each other and two to the same
+//     place do not — and Docker answers the second case with "Duplicate mount
+//     point".
+//   - A string with no colon is dropped rather than kept. The dedupe skipped
+//     anything it could not split into two fields, which removed it from the
+//     result entirely instead of leaving it alone.
+//
+// Neither is reachable once mounts travel as fields. Parsing is confined to
+// ParseBind, which exists only for the strings a project writes in its own
+// devcontainer.json, and formatting happens once, at the Docker boundary.
+type Mount struct {
+	Source string
+	Target string
+	// Options are the flags Docker accepts after the target ("ro", "z",
+	// "cached"). Kept verbatim rather than reduced to a read-only bool: a
+	// project may name any of them, and modelling only the one this code
+	// happens to set would silently drop what the project asked for.
+	Options []string
+}
+
+// Bind returns a mount of source at target.
+func Bind(source, target string, options ...string) Mount {
+	return Mount{Source: source, Target: target, Options: options}
+}
+
+// ReadOnly returns the mount with the read-only flag set.
+func (m Mount) ReadOnly() Mount {
+	for _, o := range m.Options {
+		if o == "ro" {
+			return m
+		}
+	}
+	m.Options = append(append([]string{}, m.Options...), "ro")
+	return m
+}
+
+// String renders the Docker bind form. This is the only place a mount becomes
+// a string: everything upstream compares and deduplicates by field.
+func (m Mount) String() string {
+	s := m.Source + ":" + m.Target
+	if len(m.Options) > 0 {
+		s += ":" + strings.Join(m.Options, ",")
+	}
+	return s
+}
+
+// ParseBind reads a Docker bind string. It reports false for anything that
+// does not name both a source and a target, so a caller never has to decide
+// what half a mount means.
+//
+// A leading Windows drive letter is not a field separator. Docker's own bind
+// grammar treats `C:\path` as one path, and reading it as two fields is what
+// made the target of a Windows mount its own directory name.
+func ParseBind(s string) (Mount, bool) {
+	fields := splitBindFields(s)
+	if len(fields) < 2 || fields[0] == "" || fields[1] == "" {
+		return Mount{}, false
+	}
+	m := Mount{Source: fields[0], Target: fields[1]}
+	if len(fields) > 2 && fields[2] != "" {
+		m.Options = strings.Split(fields[2], ",")
+	}
+	return m, true
+}
+
+// splitBindFields splits a bind string into at most source, target and
+// options, skipping a colon that belongs to a Windows drive letter.
+func splitBindFields(s string) []string {
+	var fields []string
+	start := 0
+	for i := 0; i < len(s) && len(fields) < 2; i++ {
+		if s[i] != ':' {
+			continue
+		}
+		if isDriveLetterColon(s, i, start) {
+			continue
+		}
+		fields = append(fields, s[start:i])
+		start = i + 1
+	}
+	return append(fields, s[start:])
+}
+
+// isDriveLetterColon reports whether the colon at i is the one in a Windows
+// drive prefix — a single letter at the start of the field, followed by a
+// path separator.
+func isDriveLetterColon(s string, i, fieldStart int) bool {
+	if i != fieldStart+1 {
+		return false
+	}
+	c := s[fieldStart]
+	if (c < 'A' || c > 'Z') && (c < 'a' || c > 'z') {
+		return false
+	}
+	return i+1 < len(s) && (s[i+1] == '\\' || s[i+1] == '/')
+}
+
+// dedupeMounts keeps one mount per target, the last one wins, in the order
+// those survivors appeared. A project's own mounts are appended after the
+// programmatic ones precisely so they take precedence, and Docker refuses a
+// create that names one target twice.
+func dedupeMounts(mounts []Mount) []Mount {
+	last := make(map[string]int, len(mounts))
+	for i, m := range mounts {
+		last[m.Target] = i
+	}
+	out := make([]Mount, 0, len(last))
+	for i, m := range mounts {
+		if last[m.Target] == i {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// bindStrings renders mounts for the Docker API.
+func bindStrings(mounts []Mount) []string {
+	if len(mounts) == 0 {
+		return nil
+	}
+	out := make([]string, len(mounts))
+	for i, m := range mounts {
+		out[i] = m.String()
+	}
+	return out
+}

--- a/internal/devcontainer/mount_test.go
+++ b/internal/devcontainer/mount_test.go
@@ -1,0 +1,90 @@
+package devcontainer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMount_StringRendersDockerBindForm(t *testing.T) {
+	assert.Equal(t, "/src:/dst", Bind("/src", "/dst").String())
+	assert.Equal(t, "/src:/dst:ro", Bind("/src", "/dst").ReadOnly().String())
+	assert.Equal(t, "/src:/dst:ro,z", Bind("/src", "/dst", "ro", "z").String())
+}
+
+func TestMount_ReadOnlyIsIdempotent(t *testing.T) {
+	assert.Equal(t, "/src:/dst:ro", Bind("/src", "/dst").ReadOnly().ReadOnly().String())
+}
+
+// ReadOnly must not write through the slice its receiver shares with the value
+// it was called on — a mount is passed by value and callers reuse the base.
+func TestMount_ReadOnlyDoesNotMutateTheOriginal(t *testing.T) {
+	base := Bind("/src", "/dst", "z")
+	ro := base.ReadOnly()
+	assert.Equal(t, "/src:/dst:z", base.String())
+	assert.Equal(t, "/src:/dst:z,ro", ro.String())
+}
+
+func TestParseBind(t *testing.T) {
+	cases := []struct {
+		in     string
+		source string
+		target string
+		opts   []string
+	}{
+		{"/host:/container", "/host", "/container", nil},
+		{"/host:/container:ro", "/host", "/container", []string{"ro"}},
+		{"/host:/container:ro,z", "/host", "/container", []string{"ro", "z"}},
+		{"named-volume:/data", "named-volume", "/data", nil},
+	}
+	for _, c := range cases {
+		m, ok := ParseBind(c.in)
+		require.True(t, ok, c.in)
+		assert.Equal(t, c.source, m.Source, c.in)
+		assert.Equal(t, c.target, m.Target, c.in)
+		assert.Equal(t, c.opts, m.Options, c.in)
+	}
+}
+
+// A Windows source path is one path, not two fields. Reading `C:\repo` as a
+// drive plus a directory made the TARGET of every Windows mount its own source
+// directory, so the dedupe compared the wrong thing in both directions.
+func TestParseBind_WindowsDriveLetterIsNotASeparator(t *testing.T) {
+	m, ok := ParseBind(`C:\repo:/workspace`)
+	require.True(t, ok)
+	assert.Equal(t, `C:\repo`, m.Source)
+	assert.Equal(t, "/workspace", m.Target)
+
+	m, ok = ParseBind(`C:\repo:/workspace:ro`)
+	require.True(t, ok)
+	assert.Equal(t, `C:\repo`, m.Source)
+	assert.Equal(t, "/workspace", m.Target)
+	assert.Equal(t, []string{"ro"}, m.Options)
+}
+
+func TestParseBind_RefusesHalfAMount(t *testing.T) {
+	for _, in := range []string{"", "/only-a-path", "/host:", ":/container"} {
+		_, ok := ParseBind(in)
+		assert.False(t, ok, in)
+	}
+}
+
+// The old dedupe skipped anything it could not split into two fields, which
+// removed it from the result rather than leaving it alone. A mount is now a
+// pair by construction, so there is nothing half-formed to drop.
+func TestDedupeMounts_KeepsEveryDistinctTarget(t *testing.T) {
+	got := dedupeMounts([]Mount{
+		Bind("/a", "/x"),
+		Bind(`C:\b`, "/y"),
+		Bind("/c", "/x"),
+	})
+	require.Len(t, got, 2)
+	assert.Equal(t, "/y", got[0].Target, "order follows the surviving entries")
+	assert.Equal(t, "/c", got[1].Source, "the last mount for a target wins")
+}
+
+func TestBindStrings_NilForEmpty(t *testing.T) {
+	assert.Nil(t, bindStrings(nil))
+	assert.Equal(t, []string{"/a:/x"}, bindStrings([]Mount{Bind("/a", "/x")}))
+}


### PR DESCRIPTION
`domain.md` entry **#15**. **#16 was measured and declined** — see below.

`buildCreateOptions` composed `"src:dst[:opts]"` strings, and `deduplicateBinds` then re-parsed — in the same file — what that function had just built, splitting on colons to recover the target it had itself put there.

## Two states that reachable code could reach

- **A Windows source path splits at its drive letter.** `C:\repo:/workspace` read as three colon-separated fields has a *target* of `\repo`. Two mounts to different places then dedupe against each other, and two to the same place do not — and Docker answers the second case with `Duplicate mount point`.
- **A string the split could not divide in two was dropped**, not left alone: `if len(parts) >= 2 && …` gated the append, so a malformed bind vanished from the result.

Mounts travel as fields now. Parsing is confined to `ParseBind`, which exists for the strings a project writes in its own `devcontainer.json` and knows a drive letter is not a separator; the Docker bind form is composed once, at the SDK boundary (`ContainerCreateOptions.Binds` is `[]Mount`, rendered in `docker_engine.go`).

`Options` stays a verbatim list rather than a `ReadOnly bool`: a project may name `z` or `cached`, and modelling only the flag this code happens to set would silently drop what the project asked for.

## #16 declined — the defect it cites had a different cause

domain.md justifies typing `[]string{"K=V"}` env with: *"exactly the shape of the duplicate-`--add-host` defect that produced a newline inside `HUMAN_PROXY_ADDR`"*.

Traced: `HUMAN_PROXY_ADDR` is set from `proxyAddrForContainer`, which returns `net.JoinHostPort(...)`. No Go path put a newline in it. The newline came from the *container* deriving the value out of `/etc/hosts` when a duplicate `--add-host` made that file return two lines — the fix for which was to hand the address over already resolved. An `Env` type rejecting `\n` in `Set` would not have caught it, because the value Go set was never wrong.

What is left of #16 does not hold up either:

- The four builders share no logic beyond `k + "=" + v`, and each assembles a different env for a different process.
- Ordering already makes precedence deterministic at every site (the daemon vars are appended last, so they win), so the missing "last-wins rule" is unstated, not absent.
- `Get(k)` would have no caller: nothing reads back from any of the four slices.
- A `\n` guard would **reject values Docker accepts** — `containerEnv` and feature options are user JSON. That is a behaviour change, not a bug fix.

Left alone, with the reasoning recorded so it is not re-planned from the same premise.

## Verification

```
make check                              exit 0
go test ./cmd/...                       clean
go vet -tags wailsapp ./desktop/...     ok
make coverage-check                     83.7%
```

New tests pin both removed states directly: a Windows drive letter parsed as one path, and every distinct target surviving the dedupe. Existing bind assertions kept their string shape via `bindStrings(...)`, so what they assert is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)