### PR TITLE
[SC-4118] Give the board agent-name grammar an owner

### DIFF
--- a/internal/agentname/agentname.go
+++ b/internal/agentname/agentname.go
@@ -1,0 +1,69 @@
+// Package agentname owns the name the daemon gives a board stage agent, and
+// the grammar that name is written in.
+//
+// It is a package of its own because two packages that cannot import each
+// other both have to agree on it. internal/daemon composes the name when it
+// launches a stage and parses it back when the stage exits; internal/capabilities
+// reads the same prefix to decide what a run inside that container may do, and
+// cannot import internal/daemon. Before this, each held its own "board-"
+// literal and a comment in one pointed at the other.
+//
+// The grammar is also read outside Go: the autofix and security-fix skill
+// prompts treat a HUMAN_AGENT_NAME starting with the prefix as a fallback
+// board-context signal. A prompt cannot import anything, so those readers stay
+// separate — but the Go side now has one place for them to be true about.
+package agentname
+
+import (
+	"regexp"
+	"strings"
+)
+
+// BoardPrefix marks a container as a board stage agent. It is the whole of the
+// board signal: a run whose name carries it holds no push credentials, because
+// the board's Deploy stage is what ships the work.
+const BoardPrefix = "board-"
+
+// IsBoard reports whether name is a board stage agent's name.
+func IsBoard(name string) bool {
+	return strings.HasPrefix(name, BoardPrefix)
+}
+
+// sanitizeRe drops characters that are invalid in an agent name (alphanumeric,
+// hyphen, underscore only) so a PM key like "SC-105" maps to a valid,
+// reversible name.
+var sanitizeRe = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+
+// SanitizeKey renders a ticket key the way it appears inside an agent name.
+// Callers that compare a live agent against a ticket need it too: matching a
+// raw key against a name would miss every key carrying a character the name
+// encoding replaced.
+func SanitizeKey(key string) string {
+	return sanitizeRe.ReplaceAllString(key, "-")
+}
+
+// Board builds the name for a stage agent working key. It is reversible by
+// ParseBoard, which is what lets an exit event be traced back to the work it
+// was for.
+//
+// The stage token must carry no hyphen: ParseBoard splits on the LAST one, so
+// a hyphenated token would take part of itself for the key. Callers keep their
+// public, hyphenated spellings elsewhere and pass the hyphen-free token here.
+func Board(key, stage string) string {
+	return BoardPrefix + SanitizeKey(key) + "-" + stage
+}
+
+// ParseBoard recovers the key and stage from a board agent name. The key comes
+// back sanitized — the form embedded in the name — which is what a caller
+// needs to match it against tickets it already fetched.
+func ParseBoard(name string) (key, stage string, ok bool) {
+	rest, found := strings.CutPrefix(name, BoardPrefix)
+	if !found {
+		return "", "", false
+	}
+	idx := strings.LastIndex(rest, "-")
+	if idx <= 0 || idx == len(rest)-1 {
+		return "", "", false
+	}
+	return rest[:idx], rest[idx+1:], true
+}

