### PR TITLE
[SC-4281] Ask for the rework nothing is running

### DIFF
--- a/desktop/frontend/dist/board-queue.js
+++ b/desktop/frontend/dist/board-queue.js
@@ -202,6 +202,49 @@ function livenessBadge(base, liveness, deadText, deadTitle) {
     }
     return base;
 }
+// reworkBadge is the badge for a card whose review returned a failing verdict.
+//
+// Nothing in the daemon launches this rework. The machine's own description of
+// the state says so — pipeline-fsm.json, `reviewed`: "a failing or incomplete
+// one waits for a rework the board must offer", whose only way out is the
+// user's start-implementation — and no code path acts on the failed verdict
+// either. SC-1830 badged this as in-flight machine work on the premise that a
+// fixer is launched automatically; that premise holds for the done-stage PR
+// review→fix loop (EvaluatePRLoop), not for the verification stage, and applying
+// it here left cards spinning at "fixing…" for days with no process behind them
+// and no ask to the user, because the machine register deliberately never asks
+// (SC-4281 measured two: five days and twenty-eight hours).
+//
+// So unknown liveness resolves the opposite way here than it does for a running
+// stage: there the machine launched an agent and silence is inconclusive, while
+// here it launched nothing and there is nothing to have gone quiet. A spinner
+// survives only for an agent actually found — the rework a user has already
+// dropped, whose implementation-started marker has not yet landed.
+function reworkBadge(card) {
+    const verdict = card.verdict ?? "";
+    if (card.agentLiveness === "live") {
+        return {
+            cls: "fixing",
+            text: "review found problems — fixing…",
+            title: `Review found problems — a fixer is reworking the code (verdict: ${verdict})`,
+            spinner: true,
+        };
+    }
+    if (card.agentLiveness === "elsewhere") {
+        return {
+            cls: "elsewhere",
+            text: "review found problems — fixing on another machine",
+            title: "Another machine's daemon owns this rework — its agent cannot be seen from here.",
+            spinner: false,
+        };
+    }
+    return {
+        cls: "warning",
+        text: "⚠ review found problems — needs rework",
+        title: `Review found problems and nothing reworks it on its own (verdict: ${verdict}). Drag the card onto Code to run the rework — the findings are in the latest [human:review-complete] comment on the ticket.`,
+        spinner: false,
+    };
+}
 // badgeInfo classifies a card's live state into a badge descriptor, or null
 // when the card rests and needs none — its queue position IS the statement of
 // completion. A review that found problems is machine-fixing work, not a demand
@@ -337,19 +380,8 @@ export function badgeInfo(card, nowMs = Date.now(), runningLabels = RUNNING_LABE
         // (ticket 405).
         return { cls: "resolved", text: "no fix needed", title: "Triage concluded no fix is warranted" };
     }
-    // A failed review verdict is machine work, not a demand on the user: the
-    // daemon auto-launches a fixer (internal/daemon/board_failure.go →
-    // pr_review_loop.go). It must read as in-flight — the gray machine-working
-    // `fixing` badge with the running spinner and copy that says what is
-    // happening — never the amber `warning`/`decision` "your turn" register with
-    // a ⚠ glyph (SC-1830).
     if (card.stage === "verification" && card.state === "done" && verdictFailed(card)) {
-        return livenessBadge({
-            cls: "fixing",
-            text: "review found problems — fixing…",
-            title: `Review found problems — a fixer is reworking the code automatically (verdict: ${card.verdict ?? ""})`,
-            spinner: true,
-        }, card.agentLiveness, "review found problems — no fixer running", `Review found problems and no fixer is running on this machine (verdict: ${card.verdict ?? ""}). Drop the card on the build stage to rework it.`);
+        return reworkBadge(card);
     }
     // A passed review with no recorded branch is a BROKEN HANDOFF that genuinely
     // needs a person: nothing can ship, so it keeps the needs-a-human `warning`

