### PR TITLE
[SC-4397] Answering a decision with "the other ticket goes first" no longer starts the work it deferred

### DIFF
--- a/desktop/frontend/dist/board-queue.js
+++ b/desktop/frontend/dist/board-queue.js
@@ -354,6 +354,18 @@ export function badgeInfo(card, nowMs = Date.now(), runningLabels = RUNNING_LABE
     // a healthy daemon. An in-progress, non-failing signal: never red, never a
     // blank card, so the user always sees the choice re-queued the work (SC-1320).
     if (card.state === "queued") {
+        // A sequencing answer — "<KEY> goes first" — queued this stage in order NOT
+        // to run it yet. It is the do-nothing register, like a paused outage: no
+        // spinner over work nobody started, no liveness reading (there is no agent
+        // to miss), and the card names the ticket it was told to go second to.
+        if (card.waitsFor) {
+            return {
+                cls: "paused",
+                text: `waiting for ${card.waitsFor}`,
+                title: `Held by your decision: ${card.waitsFor} goes first. This starts on its own once ${card.waitsFor} is done — or drop the card on its own column to start it now.`,
+                spinner: false,
+            };
+        }
         const verb = QUEUED_LABELS[card.stage] ?? "work";
         return livenessBadge({
             cls: "queued",

--- a/desktop/frontend/scripts/board-queue.test.mjs
+++ b/desktop/frontend/scripts/board-queue.test.mjs
@@ -331,6 +331,23 @@ test("a queued card shows no red error subtitle (SC-1320)", () => {
   assert.equal(cardError({ stage: "planning", state: "queued", error: "Stuck in planning" }), "");
 });
 
+// A card held by a sequencing answer is queued in order NOT to run: the badge
+// must be the do-nothing register naming what it waits for, never a spinner
+// over "picked up" work that nobody started.
+test("a held queued card names the ticket it waits for and does not spin", () => {
+  const info = badgeInfo({ stage: "implementation", state: "queued", waitsFor: "SC-4245" });
+  assert.equal(info.cls, "paused");
+  assert.match(info.text, /waiting for SC-4245/);
+  assert.ok(!info.spinner);
+});
+
+// The hold reads off the record, not off liveness: there is no agent to be
+// missing, so the dead-agent variant must not be applied to it.
+test("a held queued card is not reported as an agent that never started", () => {
+  const info = badgeInfo({ stage: "planning", state: "queued", waitsFor: "SC-4245", agentLiveness: "dead" });
+  assert.match(info.text, /waiting for SC-4245/);
+});
+
 // SC-624: columns render in the user's hand-sorted order; cards without a
 // saved slot keep fetch order after the sorted ones.
 test("sortByHandOrder: listed keys first in saved order, rest stable after", () => {

--- a/desktop/frontend/src/board-queue.ts
+++ b/desktop/frontend/src/board-queue.ts
@@ -22,6 +22,10 @@ export interface QueueCard {
   // the substrate clears, when one was parsed out of the diagnosis. Absent
   // when no time was stated — the badge then reads "paused" with no time.
   resumeAt?: string;
+  // The ticket a queued card was told to go second to, when the answer picked
+  // on its decision was a sequencing one ("<KEY> goes first"). Absent on every
+  // other queued card, which is waiting for a launch rather than for work.
+  waitsFor?: string;
   // Defect ticket: a bug card lives in the Bugs pane, a feature card on the
   // board. The Deploy selectors split on it so each control ships only its own
   // pane's ready cards.
@@ -434,6 +438,18 @@ export function badgeInfo(
   // a healthy daemon. An in-progress, non-failing signal: never red, never a
   // blank card, so the user always sees the choice re-queued the work (SC-1320).
   if (card.state === "queued") {
+    // A sequencing answer — "<KEY> goes first" — queued this stage in order NOT
+    // to run it yet. It is the do-nothing register, like a paused outage: no
+    // spinner over work nobody started, no liveness reading (there is no agent
+    // to miss), and the card names the ticket it was told to go second to.
+    if (card.waitsFor) {
+      return {
+        cls: "paused",
+        text: `waiting for ${card.waitsFor}`,
+        title: `Held by your decision: ${card.waitsFor} goes first. This starts on its own once ${card.waitsFor} is done — or drop the card on its own column to start it now.`,
+        spinner: false,
+      };
+    }
     const verb = QUEUED_LABELS[card.stage] ?? "work";
     return livenessBadge(
       {

--- a/desktop/frontend/src/board.ts
+++ b/desktop/frontend/src/board.ts
@@ -115,6 +115,10 @@ interface Card {
   // Absent when no time was stated — the badge then reads "paused" with no
   // time and the reconcile pass falls back to its own backoff.
   resumeAt?: string;
+  // The ticket a queued card was told to go second to — the `waits-for` field
+  // of the [human:option-chosen] marker that queued it. Absent unless the answer
+  // a human picked was a sequencing one.
+  waitsFor?: string;
   // RFC3339 time the newest marker of the card's current stage landed; feeds
   // the Engineering-backlog age badge.
   stageEnteredAt?: string;

--- a/internal/board/compose.go
+++ b/internal/board/compose.go
@@ -63,6 +63,7 @@ func Compose(results []daemon.TrackerIssuesResult, dockerAvailable bool) daemon.
 			PRURL:          card.PRURL,
 			Error:          card.Error,
 			ResumeAt:       card.ResumeAt,
+			WaitsFor:       card.WaitsFor,
 			Verdict:        card.Verdict,
 			VerdictFailed:  daemon.VerdictFailed(card.Verdict),
 			// The deciding marker's machine id. Compose stays host-agnostic by

--- a/internal/claude/embed/human-autofix-skill.md
+++ b/internal/claude/embed/human-autofix-skill.md
@@ -94,7 +94,9 @@ human state get <BUG_KEY> stage.preflight --field question    # the fork, when r
     --field 2="<second option>"
   ```
 
-  The board renders this as "Decision needed" and the card waits without being mistaken for a crash. When the human picks, the daemon records `[human:option-chosen]` and relaunches this run with the choice in hand; preflight then mirrors it into `decisions` and returns `ready: yes`. Do **not** invent a `needs-input` marker — this loop already exists and a second one would split the trail. In board context, alongside the options post, record the stage outcome (`stage.implementation`, exit `needs-input`, per "Recording the board stage outcome") so the daemon reads the awaited decision rather than the generic diagnose line.
+  Pass through every `waits-for-<id>:` line preflight emitted, as a field of the same name (`--field waits-for-1=<KEY>`). That line is what makes an answer meaning *"<KEY> goes first"* hold this ticket instead of starting it — dropping it turns the answer into its opposite.
+
+  The board renders this as "Decision needed" and the card waits without being mistaken for a crash. When the human picks, the daemon records `[human:option-chosen]` and relaunches this run with the choice in hand; preflight then mirrors it into `decisions` and returns `ready: yes`. An answer that declared a wait is the exception: the daemon records it and starts nothing, and the relaunch comes later, once the ticket it deferred to is done. Do **not** invent a `needs-input` marker — this loop already exists and a second one would split the trail. In board context, alongside the options post, record the stage outcome (`stage.implementation`, exit `needs-input`, per "Recording the board stage outcome") so the daemon reads the awaited decision rather than the generic diagnose line.
 
 Preflight records the capability set, so it is available to every later stage:
 

--- a/internal/claude/embed/human-preflight-agent.md
+++ b/internal/claude/embed/human-preflight-agent.md
@@ -27,7 +27,8 @@ human underway <PM_KEY>
 human search --file <path> --json --limit 10   # tickets whose plans name this exact file
 human search "<terms from the title>" --json --limit 10
 
-# Ordering, once a human has chosen it (BLOCKER first — it must finish first)
+# Ordering is decided by the fork below (`waits-for-<id>`), and the machine holds the
+# work itself. A link is for a dependency you are RECORDING, not for one being decided:
 human link <BLOCKER_KEY> <PM_KEY> --blocks
 
 # What this run may do
@@ -76,17 +77,11 @@ human state get <PM_KEY> <name> --field <field> --default '(unset)'
 
    A decision recorded here is **final**. Never re-surface it as a new fork.
 
-   One kind of answer does more than fill state. A fork settled as *"<KEY> goes first"* is a sequencing
-   decision, so put it where the pipeline can act on it and then stop — this work must not start while
-   that ticket is open:
-
-   ```bash
-   human link <BLOCKER_KEY> <PM_KEY> --blocks
-   ```
-
-   Then end the run `needs-human-work`, naming the ticket being waited for. The link is what holds the
-   work; stopping is what keeps this run from doing the thing the human just said to do second. The card
-   shows what it waits for, and the ticket is picked up again once the blocker is done.
+   A fork settled as *"<KEY> goes first"* needs nothing further from you. The machine holds the work
+   itself: that answer is recorded with the ticket it defers to, no stage is started, and this run is
+   the one the pipeline began after that ticket finished. Mirror it into `decisions` like any other
+   settled fork and **carry on** — re-applying it as a reason to stop is how a released ticket halts
+   again the moment it is picked up.
 
 5. **Read everything that could answer a question before you ask it** — the ticket description and comments, the attached plan, `.humanconfig`, `CLAUDE.md`, and the actual code. Most apparent ambiguity is answered by the codebase.
 
@@ -111,7 +106,7 @@ human state get <PM_KEY> <name> --field <field> --default '(unset)'
    human search "<an error string or symptom involved>" --json --limit 20
    ```
 
-   A hit is only a reason to act when the **other ticket has real open work**. For a candidate that looks like the same problem or touches the same file, confirm it against the forge: run `human underway <OTHER_KEY>`. Only if that is `underway` does the ordering fork apply — the two may need merging, this run may need to stop, or one may simply go first. Which goes first is a judgement about intent, and an agent silently reordering someone's backlog is worse than one that asks: use the verdict below and **propose, never create** — the link is written only after a human has chosen it (step 4). **A ticket that merely overlaps in wording, with nothing open against it, is recorded as a hint in `assumptions` and does not stop the run** — record its key, status, and the shared file(s), so the plan is built to accommodate the coming work instead of the run halting to ask about it. A closed ticket may be the *reason* this one exists; read what you find.
+   A hit is only a reason to act when the **other ticket has real open work**. For a candidate that looks like the same problem or touches the same file, confirm it against the forge: run `human underway <OTHER_KEY>`. Only if that is `underway` does the ordering fork apply — the two may need merging, this run may need to stop, or one may simply go first. Which goes first is a judgement about intent, and an agent silently reordering someone's backlog is worse than one that asks: use the verdict below and **propose, never create** — the ordering is settled by the human's answer, and the machine holds the work from that answer alone (step 4). **A ticket that merely overlaps in wording, with nothing open against it, is recorded as a hint in `assumptions` and does not stop the run** — record its key, status, and the shared file(s), so the plan is built to accommodate the coming work instead of the run halting to ask about it. A closed ticket may be the *reason* this one exists; read what you find.
 
    The forge cannot see a run that has started but has not branched yet, so one text signal still counts: a `[human:claim]` or `[human:implementation-started]` marker in the other ticket's comments means a run holds it right now. Treat that exactly as `underway` — it is the same fact, arriving before there is a branch to find. A **status** alone is not that fact and does not order anything.
 
@@ -135,7 +130,9 @@ Ask about **scope forks and product intent**. Never about implementation choices
 
 Ordering is admissible on the same terms, but only when the other ticket is **actively in progress**: two
 live runs aimed at the same code are a fork about which one the product wants first, and the options read
-as *"<TICKET_KEY> goes first"* / *"this goes first"* / *"they do not overlap — run both"*. An open ticket
+as *"<TICKET_KEY> goes first"* / *"this goes first"* / *"they do not overlap — run both"*. An option that
+defers to another ticket carries a `waits-for-<id>` line naming it (see the Verdict below) — without one
+the machine reads it as an ordinary direction and starts the work the answer put second. An open ticket
 that has **not started** is never an ordering fork — record it in the verdict below, do not ask about it.
 
 If you cannot name what you searched, you have not earned the question. Go read more.
@@ -161,7 +158,26 @@ DECISION REQUIRED: <one line: what must be decided and why>
 2: <second option, one line>
 ```
 
-(add `3:`, `4:` … for more options), and record:
+(add `3:`, `4:` … for more options).
+
+An option that means **this ticket goes second** must say so in a form the machine
+can act on, because "<OTHER_KEY> goes first" and "do it this way" are the same sentence
+to a parser — and the machine's one move on an answer is to start the work. Name the ticket
+being waited for on its own line under the option:
+
+```
+DECISION REQUIRED: <OTHER_KEY> has an open branch on the same files — which goes first?
+1: <OTHER_KEY> goes first
+waits-for-1: <OTHER_KEY>
+2: this goes first — supersede the open work on <OTHER_KEY>
+```
+
+The orchestrator passes that line through to the `[human:options]` block. Picking such
+an answer records the decision and **holds this ticket**: no stage is started, the card
+says what it waits for, and the work resumes on its own once that ticket is done. Never
+declare a wait on the ticket you are running — nothing could ever clear it.
+
+Then record:
 
 ```bash
 human state set <PM_KEY> stage.preflight --json --body-file - <<'EOF'

--- a/internal/claude/embed/human-security-fix-skill.md
+++ b/internal/claude/embed/human-security-fix-skill.md
@@ -98,7 +98,9 @@ human state get <SEC_KEY> stage.preflight --field question    # the fork, when r
     --field 2="<second option>"
   ```
 
-  The board renders this as "Decision needed" and the card waits without being mistaken for a crash. When the human picks, the daemon records `[human:option-chosen]` and relaunches this run with the choice in hand; preflight then mirrors it into `decisions` and returns `ready: yes`. Do **not** invent a `needs-input` marker — this loop already exists. In board context, alongside the options post, record the stage outcome (`stage.implementation`, exit `needs-input`, per "Recording the board stage outcome") so the daemon reads the awaited decision rather than the generic diagnose line.
+  Pass through every `waits-for-<id>:` line preflight emitted, as a field of the same name (`--field waits-for-1=<KEY>`). That line is what makes an answer meaning *"<KEY> goes first"* hold this ticket instead of starting it — dropping it turns the answer into its opposite.
+
+  The board renders this as "Decision needed" and the card waits without being mistaken for a crash. When the human picks, the daemon records `[human:option-chosen]` and relaunches this run with the choice in hand; preflight then mirrors it into `decisions` and returns `ready: yes`. An answer that declared a wait is the exception: the daemon records it and starts nothing, and the relaunch comes later, once the ticket it deferred to is done. Do **not** invent a `needs-input` marker — this loop already exists. In board context, alongside the options post, record the stage outcome (`stage.implementation`, exit `needs-input`, per "Recording the board stage outcome") so the daemon reads the awaited decision rather than the generic diagnose line.
 
 The capability set is the single source of truth for the rest of the run — do not infer permissions from flags or env vars:
 

--- a/internal/claude/embed/shared/fsm.md
+++ b/internal/claude/embed/shared/fsm.md
@@ -42,6 +42,12 @@ Three rules follow, and none of them is style:
   block stops the pipeline and waits for a person, so it is the escape hatch, not
   a way of being careful. Raise it only for a genuine fork — something the
   evidence cannot settle and that you are not entitled to choose.
+- **An answer that means "wait for another ticket" must say which one.** The
+  machine's move on an answer is to start the work, and it cannot read intent out
+  of an answer's prose. Give such an option a `waits-for-<id>: <KEY>` line in the
+  block (`--field waits-for-1=<KEY>` when posting): picking it then records the
+  decision, holds this ticket, and releases it when `<KEY>` is done. Without the
+  line the answer starts the very work it was picked to defer.
 
 If `where` reports `candidates` rather than a single `state`, it could not tell
 which phase you are in from the ticket alone. Pick the one whose `holds`

--- a/internal/daemon/board_decision_launch_test.go
+++ b/internal/daemon/board_decision_launch_test.go
@@ -1,0 +1,165 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// A fix run raises its decision in PREFLIGHT — before triage, before any plan.
+// Answering it used to hand the resume to the plan executor, which refused the
+// launch for having no plan, posted [human:needs-planning] and drove PLANNING on
+// a bug ticket: the answer produced the one outcome nobody picked. It must
+// resume the pipeline that owns the ticket (the SC-2986 class on the decision
+// path).
+func TestApplyOption_ImplementationAnswerResumesTheFixPipeline(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt(ImplementationStartedHeader, base),
+		cmt("[human:pipeline]\nkind: fix", base.Add(time.Second)),
+		cmt(optionsBody, base.Add(time.Minute)),
+	}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+
+	require.NoError(t, deps.ApplyOption(context.Background(), BoardOptionRequest{PMKey: "SC-9", OptionID: "2"}))
+
+	assert.Equal(t, 1, l.calls)
+	assert.Contains(t, l.prompt, "/human-autofix SC-9 --board")
+	assert.Contains(t, l.prompt, OptionChosenHeader, "the resumed run is pointed at the answer that resumed it")
+	for _, added := range c.added {
+		assert.NotContains(t, added, NeedsPlanningHeader,
+			"a self-planning pipeline must never be asked to go and get a plan")
+	}
+}
+
+// The security sibling.
+func TestApplyOption_ImplementationAnswerResumesTheSecurityPipeline(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt(ImplementationStartedHeader, base),
+		cmt("[human:pipeline]\nkind: security", base.Add(time.Second)),
+		cmt(optionsBody, base.Add(time.Minute)),
+	}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+
+	require.NoError(t, deps.ApplyOption(context.Background(), BoardOptionRequest{PMKey: "SC-9", OptionID: "1"}))
+
+	assert.Contains(t, l.prompt, "/human-security-fix SC-9 --board")
+}
+
+// A decision on an ordinary plan-executing card is unchanged: the executor runs
+// the plan the ticket carries.
+func TestApplyOption_ImplementationAnswerOnAPlannedCardStillExecutes(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt(PlanReadyHeader, base),
+		cmt(ImplementationStartedHeader, base.Add(time.Second)),
+		cmt(optionsBody, base.Add(time.Minute)),
+	}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+
+	require.NoError(t, deps.ApplyOption(context.Background(), BoardOptionRequest{PMKey: "SC-9", OptionID: "1"}))
+
+	assert.Contains(t, l.prompt, "/human-execute SC-9")
+}
+
+// queuedComments is a card whose decision was answered and whose stage never
+// started — what reconcileQueuedLaunch re-drives, and what a person re-dropping
+// a held card on its own column moves.
+func queuedComments(stage BoardStage, at time.Time) []tracker.Comment {
+	return []tracker.Comment{
+		cmt(OptionsHeader+"\nstage: "+string(stage)+"\n1: this way\n2: that way", at),
+		cmt(OptionChosenHeader+" 1: this way\nstage: "+string(stage), at.Add(time.Minute)),
+	}
+}
+
+// The recovery pass for a decision whose launch never happened (SC-3865) drives
+// the card through ApplyTransition — and no rule there admitted a QUEUED card,
+// so every attempt was rejected as a non-advance and charged against the retry
+// budget. The pass could not start a single card it existed for.
+func TestApplyTransition_QueuedCardLaunchesItsDecidedStage(t *testing.T) {
+	for _, tc := range []struct {
+		stage  BoardStage
+		prompt string
+		header string
+	}{
+		{BoardPlanning, "/human-ticket-review SC-9", PlanningStartedHeader},
+		{BoardVerification, "/human-review SC-9", ReviewStartedHeader},
+	} {
+		base := time.Now().Add(-time.Hour)
+		c := &fakeCommenter{comments: queuedComments(tc.stage, base)}
+		l := &fakeLauncher{}
+		deps := newDeps(c, l, &fakeDeployer{})
+
+		require.NoError(t, deps.ApplyTransition(context.Background(),
+			BoardTransitionRequest{PMKey: "SC-9", From: tc.stage, To: tc.stage}))
+
+		assert.Equal(t, 1, l.calls, "%s: the queued stage starts", tc.stage)
+		assert.Contains(t, l.prompt, tc.prompt)
+		assert.Contains(t, l.prompt, OptionChosenHeader,
+			"%s: the launch carries the answer it is carrying out", tc.stage)
+		assert.Contains(t, c.added, tc.header)
+	}
+}
+
+// The same release on a fix card: the pipeline classifier decides, exactly as
+// on the click path — and the stale [human:implementation-started] the agent
+// that ASKED the question left behind must not swallow the launch, which is
+// what ApplyFix's own marker-shaped idempotency guard would have done.
+func TestApplyTransition_QueuedFixCardResumesTheFixPipeline(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	comments := append([]tracker.Comment{
+		cmt(ImplementationStartedHeader, base),
+		cmt("[human:pipeline]\nkind: fix", base.Add(time.Second)),
+	}, queuedComments(BoardImplementation, base.Add(time.Minute))...)
+	c := &fakeCommenter{comments: comments}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+
+	require.NoError(t, deps.ApplyTransition(context.Background(),
+		BoardTransitionRequest{PMKey: "SC-9", From: BoardImplementation, To: BoardImplementation}))
+
+	assert.Equal(t, 1, l.calls)
+	assert.Contains(t, l.prompt, "/human-autofix SC-9 --board")
+}
+
+// Dropping a HELD card on its own column is the person's override: they chose
+// the order and they may change their mind without unpicking the decision.
+func TestApplyTransition_DroppingAHeldCardStartsItAnyway(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt(sequencingBody, base),
+		cmt(OptionChosenHeader+" 1: SC-4245 goes first\nstage: planning\nwaits-for: SC-4245", base.Add(time.Minute)),
+	}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+
+	require.NoError(t, deps.ApplyTransition(context.Background(),
+		BoardTransitionRequest{PMKey: "SC-9", From: BoardPlanning, To: BoardPlanning}))
+
+	assert.Equal(t, 1, l.calls, "a person can always start work the machine is holding")
+}
+
+// The daemon may take a sole direction for itself, but never a WAIT: holding a
+// ticket behind another one is a sequencing call about someone's backlog, and
+// taking it here would park the card on a decision no person ever saw.
+func TestPursueSoleDirection_NeverTakesAWait(t *testing.T) {
+	c := &fakeCommenter{comments: []tracker.Comment{cmt(PlanReadyHeader, time.Now().Add(-time.Hour))}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+
+	require.NoError(t, deps.pursueSoleDirection(context.Background(), "SC-9", c.comments,
+		BoardOption{ID: "1", Label: "rebuild against the other branch", WaitsFor: "SC-2"}))
+
+	require.NotEmpty(t, c.added)
+	assert.NotContains(t, c.added[0], "waits-for:")
+	assert.Equal(t, 1, l.calls, "the direction is still pursued")
+}

--- a/internal/daemon/board_liveness.go
+++ b/internal/daemon/board_liveness.go
@@ -35,6 +35,13 @@ func AgentNamesForCard(card BoardViewCard) []string {
 	stage := BoardStage(card.Stage)
 	state := BoardState(card.State)
 	switch {
+	case card.WaitsFor != "":
+		// A card held by a sequencing answer has no agent to miss: the decision
+		// deliberately started nothing, and it stays that way until the ticket it
+		// waits for is done. Without this it reads exactly like a queued card whose
+		// launch died — the viewer paints "agent not running" over work that is
+		// doing precisely what a person told it to.
+		return nil
 	case stage == BoardDoneStage:
 		// A done-stage card has an agent only while the pre-merge review→fix loop
 		// is mid-flight; DeployPhase is the marker-derived signal that it is. Both

--- a/internal/daemon/board_marker_post.go
+++ b/internal/daemon/board_marker_post.go
@@ -93,6 +93,13 @@ func optionsMarker(stage BoardStage, context string, opts []BoardOption) (marker
 	for _, o := range opts {
 		m.Fields[o.ID] = o.Label
 		order = append(order, o.ID)
+		// A wait an answer declares is part of the answer. Rendering the label
+		// without it would post a block whose sequencing answer reads as an
+		// ordinary direction, and picking it would start the work it defers.
+		if o.WaitsFor != "" {
+			m.Fields[marker.WaitsForPrefix+o.ID] = o.WaitsFor
+			order = append(order, marker.WaitsForPrefix+o.ID)
+		}
 	}
 	return m, order
 }

--- a/internal/daemon/board_options.go
+++ b/internal/daemon/board_options.go
@@ -21,10 +21,20 @@ const OptionsHeader = "[human:options]"
 // consumption signal that removes the block from the card.
 const OptionChosenHeader = "[human:option-chosen]"
 
+// WaitsForField is the option-chosen marker's record of the ticket a sequencing
+// answer deferred to — the field the card face and the release pass read.
+const WaitsForField = "waits-for"
+
 // BoardOption is one selectable direction from an options block.
 type BoardOption struct {
 	ID    string `json:"id"`
 	Label string `json:"label"`
+	// WaitsFor is the ticket this answer defers to, from the block's
+	// `waits-for-<id>:` line. Non-empty makes it a SEQUENCING answer: picking it
+	// records the decision and holds this ticket until that one is finished,
+	// where every other answer starts the stage. Empty on every ordinary answer,
+	// so a block that declares no wait behaves exactly as it always did.
+	WaitsFor string `json:"waits_for,omitempty"`
 }
 
 // optionStages are the stages an options block may relaunch — exactly the
@@ -57,6 +67,7 @@ var optionStageAliases = map[BoardStage]BoardStage{
 //	stage: implementation
 //	context: review found a blocking design gap
 //	1: <option label>
+//	waits-for-1: <ticket key>   (optional: picking 1 defers to that ticket)
 //	2: <option label>
 //
 // The returned stage is CANONICAL: a gate alias (optionStageAliases, e.g.
@@ -70,6 +81,7 @@ func parseOptionsBlock(body string) (BoardStage, string, []BoardOption) {
 	var raw BoardStage
 	var context string
 	var opts []BoardOption
+	waits := map[string]string{}
 	for line := range strings.SplitSeq(body, "\n") {
 		line = strings.TrimSpace(line)
 		switch {
@@ -79,18 +91,18 @@ func parseOptionsBlock(body string) (BoardStage, string, []BoardOption) {
 			raw = BoardStage(strings.TrimSpace(strings.TrimPrefix(line, "stage:")))
 		case strings.HasPrefix(line, "context:"):
 			context = strings.TrimSpace(strings.TrimPrefix(line, "context:"))
+		case strings.HasPrefix(line, marker.WaitsForPrefix):
+			if id, key, ok := parseWaitLine(line); ok {
+				waits[id] = key
+			}
 		case strings.HasPrefix(line, DaemonLinePrefix):
 			// Provenance, not a choice. Every marker body carries this stamp, and
 			// `daemon: <id>` matches the id:label shape below exactly — so without
 			// this case the board offered the daemon id as a selectable answer,
 			// and counted it toward the number of answers a block appears to have.
 		default:
-			id, label, ok := strings.Cut(line, ":")
-			if !ok || strings.TrimSpace(id) == "" || strings.ContainsAny(id, " \t") {
-				continue
-			}
-			if label = strings.TrimSpace(label); label != "" {
-				opts = append(opts, BoardOption{ID: strings.TrimSpace(id), Label: label})
+			if opt, ok := parseAnswerLine(line); ok {
+				opts = append(opts, opt)
 			}
 		}
 	}
@@ -100,11 +112,43 @@ func parseOptionsBlock(body string) (BoardStage, string, []BoardOption) {
 	if raw == "" || len(opts) == 0 {
 		return "", "", nil
 	}
+	// A wait naming no offered answer is dropped rather than kept as a phantom:
+	// posting rejects it (marker.validateOptions), so one reaching here is a
+	// block written before the check existed, and there is no answer for it to
+	// qualify.
+	for i, opt := range opts {
+		opts[i].WaitsFor = waits[opt.ID]
+	}
 	stage := raw
 	if canon, ok := optionStageAliases[raw]; ok {
 		stage = canon
 	}
 	return stage, context, opts
+}
+
+// parseWaitLine reads a `waits-for-<id>: <KEY>` line: the ticket answer <id>
+// defers to. It is metadata about an answer, not an answer — it shares the
+// `id: value` shape of one, so a parser that did not recognise it would offer
+// "waits-for-1" as a third direction a human could pick.
+func parseWaitLine(line string) (id, key string, ok bool) {
+	rest, ok := strings.CutPrefix(line, marker.WaitsForPrefix)
+	if !ok {
+		return "", "", false
+	}
+	id, key, ok = strings.Cut(rest, ":")
+	id, key = strings.TrimSpace(id), strings.TrimSpace(key)
+	return id, key, ok && id != "" && key != ""
+}
+
+// parseAnswerLine reads an `<id>: <label>` answer line. An id carrying
+// whitespace is prose that happens to contain a colon, not an answer.
+func parseAnswerLine(line string) (BoardOption, bool) {
+	id, label, ok := strings.Cut(line, ":")
+	id, label = strings.TrimSpace(id), strings.TrimSpace(label)
+	if !ok || id == "" || label == "" || strings.ContainsAny(id, " \t") {
+		return BoardOption{}, false
+	}
+	return BoardOption{ID: id, Label: label}, true
 }
 
 // openOptionsBlock returns the latest options block that is still awaiting a
@@ -265,42 +309,66 @@ func (d BoardTransitionDeps) ApplyOption(ctx context.Context, req BoardOptionReq
 	if !ok {
 		return errors.WithDetails("unknown option id", "pm", req.PMKey, "option", req.OptionID)
 	}
+	// A ticket cannot wait for itself: recording that would hold the work behind
+	// a ticket that only finishes by doing it. Refuse the click loudly and leave
+	// the block open — the stage wrote a question that cannot be answered, and
+	// silently treating it as an ordinary answer would start the very work the
+	// answer was picked to defer.
+	if chosen.WaitsFor == req.PMKey {
+		return errors.WithDetails("this answer makes the ticket wait for itself, which nothing can clear",
+			"pm", req.PMKey, "option", req.OptionID)
+	}
 	return d.pursueDecision(ctx, req.PMKey, comments, stage, chosen)
 }
 
-// pursueDecision records one answer and relaunches its stage with the direction
-// injected. Shared with the loop's sole-direction path (SC-3630) so that a
-// decision the daemon takes for itself leaves the same trail as one a human
-// clicks: the record is the audit AND the consumption signal, and a second
-// caller writing its own variant of it is how a resumed card ends up with no
-// record of why.
+// pursueDecision records one answer and, unless the answer was to wait, starts
+// its stage with the direction injected. Shared with the loop's sole-direction
+// path (SC-3630) so that a decision the daemon takes for itself leaves the same
+// trail as one a human clicks: the record is the audit AND the consumption
+// signal, and a second caller writing its own variant of it is how a resumed
+// card ends up with no record of why.
 func (d BoardTransitionDeps) pursueDecision(ctx context.Context, pmKey string, comments []tracker.Comment, stage BoardStage, chosen BoardOption) error {
 	// The pick rides in the head token, where the readers already look for it
-	// (parseOptionChosen splits id from label on the header line). The stage
-	// rides in a field because the record has to stand on its own: the loop's
-	// sole-direction path records a choice with no block in front of it at all,
-	// so a reader that recovers the stage from the neighbouring block would find
-	// nothing and place the card as if no decision had been taken.
+	// (choiceLabel splits id from label on the header line). The stage rides in a
+	// field because the record has to stand on its own: the loop's sole-direction
+	// path records a choice with no block in front of it at all, so a reader that
+	// recovers the stage from the neighbouring block would find nothing and place
+	// the card as if no decision had been taken. A sequencing answer's wait rides
+	// there for the same reason: it is what every later reader — the card face,
+	// the pass that releases the hold — asks the record for.
 	chosenMarker := marker.Marker{
 		Type:   MarkerOptionChosen,
 		Head:   chosen.ID + ": " + chosen.Label,
 		Fields: fields("stage", string(stage)),
 	}
-	if err := postMarker(ctx, d.Commenter, pmKey, chosenMarker, "stage"); err != nil {
+	if chosen.WaitsFor != "" {
+		chosenMarker.Fields[WaitsForField] = chosen.WaitsFor
+	}
+	if err := postMarker(ctx, d.Commenter, pmKey, chosenMarker, "stage", WaitsForField); err != nil {
 		return errors.WrapWithDetails(err, "recording option choice", "pm", pmKey)
 	}
 
+	// A sequencing answer is the one answer whose content is "do not start this
+	// yet". Starting the stage anyway is doing the thing the person just chose to
+	// do second, and it was the only behaviour the machine had: every answer took
+	// the launch path because nothing in an answer could say otherwise. The card
+	// stays queued for the stage, named on the record — reconcileQueuedLaunch
+	// releases it when the ticket it defers to is finished.
+	if chosen.WaitsFor != "" {
+		d.Logger.Info().Str("pm", pmKey).Str("stage", string(stage)).Str("waits for", chosen.WaitsFor).
+			Msg("board decision: the answer defers this work; holding the stage until the named ticket is done")
+		return nil
+	}
+
 	card := DeriveBoardCard(comments, tracker.CategoryUnstarted, false)
-	prompt := stagePrompt(stage, pmKey, card) +
-		" — a decision was made on this ticket: pursue the direction in the latest " +
-		OptionChosenHeader + " comment (" + chosen.Label + ")"
-	// A decision click is human-initiated, like the Fix/Retry entry points: the
-	// interval since the decision became available is the human's think-time,
-	// not a pipeline wait, so it is suppressed (empty cause, SC-2462). Resuming an
-	// implementation-stage decision still executes a plan, so it is plan-gated
-	// like any other implementation launch (SC-2596).
-	_, err := d.startAgentStage(ctx, pmKey, stage, startedHeaderFor(stage), prompt, WaitCause(""), stage == BoardImplementation)
+	_, err := d.launchDecidedStage(ctx, pmKey, stage, card, comments, chosen.Label)
 	return err
+}
+
+// waitsForOf reads the ticket a recorded choice deferred to. Empty for every
+// ordinary answer.
+func waitsForOf(chosen tracker.Comment) string {
+	return parsePrefixedLine(chosen.Body, WaitsForField+":")
 }
 
 func findOption(opts []BoardOption, id string) (BoardOption, bool) {

--- a/internal/daemon/board_options_wait_test.go
+++ b/internal/daemon/board_options_wait_test.go
@@ -1,0 +1,163 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// The fork this exists for: preflight found other open work aimed at the same
+// code and asked which goes first.
+const sequencingBody = `[human:options]
+stage: implementation
+context: SC-4245 has an open branch on the same files
+1: SC-4245 goes first
+waits-for-1: SC-4245
+2: this goes first`
+
+// The wait rides with the answer it belongs to, and is never offered as an
+// answer of its own — it shares the `id: label` shape of one, so a parser that
+// did not reserve it would put a third button on the card.
+func TestParseOptionsBlock_WaitBelongsToItsAnswer(t *testing.T) {
+	stage, _, opts := parseOptionsBlock(sequencingBody)
+
+	assert.Equal(t, BoardImplementation, stage)
+	require.Len(t, opts, 2, "the wait is metadata about answer 1, not a third answer")
+	assert.Equal(t, "SC-4245", opts[0].WaitsFor)
+	assert.Empty(t, opts[1].WaitsFor, "the other direction defers to nothing")
+}
+
+// A wait naming no offered answer is dropped rather than kept as a phantom.
+// Posting rejects it, so one reaching here predates the check.
+func TestParseOptionsBlock_WaitForAnUnofferedAnswerDropped(t *testing.T) {
+	_, _, opts := parseOptionsBlock(
+		"[human:options]\nstage: planning\n1: a\n2: b\nwaits-for-3: SC-1")
+
+	require.Len(t, opts, 2)
+	for _, o := range opts {
+		assert.Empty(t, o.WaitsFor)
+	}
+}
+
+// The defect this whole change exists to close: picking "<KEY> goes first"
+// used to start the very work it deferred, because every answer took the one
+// path the machine had. The answer is recorded — with what it waits for — and
+// NOTHING is launched.
+func TestApplyOption_SequencingAnswerHoldsTheWork(t *testing.T) {
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt(ImplementationStartedHeader, time.Now().Add(-time.Hour)),
+		cmt(sequencingBody, time.Now().Add(-time.Minute)),
+	}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+
+	require.NoError(t, deps.ApplyOption(context.Background(), BoardOptionRequest{PMKey: "SC-9", OptionID: "1"}))
+
+	require.Len(t, c.added, 1, "the choice is recorded and no stage is started")
+	assert.Equal(t, OptionChosenHeader+" 1: SC-4245 goes first\nstage: implementation\nwaits-for: SC-4245", c.added[0],
+		"the record carries the wait, so every later reader learns it from the ticket")
+	assert.Zero(t, l.calls, "the answer was to go second; starting the work is doing the opposite of it")
+}
+
+// The other answer on the same block is unchanged: it starts the stage.
+func TestApplyOption_OtherAnswerOnASequencingBlockStillLaunches(t *testing.T) {
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt(PlanReadyHeader, time.Now().Add(-2*time.Hour)),
+		cmt(ImplementationStartedHeader, time.Now().Add(-time.Hour)),
+		cmt(sequencingBody, time.Now().Add(-time.Minute)),
+	}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+
+	require.NoError(t, deps.ApplyOption(context.Background(), BoardOptionRequest{PMKey: "SC-9", OptionID: "2"}))
+
+	assert.Equal(t, 1, l.calls)
+	assert.NotContains(t, c.added[0], "waits-for:", "an ordinary answer defers to nothing")
+}
+
+// A ticket cannot wait for itself: nothing could ever clear it. The block stays
+// open — the stage asked a question that cannot be answered, and treating the
+// answer as an ordinary one would start the work it was picked to defer.
+func TestApplyOption_SelfWaitRefused(t *testing.T) {
+	c := &fakeCommenter{comments: []tracker.Comment{
+		cmt("[human:options]\nstage: planning\n1: wait\nwaits-for-1: SC-9\n2: go", time.Now().Add(-time.Minute)),
+	}}
+	l := &fakeLauncher{}
+	deps := newDeps(c, l, &fakeDeployer{})
+
+	err := deps.ApplyOption(context.Background(), BoardOptionRequest{PMKey: "SC-9", OptionID: "1"})
+
+	require.Error(t, err)
+	assert.Empty(t, c.added, "nothing is recorded, so the block is still there to answer")
+	assert.Zero(t, l.calls)
+}
+
+// The card has to SAY it is holding, or a card doing exactly what it was told
+// is indistinguishable from one nobody picked up.
+func TestDeriveBoardCard_HeldCardNamesWhatItWaitsFor(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	card := DeriveBoardCard([]tracker.Comment{
+		optComment(ImplementationStartedHeader, base),
+		optComment(sequencingBody, base.Add(time.Minute)),
+		optComment(OptionChosenHeader+" 1: SC-4245 goes first\nstage: implementation\nwaits-for: SC-4245", base.Add(2*time.Minute)),
+	}, tracker.CategoryUnstarted, false)
+
+	assert.Equal(t, BoardQueued, card.State)
+	assert.Equal(t, BoardImplementation, card.Stage)
+	assert.Equal(t, "SC-4245", card.WaitsFor)
+}
+
+// The hold ends with the record that holds it: once the released stage posts
+// its started marker, the card is running and waits for nothing.
+func TestDeriveBoardCard_HoldEndsWhenTheStageStarts(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	card := DeriveBoardCard([]tracker.Comment{
+		optComment(sequencingBody, base),
+		optComment(OptionChosenHeader+" 1: SC-4245 goes first\nstage: implementation\nwaits-for: SC-4245", base.Add(time.Minute)),
+		optComment(ImplementationStartedHeader, base.Add(2*time.Minute)),
+	}, tracker.CategoryUnstarted, false)
+
+	assert.Equal(t, BoardRunning, card.State)
+	assert.Empty(t, card.WaitsFor)
+}
+
+// An ordinary answer queues the stage for a launch, not for other work — the
+// card must not claim to be waiting for a ticket.
+func TestDeriveBoardCard_OrdinaryQueuedCardWaitsForNothing(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	card := DeriveBoardCard([]tracker.Comment{
+		optComment(optionsBody, base),
+		optComment(OptionChosenHeader+" 2: Remove the Retry plan menu item\nstage: implementation", base.Add(time.Minute)),
+	}, tracker.CategoryUnstarted, false)
+
+	assert.Equal(t, BoardQueued, card.State)
+	assert.Empty(t, card.WaitsFor)
+}
+
+// A held card has no agent to be missing: the viewer must not paint "agent not
+// running" over work the machine was told to hold.
+func TestAgentNamesForCard_HeldCardNamesNoAgent(t *testing.T) {
+	assert.Nil(t, AgentNamesForCard(BoardViewCard{
+		Key: "SC-9", Stage: string(BoardImplementation), State: string(BoardQueued), WaitsFor: "SC-4245"}))
+	assert.NotEmpty(t, AgentNamesForCard(BoardViewCard{
+		Key: "SC-9", Stage: string(BoardImplementation), State: string(BoardQueued)}),
+		"an ordinary queued card is still waiting for an agent that should exist")
+}
+
+// A block composed in Go renders the wait beside the answer it belongs to, so
+// the block that comes back off the ticket parses to the same answers that went
+// in. Without it a sequencing answer would post as an ordinary direction.
+func TestOptionsMarker_RendersTheWaitBesideItsAnswer(t *testing.T) {
+	m, order := optionsMarker(BoardImplementation, "which goes first",
+		[]BoardOption{{ID: "1", Label: "SC-4245 goes first", WaitsFor: "SC-4245"}, {ID: "2", Label: "this goes first"}})
+
+	assert.Equal(t, []string{"stage", "context", "1", "waits-for-1", "2"}, order)
+	_, _, opts := parseOptionsBlock(markerBody(m))
+	require.Len(t, opts, 2, "the wait must not read back as a third answer")
+	assert.Equal(t, "SC-4245", opts[0].WaitsFor)
+}

--- a/internal/daemon/board_reconcile_queued.go
+++ b/internal/daemon/board_reconcile_queued.go
@@ -62,6 +62,17 @@ func reconcileQueuedLaunch(ctx context.Context, drivable DrivableCards, deps Rec
 		if now.Sub(choice.Created) < QueuedLaunchGrace {
 			continue
 		}
+		// A sequencing answer queued this stage precisely so it would NOT run yet.
+		// The grace above is about a launch in flight; this is about one nobody
+		// asked for. Nothing is charged while it waits — the card is doing exactly
+		// what it was told to.
+		if waitsFor := waitsForOf(choice); waitsFor != "" {
+			if !deps.waitCleared(ctx, card.Key, waitsFor) {
+				continue
+			}
+			logger.Info().Str("pm", card.Key).Str("waited for", waitsFor).
+				Msg("board reconcile: the ticket this work waited for is done; releasing the stage")
+		}
 		// A live agent for the stage means the launch did happen and simply has
 		// not posted its started marker yet — the same alive-guard every other
 		// pass uses, and the difference between a slow launch and a missing one.
@@ -77,4 +88,26 @@ func reconcileQueuedLaunch(ctx context.Context, drivable DrivableCards, deps Rec
 		}
 	}
 	return launched
+}
+
+// waitCleared reports whether the ticket a sequencing answer deferred to has
+// finished, so the stage it held may start.
+//
+// An answer that cannot be checked reports false — no probe wired, a tracker
+// that could not be reached, a key that does not resolve. Holding is the
+// direction that cannot undo the decision: starting the work early is the one
+// outcome the person ruled out, and there is no bound on how long a deliberate
+// wait may last, so an unreadable blocker is not a reason to give up on it. The
+// card says what it waits for, and a person can start it by hand at any time.
+func (d ReconcileDeps) waitCleared(ctx context.Context, pmKey, waitsFor string) bool {
+	if d.ClosedProbe == nil {
+		return false
+	}
+	closed, err := d.ClosedProbe(ctx, waitsFor)
+	if err != nil {
+		d.Logger.Warn().Err(err).Str("pm", pmKey).Str("waits for", waitsFor).
+			Msg("board reconcile: cannot read the ticket this work waits for; keeping it held")
+		return false
+	}
+	return closed
 }

--- a/internal/daemon/board_reconcile_wait_test.go
+++ b/internal/daemon/board_reconcile_wait_test.go
@@ -1,0 +1,101 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/tracker"
+)
+
+// heldCard is a card whose answered decision was a sequencing one: the stage it
+// names must not start until the ticket the answer defers to is finished.
+func heldCard(key string, stage BoardStage, waitsFor string, now time.Time, ago time.Duration) ReconcileCard {
+	answered := now.Add(-ago)
+	return ReconcileCard{
+		Key: key,
+		Comments: []tracker.Comment{
+			cmt(OptionsHeader+"\nstage: "+string(stage)+"\n1: "+waitsFor+" goes first\nwaits-for-1: "+waitsFor+"\n2: this goes first",
+				answered.Add(-time.Minute)),
+			cmt(OptionChosenHeader+" 1: "+waitsFor+" goes first\nstage: "+string(stage)+"\nwaits-for: "+waitsFor, answered),
+		},
+	}
+}
+
+func closedProbe(closed bool) ClosedTicketProbe {
+	return func(context.Context, string) (bool, error) { return closed, nil }
+}
+
+// The pass that starts a decided stage must not start a HELD one — otherwise
+// the answer "SC-4245 goes first" is undone two minutes after it is given.
+func TestReconcileQueuedLaunch_HoldsWhileTheOtherTicketIsOpen(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	var relaunched []BoardStage
+	attempts := 0
+
+	n := reconcileQueuedLaunch(context.Background(),
+		takeoverSet([]ReconcileCard{heldCard("SC-1", BoardImplementation, "SC-2", now, time.Hour)}, alwaysReachable),
+		ReconcileDeps{LiveAgents: liveAgents(), ClosedProbe: closedProbe(false), Retry: queuedRetry(&relaunched, &attempts), DaemonID: "d1"},
+		now)
+
+	require.Zero(t, n)
+	require.Empty(t, relaunched, "the work waits for the ticket the person put first")
+	require.Zero(t, attempts, "a card doing what it was told spends none of the retry budget")
+}
+
+// And the other half: the wait is not a dead end. When the ticket it deferred
+// to is finished, the stage starts on its own.
+func TestReconcileQueuedLaunch_ReleasesWhenTheOtherTicketIsDone(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	var relaunched []BoardStage
+	attempts := 0
+
+	n := reconcileQueuedLaunch(context.Background(),
+		takeoverSet([]ReconcileCard{heldCard("SC-1", BoardImplementation, "SC-2", now, time.Hour)}, alwaysReachable),
+		ReconcileDeps{LiveAgents: liveAgents(), ClosedProbe: closedProbe(true), Retry: queuedRetry(&relaunched, &attempts), DaemonID: "d1"},
+		now)
+
+	require.Equal(t, 1, n)
+	require.Equal(t, []BoardStage{BoardImplementation}, relaunched)
+}
+
+// An unreadable blocker keeps the hold. Starting the work is the one outcome
+// the person's answer ruled out, so a tracker blip must never be the thing that
+// overrules it — and a deliberate wait has no time bound to give up at.
+func TestReconcileQueuedLaunch_UnreadableBlockerKeepsTheHold(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	for _, probe := range []ClosedTicketProbe{
+		nil,
+		func(context.Context, string) (bool, error) { return false, errors.WithDetails("tracker unreachable") },
+	} {
+		var relaunched []BoardStage
+		attempts := 0
+
+		n := reconcileQueuedLaunch(context.Background(),
+			takeoverSet([]ReconcileCard{heldCard("SC-1", BoardPlanning, "SC-2", now, time.Hour)}, alwaysReachable),
+			ReconcileDeps{LiveAgents: liveAgents(), ClosedProbe: probe, Retry: queuedRetry(&relaunched, &attempts), DaemonID: "d1"},
+			now)
+
+		require.Zero(t, n)
+		require.Empty(t, relaunched)
+	}
+}
+
+// A card queued by an ORDINARY answer never consults the probe: it is waiting
+// for a launch, not for other work, and holding it would strand it.
+func TestReconcileQueuedLaunch_OrdinaryDecisionIsNotHeld(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	var relaunched []BoardStage
+	attempts := 0
+
+	n := reconcileQueuedLaunch(context.Background(),
+		takeoverSet([]ReconcileCard{decidedCard("SC-1", BoardPlanning, now, time.Hour)}, alwaysReachable),
+		ReconcileDeps{LiveAgents: liveAgents(), ClosedProbe: closedProbe(false), Retry: queuedRetry(&relaunched, &attempts), DaemonID: "d1"},
+		now)
+
+	require.Equal(t, 1, n, "no wait was declared, so nothing holds this card")
+	require.Equal(t, []BoardStage{BoardPlanning}, relaunched)
+}

--- a/internal/daemon/board_state.go
+++ b/internal/daemon/board_state.go
@@ -29,6 +29,12 @@ type BoardCard struct {
 	// the outage carries no stated recovery time, in which case the wait falls
 	// back to the reconcile pass's own backoff exactly as before (SC-3024).
 	ResumeAt string `json:"resume_at,omitempty"`
+	// WaitsFor is the ticket a queued card was told to wait for: the `waits-for`
+	// field of the [human:option-chosen] marker that queued it, written when the
+	// answer a human picked was a sequencing one. Empty on every other card,
+	// including a queued one whose answer was an ordinary direction — that card is
+	// waiting for a launch, not for other work.
+	WaitsFor string `json:"waits_for,omitempty"`
 	// HasPlan reports a [human:plan] comment on the ticket — the plan lives
 	// here instead of on a separate engineering ticket (single-tracker
 	// topology).
@@ -200,6 +206,13 @@ func DeriveBoardCard(comments []tracker.Comment, statusType tracker.Category, is
 		card.ShippedPartialFollowOn = followOn
 	}
 	attachFailureAndResume(&card, card.placement().State(), latest)
+	// Only a queued card can be held: the record that holds it is the same
+	// option-chosen marker the queued placement was synthesized from, so the
+	// moment a started marker supersedes the choice the card stops claiming to
+	// wait for anything.
+	if card.placement().State() == BoardQueued {
+		card.WaitsFor = waitsForOf(latest)
+	}
 	card.DeployPhase = deployPhaseFor(card, comments)
 	card.StopDecision, card.StopLinkedKey, card.StopReasoning = ticketReviewStop(latest)
 	attachOpenOptions(&card, comments)

--- a/internal/daemon/board_transition.go
+++ b/internal/daemon/board_transition.go
@@ -349,6 +349,19 @@ func (d BoardTransitionDeps) applyTransition(ctx context.Context, req BoardTrans
 // forward-only path — and err carries that dispatch's own result.
 func (d BoardTransitionDeps) dispatchNonForwardMove(ctx context.Context, req BoardTransitionRequest, card BoardCard, comments []tracker.Comment) (handled bool, launched bool, err error) {
 	switch {
+	// Queued launch: a decision was answered and the stage it named has not
+	// started. The card derives to (that stage, queued) — a state none of the
+	// retry rules below admits, so this fell through to the forward-only rule and
+	// was rejected as a non-advance. That made reconcileQueuedLaunch, the pass
+	// added to start exactly these cards (SC-3865), unable to start any of them:
+	// every attempt was refused, charged against the retry budget, and the card
+	// left where it was. Dispatched first because a queued card matches this rule
+	// and no other, and because it is also the human override for a card held
+	// behind a ticket it was told to wait for.
+	case isQueuedLaunch(req.To, card):
+		launched, err := d.launchDecidedStage(ctx, req.PMKey, req.To, card, comments, choiceLabel(comments))
+		return true, launched, err
+
 	// Rework loop: a build whose review failed may be rebuilt. This is the ONE
 	// sanctioned backward move — the executor is re-dispatched with the review
 	// findings, and the resulting handoff chains into a fresh review.
@@ -527,27 +540,48 @@ func (d BoardTransitionDeps) ApplyFix(ctx context.Context, req BoardFixRequest) 
 	if _, state := latestStageState(comments, BoardVerification); state == BoardRunning {
 		return nil
 	}
-	// The --board marker is the mechanical gate that keeps a board run from
-	// pushing: the container holds no push/PR credentials, and the daemon's
-	// Deploy stage owns push → PR → CI → merge on the host against the
-	// bind-mounted repo. The skill and fixer branch on this flag to stop at the
-	// review handoff. Relying on the HUMAN_AGENT_NAME env var alone let a fixer
-	// push and fail — the fix completed and passed review but the card ended red
-	// (SC-252).
-	// The autofix pipeline triages, plans and fixes in one run, so it legitimately
-	// launches the implementation stage with no pre-written plan: requiresPlan is
-	// false (SC-2596).
-	launched, err := d.startAgentStage(ctx, req.PMKey, BoardImplementation, ImplementationStartedHeader,
-		"/human-autofix "+req.PMKey+" --board", WaitCause(""), false)
+	_, err = d.launchFixPipeline(ctx, req.PMKey, fixBug, "")
+	return err
+}
+
+// launchFixPipeline starts the self-planning fix pipeline that owns a ticket and
+// records which one it is. extra is appended to the prompt, so a run resumed by
+// a decision carries the direction that resumed it.
+//
+// The --board marker is the mechanical gate that keeps a board run from pushing:
+// the container holds no push/PR credentials, and the daemon's Deploy stage owns
+// push → PR → CI → merge on the host against the bind-mounted repo. The skill
+// and fixer branch on this flag to stop at the review handoff. Relying on the
+// HUMAN_AGENT_NAME env var alone let a fixer push and fail — the fix completed
+// and passed review but the card ended red (SC-252).
+//
+// These pipelines triage, plan and fix in one run, so they legitimately launch
+// the implementation stage with no pre-written plan: requiresPlan is false
+// (SC-2596).
+//
+// It carries NO idempotency guard of its own. The two gesture entry points
+// (ApplyFix, ApplySecurityFix) check for a running stage before calling; the
+// paths that resume a decision must not, because the agent that RAISED the
+// decision leaves a [human:implementation-started] marker standing — a stage
+// that pauses on an open block posts no *-failed marker (stagePausedOnOptions),
+// so a marker-shaped guard reads the dead run as live and swallows the resume.
+// Those paths establish liveness the honest way, from the running containers.
+func (d BoardTransitionDeps) launchFixPipeline(ctx context.Context, pmKey string, kind fixPipeline, extra string) (bool, error) {
+	skill, identity := "/human-autofix ", "fix"
+	if kind == fixSecurity {
+		skill, identity = "/human-security-fix ", "security"
+	}
+	launched, err := d.startAgentStage(ctx, pmKey, BoardImplementation, ImplementationStartedHeader,
+		skill+pmKey+" --board"+extra, WaitCause(""), false)
 	if launched {
 		// Record which pipeline this run is, durably on the ticket, so a later
-		// recovery relaunch restarts the FIX pipeline even if the ticket-kind
+		// recovery relaunch restarts the SAME pipeline even if the ticket-kind
 		// fetch blips and no verdict has been posted yet (SC-2989).
-		_ = postMarker(ctx, d.Commenter, req.PMKey, marker.Marker{
-			Type: MarkerPipeline, Fields: fields("kind", "fix"),
+		_ = postMarker(ctx, d.Commenter, pmKey, marker.Marker{
+			Type: MarkerPipeline, Fields: fields("kind", identity),
 		})
 	}
-	return err
+	return launched, err
 }
 
 // SecurityFixRequest is the wire request for launching the security-fix pipeline
@@ -577,18 +611,7 @@ func (d BoardTransitionDeps) ApplySecurityFix(ctx context.Context, req SecurityF
 	if _, state := latestStageState(comments, BoardVerification); state == BoardRunning {
 		return nil
 	}
-	// Like autofix, the security-fix pipeline produces its own plan within the
-	// run, so requiresPlan is false (SC-2596).
-	launched, err := d.startAgentStage(ctx, req.PMKey, BoardImplementation, ImplementationStartedHeader,
-		"/human-security-fix "+req.PMKey+" --board", WaitCause(""), false)
-	if launched {
-		// Durable pipeline identity, mirroring ApplyFix: a recovery relaunch reads
-		// this first and restarts the security-fix pipeline rather than refusing the
-		// run for having no plan (SC-2989).
-		_ = postMarker(ctx, d.Commenter, req.PMKey, marker.Marker{
-			Type: MarkerPipeline, Fields: fields("kind", "security"),
-		})
-	}
+	_, err = d.launchFixPipeline(ctx, req.PMKey, fixSecurity, "")
 	return err
 }
 
@@ -1128,7 +1151,14 @@ func decisionContext(outcome PRLoopOutcome) string {
 // It records the choice exactly as a human's click records it — same
 // [human:option-chosen] marker, same relaunch — so the trail reads the same
 // whoever made the call, and the card is never resumed without a record.
+//
+// The one thing it will not take from the fixer is a WAIT. Putting this ticket
+// behind another one is a sequencing judgement about a backlog, which is the
+// class of call the daemon may never make for itself; taken here it would also
+// hold the card on a decision no person ever saw. Dropped rather than refused —
+// the direction itself is still worth pursuing, and this way the loop moves.
 func (d BoardTransitionDeps) pursueSoleDirection(ctx context.Context, pmKey string, comments []tracker.Comment, only BoardOption) error {
+	only.WaitsFor = ""
 	return d.pursueDecision(ctx, pmKey, comments, BoardImplementation, only)
 }
 
@@ -1978,6 +2008,67 @@ func isDuplicateDrop(to BoardStage, card BoardCard) bool {
 // is exactly a live, undecided fork (SC-1857).
 func awaitingDecision(card BoardCard) bool {
 	return len(card.Options) > 0
+}
+
+// launchDecidedStage starts the stage a recorded decision named, with the
+// direction that decided it injected into the prompt.
+//
+// An implementation launch is routed to the self-planning fix pipeline that
+// owns the ticket when there is one. An autofix or security-fix run raises its
+// decision in PREFLIGHT, before it has written a plan, so handing the answer to
+// the plan executor refuses the launch at the plan gate and drives the card into
+// planning instead — the SC-2986 class, reappearing on the decision path because
+// this was the one relaunch site that never classified the pipeline.
+//
+// A decision is human-initiated, like the Fix/Retry entry points: the interval
+// since the decision became available is the human's think-time, not a pipeline
+// wait, so it is suppressed (empty cause, SC-2462). A plan-executing
+// implementation launch is still plan-gated like every other (SC-2596).
+func (d BoardTransitionDeps) launchDecidedStage(ctx context.Context, pmKey string, stage BoardStage, card BoardCard, comments []tracker.Comment, label string) (bool, error) {
+	direction := ""
+	if label != "" {
+		direction = " — a decision was made on this ticket: pursue the direction in the latest " +
+			OptionChosenHeader + " comment (" + label + ")"
+	}
+	if stage == BoardImplementation {
+		if kind := d.classifyFixPipeline(ctx, pmKey, comments); kind != fixNone {
+			return d.launchFixPipeline(ctx, pmKey, kind, direction)
+		}
+	}
+	return d.startAgentStage(ctx, pmKey, stage, startedHeaderFor(stage),
+		stagePrompt(stage, pmKey, card)+direction, WaitCause(""), stage == BoardImplementation)
+}
+
+// choiceLabel reads the answer text off the ticket's latest recorded choice —
+// the `<id>: <label>` head of its [human:option-chosen] marker. Empty when the
+// ticket carries no choice, which is what a launch with no direction to inject
+// looks like.
+//
+// It exists so a launch the click never made builds the SAME prompt the click
+// would have: the pass that starts a decided stage later has only the ticket to
+// read the answer from.
+func choiceLabel(comments []tracker.Comment) string {
+	chosen, ok := latestOptionChosen(comments)
+	if !ok {
+		return ""
+	}
+	m, ok := marker.ParseBody(chosen.Body)
+	if !ok {
+		return ""
+	}
+	_, label, ok := strings.Cut(m.Head, ":")
+	if !ok {
+		return strings.TrimSpace(m.Head)
+	}
+	return strings.TrimSpace(label)
+}
+
+// isQueuedLaunch reports a card whose answered decision queued a stage that
+// never started, re-dropped on that same stage. Same-stage by definition: the
+// queued placement IS the stage the decision named, so this can only ever start
+// the stage the record asks for, never move the card somewhere else.
+func isQueuedLaunch(to BoardStage, card BoardCard) bool {
+	return card.State == BoardQueued && card.Stage == to
 }
 
 // isReworkTransition reports the one allowed backward move: re-running the

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -164,6 +164,11 @@ type BoardViewCard struct {
 	// when the refusal stated one. The frontend formats it in the reader's own
 	// timezone. Empty when unknown — the card then reads "paused" with no time.
 	ResumeAt string `json:"resumeAt,omitempty"`
+	// WaitsFor is the ticket a queued card was told to go second to, when the
+	// answer a human picked was a sequencing one. It is what turns the queued
+	// badge from "picked up" — a spinner over work nobody started — into the
+	// do-nothing register naming what the card is waiting for.
+	WaitsFor string `json:"waitsFor,omitempty"`
 	// Verdict is the latest review's verdict line; a failing verdict pins the
 	// card in the Code lane with a warning instead of letting it advance.
 	Verdict string `json:"verdict,omitempty"`

--- a/internal/marker/marker.go
+++ b/internal/marker/marker.go
@@ -66,33 +66,75 @@ var reservedOptionKeys = map[string]bool{
 	MachineField: true, BuildField: true,
 }
 
-// validateOptions counts the answers a decision block actually offers. They
-// arrive as numbered fields when posted and as body lines when read back, so
-// both are counted.
+// WaitsForPrefix marks the option-block line that says an answer DEFERS the
+// work rather than directing it: `waits-for-<id>: <KEY>` means picking <id>
+// holds this ticket until <KEY> is finished. It is the one thing about an
+// answer the machine cannot read out of its prose — "SC-1 goes first" and "do
+// it this way" are the same sentence to a parser — and without it every answer
+// took the one path the machine knows, which is to start the work.
+//
+// Exported so the daemon's own block parser reserves the same prefix; two
+// spellings of it would mean a line counted as an answer on one side and as
+// metadata on the other.
+const WaitsForPrefix = "waits-for-"
+
+// isReservedOptionKey reports an option-block line that is metadata rather than
+// an answer. Prefix membership as well as exact membership: the wait a
+// sequencing answer declares is per-answer, so its key carries the answer's id.
+func isReservedOptionKey(id string) bool {
+	return reservedOptionKeys[id] || strings.HasPrefix(id, WaitsForPrefix)
+}
+
+// validateOptions counts the answers a decision block actually offers, and
+// checks that every wait it declares belongs to one of them. They arrive as
+// numbered fields when posted and as body lines when read back, so both are
+// counted.
 func validateOptions(m Marker) error {
 	ids := map[string]bool{}
+	waits := map[string]string{}
 	for key, value := range m.Fields {
-		if !reservedOptionKeys[key] && strings.TrimSpace(value) != "" {
-			ids[key] = true
-		}
+		collectOption(ids, waits, key, value)
 	}
 	for _, line := range strings.Split(m.Body, "\n") {
-		line = strings.TrimSpace(line)
-		id, label, ok := strings.Cut(line, ":")
-		id = strings.TrimSpace(id)
-		if !ok || id == "" || strings.ContainsAny(id, " \t") || reservedOptionKeys[id] {
+		id, label, ok := strings.Cut(strings.TrimSpace(line), ":")
+		if !ok {
 			continue
 		}
-		if strings.TrimSpace(label) != "" {
-			ids[id] = true
-		}
+		collectOption(ids, waits, strings.TrimSpace(id), label)
 	}
 	if len(ids) < MinDecisionOptions {
 		return errors.WithDetails(
 			"a decision block must offer at least two answers",
 			"type", m.Type, "answers", len(ids), "minimum", MinDecisionOptions)
 	}
+	// A wait naming no answer holds nothing: the block would render as an
+	// ordinary fork and the ticket it was meant to wait for would be started over
+	// anyway. Rejecting it at post time is the only moment anyone is watching.
+	for id, key := range waits {
+		if !ids[id] {
+			return errors.WithDetails(
+				"a decision block declares a wait for an answer it does not offer",
+				"type", m.Type, "answer", id, "waits for", key)
+		}
+	}
 	return nil
+}
+
+// collectOption sorts one `key: value` pair of a decision block into the
+// answers it offers or the waits it declares. Shared by the posted-fields and
+// read-back-body passes so the two cannot disagree about what an answer is.
+func collectOption(ids map[string]bool, waits map[string]string, id, value string) {
+	value = strings.TrimSpace(value)
+	if id == "" || strings.ContainsAny(id, " \t") || value == "" {
+		return
+	}
+	if answer, ok := strings.CutPrefix(id, WaitsForPrefix); ok {
+		waits[answer] = value
+		return
+	}
+	if !isReservedOptionKey(id) {
+		ids[id] = true
+	}
 }
 
 var specs = map[string]spec{

--- a/internal/marker/options_wait_test.go
+++ b/internal/marker/options_wait_test.go
@@ -1,0 +1,73 @@
+package marker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A wait declared by an answer is metadata about that answer, not a third thing
+// to pick. Counting it would let a block offering ONE real answer clear the
+// two-answer floor — the same hole the daemon stamp opened, reopened by a line
+// shaped like an answer.
+func TestValidateDoesNotCountAWaitAsAnAnswer(t *testing.T) {
+	m := Marker{
+		Type: "options",
+		Fields: map[string]string{
+			"stage":         "implementation",
+			"1":             "SC-4245 goes first",
+			"waits-for-1":   "SC-4245",
+			"waits-for-999": "SC-4245",
+		},
+	}
+
+	require.Error(t, Validate(m), "a wait is metadata about an answer, never an answer")
+}
+
+// The ordinary sequencing block: two real answers, one of which declares what
+// it waits for.
+func TestValidateAcceptsASequencingBlock(t *testing.T) {
+	m := Marker{
+		Type: "options",
+		Fields: map[string]string{
+			"stage":       "implementation",
+			"context":     "SC-4245 has an open branch on the same files",
+			"1":           "SC-4245 goes first",
+			"waits-for-1": "SC-4245",
+			"2":           "this goes first",
+		},
+	}
+
+	require.NoError(t, Validate(m))
+}
+
+// Read back off the ticket the answers arrive as body lines rather than posted
+// fields, so the same rules have to hold on that side.
+func TestValidateAcceptsASequencingBlockReadBack(t *testing.T) {
+	m := Marker{
+		Type:   "options",
+		Fields: map[string]string{"stage": "implementation"},
+		Body:   "1: SC-4245 goes first\nwaits-for-1: SC-4245\n2: this goes first",
+	}
+
+	require.NoError(t, Validate(m))
+}
+
+// A wait naming an answer the block does not offer holds nothing: the block
+// renders as an ordinary fork and the work it was meant to defer starts anyway.
+// Post time is the only moment anyone is watching.
+func TestValidateRejectsAWaitForAnAnswerNotOffered(t *testing.T) {
+	m := Marker{
+		Type: "options",
+		Fields: map[string]string{
+			"stage":       "implementation",
+			"1":           "SC-4245 goes first",
+			"2":           "this goes first",
+			"waits-for-3": "SC-4245",
+		},
+	}
+
+	err := Validate(m)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not offer")
+}

--- a/internal/pipelinefsm/pipeline-fsm.json
+++ b/internal/pipelinefsm/pipeline-fsm.json
@@ -384,13 +384,13 @@
         "state": "queued",
         "note": "Only the three stages an options block may relaunch — planning, implementation, verification (optionStages) — so backlog and done never carry it. Synthesized by optionChosenQueued when [human:option-chosen] is the newest board-relevant signal; any classified marker newer than the choice supersedes it."
       },
-      "holds": "The newest board-relevant marker is an [human:option-chosen] whose block names a resumable stage, and that stage's started marker has not been posted.",
+      "holds": "The newest board-relevant marker is an [human:option-chosen] whose block names a resumable stage, and that stage's started marker has not been posted. TWO different situations hold here and the record tells them apart: an ordinary answer is queued for a launch that is on its way, while an answer carrying a `waits-for` field is HELD — it named a ticket that goes first, and the stage must not start until that ticket is done.",
       "who_may_act": [
         "user",
         "daemon"
       ],
-      "stale_when": "Past QueuedLaunchGrace (2m) with no live agent for the stage. Recording the choice and launching the stage are the two halves of one ApplyOption call, in that order, so the ordinary window is microseconds; the grace exists only so a reconcile tick landing inside it does not race a launch already on its way.",
-      "if_nothing_happens": "reconcileQueuedLaunch starts the stage the decision named, on the next tick past the grace. It relaunches through the CHARGED, capped path (DefaultStageRetries), so a stage that cannot be launched is tried twice and then left for a person rather than forever — and a refusal that starts nothing, the plan gate, is not charged at all and routes the card itself to needs-planning. It deliberately does not go through the ordinary retry classifier: that reads the stage's last recorded exit, which here is the ExitNeedsInput of the stage that RAISED the decision, and would classify the card as one to leave for a human — refusing to start exactly the cards this pass exists for. Until SC-3865 nothing watched this state at all: it exists so the stuck-running sweep will not red a card whose decision was just answered (SC-1320), and it achieved that by being a state no sweep looked at — one property, protection from one side and a hole from the other."
+      "stale_when": "Past QueuedLaunchGrace (2m) with no live agent for the stage. Recording the choice and launching the stage are the two halves of one ApplyOption call, in that order, so the ordinary window is microseconds; the grace exists only so a reconcile tick landing inside it does not race a launch already on its way. A HELD card is never stale by time: it is doing exactly what a person told it to, for as long as the ticket it waits for takes.",
+      "if_nothing_happens": "reconcileQueuedLaunch starts the stage the decision named, on the next tick past the grace — unless the answer was a sequencing one, in which case that same pass HOLDS the card and starts it on the first tick after the ticket it named is done or closed. A held card whose blocker cannot be read stays held: starting the work is the one outcome the person's answer ruled out, and a deliberate wait has no time bound to give up at, so the way out of an unreadable one is a person dropping the card on its own column. Otherwise it relaunches through the CHARGED, capped path (DefaultStageRetries), so a stage that cannot be launched is tried twice and then left for a person rather than forever — and a refusal that starts nothing, the plan gate, is not charged at all and routes the card itself to needs-planning; a hold is charged nothing either, because nothing was attempted. It deliberately does not go through the ordinary retry classifier: that reads the stage's last recorded exit, which here is the ExitNeedsInput of the stage that RAISED the decision, and would classify the card as one to leave for a human — refusing to start exactly the cards this pass exists for. Until SC-3865 nothing watched this state at all: it exists so the stuck-running sweep will not red a card whose decision was just answered (SC-1320), and it achieved that by being a state no sweep looked at — one property, protection from one side and a hole from the other. The pass could not in fact start anything until the transition that admits a queued card existed: every re-drive was rejected as a non-advance by the forward-only rule and charged for the refusal."
     },
     {
       "name": "stopped",
@@ -470,7 +470,7 @@
       "actor": "user",
       "runs": "human-planner",
       "marker": "[human:planning-started]",
-      "where": "board_transition.go launchForwardStage / isPlanningRetry",
+      "where": "board_transition.go launchForwardStage / isPlanningRetry / isQueuedLaunch",
       "doc": "A drop on Planning. From planned it is a replan; from stopped or substrate-down it is a retry in place."
     },
     {
@@ -524,7 +524,7 @@
       "actor": "user",
       "runs": "human-autofix",
       "marker": "[human:implementation-started]",
-      "where": "board_transition.go ApplyFix",
+      "where": "board_transition.go ApplyFix; board_options.go launchDecidedStage \u2192 launchFixPipeline when the stage was queued by a decision",
       "doc": "Dropping a bug on Fix. The run is self-planning — it produces its own plan rather than requiring one."
     },
     {
@@ -668,7 +668,7 @@
       "actor": "user",
       "runs": "human-executor",
       "marker": "[human:implementation-started]",
-      "where": "board_transition.go launchForwardStage / isReworkTransition / isBuildRetry",
+      "where": "board_transition.go launchForwardStage / isReworkTransition / isBuildRetry / isQueuedLaunch",
       "doc": "The plan-executing path. From reviewed it is the rework loop — a failing review verdict sends the item back to be rebuilt with the findings."
     },
     {
@@ -927,8 +927,8 @@
       "dst": "queued",
       "actor": "user",
       "marker": "[human:option-chosen]",
-      "where": "board_options.go ApplyOption → pursueDecision — records the choice, then starts the stage; board_state.go optionChosenQueued reads the window between the two",
-      "doc": "A human picked an answer. This records it and nothing more: pursueDecision posts the choice comment and only then calls startAgentStage, so the item is queued for a stage before it is running in one. The stage that gets queued is the one the RECORD names — written onto the option-chosen marker itself, with the block read only for choices recorded before that field existed — not the one the item sits in — planning is the common case, while a PR-loop escalation deliberately names implementation even though the item is in the deploy stage, because the fixer raised a question only a code change can answer and the rebuild re-adopts the still-open draft PR. The item pauses correctly meanwhile, because an open block pauses every card whose own stage ranks at or after the one named. The stage is derived; the state is not — every answered decision lands here first.",
+      "where": "board_options.go ApplyOption → pursueDecision — records the choice, then starts the stage unless the answer was to wait; board_state.go optionChosenQueued reads the window between the two",
+      "doc": "A human picked an answer. This records it and nothing more: pursueDecision posts the choice comment and only then calls startAgentStage, so the item is queued for a stage before it is running in one. ONE answer stops there: an option carrying a `waits-for-<id>` line means this ticket goes second, so the choice is recorded with that ticket named on it and no stage is started at all. Starting it is the exact opposite of what was chosen, and it was the machine's only move on any answer until an answer could say otherwise — nothing in an option's prose distinguishes \"SC-1 goes first\" from \"do it this way\". The stage that gets queued is the one the RECORD names — written onto the option-chosen marker itself, with the block read only for choices recorded before that field existed — not the one the item sits in — planning is the common case, while a PR-loop escalation deliberately names implementation even though the item is in the deploy stage, because the fixer raised a question only a code change can answer and the rebuild re-adopts the still-open draft PR. The item pauses correctly meanwhile, because an open block pauses every card whose own stage ranks at or after the one named. The stage is derived; the state is not — every answered decision lands here first.",
       "dst_is_derived": false
     },
     {


### PR DESCRIPTION
PM ticket: SC-4397

Picking an ordering answer on a card's decision block — "SC-XXXX goes first" — started the work anyway. Three defects in one flow, all verified against the code:

1. **A sequencing answer was not representable.** `pursueDecision` records the choice and starts the stage for every answer; nothing in an option could say "this one means wait".
2. **A decision on a bug or security card misrouted.** Those runs raise their decision in preflight, before a plan exists, so the resume hit the plan gate: `[human:needs-planning]` and a planning run on a bug ticket.
3. **`reconcileQueuedLaunch` could never launch.** No transition rule admitted a queued card, so every re-drive was rejected as a non-advance — and charged against the retry budget.

## The change

An options block may declare, per answer, the ticket that answer defers to:

```
[human:options]
stage: implementation
context: SC-4245 has an open branch on the same files
1: SC-4245 goes first
waits-for-1: SC-4245
2: this goes first
```

Picking answer 1 records `[human:option-chosen]` with `waits-for: SC-4245` and starts nothing. The card stays queued, reads "waiting for SC-4245" in the do-nothing register, and `reconcileQueuedLaunch` releases it on the first tick after that ticket is done — spending no retry budget while it waits. Dropping the card on its own column starts it earlier; that same transition is what makes the recovery pass work at all.

Guards: a wait naming no offered answer is rejected at post time; a wait naming the ticket it sits on is refused at the click; an unreadable blocker keeps the hold rather than clearing it; the PR loop's sole-direction path will not take a wait for itself.

## Limits

- The wait is recorded on the marker, not as a tracker `--blocks` link. Deliberate: only Shortcut can store a directed link, and a link outlives the wait — after release the card would keep a "waits for X (off board)" badge forever.
- A held card whose blocker key cannot be resolved stays held with a warn per reconcile tick. The way out is a person dropping the card on its column.

Tests fail on the old code and pass on the new one (verified by stashing the production changes). `make check` green, `go test ./cmd/...` green, `go vet -tags wailsapp ./desktop/...` clean, `make fsm` well-formed.