--- a/internal/agentname/agentname_test.go
+++ b/internal/agentname/agentname_test.go
@@ -1,0 +1,71 @@
+package agentname
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoard_RoundTrips(t *testing.T) {
+	cases := []struct{ key, stage, want string }{
+		{"SC-105", "implementation", "board-SC-105-implementation"},
+		{"SC-1", "prreview", "board-SC-1-prreview"},
+		{"octocat/repo#42", "planning", "board-octocat-repo-42-planning"},
+	}
+	for _, c := range cases {
+		name := Board(c.key, c.stage)
+		assert.Equal(t, c.want, name)
+
+		key, stage, ok := ParseBoard(name)
+		require.True(t, ok, name)
+		assert.Equal(t, SanitizeKey(c.key), key, "the key comes back in the form the name carries")
+		assert.Equal(t, c.stage, stage)
+	}
+}
+
+func TestIsBoard(t *testing.T) {
+	assert.True(t, IsBoard("board-SC-1-implementation"))
+	assert.False(t, IsBoard("agent-SC-1"))
+	assert.False(t, IsBoard(""))
+	// The prefix alone is a board name by this test and no more: it carries no
+	// key or stage, which ParseBoard is what refuses.
+	assert.True(t, IsBoard(BoardPrefix))
+	_, _, ok := ParseBoard(BoardPrefix)
+	assert.False(t, ok)
+}
+
+func TestParseBoard_RefusesWhatIsNotOne(t *testing.T) {
+	for _, name := range []string{"", "board-", "SC-1-implementation", "board--implementation", "board-SC-1-"} {
+		_, _, ok := ParseBoard(name)
+		assert.False(t, ok, name)
+	}
+}
+
+// A two-token name is not refused: the grammar cannot tell "key SC, stage 1"
+// from a truncated name, and it does not try. Pinned because it is what the
+// parse has always done, not because it is desirable — a caller that cares
+// checks the stage against the ones it knows.
+func TestParseBoard_TwoTokensParseAsKeyAndStage(t *testing.T) {
+	key, stage, ok := ParseBoard("board-SC-1")
+	require.True(t, ok)
+	assert.Equal(t, "SC", key)
+	assert.Equal(t, "1", stage)
+}
+
+// The stage token must carry no hyphen: the parse splits on the LAST one, so a
+// hyphenated token takes part of itself for the key. This is the invariant the
+// daemon's hyphen-free stage constants exist to satisfy — pinned here, beside
+// the parse that depends on it, rather than only in a comment beside them.
+func TestParseBoard_SplitsOnTheLastHyphen(t *testing.T) {
+	key, stage, ok := ParseBoard(Board("SC-1", "pr-review"))
+	require.True(t, ok)
+	assert.Equal(t, "SC-1-pr", key, "a hyphenated stage token loses its head to the key")
+	assert.Equal(t, "review", stage)
+}
+
+func TestSanitizeKey(t *testing.T) {
+	assert.Equal(t, "SC-105", SanitizeKey("SC-105"))
+	assert.Equal(t, "octocat-repo-42", SanitizeKey("octocat/repo#42"))
+	assert.Equal(t, "a-b", SanitizeKey("a   b"), "a run of invalid characters collapses to one hyphen")
+}

--- a/internal/capabilities/capabilities.go
+++ b/internal/capabilities/capabilities.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/gethuman-sh/human/internal/agentname"
 	"github.com/gethuman-sh/human/internal/env"
 )
 
