### PR TITLE
[SC-4324] Open the board with its cards where they were

### DIFF
--- a/cmd/cmddaemon/cached_board_view_test.go
+++ b/cmd/cmddaemon/cached_board_view_test.go
@@ -1,0 +1,73 @@
+package cmddaemon
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/daemon"
+)
+
+// placedView is a remembered board whose card is somewhere other than Backlog —
+// the case the quick paint gets wrong on its own.
+func placedView() daemon.BoardView {
+	return daemon.BoardView{Cards: []daemon.BoardViewCard{
+		{Key: "SC-1", Title: "one", Stage: string(daemon.BoardVerification)},
+	}}
+}
+
+// The cached route serves the remembered board so an opening board can place its
+// cards before any stage has been derived (SC-4324).
+func TestCachedBoardViewFunc_ServesTheRememberedBoard(t *testing.T) {
+	dir := t.TempDir()
+	reg, err := daemon.NewProjectRegistry([]string{dir})
+	require.NoError(t, err)
+	cache := tmpCache(t)
+	rememberBoardView(cache, dir, placedView(), zerolog.Nop())
+
+	view := cachedBoardViewFunc(reg, cache)()
+
+	require.Len(t, view.Cards, 1)
+	assert.Equal(t, string(daemon.BoardVerification), view.Cards[0].Stage)
+}
+
+// Nothing remembered yields an empty board rather than an error: the caller has
+// already composed one and is only asking whether it can be placed better.
+func TestCachedBoardViewFunc_NothingRememberedIsEmpty(t *testing.T) {
+	reg, err := daemon.NewProjectRegistry([]string{t.TempDir()})
+	require.NoError(t, err)
+
+	view := cachedBoardViewFunc(reg, tmpCache(t))()
+
+	assert.Empty(t, view.Cards)
+}
+
+// The snapshot is keyed by project, so another project's board is not this
+// project's answer — the key that scoped the save must scope the read (SC-1654).
+func TestCachedBoardViewFunc_AnotherProjectsSnapshotIsNotServed(t *testing.T) {
+	reg, err := daemon.NewProjectRegistry([]string{t.TempDir()})
+	require.NoError(t, err)
+	cache := tmpCache(t)
+	rememberBoardView(cache, "/some/other/project", placedView(), zerolog.Nop())
+
+	view := cachedBoardViewFunc(reg, cache)()
+
+	assert.Empty(t, view.Cards)
+}
+
+// The cached board is served plain. serveLastGoodView's staleness banner says
+// "this refresh failed"; here a refresh is running behind the paint, so the same
+// sentence would name a failure that has not happened.
+func TestCachedBoardViewFunc_CarriesNoStaleBanner(t *testing.T) {
+	dir := t.TempDir()
+	reg, err := daemon.NewProjectRegistry([]string{dir})
+	require.NoError(t, err)
+	cache := tmpCache(t)
+	rememberBoardView(cache, dir, placedView(), zerolog.Nop())
+
+	view := cachedBoardViewFunc(reg, cache)()
+
+	assert.Empty(t, view.Error)
+}

--- a/cmd/cmddaemon/daemon.go
+++ b/cmd/cmddaemon/daemon.go
@@ -438,40 +438,48 @@ func initDaemon(cmd *cobra.Command, addr, chromeAddr, proxyAddr string, safe, de
 		return len(leases) > 0, nil
 	}
 
