### PR TITLE
[SC-4299] Offer Rework on the card that asks for it

### DIFF
--- a/desktop/frontend/dist/board-queue.js
+++ b/desktop/frontend/dist/board-queue.js
@@ -49,6 +49,18 @@ export function queueOf(card) {
 export function isReworkable(card) {
     return card.stage === "verification" && card.state === "done" && (verdictFailed(card) || !card.branch);
 }
+// reworkKind names the pipeline that reworks a card, so the Rework menu action
+// starts the same run its drop target would have. A drop derives that from the
+// column the card was released on; a menu has no target, so it derives it from
+// the card — the two agree because a bug's only rework target is the Fix column
+// and a security ticket's is the Security one.
+export function reworkKind(card) {
+    if (card.bug)
+        return "bug";
+    if (card.security)
+        return "security";
+    return "build";
+}
 // ageDays converts a card's stage timestamp into whole days elapsed, or null
 // when the timestamp is absent or unparseable.
 export function ageDays(stageEnteredAt, now) {
@@ -241,7 +253,7 @@ function reworkBadge(card) {
     return {
         cls: "warning",
         text: "⚠ review found problems — needs rework",
-        title: `Review found problems and nothing reworks it on its own (verdict: ${verdict}). Drag the card onto Code to run the rework — the findings are in the latest [human:review-complete] comment on the ticket.`,
+        title: `Review found problems and nothing reworks it on its own (verdict: ${verdict}). Right-click the card and choose Rework to run it — the findings are in the latest [human:review-complete] comment on the ticket.`,
         spinner: false,
     };
 }

--- a/desktop/frontend/dist/board.js
+++ b/desktop/frontend/dist/board.js
@@ -16,7 +16,7 @@ import { initMockupsView, showMockups, setPendingMockupSlug, setChosenMockup, } 
 import { initSettingsView, showSettings, settingsIndex, saveSetting, setPaletteOpener, setActiveSection, } from "./settingsview.js";
 import { initPalette, openPalette, isPaletteChord } from "./palette.js";
 import { initStatsView, showStats, startStatsPoll, stopStatsPoll, } from "./statsview.js";
-import { QUEUES, QUEUE_TRANSITION_TO, queueOf, isReworkable, isReviewRetryable, isReopenable, ageBadge, isReplannable, forwardDropAllowed, badgeInfo, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReadyToDeploy, deployableCards, deployControlView, safetyPollShouldReconcile, safetyReconcileError, RUNNING_LABELS, } from "./board-queue.js";
+import { QUEUES, QUEUE_TRANSITION_TO, queueOf, isReworkable, reworkKind, isReviewRetryable, isReopenable, ageBadge, isReplannable, forwardDropAllowed, badgeInfo, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReadyToDeploy, deployableCards, deployControlView, safetyPollShouldReconcile, safetyReconcileError, RUNNING_LABELS, } from "./board-queue.js";
 import { linksWithin, arrowPath, plan, gapsBySide } from "./board-arrows.js";
 import { buildDeployControl } from "./board-deploy.js";
 import { buildCostSection, buildDetailSections, buildOptionsSection, buildShippedPartialSection, buildStopDecisionSection } from "./board-detail.js";
@@ -403,6 +403,37 @@ function showCardMenu(card, x, y) {
             void transition(card.key, card.title, "verification", "verification");
         });
         menu.appendChild(retryReview);
+    }
+    // The rework a failing review verdict needs. Nothing starts it on its own —
+    // pipeline-fsm.json's `reviewed` state says it waits for a rework the board
+    // must offer — and until now the board offered it only as a drag back onto
+    // the card's build column, which is invisible unless you already know it.
+    // Every other stage a person has to restart by hand has a menu action for it
+    // (Retry plan, Replan, Retry build, Retry review, Retry deploy); this was the
+    // gap, on the one state where the badge explicitly asks the user to act
+    // (SC-4299). Each kind starts the same run its drop target would have.
+    if (isReworkable(card)) {
+        const rework = document.createElement("button");
+        rework.type = "button";
+        rework.className = "context-menu-item";
+        rework.textContent = "Rework";
+        rework.disabled = !current.dockerAvailable;
+        if (rework.disabled)
+            rework.title = "Docker required";
+        rework.addEventListener("click", () => {
+            menu.remove();
+            switch (reworkKind(card)) {
+                case "bug":
+                    void fixBug(card.key, card.title);
+                    return;
+                case "security":
+                    void fixSecurity(card.key, card.title);
+                    return;
+                default:
+                    void transition(card.key, card.title, "verification", "implementation");
+            }
+        });
+        menu.appendChild(rework);
     }
     // A resolved card — the pipeline concluded there is nothing to do, or no fix
     // is needed — had no gesture at all. The retry paths key on failed or outage