--- a/desktop/frontend/scripts/board-queue.test.mjs
+++ b/desktop/frontend/scripts/board-queue.test.mjs
@@ -94,7 +94,7 @@ test("badgeInfo preserves prior classifications", () => {
   assert.equal(badgeInfo({ stage: "planning", state: "resolved" }).text, "already shipped");
   assert.equal(
     badgeInfo({ stage: "verification", state: "done", verdict: "fail", branch: "b" }).cls,
-    "fixing",
+    "warning",
   );
   assert.equal(
     badgeInfo({ stage: "verification", state: "done", verdict: "pass", branch: "b" }),
@@ -144,19 +144,45 @@ test("STOP_DECISION_LABELS covers the three stop heads (SC-2699)", () => {
   assert.equal(STOP_DECISION_LABELS.rejected.text, "not a real problem");
 });
 
-// SC-1830 regression: a failed review verdict is machine work (the daemon
-// auto-launches a fixer), NOT a demand on the user. Its badge must read as
-// in-flight — a dedicated machine-working class, the running spinner, and copy
-// that says what is happening ("fixing…") — never the amber `warning`/`decision`
-// register with a ⚠ glyph that means "your turn".
-test("failed review verdict badges as in-flight machine work, not a warning (SC-1830)", () => {
+// SC-4281: a failed review verdict is the USER's move. SC-1830 badged it as
+// machine work on the premise that the daemon auto-launches a fixer — true of
+// the done-stage PR review→fix loop, false here: no code acts on the verdict,
+// and pipeline-fsm.json's `reviewed` state says it "waits for a rework the board
+// must offer", reachable only by the user's start-implementation. Badging it as
+// in-flight left cards spinning at "fixing…" for days with nothing running and
+// nobody asked, because the machine register deliberately never asks.
+test("failed review verdict asks the user, since nothing reworks it (SC-4281)", () => {
   const info = badgeInfo({ stage: "verification", state: "done", verdict: "fail", branch: "b" });
   assert.notEqual(info, null);
-  assert.equal(info.cls, "fixing", "failed verdict must use the machine-working class, not amber `warning`");
-  assert.notEqual(info.cls, "decision", "must not share the needs-a-human decision class");
-  assert.equal(info.spinner, true, "must carry the running spinner so it reads as in-flight");
-  assert.match(info.text, /fixing…/, "copy must say what is happening, not hand a verdict to the user");
-  assert.doesNotMatch(info.text, /⚠/, "the alarm glyph belongs to needs-a-human states only");
+  assert.equal(info.cls, "warning", "nothing runs this rework, so it belongs in the needs-a-person register");
+  assert.notEqual(info.spinner, true, "no process is behind it — a spinner would be a claim of work");
+  assert.match(info.text, /rework/, "the copy must name the move the user has to make");
+  assert.match(info.title, /Drag the card onto Code/, "and the title must name the gesture that makes it");
+});
+
+// The spinner survives for exactly one case: a rework already dropped, whose
+// implementation-started marker has not landed yet, so an agent IS found behind
+// a card still reading verification/done.
+test("a failed verdict with a live agent still reads as in-flight (SC-4281)", () => {
+  const info = badgeInfo({ stage: "verification", state: "done", verdict: "fail", branch: "b", agentLiveness: "live" });
+  assert.equal(info.cls, "fixing");
+  assert.equal(info.spinner, true);
+  assert.match(info.text, /fixing…/);
+});
+
+// A peer machine's rework is neither this machine's work nor the user's move
+// here — it says so instead of spinning or demanding (SC-3569 precedent).
+test("a failed verdict reworked elsewhere says so (SC-4281)", () => {
+  const info = badgeInfo({
+    stage: "verification",
+    state: "done",
+    verdict: "fail",
+    branch: "b",
+    agentLiveness: "elsewhere",
+  });
+  assert.equal(info.cls, "elsewhere");
+  assert.notEqual(info.spinner, true);
+  assert.match(info.text, /another machine/);
 });
 
 // 1290: an open decision block must outrank a `failed` state too, not just the
@@ -188,8 +214,8 @@ test("open options render a decision-needed badge over the review warning", () =
   const info = badgeInfo(card);
   assert.equal(info.cls, "decision");
   assert.match(info.text, /decision needed/);
-  // Without options the same card falls back to the fixing badge.
-  assert.equal(badgeInfo({ ...card, options: [] }).cls, "fixing");
+  // Without options the same card falls back to the needs-rework badge.
+  assert.equal(badgeInfo({ ...card, options: [] }).cls, "warning");
 });
 
 // SC-1669: a card parked on an open decision whose state is still "running"
@@ -728,11 +754,14 @@ test("a recovering agent stays in the machine register, never the person's (SC-3
 test("queued and fixing badges also drop the spinner for a dead agent (SC-3569)", () => {
   const queued = badgeInfo({ stage: "implementation", state: "queued", agentLiveness: "dead" });
   assert.equal(queued.spinner, false);
+  // A dead agent and an unknown one now read alike on a failed verdict, because
+  // they mean the same thing there — nothing is reworking it (SC-4281). What
+  // SC-3569 asked of this badge is unchanged: no spinner without a process.
   const fixing = badgeInfo({
     stage: "verification", state: "done", verdict: "fail", branch: "b", agentLiveness: "dead",
   });
   assert.equal(fixing.spinner, false);
-  assert.match(fixing.text, /no fixer running/);
+  assert.match(fixing.text, /needs rework/);
 });
 
 // --- A red card whose agent is working says so (SC-4151 A1) ---

--- a/desktop/frontend/scripts/style.test.mjs
+++ b/desktop/frontend/scripts/style.test.mjs
@@ -170,7 +170,7 @@ test("board exposes a persistent horizontal scroll affordance (SC-1451)", () => 
 // SC-1830 regression: badge colour answers "whose turn is it?", not severity.
 // The machine-working failed-verdict badge must not wear the same amber as the
 // needs-a-human decision badge.
-test("failed-verdict badge uses the machine-working colour, not the decision amber (SC-1830)", () => {
+test("the machine-working badge keeps its own colour, never the decision amber (SC-1830)", () => {
   const fixing = ruleBody(".badge.fixing");
   const decision = ruleBody(".badge.decision");
   assert.match(fixing, /color:\s*var\(--turn-machine\)/, ".badge.fixing must use the gray machine-working token");

--- a/desktop/frontend/src/board-queue.ts
+++ b/desktop/frontend/src/board-queue.ts
@@ -276,6 +276,50 @@ function livenessBadge(base: BadgeInfo, liveness: string | undefined, deadText: 
   return base;
 }
 
+// reworkBadge is the badge for a card whose review returned a failing verdict.
+//
+// Nothing in the daemon launches this rework. The machine's own description of
+// the state says so — pipeline-fsm.json, `reviewed`: "a failing or incomplete
+// one waits for a rework the board must offer", whose only way out is the
+// user's start-implementation — and no code path acts on the failed verdict
+// either. SC-1830 badged this as in-flight machine work on the premise that a
+// fixer is launched automatically; that premise holds for the done-stage PR
+// review→fix loop (EvaluatePRLoop), not for the verification stage, and applying
+// it here left cards spinning at "fixing…" for days with no process behind them
+// and no ask to the user, because the machine register deliberately never asks
+// (SC-4281 measured two: five days and twenty-eight hours).
+//
+// So unknown liveness resolves the opposite way here than it does for a running
+// stage: there the machine launched an agent and silence is inconclusive, while
+// here it launched nothing and there is nothing to have gone quiet. A spinner
+// survives only for an agent actually found — the rework a user has already
+// dropped, whose implementation-started marker has not yet landed.
+function reworkBadge(card: QueueCard): BadgeInfo {
+  const verdict = card.verdict ?? "";
+  if (card.agentLiveness === "live") {
+    return {
+      cls: "fixing",
+      text: "review found problems — fixing…",
+      title: `Review found problems — a fixer is reworking the code (verdict: ${verdict})`,
+      spinner: true,
+    };
+  }
+  if (card.agentLiveness === "elsewhere") {
+    return {
+      cls: "elsewhere",
+      text: "review found problems — fixing on another machine",
+      title: "Another machine's daemon owns this rework — its agent cannot be seen from here.",
+      spinner: false,
+    };
+  }
+  return {
+    cls: "warning",
+    text: "⚠ review found problems — needs rework",
+    title: `Review found problems and nothing reworks it on its own (verdict: ${verdict}). Drag the card onto Code to run the rework — the findings are in the latest [human:review-complete] comment on the ticket.`,
+    spinner: false,
+  };
+}
+
 // badgeInfo classifies a card's live state into a badge descriptor, or null
 // when the card rests and needs none — its queue position IS the statement of
 // completion. A review that found problems is machine-fixing work, not a demand
@@ -421,24 +465,8 @@ export function badgeInfo(
     // (ticket 405).
     return { cls: "resolved", text: "no fix needed", title: "Triage concluded no fix is warranted" };
   }
-  // A failed review verdict is machine work, not a demand on the user: the
-  // daemon auto-launches a fixer (internal/daemon/board_failure.go →
-  // pr_review_loop.go). It must read as in-flight — the gray machine-working
-  // `fixing` badge with the running spinner and copy that says what is
-  // happening — never the amber `warning`/`decision` "your turn" register with
-  // a ⚠ glyph (SC-1830).
   if (card.stage === "verification" && card.state === "done" && verdictFailed(card)) {
-    return livenessBadge(
-      {
-        cls: "fixing",
-        text: "review found problems — fixing…",
-        title: `Review found problems — a fixer is reworking the code automatically (verdict: ${card.verdict ?? ""})`,
-        spinner: true,
-      },
-      card.agentLiveness,
-      "review found problems — no fixer running",
-      `Review found problems and no fixer is running on this machine (verdict: ${card.verdict ?? ""}). Drop the card on the build stage to rework it.`,
-    );
+    return reworkBadge(card);
   }
   // A passed review with no recorded branch is a BROKEN HANDOFF that genuinely
   // needs a person: nothing can ship, so it keeps the needs-a-human `warning`


### PR DESCRIPTION
Follow-up to #483, same complaint: a card shows running with no agent behind it. Different cause.

A failed review verdict badges `review found problems — fixing…` with a spinner. Nothing is fixing it.

```
$ human fsm where SC-3577
state: reviewed
if_nothing_happens: "Nothing automatic on the shipping path: … a failing or
  incomplete one waits for a rework the board must offer"
ways_out: start-implementation → actor: user, yours: false
```

The code agrees with the document: every caller of `VerdictFailed` is rendering, the work gate, or a user-initiated transition. Nothing launches a rework, and `chainReviewAfterCleanBuild` explicitly does nothing on a fail verdict.

SC-1830 moved this badge into the machine register on the premise that "the daemon auto-launches a fixer (board_failure.go → pr_review_loop.go)". That premise holds for the **done-stage** PR review→fix loop (`EvaluatePRLoop`) and not for the **verification** stage. Because the machine register deliberately never asks — no ⚠, no "your turn" — the card claimed work nobody was doing and nobody was asked to start it. Measured on this board: SC-2873 spinning since 2026-08-05, SC-3577 since 2026-08-09 09:50.

## Change

`reworkBadge` replaces the `livenessBadge` wrapper on that one branch. Unknown liveness resolves the opposite way here than on a running stage: there the machine launched an agent and silence is inconclusive; here it launched nothing, so there is nothing to have gone quiet.

| liveness | badge |
| --- | --- |
| live | `review found problems — fixing…` + spinner (a rework already dropped, marker not yet landed) |
| elsewhere | `review found problems — fixing on another machine` |
| dead / unknown | `⚠ review found problems — needs rework`, title naming the gesture: drag the card onto Code |

The SC-1830 regression test is inverted with its premise recorded; SC-3569's requirement of that badge (no spinner without a process) is unchanged and still asserted. 269 frontend tests pass, `make check` green, dist rebuilt and committed (drift guard clean).

## Not done here

The alternative fix is to make the daemon relaunch the rework itself, which is what "machine acts, never asks" would want. That contradicts `pipeline-fsm.json` as written — `reviewed`'s only rework edge is the user's — so it is a pipeline change with a document change in the same commit, not a board fix. Worth deciding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)