+	// One store for both board routes: the live composer remembers the board it
+	// built, the cached route serves it back.
+	boardCache := boardcache.NewStore(boardcache.DefaultPath())
+
 	srv := &daemon.Server{
-		Addr:               addr,
-		Token:              token,
-		SafeMode:           safe,
-		DaemonStartedAt:    time.Now().UTC(),
-		CmdFactory:         cmdFactory,
-		Logger:             logger,
-		ConnectedPIDs:      connTracker,
-		HookEvents:         hookStore,
-		NetworkEvents:      networkStore,
-		ModelOutcomes:      modelSink,
-		CostLedger:         costStore,
-		CostLedgerProject:  resolveProject,
-		IssueFetcher:       issueFetcher,
-		LiteIssueFetcher:   fetchTrackerIssuesLiteFunc(projectRegistry, vaultResolver),
-		BoardViewFetcher:   boardViewFunc(issueFetcher, doctor, projectRegistry, boardcache.NewStore(boardcache.DefaultPath()), logger),
-		IssueGetter:        daemon.NewCachedIssueGetter(issueGetterFunc(projectRegistry, vaultResolver)),
-		CurrentUserFetcher: currentUserFunc(projectRegistry, vaultResolver),
-		TrackerDiagnoser:   trackerDiagnoserFunc(projectRegistry, vaultResolver),
-		Doctor:             doctor,
-		Projects:           projectRegistry,
-		PendingConfirms:    confirmStore,
-		StatsWriter:        statsWriter,
-		StatsStore:         statsStore,
-		AuditSink:          auditWriter,
-		AuditStore:         auditStore,
-		AgentCleaner:       &dockerAgentCleaner{},
-		VaultResolver:      vaultResolver,
-		BoardTransitioner:  boardTransitionerFunc(projectRegistry, vaultResolver, daemonID, logger, launchGate, agentIPs),
-		BoardFixer:         boardFixerFunc(projectRegistry, vaultResolver, daemonID, logger, launchGate, agentIPs),
-		BoardSecurityFixer: securityFixerFunc(projectRegistry, vaultResolver, daemonID, logger, launchGate, agentIPs),
-		BoardOptioner:      boardOptionerFunc(projectRegistry, vaultResolver, daemonID, logger, launchGate, agentIPs),
-		BugCreator:         bugCreatorFunc(projectRegistry, vaultResolver, relateLauncherFunc(projectRegistry, daemonID)),
-		WhereComments:      whereCommentsFunc(projectRegistry, vaultResolver),
+		Addr:              addr,
+		Token:             token,
+		SafeMode:          safe,
+		DaemonStartedAt:   time.Now().UTC(),
+		CmdFactory:        cmdFactory,
+		Logger:            logger,
+		ConnectedPIDs:     connTracker,
+		HookEvents:        hookStore,
+		NetworkEvents:     networkStore,
+		ModelOutcomes:     modelSink,
+		CostLedger:        costStore,
+		CostLedgerProject: resolveProject,
+		IssueFetcher:      issueFetcher,
+		LiteIssueFetcher:  fetchTrackerIssuesLiteFunc(projectRegistry, vaultResolver),
+		BoardViewFetcher:  boardViewFunc(issueFetcher, doctor, projectRegistry, boardCache, logger),
+		// Shares the store the live composer writes to, rather than opening a
+		// second one on the same path: the store serializes its own
+		// read-modify-write, and two of them would each hold half a lock.
+		CachedBoardViewFetcher: cachedBoardViewFunc(projectRegistry, boardCache),
+		IssueGetter:            daemon.NewCachedIssueGetter(issueGetterFunc(projectRegistry, vaultResolver)),
+		CurrentUserFetcher:     currentUserFunc(projectRegistry, vaultResolver),
+		TrackerDiagnoser:       trackerDiagnoserFunc(projectRegistry, vaultResolver),
+		Doctor:                 doctor,
+		Projects:               projectRegistry,
+		PendingConfirms:        confirmStore,
+		StatsWriter:            statsWriter,
+		StatsStore:             statsStore,
+		AuditSink:              auditWriter,
+		AuditStore:             auditStore,
+		AgentCleaner:           &dockerAgentCleaner{},
+		VaultResolver:          vaultResolver,
+		BoardTransitioner:      boardTransitionerFunc(projectRegistry, vaultResolver, daemonID, logger, launchGate, agentIPs),
+		BoardFixer:             boardFixerFunc(projectRegistry, vaultResolver, daemonID, logger, launchGate, agentIPs),
+		BoardSecurityFixer:     securityFixerFunc(projectRegistry, vaultResolver, daemonID, logger, launchGate, agentIPs),
+		BoardOptioner:          boardOptionerFunc(projectRegistry, vaultResolver, daemonID, logger, launchGate, agentIPs),
+		BugCreator:             bugCreatorFunc(projectRegistry, vaultResolver, relateLauncherFunc(projectRegistry, daemonID)),
+		WhereComments:          whereCommentsFunc(projectRegistry, vaultResolver),
 		WhereAttempts: func(pmKey string, stage daemon.BoardStage) (int, error) {
 			// The READ-ONLY twin of the retry path's counter. bumpStageRetries
 			// increments as it reads, so wiring it here would spend a ticket's
@@ -2068,17 +2076,48 @@ func boardProjectKey(reg *daemon.ProjectRegistry) string {
 //
 // Nothing remembered means nothing truer to show than the failure itself.
 func serveLastGoodView(cache *boardcache.Store, project string, cause error, logger zerolog.Logger) (daemon.BoardView, error) {
-	raw, ok := cache.Load(project)
+	view, ok := loadBoardSnapshot(cache, project)
 	if !ok {
-		return daemon.BoardView{}, cause
-	}
-	var view daemon.BoardView
-	if err := json.Unmarshal(raw, &view); err != nil {
 		return daemon.BoardView{}, cause
 	}
 	logger.Warn().Err(cause).Msg("board view: refresh failed, serving the last good board marked stale")
 	view.Error = staleBoardBanner(view.CachedAt, time.Now(), cause)
 	return view, nil
+}
+
+// loadBoardSnapshot decodes the remembered board for a project. Held once
+// because two callers want it for opposite reasons — one to survive a failure,
+// one to speed up a success — and a snapshot that decodes differently on the two
+// paths would put a card in two places.
+//
+// A miss and an undecodable snapshot are the same answer: nothing remembered.
+func loadBoardSnapshot(cache *boardcache.Store, project string) (daemon.BoardView, bool) {
+	raw, ok := cache.Load(project)
+	if !ok {
+		return daemon.BoardView{}, false
+	}
+	var view daemon.BoardView
+	if err := json.Unmarshal(raw, &view); err != nil {
+		return daemon.BoardView{}, false
+	}
+	return view, true
+}
+
+// cachedBoardViewFunc builds the fetcher behind the board-view-cached route: the
+// remembered board, served with no tracker call and no comment scan.
+//
+// It carries no staleness banner, unlike serveLastGoodView. The reader of this
+// board is not being shown it INSTEAD of a fresh one — a live fetch is already
+// running behind it, and every card renders with a resolving spinner until that
+// lands, which is the whole of what the reader needs to know.
+func cachedBoardViewFunc(reg *daemon.ProjectRegistry, cache *boardcache.Store) func() daemon.BoardView {
+	return func() daemon.BoardView {
+		view, ok := loadBoardSnapshot(cache, boardProjectKey(reg))
+		if !ok {
+			return daemon.BoardView{}
+		}
+		return view
+	}
 }
 
 // staleBoardBanner says which board is being shown and HOW OLD it is. Without

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -292,11 +292,17 @@ func (a *App) SetCardHidden(pmKey string, hidden bool) error {
 }
 
 // CardsQuick fetches issue titles only — skipping the per-ticket comment scan
-// that derives board stages — and places every open PM issue in the Backlog. It
-// returns far faster than Cards(), so the board can render titles immediately;
-// the subsequent Cards() call reconciles each card into its real stage. Docker
+// that derives board stages — so the board can render immediately; the
+// subsequent Cards() call reconciles each card into its real stage. Docker
 // availability is assumed here (the real value arrives with Cards()) so the quick
 // path never blocks on a Docker round-trip.
+//
+// Because no stage is derived here, the composer has nothing to place cards by
+// and falls every open ticket to Backlog — which opened the board as one tall
+// Backlog column that rearranged itself seconds later, reading as a wrong board
+// rather than a loading one (SC-4324). So the remembered board is asked where
+// each card was, and the two fetches are joined: this one owns which tickets
+// exist, that one owns where they go.
 func (a *App) CardsQuick() (BoardData, error) {
 	client, info, err := a.daemonClientInfo()
 	if err != nil {
@@ -307,11 +313,19 @@ func (a *App) CardsQuick() (BoardData, error) {
 	if err != nil {
 		return BoardData{}, daemonCause(err)
 	}
+	// A daemon that cannot answer — one predating the route, or one with nothing
+	// remembered — leaves the board exactly as it composes without it. Nothing
+	// here is worth failing a paint over.
+	last, _ := client.GetCachedBoardView()
 	project := projectKeyOf(info)
 	// The quick path never blocks on a Docker round-trip (that is what makes it
 	// quick), so it leaves liveness unknown; the full Cards() reconcile that
 	// follows fills it in a moment later.
-	return boardFromResults(results, true, a.ideas.Assignments(project), cardMockups(), a.prefs.Snapshot(project), a.viewerIdentity(client, info), a.boardAppearance(info), board.LiveAgents{}), nil
+	// Restoring before applyLocal is load-bearing: the viewer overlay reads a
+	// card's stage to decide its Ideas sub-column, so a card placed after it runs
+	// would land in Ideas without one.
+	view := board.RestoreStages(board.Compose(results, true), last)
+	return applyLocal(view, a.ideas.Assignments(project), cardMockups(), a.prefs.Snapshot(project), a.viewerIdentity(client, info), a.boardAppearance(info), board.LiveAgents{}), nil
 }
 
 // viewerIdentity returns the names that mean "me" for the board's ownership
@@ -406,13 +420,6 @@ func (a *App) boardView(client *daemon.Client) (daemon.BoardView, []daemon.Track
 		return view, results, nil
 	}
 	return board.Compose(results, dockerAvailable()), results, nil
-}
-
-// boardFromResults composes the shared board and then applies this viewer's own
-// overlay. The split is the point: Compose produces what is true of the project,
-// applyLocal adds what is true only of the person looking.
-func boardFromResults(results []daemon.TrackerIssuesResult, dockerAvailable bool, ideaCols map[string]int, mocks map[string]cardMockupInfo, prefs boardprefs.Prefs, viewer vieweridentity.Identity, dimPercent int, live board.LiveAgents) BoardData {
-	return applyLocal(board.Compose(results, dockerAvailable), ideaCols, mocks, prefs, viewer, dimPercent, live)
 }
 
 // applyLocal fills the fields Compose deliberately leaves blank because they

--- a/desktop/quickpaint_test.go
+++ b/desktop/quickpaint_test.go
@@ -1,0 +1,71 @@
+//go:build wailsapp
+
+package main
+
+import (
+	"testing"
+
+	"github.com/gethuman-sh/human/internal/board"
+	"github.com/gethuman-sh/human/internal/boardprefs"
+	"github.com/gethuman-sh/human/internal/daemon"
+	"github.com/gethuman-sh/human/internal/tracker"
+	"github.com/gethuman-sh/human/internal/vieweridentity"
+)
+
+// liteResults is what the quick fetch returns: issues with no derived
+// BoardCards, so nothing tells the composer which column a card belongs in.
+func liteResults(keys ...string) []daemon.TrackerIssuesResult {
+	issues := make([]tracker.Issue, 0, len(keys))
+	for _, key := range keys {
+		issues = append(issues, tracker.Issue{Key: key, Title: key, Status: "In Progress"})
+	}
+	return []daemon.TrackerIssuesResult{{
+		TrackerName: "human",
+		TrackerKind: "shortcut",
+		TrackerRole: "pm",
+		Project:     "board",
+		Issues:      issues,
+	}}
+}
+
+// The order CardsQuick composes in is load-bearing, and this is the case that
+// proves it: the viewer overlay reads a card's stage to assign its Ideas
+// sub-column, so a card restored into Ideas AFTER applyLocal would land there
+// without one. Restoring first gives it both (SC-4324).
+func TestQuickPaintRestoresColumnsBeforeTheViewerOverlay(t *testing.T) {
+	last := daemon.BoardView{Cards: []daemon.BoardViewCard{
+		{Key: "SC-1", Stage: string(daemon.BoardIdeas)},
+		{Key: "SC-2", Stage: string(daemon.BoardVerification)},
+	}}
+
+	view := board.RestoreStages(board.Compose(liteResults("SC-1", "SC-2"), true), last)
+	got := applyLocal(view, map[string]int{"SC-1": 2}, nil, boardprefs.Prefs{}, vieweridentity.Identity{}, 0, board.LiveAgents{})
+
+	byKey := map[string]daemon.BoardViewCard{}
+	for _, card := range got.Cards {
+		byKey[card.Key] = card
+	}
+	if stage := byKey["SC-1"].Stage; stage != string(daemon.BoardIdeas) {
+		t.Fatalf("SC-1 stage = %q, want %q", stage, daemon.BoardIdeas)
+	}
+	if col := byKey["SC-1"].IdeaColumn; col != 2 {
+		t.Fatalf("SC-1 idea sub-column = %d, want 2 — the overlay ran before the card was placed", col)
+	}
+	if stage := byKey["SC-2"].Stage; stage != string(daemon.BoardVerification) {
+		t.Fatalf("SC-2 stage = %q, want %q", stage, daemon.BoardVerification)
+	}
+}
+
+// Without a remembered board the quick paint is exactly what it was: every open
+// ticket in Backlog, which is the behaviour a daemon predating the route keeps.
+func TestQuickPaintWithoutARememberedBoardIsUnchanged(t *testing.T) {
+	view := board.RestoreStages(board.Compose(liteResults("SC-1"), true), daemon.BoardView{})
+	got := applyLocal(view, nil, nil, boardprefs.Prefs{}, vieweridentity.Identity{}, 0, board.LiveAgents{})
+
+	if len(got.Cards) != 1 {
+		t.Fatalf("cards = %d, want 1", len(got.Cards))
+	}
+	if stage := got.Cards[0].Stage; stage != string(daemon.BoardBacklog) {
+		t.Fatalf("stage = %q, want %q", stage, daemon.BoardBacklog)
+	}
+}

--- a/internal/board/restore.go
+++ b/internal/board/restore.go
@@ -1,0 +1,45 @@
+package board
+
+import "github.com/gethuman-sh/human/internal/daemon"
+
+// RestoreStages puts each card back in the column the last known board had it
+// in.
+//
+// It exists for the quick paint, and only there: that path fetches titles
+// without the per-ticket comment scan, so no card carries a derived stage and
+// composedStage falls every open ticket to Backlog. A board whose work is in
+// Verification and Implementation therefore opens as one Backlog column and
+// rearranges itself a moment later, which reads as the board being wrong rather
+// than as it still loading (SC-4324).
+//
+// The join is deliberate about which half it trusts for what. The ticket SET
+// comes from view, because that is the live fetch and the only thing that knows
+// a ticket was created or closed since; the PLACEMENT comes from last, because
+// a stale column is still the best answer available before the scan resolves.
+// A key the snapshot never saw keeps its default, and a key the snapshot has but
+// the fetch does not is dropped with it — a closed ticket must not be
+// resurrected by a snapshot taken before it closed.
+//
+// Only Stage is restored. State, Verdict and the rest stay as composed: the
+// quick paint marks every card as still resolving, and a stale "running" badge
+// under that spinner would be indistinguishable from a live one.
+//
+// Callers pass a zero BoardView for last when no snapshot is available, which
+// leaves the view exactly as composed.
+func RestoreStages(view daemon.BoardView, last daemon.BoardView) daemon.BoardView {
+	if len(last.Cards) == 0 || len(view.Cards) == 0 {
+		return view
+	}
+	stages := make(map[string]string, len(last.Cards))
+	for _, card := range last.Cards {
+		if card.Stage != "" {
+			stages[card.Key] = card.Stage
+		}
+	}
+	for i := range view.Cards {
+		if stage, ok := stages[view.Cards[i].Key]; ok {
+			view.Cards[i].Stage = stage
+		}
+	}
+	return view
+}

--- a/internal/board/restore_test.go
+++ b/internal/board/restore_test.go
@@ -1,0 +1,123 @@
+package board
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/daemon"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// quickView composes what the quick paint composes: open issues with no derived
+// BoardCards at all, which is the state RestoreStages exists to repair.
+func quickView(keys ...string) daemon.BoardView {
+	issues := make([]tracker.Issue, 0, len(keys))
+	for _, key := range keys {
+		issues = append(issues, tracker.Issue{Key: key, Title: key, Status: "In Progress"})
+	}
+	return Compose([]daemon.TrackerIssuesResult{pmResult(issues, nil)}, true)
+}
+
+// The reported symptom: without a snapshot every in-flight card opens in
+// Backlog, because the quick paint derives no stage for any of them.
+func TestRestoreStages_QuickPaintWithoutASnapshotIsAllBacklog(t *testing.T) {
+	view := quickView("SC-1", "SC-2")
+
+	got := RestoreStages(view, daemon.BoardView{})
+
+	require.Len(t, got.Cards, 2)
+	for _, card := range got.Cards {
+		assert.Equal(t, string(daemon.BoardBacklog), card.Stage,
+			"a card with no derived stage and no snapshot has nowhere else to go")
+	}
+}
+
+// The fix: a card the last good board had in Verification opens in Verification.
+func TestRestoreStages_PutsCardsBackInTheirLastKnownColumn(t *testing.T) {
+	view := quickView("SC-1", "SC-2")
+	last := daemon.BoardView{Cards: []daemon.BoardViewCard{
+		{Key: "SC-1", Stage: string(daemon.BoardVerification)},
+		{Key: "SC-2", Stage: string(daemon.BoardImplementation)},
+	}}
+
+	got := RestoreStages(view, last)
+
+	assert.Equal(t, string(daemon.BoardVerification), cardByKey(t, got, "SC-1").Stage)
+	assert.Equal(t, string(daemon.BoardImplementation), cardByKey(t, got, "SC-2").Stage)
+}
+
+// The live fetch owns the ticket SET: a ticket created since the snapshot has no
+// last known column and keeps the default rather than disappearing.
+func TestRestoreStages_AKeyTheSnapshotNeverSawKeepsItsDefault(t *testing.T) {
+	view := quickView("SC-1", "SC-NEW")
+	last := daemon.BoardView{Cards: []daemon.BoardViewCard{
+		{Key: "SC-1", Stage: string(daemon.BoardVerification)},
+	}}
+
+	got := RestoreStages(view, last)
+
+	require.Len(t, got.Cards, 2)
+	assert.Equal(t, string(daemon.BoardVerification), cardByKey(t, got, "SC-1").Stage)
+	assert.Equal(t, string(daemon.BoardBacklog), cardByKey(t, got, "SC-NEW").Stage)
+}
+
+// A ticket that left the board since the snapshot must not come back with it —
+// the snapshot answers where a card goes, never whether it exists.
+func TestRestoreStages_ASnapshotKeyTheFetchDroppedIsNotResurrected(t *testing.T) {
+	view := quickView("SC-1")
+	last := daemon.BoardView{Cards: []daemon.BoardViewCard{
+		{Key: "SC-1", Stage: string(daemon.BoardVerification)},
+		{Key: "SC-CLOSED", Stage: string(daemon.BoardDoneStage)},
+	}}
+
+	got := RestoreStages(view, last)
+
+	require.Len(t, got.Cards, 1)
+	assert.Equal(t, "SC-1", got.Cards[0].Key)
+}
+
+// Only the column is restored: the quick paint marks every card as resolving, so
+// a stale badge under that spinner would read as live.
+func TestRestoreStages_RestoresTheColumnOnly(t *testing.T) {
+	view := quickView("SC-1")
+	last := daemon.BoardView{Cards: []daemon.BoardViewCard{{
+		Key:     "SC-1",
+		Stage:   string(daemon.BoardVerification),
+		State:   string(daemon.BoardRunning),
+		Verdict: "changes requested",
+		Branch:  "fix/sc-1",
+	}}}
+
+	got := RestoreStages(view, last)
+
+	card := cardByKey(t, got, "SC-1")
+	assert.Equal(t, string(daemon.BoardVerification), card.Stage)
+	assert.Empty(t, card.State, "a stale run state must not paint under the resolving spinner")
+	assert.Empty(t, card.Verdict)
+	assert.Empty(t, card.Branch)
+}
+
+// A snapshot card with no stage carries no answer, so it must not blank the
+// default the composer already chose.
+func TestRestoreStages_ASnapshotCardWithNoStageLeavesTheDefault(t *testing.T) {
+	view := quickView("SC-1")
+	last := daemon.BoardView{Cards: []daemon.BoardViewCard{{Key: "SC-1"}}}
+
+	got := RestoreStages(view, last)
+
+	assert.Equal(t, string(daemon.BoardBacklog), cardByKey(t, got, "SC-1").Stage)
+}
+
+// An empty board is not something a snapshot can populate.
+func TestRestoreStages_AnEmptyViewStaysEmpty(t *testing.T) {
+	last := daemon.BoardView{Cards: []daemon.BoardViewCard{
+		{Key: "SC-1", Stage: string(daemon.BoardVerification)},
+	}}
+
+	got := RestoreStages(daemon.BoardView{Error: "daemon unreachable"}, last)
+
+	assert.Empty(t, got.Cards)
+	assert.Equal(t, "daemon unreachable", got.Error, "the view's own banner survives the join")
+}

--- a/internal/daemon/cached_board_view_route_test.go
+++ b/internal/daemon/cached_board_view_route_test.go
@@ -1,0 +1,47 @@
+package daemon
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The board-view-cached route exists so the quick paint can place its cards
+// where the board last had them instead of stacking them all in Backlog while
+// the real stages are still being derived (SC-4324).
+func TestServer_HandleCachedBoardView_ReturnsTheRememberedBoard(t *testing.T) {
+	token := "test-token"
+	addr, _ := startTestServerCustom(t, token, func(s *Server) {
+		s.CachedBoardViewFetcher = func() BoardView {
+			return BoardView{Cards: []BoardViewCard{
+				{Key: "SC-1", Title: "one", Stage: string(BoardVerification)},
+			}}
+		}
+	})
+
+	resp := sendRequest(t, addr, Request{Token: token, Args: []string{"board-view-cached"}})
+	require.Equal(t, 0, resp.ExitCode)
+
+	var view BoardView
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(resp.Stdout)), &view))
+	require.Len(t, view.Cards, 1)
+	assert.Equal(t, string(BoardVerification), view.Cards[0].Stage)
+}
+
+// Nothing remembered is an answer, not a failure: the caller already has a board
+// and is only asking whether it can be improved. Erroring here would buy the
+// caller a fallback it has to write anyway.
+func TestServer_HandleCachedBoardView_NothingRememberedIsAnEmptyBoard(t *testing.T) {
+	token := "test-token"
+	addr, _ := startTestServerCustom(t, token, func(s *Server) { s.CachedBoardViewFetcher = nil })
+
+	resp := sendRequest(t, addr, Request{Token: token, Args: []string{"board-view-cached"}})
+	require.Equal(t, 0, resp.ExitCode, "an unremembered board is not a broken daemon")
+
+	var view BoardView
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(resp.Stdout)), &view))
+	assert.Empty(t, view.Cards)
+}

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -454,6 +454,27 @@ func (c *Client) GetBoardView() (BoardView, error) {
 	return view, nil
 }
 