--- a/desktop/frontend/scripts/board-queue.test.mjs
+++ b/desktop/frontend/scripts/board-queue.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { queueOf, isReworkable, isReopenable, verdictFailed, forwardDropAllowed, planReady, badgeInfo, sinceText, safetyReconcileError, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReviewRetryable, STOP_DECISION_LABELS } from "../build/board-queue.js";
+import { queueOf, isReworkable, reworkKind, isReopenable, verdictFailed, forwardDropAllowed, planReady, badgeInfo, sinceText, safetyReconcileError, cardError, sortByHandOrder, insertKeyAt, boardStateFromPayload, isReviewRetryable, STOP_DECISION_LABELS } from "../build/board-queue.js";
 import { DAEMON_FORWARDED_STATES } from "../build/board-states.js";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -57,6 +57,27 @@ test("isReviewRetryable is true only for verification/failed (SC-695)", () => {
   assert.equal(isReviewRetryable({ stage: "verification", state: "done", verdict: "fail", branch: "b" }), false);
   assert.equal(isReviewRetryable({ stage: "verification", state: "running" }), false);
   assert.equal(isReviewRetryable({ stage: "implementation", state: "failed" }), false);
+});
+
+// SC-4299: the Rework menu action must start the same run the card's drop
+// target would have — the fix pipeline for a bug or a security ticket, the
+// build stage for a feature. A feature card misrouted to fixBug would run
+// autofix on a ticket that has no bug verdict.
+test("reworkKind routes each card kind to its own rework pipeline (SC-4299)", () => {
+  const failed = { stage: "verification", state: "done", verdict: "fail", branch: "b" };
+  assert.equal(reworkKind({ ...failed, bug: true }), "bug");
+  assert.equal(reworkKind({ ...failed, security: true }), "security");
+  assert.equal(reworkKind(failed), "build");
+});
+
+// The action is offered for exactly the cards the drop gate accepts — including
+// a passed review with no branch recorded, which is reworkable for the other
+// reason (nothing to ship) and has the same one move out.
+test("every reworkable card kind qualifies for the action (SC-4299)", () => {
+  assert.equal(isReworkable({ stage: "verification", state: "done", verdict: "fail", branch: "b" }), true);
+  assert.equal(isReworkable({ stage: "verification", state: "done", verdict: "pass" }), true, "no branch recorded");
+  assert.equal(isReworkable({ stage: "verification", state: "done", verdict: "pass", branch: "b" }), false);
+  assert.equal(isReworkable({ stage: "verification", state: "running" }), false);
 });
 
 // SC-429 regression: "fix complete, review not started" (stage=implementation,
@@ -157,7 +178,7 @@ test("failed review verdict asks the user, since nothing reworks it (SC-4281)", 
   assert.equal(info.cls, "warning", "nothing runs this rework, so it belongs in the needs-a-person register");
   assert.notEqual(info.spinner, true, "no process is behind it — a spinner would be a claim of work");
   assert.match(info.text, /rework/, "the copy must name the move the user has to make");
-  assert.match(info.title, /Drag the card onto Code/, "and the title must name the gesture that makes it");
+  assert.match(info.title, /choose Rework/, "and the title must name the action that makes it");
 });
 
 // The spinner survives for exactly one case: a rework already dropped, whose

--- a/desktop/frontend/src/board-queue.ts
+++ b/desktop/frontend/src/board-queue.ts
@@ -107,6 +107,17 @@ export function isReworkable(card: QueueCard): boolean {
   return card.stage === "verification" && card.state === "done" && (verdictFailed(card) || !card.branch);
 }
 
