### PR TITLE
[SC-4118] Three paired values that were kept apart

### DIFF
--- a/internal/daemon/hookstore.go
+++ b/internal/daemon/hookstore.go
@@ -20,14 +20,26 @@ const maxHookEventsPerSession = 200
 // overflows that bound before reaching visible pruning behaviour.
 const maxHookEvents = 10000
 
+// seqEvent is one stored event and the monotonic sequence assigned when it was
+// appended. The sequence is what lets a subscriber ask for everything after
+// what it last saw, independently of the ring's length — tracking deltas by
+// slice length stops working the moment the ring saturates.
+type seqEvent struct {
+	seq uint64
+	evt hookevents.Event
+}
+
 // HookEventStore is a thread-safe ring buffer of recent hook events.
 // It stores raw events and can derive per-session snapshots on demand.
 // Subscribers are notified (non-blocking) whenever a new event is appended.
 type HookEventStore struct {
-	mu          sync.Mutex
-	events      []hookevents.Event
-	eventSeqs   []uint64 // monotonic id per event, index-aligned with events
-	appended    uint64   // total events ever appended (last assigned sequence)
+	mu sync.Mutex
+	// events is the ring, each entry carrying the sequence assigned when it was
+	// appended. One slice of pairs rather than two index-aligned slices: the
+	// alignment was an invariant three separate splices had to preserve by
+	// hand, and nothing checked that they did.
+	events      []seqEvent
+	appended    uint64 // total events ever appended (last assigned sequence)
 	subscribers []chan struct{}
 	// progress is the last sign of life per agent, kept outside the ring so
 	// eviction cannot make a quiet-but-working agent look hung.
@@ -42,9 +54,8 @@ type HookEventStore struct {
 // NewHookEventStore creates an empty store.
 func NewHookEventStore() *HookEventStore {
 	return &HookEventStore{
-		events:    make([]hookevents.Event, 0, maxHookEvents),
-		eventSeqs: make([]uint64, 0, maxHookEvents),
-		progress:  make(map[string]AgentProgress),
+		events:   make([]seqEvent, 0, maxHookEvents),
+		progress: make(map[string]AgentProgress),
 	}
 }
 
@@ -69,15 +80,14 @@ func (s *HookEventStore) Append(evt hookevents.Event) {
 	if evt.SessionID != "" {
 		sessionCount := 0
 		for _, e := range s.events {
-			if e.SessionID == evt.SessionID {
+			if e.evt.SessionID == evt.SessionID {
 				sessionCount++
 			}
 		}
 		if sessionCount >= maxHookEventsPerSession {
 			for i, e := range s.events {
-				if e.SessionID == evt.SessionID {
+				if e.evt.SessionID == evt.SessionID {
 					s.events = append(s.events[:i], s.events[i+1:]...)
-					s.eventSeqs = append(s.eventSeqs[:i], s.eventSeqs[i+1:]...)
 					break
 				}
 			}
@@ -88,13 +98,10 @@ func (s *HookEventStore) Append(evt hookevents.Event) {
 	}
 	trackProgress(s.progress, evt)
 	s.appended++
-	s.events = append(s.events, evt)
-	s.eventSeqs = append(s.eventSeqs, s.appended)
+	s.events = append(s.events, seqEvent{seq: s.appended, evt: evt})
 	if len(s.events) > maxHookEvents {
 		copy(s.events, s.events[len(s.events)-maxHookEvents:])
 		s.events = s.events[:maxHookEvents]
-		copy(s.eventSeqs, s.eventSeqs[len(s.eventSeqs)-maxHookEvents:])
-		s.eventSeqs = s.eventSeqs[:maxHookEvents]
 	}
 	subs := make([]chan struct{}, len(s.subscribers))
 	copy(subs, s.subscribers)
@@ -164,7 +171,8 @@ func (s *HookEventStore) Snapshot() map[string]hookevents.SessionSnapshot {
 	defer s.mu.Unlock()
 
 	sessions := make(map[string]hookevents.SessionSnapshot)
-	for _, evt := range s.events {
+	for _, e := range s.events {
+		evt := e.evt
 		if evt.SessionID == "" {
 			continue
 		}
@@ -185,7 +193,9 @@ func (s *HookEventStore) RecentEvents() []hookevents.Event {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	out := make([]hookevents.Event, len(s.events))
-	copy(out, s.events)
+	for i, e := range s.events {
+		out[i] = e.evt
+	}
 	return out
 }
 
@@ -198,9 +208,9 @@ func (s *HookEventStore) EventsSince(since uint64) ([]hookevents.Event, uint64) 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	var out []hookevents.Event
-	for i, seq := range s.eventSeqs {
-		if seq > since {
-			out = append(out, s.events[i])
+	for _, e := range s.events {
+		if e.seq > since {
+			out = append(out, e.evt)
 		}
 	}
 	return out, s.appended
@@ -291,7 +301,7 @@ func (s *HookEventStore) DurationMsSincePre(sessionID, toolName string, postTS t
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for i := len(s.events) - 1; i >= 0; i-- {
-		e := s.events[i]
+		e := s.events[i].evt
 		if e.SessionID != sessionID || e.ToolName != toolName {
 			continue
 		}

--- a/internal/daemon/hookstore_test.go
+++ b/internal/daemon/hookstore_test.go
@@ -147,7 +147,8 @@ func TestHookEventStore_PerSessionCapProtectsOtherSessions(t *testing.T) {
 
 	store.mu.Lock()
 	var legitCount int
-	for _, e := range store.events {
+	for _, se := range store.events {
+		e := se.evt
 		if e.SessionID == "legit" {
 			legitCount++
 		}

--- a/internal/devcontainer/image.go
+++ b/internal/devcontainer/image.go
@@ -27,17 +27,26 @@ type ImageBuilder struct {
 	Puller FeaturePuller
 }
 
+// Image is a built or pulled container image: the digest Docker assigned and
+// the name the container is created from. Both are strings and they were
+// returned side by side through four functions that thread them into each
+// other, so returning them the wrong way round compiled and reviewed clean.
+type Image struct {
+	ID   string
+	Name string
+}
+
 // EnsureImage ensures a devcontainer image exists. If not cached (or rebuild
 // requested), it builds/pulls the image per the devcontainer config.
 // Returns the image ID.
-func (b *ImageBuilder) EnsureImage(ctx context.Context, cfg *DevcontainerConfig, projectDir, configHash string, rebuild bool, out io.Writer) (string, string, error) {
+func (b *ImageBuilder) EnsureImage(ctx context.Context, cfg *DevcontainerConfig, projectDir, configHash string, rebuild bool, out io.Writer) (Image, error) {
 	imageName := ImageName(projectDir, configHash)
 
 	// Check cache: a committed image with features already baked in.
 	if !rebuild {
 		if resp, err := b.Docker.ImageInspect(ctx, imageName); err == nil {
 			_, _ = fmt.Fprintf(out, "Using cached image %s\n", imageName) // #nosec G705 -- CLI output
-			return resp.ID, imageName, nil
+			return Image{ID: resp.ID, Name: imageName}, nil
 		}
 	}
 
@@ -45,35 +54,35 @@ func (b *ImageBuilder) EnsureImage(ctx context.Context, cfg *DevcontainerConfig,
 	var baseRef string
 	switch {
 	case cfg.Build != nil && cfg.Build.Dockerfile != "":
-		id, name, err := b.buildFromDockerfile(ctx, cfg, projectDir, imageName, out)
+		img, err := b.buildFromDockerfile(ctx, cfg, projectDir, imageName, out)
 		if err != nil {
-			return "", "", err
+			return Image{}, err
 		}
 		if len(cfg.Features) == 0 {
-			return id, name, nil
+			return img, nil
 		}
-		baseRef = name
+		baseRef = img.Name
 	case cfg.DockerFile != "":
 		build := &BuildConfig{Dockerfile: cfg.DockerFile}
-		id, name, err := b.buildFromDockerfile(ctx, &DevcontainerConfig{Build: build}, projectDir, imageName, out)
+		img, err := b.buildFromDockerfile(ctx, &DevcontainerConfig{Build: build}, projectDir, imageName, out)
 		if err != nil {
-			return "", "", err
+			return Image{}, err
 		}
 		if len(cfg.Features) == 0 {
-			return id, name, nil
+			return img, nil
 		}
-		baseRef = name
+		baseRef = img.Name
 	case cfg.Image != "":
-		id, ref, err := b.pullImage(ctx, cfg.Image, imageName, out)
+		img, err := b.pullImage(ctx, cfg.Image, imageName, out)
 		if err != nil {
-			return "", "", err
+			return Image{}, err
 		}
 		if len(cfg.Features) == 0 {
-			return id, ref, nil
+			return img, nil
 		}
-		baseRef = ref
+		baseRef = img.Name
 	default:
-		return "", "", errors.WithDetails("devcontainer.json must specify image or build.dockerfile")
+		return Image{}, errors.WithDetails("devcontainer.json must specify image or build.dockerfile")
 	}
 
 	// Features present: install in a temp container and commit as the cached image.
@@ -83,7 +92,7 @@ func (b *ImageBuilder) EnsureImage(ctx context.Context, cfg *DevcontainerConfig,
 // buildWithFeatures creates a temp container, installs features, and commits
 // the result as the cached image. This ensures subsequent container creations
 // from this image skip feature installation entirely.
-func (b *ImageBuilder) buildWithFeatures(ctx context.Context, cfg *DevcontainerConfig, baseRef, imageName string, out io.Writer) (string, string, error) {
+func (b *ImageBuilder) buildWithFeatures(ctx context.Context, cfg *DevcontainerConfig, baseRef, imageName string, out io.Writer) (Image, error) {
 	remoteUser := cfg.RemoteUser
 	if remoteUser == "" {
 		remoteUser = "root"
@@ -99,14 +108,14 @@ func (b *ImageBuilder) buildWithFeatures(ctx context.Context, cfg *DevcontainerC
 		Cmd:   []string{"sleep", "infinity"},
 	})
 	if err != nil {
-		return "", "", errors.WrapWithDetails(err, "creating temp container for features")
+		return Image{}, errors.WrapWithDetails(err, "creating temp container for features")
 	}
 	defer func() {
 		_ = b.Docker.ContainerRemove(ctx, tempID, ContainerRemoveOptions{Force: true})
 	}()
 
 	if err := b.Docker.ContainerStart(ctx, tempID); err != nil {
-		return "", "", errors.WrapWithDetails(err, "starting temp container")
+		return Image{}, errors.WrapWithDetails(err, "starting temp container")
 	}
 
 	// Install features. The returned env is each feature's containerEnv (e.g. the
@@ -118,46 +127,46 @@ func (b *ImageBuilder) buildWithFeatures(ctx context.Context, cfg *DevcontainerC
 	}
 	featureEnv, err := InstallFeatures(ctx, b.Docker, puller, tempID, cfg.Features, remoteUser, b.Logger, out)
 	if err != nil {
-		return "", "", errors.WrapWithDetails(err, "installing features")
+		return Image{}, errors.WrapWithDetails(err, "installing features")
 	}
 
 	// Commit the container as the cached image, baking in the feature env.
 	committedID, err := b.Docker.ContainerCommit(ctx, tempID, imageName, featureEnv)
 	if err != nil {
-		return "", "", errors.WrapWithDetails(err, "committing image with features")
+		return Image{}, errors.WrapWithDetails(err, "committing image with features")
 	}
 
 	_, _ = fmt.Fprintf(out, "Image cached: %s\n", imageName) // #nosec G705 -- CLI output
-	return committedID, imageName, nil
+	return Image{ID: committedID, Name: imageName}, nil
 }
 
 // pullImage pulls a base image. The container is created using the original
 // image ref directly (no re-tagging needed for image-only configs).
-func (b *ImageBuilder) pullImage(ctx context.Context, ref, targetName string, out io.Writer) (string, string, error) {
+func (b *ImageBuilder) pullImage(ctx context.Context, ref, targetName string, out io.Writer) (Image, error) {
 	_, _ = fmt.Fprintf(out, "Pulling %s...\n", ref) // #nosec G705 -- CLI output
 	reader, err := b.Docker.ImagePull(ctx, ref, ImagePullOptions{})
 	if err != nil {
-		return "", "", errors.WrapWithDetails(err, "pulling image", "ref", ref)
+		return Image{}, errors.WrapWithDetails(err, "pulling image", "ref", ref)
 	}
 	defer func() { _ = reader.Close() }()
 
 	// Drain pull output, capturing any error messages.
 	if pullErr := drainDockerOutput(reader); pullErr != nil {
-		return "", "", errors.WrapWithDetails(pullErr, "image pull failed", "ref", ref)
+		return Image{}, errors.WrapWithDetails(pullErr, "image pull failed", "ref", ref)
 	}
 
 	resp, err := b.Docker.ImageInspect(ctx, ref)
 	if err != nil {
-		return "", "", errors.WrapWithDetails(err, "inspecting pulled image", "ref", ref)
+		return Image{}, errors.WrapWithDetails(err, "inspecting pulled image", "ref", ref)
 	}
 
 	_, _ = fmt.Fprintf(out, "Image ready: %s\n", ref) // #nosec G705 -- CLI output
 	// Use the original ref as imageName so ContainerCreate can find it.
-	return resp.ID, ref, nil
+	return Image{ID: resp.ID, Name: ref}, nil
 }
 
 // buildFromDockerfile builds an image from a Dockerfile.
-func (b *ImageBuilder) buildFromDockerfile(ctx context.Context, cfg *DevcontainerConfig, projectDir, imageName string, out io.Writer) (string, string, error) {
+func (b *ImageBuilder) buildFromDockerfile(ctx context.Context, cfg *DevcontainerConfig, projectDir, imageName string, out io.Writer) (Image, error) {
 	dockerfile := cfg.Build.Dockerfile
 
 	// Resolve build context directory.
@@ -171,7 +180,7 @@ func (b *ImageBuilder) buildFromDockerfile(ctx context.Context, cfg *Devcontaine
 	// Create tar archive of the build context.
 	buildCtx, err := createBuildContext(contextDir, filepath.Join(projectDir, ".devcontainer", dockerfile))
 	if err != nil {
-		return "", "", errors.WrapWithDetails(err, "creating build context", "dir", contextDir)
+		return Image{}, errors.WrapWithDetails(err, "creating build context", "dir", contextDir)
 	}
 
 	// Convert build args.
@@ -189,22 +198,22 @@ func (b *ImageBuilder) buildFromDockerfile(ctx context.Context, cfg *Devcontaine
 		Remove:     true,
 	})
 	if err != nil {
-		return "", "", errors.WrapWithDetails(err, "building image")
+		return Image{}, errors.WrapWithDetails(err, "building image")
 	}
 	defer func() { _ = reader.Close() }()
 
 	// Drain build output, capturing any error messages.
 	if buildErr := drainDockerOutput(reader); buildErr != nil {
-		return "", "", errors.WrapWithDetails(buildErr, "image build failed")
+		return Image{}, errors.WrapWithDetails(buildErr, "image build failed")
 	}
 
 	resp, err := b.Docker.ImageInspect(ctx, imageName)
 	if err != nil {
-		return "", "", errors.WrapWithDetails(err, "inspecting built image")
+		return Image{}, errors.WrapWithDetails(err, "inspecting built image")
 	}
 
 	_, _ = fmt.Fprintf(out, "Image built: %s\n", imageName)
-	return resp.ID, imageName, nil
+	return Image{ID: resp.ID, Name: imageName}, nil
 }
 
 // dockerMessage is a line from Docker build/pull JSON output stream.

--- a/internal/devcontainer/image_test.go
+++ b/internal/devcontainer/image_test.go
@@ -28,12 +28,12 @@ func TestBuildWithFeatures_BakesContainerEnv(t *testing.T) {
 		Image:    "mcr.microsoft.com/devcontainers/base:ubuntu",
 		Features: map[string]any{"ghcr.io/devcontainers/features/node:1": map[string]any{}},
 	}
-	id, _, err := builder.buildWithFeatures(context.Background(), cfg, "base:ref", "human-dc-test:hash", &strings.Builder{})
+	img, err := builder.buildWithFeatures(context.Background(), cfg, "base:ref", "human-dc-test:hash", &strings.Builder{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if id != "sha256:withenv" {
-		t.Errorf("commit id = %q, want sha256:withenv", id)
+	if img.ID != "sha256:withenv" {
+		t.Errorf("commit id = %q, want sha256:withenv", img.ID)
 	}
 	if mock.commitEnv["NVM_DIR"] != "/usr/local/share/nvm" {
 		t.Errorf("commit env NVM_DIR = %q, want it baked in", mock.commitEnv["NVM_DIR"])
@@ -49,15 +49,15 @@ func TestEnsureImage_Cached(t *testing.T) {
 	}
 	builder := &ImageBuilder{Docker: mock, Logger: testLogger()}
 
-	id, name, err := builder.EnsureImage(context.Background(), &DevcontainerConfig{Image: "ubuntu"}, "/tmp/test", "abc123abc123def456", false, &strings.Builder{})
+	img, err := builder.EnsureImage(context.Background(), &DevcontainerConfig{Image: "ubuntu"}, "/tmp/test", "abc123abc123def456", false, &strings.Builder{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if id != "sha256:cached" {
-		t.Errorf("expected cached image ID, got %q", id)
+	if img.ID != "sha256:cached" {
+		t.Errorf("expected cached image ID, got %q", img.ID)
 	}
-	if !strings.HasPrefix(name, "human-dc-") {
-		t.Errorf("unexpected image name: %q", name)
+	if !strings.HasPrefix(img.Name, "human-dc-") {
+		t.Errorf("unexpected image name: %q", img.Name)
 	}
 	// Should not have pulled.
 	if len(mock.pullCalls) != 0 {
@@ -81,7 +81,7 @@ func TestEnsureImage_PullOnMiss(t *testing.T) {
 	}
 
 	builder := &ImageBuilder{Docker: mock2, Logger: testLogger()}
-	_, _, err := builder.EnsureImage(context.Background(), &DevcontainerConfig{Image: "ubuntu"}, "/tmp/test", "abc123abc123def456", false, &strings.Builder{})
+	_, err := builder.EnsureImage(context.Background(), &DevcontainerConfig{Image: "ubuntu"}, "/tmp/test", "abc123abc123def456", false, &strings.Builder{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,15 +103,15 @@ func TestEnsureImage_ForcedRebuild(t *testing.T) {
 	}
 
 	builder := &ImageBuilder{Docker: mock2, Logger: testLogger()}
-	id, _, err := builder.EnsureImage(context.Background(), &DevcontainerConfig{Image: "ubuntu"}, "/tmp/test", "abc123abc123", true, &strings.Builder{})
+	img, err := builder.EnsureImage(context.Background(), &DevcontainerConfig{Image: "ubuntu"}, "/tmp/test", "abc123abc123", true, &strings.Builder{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(mock.pullCalls) != 1 {
 		t.Errorf("expected pull on rebuild, got %d calls", len(mock.pullCalls))
 	}
-	if id != "sha256:fresh" {
-		t.Errorf("expected fresh image ID, got %q", id)
+	if img.ID != "sha256:fresh" {
+		t.Errorf("expected fresh image ID, got %q", img.ID)
 	}
 }
 
@@ -120,7 +120,7 @@ func TestEnsureImage_NoImageOrBuild(t *testing.T) {
 		imageInspectErr: fmt.Errorf("not found"),
 	}
 	builder := &ImageBuilder{Docker: mock, Logger: testLogger()}
-	_, _, err := builder.EnsureImage(context.Background(), &DevcontainerConfig{}, "/tmp/test", "hash", false, &strings.Builder{})
+	_, err := builder.EnsureImage(context.Background(), &DevcontainerConfig{}, "/tmp/test", "hash", false, &strings.Builder{})
 	if err == nil {
 		t.Error("expected error when neither image nor build specified")
 	}
@@ -209,7 +209,7 @@ func TestEnsureImage_DockerFileShorthand(t *testing.T) {
 
 	builder := &ImageBuilder{Docker: mock2, Logger: testLogger()}
 	cfg := &DevcontainerConfig{DockerFile: "Dockerfile"}
-	_, _, err := builder.EnsureImage(context.Background(), cfg, tmp, "abc123abc123def456", false, &strings.Builder{})
+	_, err := builder.EnsureImage(context.Background(), cfg, tmp, "abc123abc123def456", false, &strings.Builder{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/devcontainer/manager.go
+++ b/internal/devcontainer/manager.go
@@ -107,7 +107,7 @@ func (m *Manager) Up(ctx context.Context, opts UpOptions) (*Meta, error) {
 func (m *Manager) createFresh(ctx context.Context, cfg *DevcontainerConfig, projectDir, containerName, hash string, opts UpOptions, out io.Writer) (*Meta, error) {
 	builder := &ImageBuilder{Docker: m.Docker, Logger: m.Logger}
 	_, _ = fmt.Fprintln(out, "Building devcontainer image...")
-	imageID, imageName, err := builder.EnsureImage(ctx, cfg, projectDir, hash, opts.Rebuild, out)
+	img, err := builder.EnsureImage(ctx, cfg, projectDir, hash, opts.Rebuild, out)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (m *Manager) createFresh(ctx context.Context, cfg *DevcontainerConfig, proj
 	}
 	// Docker bind mounts require absolute paths.
 	sourceDir, _ = filepath.Abs(sourceDir)
-	createOpts := m.buildCreateOptions(cfg, sourceDir, projectDir, containerName, imageName, workspaceDir, hash, opts.DaemonInfo, opts.GitDir, opts.cacheVolumes)
+	createOpts := m.buildCreateOptions(cfg, sourceDir, projectDir, containerName, img.Name, workspaceDir, hash, opts.DaemonInfo, opts.GitDir, opts.cacheVolumes)
 	ParseRunArgs(cfg.RunArgs, &createOpts, m.Logger)
 
 	_, _ = fmt.Fprintf(out, "Creating container %s...\n", containerName)
@@ -156,7 +156,7 @@ func (m *Manager) createFresh(ctx context.Context, cfg *DevcontainerConfig, proj
 	meta := Meta{
 		Name: SanitizeName(filepath.Base(projectDir)), ProjectDir: projectDir,
 		ContainerID: containerID, ContainerName: containerName,
-		ImageID: imageID, ImageName: imageName,
+		ImageID: img.ID, ImageName: img.Name,
 		Status: StatusRunning, CreatedAt: now, StartedAt: now,
 		WorkspaceDir: workspaceDir, RemoteUser: remoteUser, ConfigHash: hash,
 	}

--- a/internal/tracker/shortcut/client.go
+++ b/internal/tracker/shortcut/client.go
@@ -23,13 +23,25 @@ var _ tracker.Provider = (*Client)(nil)
 var _ tracker.CurrentUserNamer = (*Client)(nil)
 
 // Client is a Shortcut REST API client that implements tracker.Provider.
+// workflowState is one Shortcut workflow state: what it is called and which
+// normalised category it maps to. The two are read from the same fetch and are
+// only ever meaningful together.
+type workflowState struct {
+	name     string
+	category tracker.Category
+}
+
 type Client struct {
 	api *apiclient.Client
 
-	statesMu       sync.Mutex
-	states         map[int64]string           // workflow_state_id → state name
-	stateTypes     map[int64]tracker.Category // workflow_state_id → normalised category
-	defaultStateID int64                      // first Unstarted state (for creating stories)
+	statesMu sync.Mutex
+	// states holds one entry per workflow state, so a state's name and its
+	// normalised category cannot disagree about whether the state exists. Two
+	// maps on one key could: a state present in the first and missing from the
+	// second read back as CategoryUnknown with no error, which lands the ticket
+	// in the wrong board column and says nothing.
+	states         map[int64]workflowState
+	defaultStateID int64 // first Unstarted state (for creating stories)
 
 	membersMu sync.Mutex
 	members   map[string]string // member UUID → display name
@@ -387,10 +399,10 @@ func (c *Client) ListStatuses(ctx context.Context, _ string) ([]tracker.Status, 
 	}
 
 	statuses := make([]tracker.Status, 0, len(c.states))
-	for id, name := range c.states {
+	for _, st := range c.states {
 		statuses = append(statuses, tracker.Status{
-			Name:     name,
-			Category: c.stateTypes[id],
+			Name:     st.name,
+			Category: st.category,
 		})
 	}
 	slices.SortFunc(statuses, func(a, b tracker.Status) int {
@@ -412,23 +424,23 @@ func (c *Client) resolveStateByName(ctx context.Context, targetStatus string) (i
 	}
 
 	// Try exact name match (case-insensitive).
-	for id, name := range c.states {
-		if strings.EqualFold(name, targetStatus) {
+	for id, st := range c.states {
+		if strings.EqualFold(st.name, targetStatus) {
 			return id, nil
 		}
 	}
 
 	// Fall back to type-based match for backward compat with "issue start".
 	targetLower := tracker.Category(strings.ToLower(targetStatus))
-	for id, typ := range c.stateTypes {
-		if typ == targetLower {
+	for id, st := range c.states {
+		if st.category == targetLower {
 			return id, nil
 		}
 	}
 
 	names := make([]string, 0, len(c.states))
-	for _, name := range c.states {
-		names = append(names, name)
+	for _, st := range c.states {
+		names = append(names, st.name)
 	}
 	return 0, errors.WithDetails("workflow state not found",
 		"targetStatus", targetStatus, "available", strings.Join(names, ", "))
@@ -829,8 +841,8 @@ func (c *Client) resolveStateName(ctx context.Context, stateID int64) (string, e
 		}
 	}
 
-	if name, ok := c.states[stateID]; ok {
-		return name, nil
+	if st, ok := c.states[stateID]; ok {
+		return st.name, nil
 	}
 	return fmt.Sprintf("Unknown(%d)", stateID), nil
 }
@@ -847,13 +859,11 @@ func (c *Client) fetchWorkflowsLocked(ctx context.Context) error {
 		return err
 	}
 
-	c.states = make(map[int64]string)
-	c.stateTypes = make(map[int64]tracker.Category)
+	c.states = make(map[int64]workflowState)
 	for _, wf := range workflows {
 		for _, st := range wf.States {
 			category := tracker.Category(st.Type)
-			c.states[st.ID] = st.Name
-			c.stateTypes[st.ID] = category
+			c.states[st.ID] = workflowState{name: st.Name, category: category}
 			if c.defaultStateID == 0 && category == tracker.CategoryUnstarted {
 				c.defaultStateID = st.ID
 			}
@@ -977,9 +987,9 @@ func (c *Client) isDoneOrArchived(story scStory) bool {
 // having been finished.
 func (c *Client) isDone(story scStory) bool {
 	c.statesMu.Lock()
-	stateType := c.stateTypes[story.WorkflowStateID]
+	st := c.states[story.WorkflowStateID]
 	c.statesMu.Unlock()
-	return stateType == tracker.CategoryDone
+	return st.category == tracker.CategoryDone
 }
 
 // belongsInResult reports whether a story survives the caller's filter.
@@ -1052,7 +1062,7 @@ func (c *Client) toTrackerIssue(ctx context.Context, story scStory, project stri
 
 	// Resolve status type from the cached state types map.
 	c.statesMu.Lock()
-	statusType := c.stateTypes[story.WorkflowStateID]
+	statusType := c.states[story.WorkflowStateID].category
 	c.statesMu.Unlock()
 
 	assignee := ""

--- a/internal/tracker/shortcut/client_test.go
+++ b/internal/tracker/shortcut/client_test.go
@@ -657,8 +657,7 @@ func TestDoRequest_authHeader(t *testing.T) {
 
 	client := New(srv.URL, "my-secret-token")
 	// Pre-populate state cache to avoid extra requests.
-	client.states = map[int64]string{500: "To Do"}
-	client.stateTypes = map[int64]tracker.Category{500: tracker.CategoryUnstarted}
+	client.states = map[int64]workflowState{500: {name: "To Do", category: tracker.CategoryUnstarted}}
 	_, err := client.GetIssue(context.Background(), "1")
 
 	require.NoError(t, err)


### PR DESCRIPTION
`domain.md` entries **#4**, **#8** and **#17** — the last of the survey I am confident in. **#5, #6, #7, #18 and #19 were measured and declined**; reasons below.

## Shipped

**#8 — the hook ring.** `events` and `eventSeqs` were index-aligned slices, spliced in tandem at three places (per-session eviction, append, aggregate cap) and joined by index in `EventsSince`. The alignment was an invariant three separate edits had to preserve by hand, with nothing checking they did. One slice of pairs; the join is a field access.

**#4 — Shortcut workflow states.** `states` and `stateTypes` were two maps on one key, filled in one loop and read apart in five places. A state present in the first and missing from the second reads back as `CategoryUnknown` **with no error** — the ticket lands in the wrong board column and nothing says why. One map of a name and its category.

**#17 — the image pair.** `EnsureImage`, `buildWithFeatures`, `pullImage` and `buildFromDockerfile` each returned `(id, name, error)` and threaded the pair into one another. Both are strings, so returning them the wrong way round compiled and reviewed clean — and the vocabulary had already drifted, one call site naming the second value `ref` and another `name`.

## Declined

**#18 (the CA triple)** — `(*x509.Certificate, *ecdsa.PrivateKey, *tls.Certificate)` are three *different* types, so the swap the entry implies is impossible; the compiler already refuses it. Two external call sites, one of which discards the third value. No illegal state to remove.

**#19 (values + warnings)** — the warning `[]string` is not internal: `desktop/frontend/src/settingsview.ts:208` renders it. Giving warnings a `Path` and a severity is a feature nothing currently asks for, and it changes a JSON shape the desktop reads across daemon/desktop version skew.

**#5 (four caches in one client)** — same lesson as #10, second data point. The three Shortcut caches are a bulk fill (`states`), a **per-key lazy fetch with negative caching** (`members` caches the empty name so a transient failure does not re-fetch), and another bulk fill (`groups`). A generic `cache[K,V]` would have to carry all three fill and failure policies. #4 above takes the part that genuinely is one concept.

**#6 (three parallel result maps)** — the three maps are **two key spaces**, not one: `cards` is keyed by PM issue keys and read in the `pm` branch; `ready` and `prs` are keyed by engineering keys and read in the `engineering` branch. One struct per key would be half-empty in every entry. The honest reduction is merging `ready map[string]bool` and `prs map[string]string` into one map where presence means ready — smaller than the entry describes, in the largest file in the repo.

Also: the entry calls out that "a key in `readyPRs` but not `readyKeys` is dropped without a word". It is, and that is correct — a PR URL for a ticket not flagged ready should not surface.

**#7 (jobs/results aligned 1:1)** — sound but marginal. The invariant is stated in prose twice and is currently correct; `listTrackerIssues` has three callers, one of which discards `jobs`, so the change is churn in `cmd/cmddaemon/daemon.go` for an invariant nothing has broken.

## Verification

```
make check                              exit 0   (5243 tests, 2 skipped)
go test ./cmd/...                       clean
go vet -tags wailsapp ./desktop/...     ok
make coverage-check                     83.7%
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)