+// GetCachedBoardView fetches the last board the daemon composed successfully,
+// with no tracker call behind it. The quick paint uses it to place cards whose
+// real stage has not been derived yet, so an opening board shows its work where
+// it was rather than stacking every ticket in Backlog (SC-4324).
+//
+// Any error — a daemon predating this route, an unreachable one, unreadable JSON
+// — means "no remembered board", and the caller renders exactly what it composed
+// without it. Nothing here is worth failing a board over: this route only ever
+// improves a picture the caller already has.
+func (c *Client) GetCachedBoardView() (BoardView, error) {
+	out, err := c.RunRemoteCapture([]string{"board-view-cached"})
+	if err != nil {
+		return BoardView{}, err
+	}
+	var view BoardView
+	if err := json.Unmarshal(out, &view); err != nil {
+		return BoardView{}, errors.WrapWithDetails(err, "invalid cached board view JSON")
+	}
+	return view, nil
+}
+
 // GetCurrentUserName fetches the authenticated PM-tracker user's display name
 // for the board's ownership dimming (SC-3339). An empty name (or any error,
 // e.g. a daemon predating this route answering command-not-found) means the

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -75,6 +75,13 @@ type Server struct {
 	// nil disables the board-view route, which is what an older client falls
 	// back from.
 	BoardViewFetcher func() (BoardView, error)
+	// CachedBoardViewFetcher returns the last board that composed successfully,
+	// read from the snapshot and never fetched. It answers the one question the
+	// live composer is too slow for: where a card was the last time anyone
+	// looked. The quick paint asks it so an opening board places its work
+	// instead of stacking it all in Backlog (SC-4324). A miss is not a failure —
+	// it returns a zero BoardView, and the caller then paints what it composed.
+	CachedBoardViewFetcher func() BoardView
 	// IssueGetter fetches one full issue for the board's detail panel plus its
 	// comment-sourced extras (review findings, failure reason, fix summary).
 	// List endpoints on some trackers (e.g. Shortcut) return slim payloads
@@ -517,6 +524,7 @@ func (s *Server) routeSimpleCommand(conn net.Conn, args []string, projectDir str
 		"tracker-diagnose":    func() { s.handleTrackerDiagnose(conn, projectDir) },
 		"tracker-issues":      func() { s.handleTrackerIssues(conn) },
 		"board-view":          func() { s.handleBoardView(conn) },
+		"board-view-cached":   func() { s.handleCachedBoardView(conn) },
 		"tracker-issues-lite": func() { s.handleTrackerIssuesLite(conn) },
 		"tracker-issue":       func() { s.handleTrackerIssue(conn, args[1:]) },
 		"current-user":        func() { s.handleCurrentUser(conn) },
@@ -728,6 +736,28 @@ func (s *Server) handleBoardView(conn net.Conn) {
 	if err != nil {
 		s.writeError(conn, err.Error(), 1)
 		return
+	}
+	data, err := json.Marshal(view)
+	if err != nil {
+		s.writeError(conn, err.Error(), 1)
+		return
+	}
+	_ = json.NewEncoder(conn).Encode(Response{Stdout: string(data) + "\n"})
+}
+
+// handleCachedBoardView returns the last board that composed successfully,
+// without fetching anything. It is the cheap half of the board: no tracker call,
+// no comment scan, just where each card was when the board last loaded.
+//
+// Unlike handleBoardView, an unavailable snapshot is answered with an empty
+// board rather than an error. The caller uses this to improve a board it has
+// already composed, so "nothing remembered" and "nothing to improve" are the
+// same instruction, and failing the route would only make the caller write the
+// same fallback twice.
+func (s *Server) handleCachedBoardView(conn net.Conn) {
+	var view BoardView
+	if s.CachedBoardViewFetcher != nil {
+		view = s.CachedBoardViewFetcher()
 	}
 	data, err := json.Marshal(view)
 	if err != nil {


### PR DESCRIPTION
## What

Opening the desktop board painted every open ticket in Backlog for the first seconds, then cards jumped into their real columns.

The quick paint fetches titles without the comment scan that derives stages, so no card carries a stage and `composedStage` falls every open ticket to the Backlog default (`internal/board/compose.go:152-161`). The daemon already holds the last board that composed — with the correct column per card — but only served it when a refresh failed.

Measured on the live snapshot: 16 cards, 5 outside Backlog (`verification` ×3, `implementation` ×1, `done` ×1). All of those opened in Backlog.

## How

Join the two fetches. The live one owns which tickets exist; the remembered one owns where each goes.

- `board.RestoreStages(view, last)` — key→stage overlay. A key the snapshot never saw keeps its default; a key the fetch dropped is not resurrected; only `Stage` is restored, since the quick paint marks every card as resolving and a stale `State` badge under that spinner would read as live.
- `board-view-cached` daemon route — the remembered board, no tracker call, no comment scan, no staleness banner (a live fetch is running behind this paint, not instead of it). Nothing remembered answers with an empty board rather than an error.
- `CardsQuick` composes, restores, then applies the viewer overlay. That order is load-bearing: the overlay reads a card's stage to assign its Ideas sub-column.
- `loadBoardSnapshot` holds the decode once, shared with `serveLastGoodView`.

`boardFromResults` is gone — its whole body was the two steps this path now needs three of; it had one caller.

## Limits

- A card the lite fetch drops (a closed ticket in the `done` column) is still absent from the quick paint and appears when the full fetch lands. The snapshot answers where a card goes, never whether it exists.
- A card that changed column since the snapshot shows the old one until the full fetch lands — one card moving instead of all of them.
- No FSM document change: no state, transition or marker moves, and the `board:{stage,state}` mapping is untouched.
- No `frontend/src` change, so no bundle rebuild.

## Verification

`make check` exit 0; `go test ./cmd/...` clean (the check target skips that tree); `go test -tags wailsapp ./desktop/...` green (the gates never compile `desktop/`). Coverage: `internal/board` 94.6%, `internal/daemon` 84.2%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)