+// reworkKind names the pipeline that reworks a card, so the Rework menu action
+// starts the same run its drop target would have. A drop derives that from the
+// column the card was released on; a menu has no target, so it derives it from
+// the card — the two agree because a bug's only rework target is the Fix column
+// and a security ticket's is the Security one.
+export function reworkKind(card: QueueCard): "bug" | "security" | "build" {
+  if (card.bug) return "bug";
+  if (card.security) return "security";
+  return "build";
+}
+
 // ageDays converts a card's stage timestamp into whole days elapsed, or null
 // when the timestamp is absent or unparseable.
 export function ageDays(stageEnteredAt: string | undefined, now: Date): number | null {
@@ -315,7 +326,7 @@ function reworkBadge(card: QueueCard): BadgeInfo {
   return {
     cls: "warning",
     text: "⚠ review found problems — needs rework",
-    title: `Review found problems and nothing reworks it on its own (verdict: ${verdict}). Drag the card onto Code to run the rework — the findings are in the latest [human:review-complete] comment on the ticket.`,
+    title: `Review found problems and nothing reworks it on its own (verdict: ${verdict}). Right-click the card and choose Rework to run it — the findings are in the latest [human:review-complete] comment on the ticket.`,
     spinner: false,
   };
 }

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -49,6 +49,7 @@ import {
   QUEUE_TRANSITION_TO,
   queueOf,
   isReworkable,
+  reworkKind,
   isReviewRetryable,
   isReopenable,
   ageBadge,
@@ -856,6 +857,37 @@ function showCardMenu(card: Card, x: number, y: number): void {
       void transition(card.key, card.title, "verification", "verification");
     });
     menu.appendChild(retryReview);
+  }
+
+  // The rework a failing review verdict needs. Nothing starts it on its own —
+  // pipeline-fsm.json's `reviewed` state says it waits for a rework the board
+  // must offer — and until now the board offered it only as a drag back onto
+  // the card's build column, which is invisible unless you already know it.
+  // Every other stage a person has to restart by hand has a menu action for it
+  // (Retry plan, Replan, Retry build, Retry review, Retry deploy); this was the
+  // gap, on the one state where the badge explicitly asks the user to act
+  // (SC-4299). Each kind starts the same run its drop target would have.
+  if (isReworkable(card)) {
+    const rework = document.createElement("button");
+    rework.type = "button";
+    rework.className = "context-menu-item";
+    rework.textContent = "Rework";
+    rework.disabled = !current.dockerAvailable;
+    if (rework.disabled) rework.title = "Docker required";
+    rework.addEventListener("click", () => {
+      menu.remove();
+      switch (reworkKind(card)) {
+        case "bug":
+          void fixBug(card.key, card.title);
+          return;
+        case "security":
+          void fixSecurity(card.key, card.title);
+          return;
+        default:
+          void transition(card.key, card.title, "verification", "implementation");
+      }
+    });
+    menu.appendChild(rework);
   }
 
   // A resolved card — the pipeline concluded there is nothing to do, or no fix


### PR DESCRIPTION
Follow-up to #485: the badge now says a card needs rework, and right-clicking it offered nothing that starts one.

The only gesture that acted was dragging the card back onto its build column — an affordance that is invisible unless you already know it exists, on the one card state where the board explicitly asks the user to act. Every other stage a person restarts by hand has a menu action: Retry plan, Replan, Retry build, Retry review, Retry deploy. This was the gap in that set.

`Rework` is offered for exactly the cards the drop gate accepts (`isReworkable` — a failing verdict, or a passed review with no branch recorded), under the same Docker gate as its siblings, and starts the same run the drop target would have:

| card | action |
| --- | --- |
| bug | `fixBug` — the autofix pipeline |
| security | `fixSecurity` |
| feature | `transition(verification → implementation)` |

`reworkKind` holds that routing as one tested fact instead of a condition repeated per call site. `performDrop` is untouched: it keys on the column the card was released on, which is the user's explicit choice, and the two agree because a bug's only rework target is the Fix column.

271 frontend tests pass, `make check` green, dist rebuilt and committed (drift guard clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)