@@ -49,7 +50,7 @@ type RemoteProbe func(ctx context.Context) bool
 // Deploy stage owns shipping, so it may neither push, open a PR, nor deploy.
 func Detect(ctx context.Context, probe RemoteProbe) Set {
 	agent := env.Lookup(ctx, "HUMAN_AGENT_NAME")
-	board := strings.HasPrefix(agent, "board-")
+	board := agentname.IsBoard(agent)
 
 	set := Set{BoardContext: board, Agent: agent, Workspace: WorkspaceLocal}
 	if board {

--- a/internal/daemon/board_failure.go
+++ b/internal/daemon/board_failure.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/gethuman-sh/human/internal/agentname"
 	"github.com/gethuman-sh/human/internal/claude/hookevents"
 	"github.com/gethuman-sh/human/internal/marker"
 	"github.com/gethuman-sh/human/internal/proxy"
@@ -190,7 +191,7 @@ func RunBoardFailureWatch(ctx context.Context, store *HookEventStore, runs *RunR
 			newEvents, seq := store.EventsSince(lastSeq)
 			lastSeq = seq
 			for _, evt := range newEvents {
-				if !strings.HasPrefix(evt.AgentName, "board-") {
+				if !agentname.IsBoard(evt.AgentName) {
 					continue
 				}
 				if !hookevents.IsRunEnd(evt.EventName) {

--- a/internal/daemon/board_reconcile_orphan.go
+++ b/internal/daemon/board_reconcile_orphan.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"context"
+
+	"github.com/gethuman-sh/human/internal/agentname"
 )
 
 // ClosedTicketProbe reports whether pmKey's ticket has left the board as
@@ -39,11 +41,11 @@ func reconcileOrphanedAgents(ctx context.Context, cards []ReconcileCard, deps Re
 		return 0
 	}
 	// Agent names embed the SANITIZED key, so open cards are matched through the
-	// same sanitize() the launcher used — raw-key equality would miss any key
+	// same agentname.SanitizeKey() the launcher used — raw-key equality would miss any key
 	// carrying characters the name encoding replaced.
 	open := make(map[string]struct{}, len(cards))
 	for _, card := range cards {
-		open[sanitize(card.Key)] = struct{}{}
+		open[agentname.SanitizeKey(card.Key)] = struct{}{}
 	}
 	candidates, order := orphanCandidates(names, open)
 

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -13,6 +12,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/agentname"
 	"github.com/gethuman-sh/human/internal/forge"
 	"github.com/gethuman-sh/human/internal/marker"
 	"github.com/gethuman-sh/human/internal/tracker"
@@ -226,15 +226,6 @@ type BoardTransitionDeps struct {
 	Getter tracker.Getter
 }
 
-// sanitizeRe drops characters that are invalid in an agent name (alphanumeric,
-// hyphen, underscore only) so a PM key like "SC-105" maps to a valid,
-// reversible agent name.
-var sanitizeRe = regexp.MustCompile(`[^a-zA-Z0-9]+`)
-
-func sanitize(s string) string {
-	return sanitizeRe.ReplaceAllString(s, "-")
-}
-
 // Hyphen-free agent-name suffixes for the PR review→fix loop steps. parseAgentName
 // splits on the last hyphen, so the token itself must carry none — the public
 // marker/state names keep their hyphenated form (pr-review-started, stage.pr-review);
@@ -245,26 +236,19 @@ const (
 	deployFixAgentStage BoardStage = "deployfix"
 )
 
-// agentNameFor builds the agent name for a board stage. It is reversible (see
-// parseAgentName) so the failure watcher can recover (pmKey, stage) from a
-// SessionEnd event.
+// agentNameFor builds the agent name for a board stage. The grammar lives in
+// internal/agentname, which internal/capabilities reads too; these two wrappers
+// exist only to carry BoardStage across it.
 func agentNameFor(pmKey string, stage BoardStage) string {
-	return "board-" + sanitize(pmKey) + "-" + string(stage)
+	return agentname.Board(pmKey, string(stage))
 }
 
 // parseAgentName recovers the PM key and stage from a board agent name. The PM
 // key is returned sanitized (the form embedded in the name), which is
 // sufficient to re-resolve comments since the daemon fetched the same keys.
 func parseAgentName(name string) (pmKey string, stage BoardStage, ok bool) {
-	rest, found := strings.CutPrefix(name, "board-")
-	if !found {
-		return "", "", false
-	}
-	idx := strings.LastIndex(rest, "-")
-	if idx <= 0 || idx == len(rest)-1 {
-		return "", "", false
-	}
-	return rest[:idx], BoardStage(rest[idx+1:]), true
+	key, s, ok := agentname.ParseBoard(name)
+	return key, BoardStage(s), ok
 }
 
 // ApplyTransition advances a card from its current stage to the requested next

--- a/internal/daemon/close_cancel.go
+++ b/internal/daemon/close_cancel.go
@@ -6,16 +6,17 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/agentname"
 )
 
 // AgentsForPMKey returns the board-agent names in names that belong to pmKey,
 // across every stage. An agent name embeds the sanitized PM key (see
-// agentNameFor), so a live agent is matched by the same sanitize() the launcher
+// agentNameFor), so a live agent is matched by the same agentname.SanitizeKey() the launcher
 // used — not by raw-key equality, which would miss keys carrying characters the
 // name-encoding replaced. Names that are not board agents (or are malformed) are
 // skipped.
 func AgentsForPMKey(names []string, pmKey string) []string {
-	want := sanitize(pmKey)
+	want := agentname.SanitizeKey(pmKey)
 	var out []string
 	for _, name := range names {
 		key, _, ok := parseAgentName(name)


### PR DESCRIPTION
`domain.md` entry **#14**. **#12 and #13 were measured and declined** — see below.

The `board-` prefix is the whole of the board-context signal: a run whose name carries it holds no push credentials, because the board's Deploy stage ships the work. It was written out in **two packages that cannot import each other** — `internal/daemon` composes and parses the name, `internal/capabilities` reads the prefix to decide what the run may do — with a comment in the second pointing at the first as the thing it must agree with.

`internal/agentname` owns it now, alongside the key sanitisation two more daemon call sites needed for the same reason: matching a live agent against a ticket means comparing the key in the form the name carries it. `grep -rn '"board-"' --include="*.go"` now returns one declaration.

Two behaviours are pinned by tests beside the parse rather than by a comment beside the constants: the split-on-the-**last**-hyphen rule the hyphen-free stage tokens exist to satisfy, and the fact that a two-token name parses as key plus stage because the grammar cannot tell that from a truncation. The second is recorded because it is true, not because it is desirable.

Two skill prompts read the same prefix as a fallback board-context signal (`human-autofix-skill.md`, `human-security-fix-skill.md`). A prompt cannot import a type, so those stay separate — but the Go side now has one place for them to be true about.

## #12 declined — an import cycle makes the single-owner version impossible

domain.md proposes `tracker.Ref{Kind, Name}`. `internal/tracker` **imports** `internal/config` (`policy_config.go:4`), so `internal/config` cannot import `internal/tracker` — and `config/validate.go:192` is one of the two sites that builds the `kind + "/" + name` key. The other is `cmd/cmddaemon/daemon.go:1800`, a third package again.

A `Ref` therefore fragments into three local types in three packages: the same shape written three times, which is what the entry set out to remove. The remaining `(kind, name)` parameter pair is 5 call sites, all inside `config/document.go` plus one in `settings/migrate.go`, and CLAUDE.md requires a separate forge type regardless — two new types for a handful of calls.

Also worth recording: the composite is **never parsed back**. Two uses are dedupe map keys, two are display strings. There is no round-trip hazard to remove.

## #13 declined — its stated risk is unfixable under the layering rule

The entry names the real risk as "two independent spellings of one grammar": `internal/tracker/urlparse.go` composes `owner + "/" + repo + "#" + num`, and `internal/tracker/github/client.go` parses it. Sharing a type between them would put provider-specific logic in `internal/tracker/`, which CLAUDE.md forbids in capitals. **So the divergence the entry exists to close cannot be closed this way.**

What is left is swap-proofing `parseIssueKey`/`splitProject` — 25 call sites across the two GitHub clients. But the swap does not disappear: the call sites feed methods like `c.pullNodeID(ctx, owner, repo, number)`, and removing it there means threading a ref through the whole client down to URL construction. That is a real change, just not the one the entry describes, and not one I would make on a hypothetical in the two clients that open PRs and read issues.

## Verification

```
make check                              exit 0
go test ./cmd/...                       clean
go vet -tags wailsapp ./desktop/...     ok
make fsm                                well-formed machine
make coverage-check                     83.7%
```

One caveat: the first `make check` failed `TestRunBoardFreshnessPoll_PokesOnChange`. It passes 8/8 both with and without this change, and the second full run was green — a timing-sensitive poll test under parallel load, unrelated to agent names. Flagging it rather than calling it clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)